### PR TITLE
fixing slab panic on drop issue in async rt

### DIFF
--- a/nexus-async-rt/Cargo.toml
+++ b/nexus-async-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-async-rt"
-version = "0.4.1"
+version = "0.4.2"
 description = "Single-threaded async executor with pre-allocated task storage"
 edition.workspace = true
 rust-version.workspace = true

--- a/nexus-async-rt/src/alloc.rs
+++ b/nexus-async-rt/src/alloc.rs
@@ -90,8 +90,15 @@ pub(crate) struct SlabTlsConfig {
     pub(crate) slot_size: usize,
 }
 
-/// Install slab TLS from a config. Returns RAII guard.
-pub(crate) fn install_slab(config: &SlabTlsConfig) -> SlabGuard {
+/// Install slab TLS and return an RAII guard that owns the slab.
+///
+/// The guard restores the previous TLS state on drop (in its manual
+/// Drop body), then releases the slab memory (via field drop). Caller
+/// is responsible for ensuring the guard outlives any code that might
+/// dispatch through TLS — typically by storing it as the LAST field
+/// on the type that owns the runtime state. See BUG-1 (#167) for the
+/// failure mode this prevents.
+pub(crate) fn install_slab(slab: Box<dyn std::any::Any>, config: &SlabTlsConfig) -> SlabGuard {
     let prev_ptr = SLAB_PTR.with(|c| c.replace(config.slab_ptr));
     let prev_claim = SLAB_CLAIM.with(|c| c.replace(config.claim_fn));
     let prev_free = SLAB_FREE.with(|c| c.replace(config.free_fn));
@@ -105,6 +112,7 @@ pub(crate) fn install_slab(config: &SlabTlsConfig) -> SlabGuard {
         prev_try_claim,
         prev_claim_free,
         prev_slot_size,
+        _slab: slab,
     }
 }
 
@@ -116,10 +124,19 @@ pub(crate) struct SlabGuard {
     prev_try_claim: TryClaimFn,
     prev_claim_free: ClaimFreeFn,
     prev_slot_size: usize,
+
+    // Owns the type-erased slab. Drops AFTER the manual Drop body
+    // returns, so TLS is already restored when slab memory is released.
+    // Slab's own Drop touches its own memory only — never the TLS
+    // dispatch path — so this ordering is safe even though prev_* may
+    // point to the no-slab panic stubs at that point.
+    _slab: Box<dyn std::any::Any>,
 }
 
 impl Drop for SlabGuard {
     fn drop(&mut self) {
+        // Restore TLS to whatever was there before this install.
+        // After this body returns, _slab field drops and the slab is freed.
         SLAB_PTR.with(|c| c.set(self.prev_ptr));
         SLAB_CLAIM.with(|c| c.set(self.prev_claim));
         SLAB_FREE.with(|c| c.set(self.prev_free));

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -257,14 +257,20 @@ pub struct Runtime {
     /// Slab allocator + TLS install. Owned via a single guard so that
     /// TLS dispatch stays valid for the Runtime's entire lifetime.
     ///
-    /// **MUST be the last data field**: it drops AFTER `executor`, so
-    /// when `Executor::drop` frees surviving slab tasks via TLS
-    /// dispatch, the slab and its install are still alive. Reordering
-    /// re-introduces BUG-1 (#167) — a panic at `Runtime::drop` from
-    /// surviving slab tasks calling into a cleared TLS dispatch path.
-    /// The `const _: ()` block below this struct enforces the ordering
-    /// at compile time.
+    /// **MUST drop AFTER `executor`**: when `Executor::drop` frees
+    /// surviving slab tasks via TLS dispatch, the slab and its install
+    /// must still be alive. Reordering re-introduces BUG-1 (#167) — a
+    /// panic at `Runtime::drop` from surviving slab tasks calling into
+    /// a cleared TLS dispatch path. The `const _: ()` block below this
+    /// struct enforces the ordering at compile time.
     _slab_guard: Option<crate::alloc::SlabGuard>,
+
+    /// Tracks Runtime presence on the thread. Installed at construction
+    /// (panics if another Runtime is already alive), cleared on drop.
+    /// Declared after `_slab_guard` so the "Runtime alive" flag stays
+    /// set throughout the entire drop sequence — defensive against any
+    /// inner Drop impl trying to construct another Runtime mid-teardown.
+    _runtime_presence: RuntimePresenceGuard,
 
     /// Marker — `Runtime` is intrinsically thread-bound (per-thread TLS
     /// state). `*const ()` is `!Send + !Sync`; the `PhantomData`
@@ -514,6 +520,11 @@ impl<'w> RuntimeBuilder<'w> {
 
     /// Build the runtime.
     pub fn build(self) -> Runtime {
+        // Fail-fast if another Runtime is already alive on this thread.
+        // Done before any resource allocation so we don't leak IoDriver,
+        // mio::Poll, etc. on the panic path.
+        let runtime_presence = RuntimePresenceGuard::install();
+
         let io = IoDriver::new(self.event_capacity, self.token_capacity)
             .expect("failed to create mio::Poll");
         let mut shutdown = crate::ShutdownHandle::new();
@@ -527,10 +538,10 @@ impl<'w> RuntimeBuilder<'w> {
 
         // Create slab if configured and install TLS immediately. The
         // returned guard owns the slab and the TLS install; it lives
-        // on Runtime as the last field so it drops AFTER `executor`
-        // (which frees surviving slab tasks via TLS dispatch). This is
-        // the architectural fix for BUG-1 (#167) — TLS scope now
-        // matches Runtime lifetime instead of run_loop scope.
+        // on Runtime so it drops AFTER `executor` (which frees surviving
+        // slab tasks via TLS dispatch). This is the architectural fix
+        // for BUG-1 (#167) — TLS scope now matches Runtime lifetime
+        // instead of run_loop scope.
         let slab_guard = self.slab_installer.map(|install| {
             let (slab, config) = install();
             crate::alloc::install_slab(slab, &config)
@@ -553,6 +564,7 @@ impl<'w> RuntimeBuilder<'w> {
             cross_thread_drain_limit: self.cross_thread_drain_limit,
             event_interval: self.event_interval,
             _slab_guard: slab_guard,
+            _runtime_presence: runtime_presence,
             _not_thread_safe: PhantomData,
         };
 
@@ -786,6 +798,51 @@ impl RuntimeGuard {
 impl Drop for RuntimeGuard {
     fn drop(&mut self) {
         CURRENT.with(|cell| cell.set(self.prev));
+    }
+}
+
+// =============================================================================
+// RAII guard for Runtime presence on this thread
+// =============================================================================
+//
+// Enforces "at most one Runtime alive per thread" at construction time. This
+// is the right scope because:
+//
+//  - Slab TLS is installed at construction (post BUG-1 fix). A second
+//    construction would silently overwrite the first's slab dispatch state,
+//    corrupting allocator routing for the first Runtime's surviving tasks.
+//  - !Send + !Sync prevents cross-thread coexistence at the type level.
+//    This guard prevents same-thread coexistence at runtime.
+//
+// Different from `RuntimeGuard` above: that one is per-`block_on` for spawn
+// TLS, this one is per-Runtime for existence tracking.
+
+thread_local! {
+    static RUNTIME_PRESENT: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) struct RuntimePresenceGuard;
+
+impl RuntimePresenceGuard {
+    /// Install the Runtime-presence flag. Panics if another Runtime is
+    /// already alive on this thread.
+    fn install() -> Self {
+        assert!(
+            !RUNTIME_PRESENT.with(Cell::get),
+            "nexus-async-rt: another Runtime is already alive on this \
+             thread. Only one Runtime is supported per thread because \
+             thread-local state (slab dispatch, IO/timer drivers, \
+             cross-thread wake context) cannot be shared between \
+             Runtimes. Drop the existing Runtime first."
+        );
+        RUNTIME_PRESENT.with(|c| c.set(true));
+        Self
+    }
+}
+
+impl Drop for RuntimePresenceGuard {
+    fn drop(&mut self) {
+        RUNTIME_PRESENT.with(|c| c.set(false));
     }
 }
 

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -18,6 +18,7 @@
 
 use std::cell::Cell;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll, Wake, Waker};
 use std::time::{Duration, Instant};
@@ -157,6 +158,23 @@ pub fn claim_slab() -> crate::alloc::SlabClaim {
 
 /// Single-threaded async runtime.
 ///
+/// `Runtime` is intrinsically thread-bound — its slab TLS state is
+/// per-thread, so moving it to another thread would silently
+/// desynchronize allocation dispatch. The type is therefore both
+/// `!Send` and `!Sync`, enforced by a `PhantomData<*const ()>` marker.
+///
+/// ```compile_fail
+/// use nexus_async_rt::Runtime;
+/// fn assert_send<T: Send>() {}
+/// assert_send::<Runtime>();
+/// ```
+///
+/// ```compile_fail
+/// use nexus_async_rt::Runtime;
+/// fn assert_sync<T: Sync>() {}
+/// assert_sync::<Runtime>();
+/// ```
+///
 /// # Examples
 ///
 /// ```ignore
@@ -182,8 +200,26 @@ pub fn claim_slab() -> crate::alloc::SlabClaim {
 ///     spawn_slab(async { /* slab-allocated */ });
 /// });
 /// ```
+//
+// `#[repr(C)]` is required for the `offset_of` assertion below to be
+// sound. Under `repr(Rust)` (the default), the compiler is free to
+// reorder fields for layout optimization, which would let an accidental
+// declaration-order swap silently re-introduce BUG-1 (#167) while the
+// offset comparison still happened to pass. `#[repr(C)]` guarantees
+// field offsets follow declaration order modulo alignment padding,
+// making the assertion enforce what it claims.
+//
+// This is NOT for FFI — `Runtime` has no foreign caller. It's purely
+// to back the BUG-1 invariant with a language-spec guarantee instead
+// of empirical rustc behavior.
+#[repr(C)]
 pub struct Runtime {
     /// Spawned task storage.
+    ///
+    /// Drops first (declaration order). `Executor::drop` walks
+    /// `all_tasks` and frees any survivors via the slab TLS dispatch
+    /// path, which requires `_slab_guard` to still be alive — see the
+    /// field-order invariant on `_slab_guard`.
     executor: Executor,
 
     /// IO driver (mio). Wrapped in `UnsafeCell` because a raw pointer
@@ -218,15 +254,37 @@ pub struct Runtime {
     /// Loop iterations between non-blocking IO polls.
     event_interval: u32,
 
-    /// Optional slab allocator. Stored as a boxed trait object for
-    /// type erasure (the const generic lives inside). The slab itself
-    /// is accessed via TLS fn pointers — this field just owns the memory.
-    _slab: Option<Box<dyn std::any::Any>>,
+    /// Slab allocator + TLS install. Owned via a single guard so that
+    /// TLS dispatch stays valid for the Runtime's entire lifetime.
+    ///
+    /// **MUST be the last data field**: it drops AFTER `executor`, so
+    /// when `Executor::drop` frees surviving slab tasks via TLS
+    /// dispatch, the slab and its install are still alive. Reordering
+    /// re-introduces BUG-1 (#167) — a panic at `Runtime::drop` from
+    /// surviving slab tasks calling into a cleared TLS dispatch path.
+    /// The `const _: ()` block below this struct enforces the ordering
+    /// at compile time.
+    _slab_guard: Option<crate::alloc::SlabGuard>,
 
-    /// Slab TLS config for deferred installation in run_loop.
-    /// None = no slab (Box-only).
-    slab_tls: Option<crate::alloc::SlabTlsConfig>,
+    /// Marker — `Runtime` is intrinsically thread-bound (per-thread TLS
+    /// state). `*const ()` is `!Send + !Sync`; the `PhantomData`
+    /// propagates that at the type level regardless of other field
+    /// changes. See the `compile_fail` doc-tests on `Runtime`.
+    _not_thread_safe: PhantomData<*const ()>,
 }
+
+// BUG-1 (#167) invariant: `_slab_guard` MUST drop after `executor`.
+// Field drop order is declaration order, and offset is a proxy: a
+// later-declared field has a higher offset (modulo alignment padding,
+// which preserves order). If anyone reorders the fields above, this
+// fires at compile time.
+const _: () = assert!(
+    std::mem::offset_of!(Runtime, _slab_guard) > std::mem::offset_of!(Runtime, executor),
+    "BUG-1 (#167) invariant violated: Runtime::_slab_guard MUST be \
+     declared after Runtime::executor so it drops after the executor \
+     frees surviving slab tasks. Restore the declaration order or BUG-1 \
+     reappears as a panic at Runtime::drop."
+);
 
 impl Runtime {
     /// Create a runtime with default settings. Box-allocated tasks only.
@@ -467,10 +525,15 @@ impl<'w> RuntimeBuilder<'w> {
         let ctx = WorldCtx::new(self.world);
         let event_time = Cell::new(Instant::now());
 
-        // Create slab if configured. TLS is installed later in run_loop.
-        let (slab, slab_tls) = self.slab_installer.map_or((None, None), |install| {
+        // Create slab if configured and install TLS immediately. The
+        // returned guard owns the slab and the TLS install; it lives
+        // on Runtime as the last field so it drops AFTER `executor`
+        // (which frees surviving slab tasks via TLS dispatch). This is
+        // the architectural fix for BUG-1 (#167) — TLS scope now
+        // matches Runtime lifetime instead of run_loop scope.
+        let slab_guard = self.slab_installer.map(|install| {
             let (slab, config) = install();
-            (Some(slab), Some(config))
+            crate::alloc::install_slab(slab, &config)
         });
 
         let cross_wake = std::sync::Arc::new(crate::cross_wake::CrossWakeContext {
@@ -489,8 +552,8 @@ impl<'w> RuntimeBuilder<'w> {
             cross_wake,
             cross_thread_drain_limit: self.cross_thread_drain_limit,
             event_interval: self.event_interval,
-            _slab: slab,
-            slab_tls,
+            _slab_guard: slab_guard,
+            _not_thread_safe: PhantomData,
         };
 
         if self.signal_handlers {
@@ -540,8 +603,9 @@ impl Runtime {
             std::ptr::from_ref(&self.shutdown.task_waker),
         );
 
-        // Install slab TLS if configured (scoped to run_loop).
-        let _slab_guard = self.slab_tls.as_ref().map(crate::alloc::install_slab);
+        // Slab TLS is installed at Runtime construction (BUG-1 #167 fix)
+        // and torn down when the Runtime drops — no longer scoped to
+        // run_loop, so nothing to install here.
 
         // Install cross-thread wake context in TLS.
         let _cross_wake_guard = crate::cross_wake::install_cross_wake(&self.cross_wake);

--- a/nexus-async-rt/tests/slab_shutdown_bug.rs
+++ b/nexus-async-rt/tests/slab_shutdown_bug.rs
@@ -137,3 +137,26 @@ fn multiple_block_on_with_slab_tasks() {
 
     drop(rt);
 }
+
+#[test]
+#[should_panic(expected = "another Runtime is already alive on this thread")]
+fn second_runtime_on_same_thread_panics() {
+    // Runtime presence guard: only one Runtime per thread allowed.
+    // Constructing a second one with the first still alive must panic.
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let _rt1 = Runtime::builder(&mut world).build();
+    let _rt2 = Runtime::builder(&mut world).build(); // panics here
+}
+
+#[test]
+fn runtime_construct_drop_construct_works() {
+    // After dropping the first Runtime, constructing another on the
+    // same thread must succeed — the presence flag is cleared on drop.
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    {
+        let _rt1 = Runtime::builder(&mut world).build();
+    } // _rt1 dropped here, presence flag cleared
+    let _rt2 = Runtime::builder(&mut world).build(); // must NOT panic
+}

--- a/nexus-async-rt/tests/slab_shutdown_bug.rs
+++ b/nexus-async-rt/tests/slab_shutdown_bug.rs
@@ -1,18 +1,20 @@
-//! Reproduction for BUG-1 (tracked in issue #167): slab task in all_tasks
-//! at `Runtime::drop` triggers panic in `slab_free_task` because the
-//! `SLAB_FREE` TLS is cleared after `run_loop` exits, but `Executor::drop`
-//! still calls `free_task` on surviving slab tasks.
+//! Regression tests for BUG-1 (#167): slab tasks surviving past
+//! `block_on` are freed cleanly when the `Runtime` is dropped.
 //!
-//! Tests are marked `#[should_panic]` so CI documents the bug without
-//! blocking unrelated work. When #167 is fixed, invert these to
-//! `#[test]` (no panic expected) and they become regression tests.
+//! Before the architectural fix, these tests panicked with
+//! "slab free called without a slab configured" because slab TLS was
+//! scoped to `run_loop` and cleared before `Executor::drop` could free
+//! surviving slab tasks via the TLS dispatch path.
+//!
+//! After the fix (slab TLS installed at Runtime construction, restored
+//! when the Runtime drops via field-order RAII on `_slab_guard`),
+//! surviving slab tasks free cleanly during the normal drop sequence.
 
 use nexus_async_rt::{Runtime, spawn_slab};
 use nexus_rt::WorldBuilder;
 
 #[test]
-#[should_panic(expected = "slab free called without a slab configured")]
-fn slab_task_uncompleted_at_runtime_drop_panics() {
+fn slab_task_uncompleted_at_runtime_drop_no_panic() {
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -26,32 +28,112 @@ fn slab_task_uncompleted_at_runtime_drop_panics() {
             std::future::pending::<()>().await;
         }));
     });
-    // TLS cleared here. executor.all_tasks has one slab task, not completed.
 
-    // drop(rt) should NOT panic — but I expect it does.
+    // Pre-fix: this panicked. Post-fix: clean — TLS still installed
+    // when Executor::drop frees the surviving slab task.
     drop(rt);
 }
 
 #[test]
-#[should_panic(expected = "slab free called without a slab configured")]
-fn slab_handle_dropped_outside_block_on_panics() {
+#[allow(clippy::async_yields_async)] // Intentional: returning the unawaited
+// JoinHandle so we can drop it outside block_on and exercise BUG-1's path.
+fn slab_handle_dropped_outside_block_on_no_panic() {
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
     let mut rt = Runtime::builder(&mut world).slab_unbounded(slab).build();
 
-    // Return handle from block_on — task hasn't run.
-    let handle = rt.block_on(async {
-        spawn_slab(async { 42u32 })
-    });
-    // TLS cleared. Task not completed, refcount=2 (exec + handle).
+    // Return the JoinHandle from block_on — task hasn't completed.
+    let handle = rt.block_on(async { spawn_slab(async { 42u32 }) });
 
-    drop(handle);
     // JoinHandle::Drop: task not completed → don't drop output.
-    // clear_has_join, ref_dec → refcount 1, Retain.
-    // Task still in all_tasks.
+    // clear_has_join, ref_dec → refcount 1, Retain. Task still in all_tasks.
+    drop(handle);
+
+    // Pre-fix: Executor::drop frees the task → free_task → TLS null → PANIC.
+    // Post-fix: TLS still installed → frees correctly into the slab.
+    drop(rt);
+}
+
+#[test]
+fn many_slab_tasks_at_varying_lifecycle_states() {
+    let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(64) };
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::builder(&mut world).slab_unbounded(slab).build();
+
+    let held = rt.block_on(async {
+        // Group 1: completes during block_on.
+        for i in 0..16i32 {
+            let h = spawn_slab(async move { i });
+            assert_eq!(h.await, i);
+        }
+        // Group 2: handle dropped, never completes.
+        for _i in 0..16 {
+            drop(spawn_slab(async {
+                std::future::pending::<()>().await;
+            }));
+        }
+        // Group 3: handle held outside block_on. Returned out of the
+        // async block so it borrows nothing from the surrounding scope
+        // (block_on requires F: 'static).
+        let mut held = Vec::new();
+        for i in 0..8i32 {
+            held.push(spawn_slab(async move {
+                std::future::pending::<i32>().await;
+                i
+            }));
+        }
+        held
+    });
+
+    // Drop handles after block_on — must not panic.
+    drop(held);
+    // Final drop — must not panic.
+    drop(rt);
+}
+
+#[test]
+fn no_slab_no_panic() {
+    // Regression: ensure the no-slab path (Box-only tasks) still works.
+    // _slab_guard is None, no TLS install, no Drop side effect.
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::builder(&mut world).build();
+
+    rt.block_on(async {});
+    drop(rt);
+}
+
+#[test]
+fn slab_task_completed_during_block_on() {
+    // Path where the bug never fired (TLS held during free during run_loop).
+    // Confirm the new lifecycle doesn't break it.
+    let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::builder(&mut world).slab_unbounded(slab).build();
+
+    let result = rt.block_on(async { spawn_slab(async { 100u32 }).await });
+    assert_eq!(result, 100);
 
     drop(rt);
-    // Executor::drop: finds task, drop_task_future, complete_and_unref → FreeSlab,
-    // free_task → slab_free_task → TLS null → PANIC.
+}
+
+#[test]
+fn multiple_block_on_with_slab_tasks() {
+    // Multiple block_on calls on the same Runtime. TLS is installed
+    // once at construction; block_on no longer manages it, so calls
+    // across separate block_on invocations all see the same slab.
+    let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::builder(&mut world).slab_unbounded(slab).build();
+
+    let r1 = rt.block_on(async { spawn_slab(async { 1u32 }).await });
+    let r2 = rt.block_on(async { spawn_slab(async { 2u32 }).await });
+    assert_eq!(r1, 1);
+    assert_eq!(r2, 2);
+
+    drop(rt);
 }


### PR DESCRIPTION
## Summary

Architectural fix for BUG-1 (slab tasks panic at Runtime drop), plus
related lifecycle hardening that came out of review.

Closes #167

## What changed

### 1. BUG-1 (#167) — slab TLS scope = Runtime lifetime

Previously, slab TLS was scoped to `run_loop`, but `Executor::drop`
runs after `run_loop` exits. Surviving slab tasks tried to dispatch
through cleared TLS → panic. Fixed by moving the slab TLS install from
`run_loop` to `Runtime` construction, restored on Runtime drop via
field-order RAII. `SlabGuard` now owns the slab itself (consolidating
`_slab` + `slab_tls` into one field), and `_slab_guard` drops AFTER
`executor` so the executor frees surviving slab tasks via still-installed
TLS dispatch.

### 2. Single Runtime per thread — enforced at construction

Added `RuntimePresenceGuard` (RAII over a TLS bool). `RuntimeBuilder::build`
panics if another Runtime is already alive on the same thread. Why
construction-time and not `block_on`-time (tokio's pattern): the new
architecture installs slab TLS at construction, so a second construction
silently overwrites the first's TLS dispatch state. Catching at `block_on`
is too late.

The construct → drop → construct pattern still works (flag is cleared
on drop). Sending across threads is still blocked at compile time by
`!Send` + `!Sync`.

### 3. `Runtime` is explicitly `!Send + !Sync`

Added `_not_thread_safe: PhantomData<*const ()>` field. Documented via
`compile_fail` doctests on `Runtime`'s rustdoc — both verified to fire.

### 4. `#[repr(C)]` on `Runtime` (John's review catch)

The `const _: () = assert!(offset_of!(_slab_guard) > offset_of!(executor))`
field-order check uses offset as a proxy for declaration order. Under
`repr(Rust)` (the default), the compiler is free to reorder fields for
layout optimization, which means the assertion was technically a
heuristic, not a proof. Adding `#[repr(C)]` guarantees offsets follow
declaration order modulo alignment padding. Runtime has no FFI surface,
so this is purely about backing the BUG-1 invariant with a
language-spec guarantee instead of empirical rustc behavior.

## Behavior changes downstream might notice

- Constructing two `Runtime`s on the same thread now panics on the
  second construction. Previously was silently UB-prone for slab
  Runtimes; the new code makes the constraint overt.
- `Runtime` is now explicitly `!Send`. It was already `!Sync` via
  `UnsafeCell<IoDriver>` and `Cell<Instant>`; the new `!Send` constraint
  was previously implicit via the same fields' Send semantics. The
  PhantomData makes both explicit and future-proof.

## Test coverage

8 tests in `tests/slab_shutdown_bug.rs`:

- `slab_task_uncompleted_at_runtime_drop_no_panic` — original BUG-1
  repro, inverted from `#[should_panic]` to regression test
- `slab_handle_dropped_outside_block_on_no_panic` — second BUG-1 repro,
  same inversion
- `many_slab_tasks_at_varying_lifecycle_states` — mixed completed /
  pending / handle-held tasks all going through the new drop path
- `no_slab_no_panic` — Box-only Runtime path (the `_slab_guard = None`
  branch)
- `slab_task_completed_during_block_on` — happy path, slab task that
  completes inside `block_on` (didn't trigger BUG-1 even pre-fix, but
  worth confirming the new lifecycle doesn't break it)
- `multiple_block_on_with_slab_tasks` — multiple `block_on` calls on
  the same Runtime; TLS installed once at construction, persists across
  calls
- `second_runtime_on_same_thread_panics` — verifies the
  `RuntimePresenceGuard` enforcement
- `runtime_construct_drop_construct_works` — verifies the presence
  flag is properly cleared on drop, so serial Runtime use still works

Plus 2 `compile_fail` doctests on `Runtime` for `!Send` and `!Sync`.

## Verification

- `cargo build -p nexus-async-rt` clean (default + `--all-features`)
- `cargo test -p nexus-async-rt` all green debug + release
- `cargo test --test slab_shutdown_bug` 8/8 pass debug + release
- `cargo test --test channel_latency --release -- --ignored` 10/10 pass
  (SIGABRT canary)
- `MIRIFLAGS=... cargo +nightly miri test` clean across `miri_alloc`,
  `miri_task`, `slab_shutdown_bug`
- `cargo clippy --lib -- -D warnings` clean
- `cargo clippy --test slab_shutdown_bug -- -D warnings` clean
- `cargo fmt` clean on touched files

Pre-existing baseline issues (`clippy --tests` + `fmt` drift in
unrelated `src/channel/*` and `src/task.rs` and the `#[cfg(test)]`
module of `src/runtime.rs`) are unchanged. Worth a separate cleanup PR
but out of scope here.

## Files touched

**Modified:**
- `nexus-async-rt/src/alloc.rs` — `SlabGuard` owns the boxed slab,
  `install_slab` takes it by value
- `nexus-async-rt/src/runtime.rs` — Runtime field set, `#[repr(C)]`,
  `compile_fail` doctests, `const _: ()` offset assertion,
  `RuntimePresenceGuard` + thread_local + builder install
- `nexus-async-rt/tests/slab_shutdown_bug.rs` — 6 new tests + 2
  inverted, header rewrite

**New:** none.

## Review trail

- Plan: `.claude/plan.md` (architectural-fix version)
- Carl's pre-impl questions + post-impl summary: `.claude/feedback.md`
- Martin + John review + Copilot follow-up: `.claude/review.md`
- Original audit: `.claude/audit-2026-04-20.md` § BUG-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)