### PR TITLE
fixing uaf bugs in async rt channels

### DIFF
--- a/nexus-async-rt/Cargo.toml
+++ b/nexus-async-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-async-rt"
-version = "0.4.2"
+version = "0.4.3"
 description = "Single-threaded async executor with pre-allocated task storage"
 edition.workspace = true
 rust-version.workspace = true

--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -68,7 +68,31 @@ impl RxWakerSlot {
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING, "concurrent register on RxWakerSlot");
 
-        self.task_ptr.store(task_ptr, Ordering::Relaxed);
+        // BUG-2 (#168) fix: hold a refcount on the task while registered
+        // so a sender that captures the pointer mid-`wake()` can't have
+        // it freed underneath. The matching `ref_dec` happens in `wake`
+        // (after `wake_task_cross_thread` returns), `clear`, or `Drop`.
+        // SAFETY: caller (RecvFut::poll) just received task_ptr from the
+        // active receiver task whose refcount is >= 1.
+        unsafe { crate::task::ref_inc(task_ptr) };
+
+        // Release any prior registration's ref. Always check prev_ptr —
+        // not gated on `prev == STORED` — because a sender's `wake()`
+        // CAS may have transitioned state STORED→EMPTY without yet
+        // taking the task_ptr (the swap is the second step). In that
+        // race window, prev_ptr is still non-null even though state was
+        // EMPTY when we observed it. Skipping the release leaks the
+        // ref. (BUG-2 follow-up — found by John in PR review.)
+        //
+        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
+        // we own that ref now and must release it. wake/clear/Drop
+        // operate on the new pointer we just stored — both refs are
+        // tracked correctly in all interleavings.
+        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
+        if !prev_ptr.is_null() {
+            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
+        }
+
         self.state.store(STORED, Ordering::Release);
     }
 
@@ -94,9 +118,17 @@ impl RxWakerSlot {
             if !task_ptr.is_null() {
                 // Push to cross-thread inbox + conditional eventfd poke.
                 // SAFETY: cross_ctx is valid for the lifetime of the channel.
+                // task_ptr is alive because `register` ref_inc'd before
+                // storing — that ref keeps the task allocated through the
+                // dispatch (see BUG-2 #168).
                 let ctx = unsafe { &*self.cross_ctx };
-                // SAFETY: task_ptr is a valid task (set by register from RecvFut).
                 unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
+
+                // BUG-2 fix: release the ref `register` acquired. Must
+                // happen AFTER `wake_task_cross_thread` returns so the
+                // task is alive for the deref inside it.
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
                 return true;
             }
         }
@@ -113,8 +145,70 @@ impl RxWakerSlot {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
-            self.task_ptr
-                .store(std::ptr::null_mut(), Ordering::Release);
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // BUG-2 fix: release the ref `register` acquired.
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+impl Drop for RxWakerSlot {
+    fn drop(&mut self) {
+        // BUG-2 (#168) fix: if still registered when dropped, release
+        // our ref. Slot drops when the channel `Inner` drops — both
+        // sides of the channel are gone, so any registered receiver
+        // task can no longer be woken via this slot. Releasing the ref
+        // here matches the wake/clear release paths.
+        //
+        // &mut self gives exclusive access; no concurrent mutator.
+        if *self.state.get_mut() == STORED {
+            let task_ptr = *self.task_ptr.get_mut();
+            if !task_ptr.is_null() {
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+/// Release the slot's ref on `task_ptr`. If this turns out to be the
+/// terminal ref, route the pointer back to the executor for free +
+/// bookkeeping via the cross-thread queue. Mirrors the pattern in
+/// `tokio_compat::cross_task_wake` — the executor's `drain_cross_thread`
+/// recognizes terminal entries and routes them to `deferred_free`.
+///
+/// # Safety
+///
+/// `task_ptr` must point to a task on which `register` previously called
+/// `ref_inc`. `cross_ctx` must point to a valid `CrossWakeContext`.
+unsafe fn release_slot_ref(
+    task_ptr: *mut u8,
+    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+) {
+    match unsafe { crate::task::ref_dec(task_ptr) } {
+        crate::task::FreeAction::Retain => {}
+        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
+            // Terminal. Route to the executor: try_set_queued + push +
+            // conditional mio wake. Slab tasks need executor-thread TLS
+            // to free; box tasks could be freed here directly, but routing
+            // both keeps `all_tasks` bookkeeping consistent (the executor
+            // removes the task from `all_tasks` when it processes the
+            // terminal entry).
+            // SAFETY: cross_ctx is valid (caller guarantee).
+            let ctx = unsafe { &*cross_ctx };
+            // SAFETY: task_ptr was alive until ref_dec; for a terminal
+            // result it's still alive (we haven't freed it ourselves).
+            if unsafe { crate::task::try_set_queued(task_ptr) } {
+                // SAFETY: task_ptr valid; QUEUED is now set so it can
+                // safely live in the cross-thread queue's intrusive list.
+                unsafe { ctx.queue.push(task_ptr) };
+                if ctx.parked.load(Ordering::Acquire) {
+                    let _ = ctx.mio_waker.wake();
+                }
+            }
         }
     }
 }
@@ -936,5 +1030,309 @@ mod tests {
 
         // Should be closed, not crashed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Closed));
+    }
+}
+
+// =============================================================================
+// BUG-2 (#168) — verify use-after-free in the cross-thread wake path
+// =============================================================================
+//
+// Hypothesis: `RxWakerSlot::register` stores `task_ptr` without calling
+// `task::ref_inc`. A sender that wins the wake CAS captures the pointer,
+// then dereferences it inside `wake_task_cross_thread` (`is_completed`,
+// `try_set_queued`, `queue.push`). If the task completes and is freed
+// in the gap between CAS and deref — typically because a `select!`
+// resolved on a different arm — the deref hits freed memory.
+//
+// The white-box test below orchestrates the race deterministically:
+// it CAS-claims the slot itself, completes-and-frees the task, and THEN
+// calls `wake_task_cross_thread`. Run under tree-borrows miri to expose
+// the UAF.
+//
+// Run pre-fix (UAF expected):
+//   MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-ignore-leaks" \
+//     cargo +nightly miri test -p nexus-async-rt --lib uaf_tests
+//
+// After the fix (`register` ref_incs, `wake`/`clear`/`Drop` ref_dec),
+// this same test runs clean under miri because the slot's ref keeps
+// the task alive across the dispatch window.
+#[cfg(test)]
+mod uaf_tests {
+    use super::*;
+    use crate::cross_wake::wake_task_cross_thread;
+    use crate::task::{self, FreeAction, Task};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    struct UafNoop;
+    impl Future for UafNoop {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Ready(())
+        }
+    }
+
+    fn make_uaf_task() -> *mut u8 {
+        // Refcount = 1 (single executor-style ref) per Task::new_boxed.
+        let task = Box::new(Task::new_boxed(UafNoop, 0));
+        Box::into_raw(task) as *mut u8
+    }
+
+    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
+        let poll = mio::Poll::new().unwrap();
+        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
+        Arc::new(crate::cross_wake::CrossWakeContext {
+            queue: crate::cross_wake::CrossWakeQueue::new(),
+            mio_waker,
+            parked: AtomicBool::new(false),
+        })
+    }
+
+    /// Reproduces BUG-2: sender derefs the task pointer after the
+    /// receiver task has been freed.
+    ///
+    /// Pre-fix: the call to `wake_task_cross_thread(captured, ...)`
+    /// reads task state from freed memory. Tree-borrows miri flags
+    /// this. The exact failure surface depends on which read miri
+    /// trips on first (`is_completed` is the first deref).
+    ///
+    /// Post-fix: `register` ref_incs (refcount goes 1→2), so
+    /// `complete_and_unref` returns `Retain` instead of `FreeBox`. The
+    /// task allocation is alive when the sender derefs it; the deref
+    /// reads `COMPLETED` and the function returns early. The slot's
+    /// `Drop` then releases the final ref, freeing the task cleanly.
+    #[test]
+    fn waker_slot_uaf_when_task_freed_mid_dispatch() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Sanity: starting refcount is 1 (Task::new_boxed initial state).
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            1,
+            "make_uaf_task should produce refcount=1"
+        );
+
+        // Construct the slot pointing at the cross-wake context, then
+        // register the task pointer — this is the operation under test.
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+
+        // Mirror the sender's first half of `slot.wake()`: CAS state
+        // STORED→EMPTY, swap the pointer out. After this, the sender
+        // owns the captured pointer and is about to call
+        // `wake_task_cross_thread`.
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok(),
+            "slot was registered; CAS STORED→EMPTY must succeed"
+        );
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+
+        // Simulate "select resolved on the other arm during the
+        // dispatch window": the executor calls `complete_and_unref` on
+        // the task, which atomically sets COMPLETED and decrements the
+        // executor's ref. Pre-fix this is the last ref → FreeBox.
+        // Post-fix the slot still holds a ref → Retain.
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+
+        // Track which path we're on — the test must clean up differently
+        // pre-fix vs post-fix. Pre-fix: task is already freed below.
+        // Post-fix: task is still alive (slot's ref); we must release it
+        // ourselves at the end since the slot's `state` is EMPTY (we
+        // CAS'd it above), so any future `Drop`-time release won't fire.
+        let pre_fix = match action {
+            FreeAction::FreeBox => {
+                // PRE-FIX path. The sender is about to deref freed memory.
+                // Free now to make the UAF deterministic for miri.
+                unsafe { task::free_task(task_ptr) };
+                true
+            }
+            FreeAction::Retain => false,
+            FreeAction::FreeSlab => {
+                panic!("box-allocated test task must not produce FreeSlab");
+            }
+        };
+
+        // Sender continues with the captured pointer.
+        // PRE-FIX: derefs freed memory → tree-borrows UAF.
+        // POST-FIX: derefs alive task, observes COMPLETED, returns early.
+        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
+
+        if !pre_fix {
+            // POST-FIX cleanup: release the slot's captured ref. In real
+            // code this is the ref_dec that `wake()` does after
+            // `wake_task_cross_thread` returns.
+            match unsafe { task::ref_dec(captured) } {
+                FreeAction::FreeBox => unsafe { task::free_task(captured) },
+                FreeAction::Retain | FreeAction::FreeSlab => {
+                    panic!("post-fix cleanup must terminate the box task")
+                }
+            }
+        }
+
+        // Drop the slot. State is EMPTY (CAS'd above), so any
+        // `Drop`-time release path is a no-op for this scenario.
+        drop(slot);
+    }
+
+    /// Companion test: when a registered slot is dropped without ever
+    /// being woken or cleared, the slot's `Drop` must release its ref.
+    /// Otherwise the task allocation leaks.
+    ///
+    /// **Sensitive to the fix via explicit refcount assertions.** This
+    /// test FAILS pre-fix because no `Drop` impl exists on `RxWakerSlot`,
+    /// so `register` doesn't take a ref and Drop doesn't release one.
+    /// PASSES post-fix because `register` ref_incs and Drop ref_decs.
+    #[test]
+    fn slot_drop_releases_ref_when_still_registered() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Mark the task COMPLETED first via complete_and_unref. Bump the
+        // ref to 2 so complete_and_unref returns Retain (rather than
+        // freeing). After: refcount = 1, COMPLETED set.
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+        // Post-fix: register ref_inc → refcount = 2.
+        // Pre-fix: register did NOT ref_inc → refcount = 1.
+        let after_register = unsafe { task::ref_count(task_ptr) };
+
+        // Drop the slot WITHOUT calling wake() or clear().
+        // Post-fix: Drop sees state == STORED, ref_dec → refcount = 1, returns Retain.
+        // Pre-fix: no Drop impl → refcount unchanged.
+        drop(slot);
+        let after_drop = unsafe { task::ref_count(task_ptr) };
+
+        // **The strengthened assertion**: register-then-drop must net to
+        // zero change in refcount. Pre-fix register doesn't take a ref AND
+        // Drop doesn't release one, so this ALSO nets to zero — but the
+        // explicit `register-took-a-ref` check below catches the regression.
+        assert_eq!(
+            after_register,
+            after_drop + 1,
+            "Post-fix Drop must release the ref that register acquired. \
+             If this fires pre-fix (register skipped ref_inc), there's no \
+             Drop ref_dec to compensate, so the net is 0 instead of -1."
+        );
+        assert_eq!(
+            after_register,
+            baseline_refcount + 1,
+            "Post-fix register must bump refcount by 1. If this fires \
+             pre-fix, register skipped ref_inc — that's BUG-2's root cause."
+        );
+
+        // Cleanup: refcount is 1 (post-fix or pre-fix), COMPLETED set.
+        // Final ref_dec should return FreeBox; free the allocation.
+        let action = unsafe { task::ref_dec(task_ptr) };
+        match action {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+
+    /// Race regression for John's review item 1 (BUG-2 follow-up).
+    ///
+    /// `register()` previously gated the prev-ref release on
+    /// `prev == STORED && !prev_ptr.is_null()`. That gate was wrong:
+    /// a sender's `wake()` first CAS's state STORED→EMPTY, THEN swaps
+    /// `task_ptr`. If a re-register interleaves between those two
+    /// steps it observes `prev == EMPTY` (CAS happened) but
+    /// `prev_ptr` is still non-null (swap hasn't happened) — the gate
+    /// skipped releasing the old ref, leaking it.
+    ///
+    /// The fix removes the `prev == STORED` part of the gate; we now
+    /// always release a non-null prev_ptr.
+    ///
+    /// This test drives the interleave manually and asserts refcount
+    /// returns to baseline. Pre-fix it lands at baseline+1 (leak).
+    #[test]
+    fn register_during_wake_does_not_leak_ref() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Bump the ref so the test's manual ref_decs don't trigger
+        // free mid-test. After complete_and_unref, refcount = 1 with
+        // COMPLETED set — this is our baseline.
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline, 1, "baseline must be 1 (executor-style ref)");
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+
+        // ---- T0: initial register ----
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "initial register must take a ref (slot owns +1)"
+        );
+
+        // ---- T1 wake (first half): CAS only, do NOT swap task_ptr yet ----
+        // Mirrors the entry of `wake()` paused mid-function. After
+        // this, state is EMPTY but task_ptr still points at task_ptr.
+        let cas_ok = slot
+            .state
+            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok();
+        assert!(cas_ok, "wake's CAS must succeed when state is STORED");
+
+        // ---- T2: re-register (the race) ----
+        // Mirrors RecvFut::poll re-registering after a wake from
+        // another source (timer, parent select arm fired). Same task
+        // — same task_ptr. Pre-fix: register's gate sees prev==EMPTY,
+        // skips the release, leaks the old ref. Post-fix: release fires.
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "race register must NET to baseline+1 (slot still owns one ref). \
+             Pre-fix the gate skipped the release of the original; this \
+             assertion would fire baseline+2 — the leak."
+        );
+
+        // ---- T1 wake (second half): swap task_ptr, release ----
+        // Skip wake_task_cross_thread — we're testing refcount balance,
+        // not the dispatch path. release_slot_ref is the operation
+        // wake() performs after the dispatch.
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
+
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "after wake's release, slot owes 0 refs to task. Pre-fix \
+             this is baseline+1 (the leaked original)."
+        );
+
+        // ---- Cleanup ----
+        // After the race, slot is in (state=STORED, task_ptr=null).
+        // Drop sees state=STORED but task_ptr is null, so it releases
+        // nothing — confirms the Drop impl correctly handles this
+        // benign "post-race" inconsistency.
+        drop(slot);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "Drop on a STORED-but-null-task_ptr slot must be a no-op for refcount"
+        );
+
+        // Final ref_dec → FreeBox.
+        match unsafe { task::ref_dec(task_ptr) } {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
     }
 }

--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -65,6 +65,11 @@ impl RxWakerSlot {
     /// Register the receiver's task pointer. Called by RecvFut::poll.
     /// Single-registerer only.
     fn register(&self, task_ptr: *mut u8) {
+        debug_assert!(
+            !task_ptr.is_null(),
+            "RxWakerSlot::register called with null task_ptr — \
+             contract violation by caller (typically RecvFut::poll)"
+        );
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING, "concurrent register on RxWakerSlot");
 
@@ -73,7 +78,8 @@ impl RxWakerSlot {
         // it freed underneath. The matching `ref_dec` happens in `wake`
         // (after `wake_task_cross_thread` returns), `clear`, or `Drop`.
         // SAFETY: caller (RecvFut::poll) just received task_ptr from the
-        // active receiver task whose refcount is >= 1.
+        // active receiver task whose refcount is >= 1; the debug_assert
+        // above catches the null case in development.
         unsafe { crate::task::ref_inc(task_ptr) };
 
         // Release any prior registration's ref. Always check prev_ptr —
@@ -1146,10 +1152,24 @@ mod uaf_tests {
         // CAS'd it above), so any future `Drop`-time release won't fire.
         let pre_fix = match action {
             FreeAction::FreeBox => {
-                // PRE-FIX path. The sender is about to deref freed memory.
-                // Free now to make the UAF deterministic for miri.
-                unsafe { task::free_task(task_ptr) };
-                true
+                // PRE-FIX path: register skipped the ref_inc, so the
+                // executor's complete_and_unref produced terminal. Under
+                // regular `cargo test`, fail early — the deref below
+                // would manifest as a segfault rather than a clean
+                // assertion failure. Under `cargo +nightly miri test`,
+                // proceed to trigger the UAF so miri can produce its
+                // diagnostic trace (the original BUG-2 proof).
+                #[cfg(not(miri))]
+                panic!(
+                    "BUG-2 regression detected: register skipped ref_inc, \
+                     so complete_and_unref produced FreeBox instead of \
+                     Retain. Run under miri for the full UAF trace."
+                );
+                #[cfg(miri)]
+                {
+                    unsafe { task::free_task(task_ptr) };
+                    true
+                }
             }
             FreeAction::Retain => false,
             FreeAction::FreeSlab => {

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -62,12 +62,39 @@ impl RxWakerSlot {
         }
     }
 
+    /// Register the receiver's task pointer. Single-registerer only.
+    fn register(&self, task_ptr: *mut u8) {
+        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
+        debug_assert_ne!(prev, REGISTERING);
+
+        // BUG-2 (#168) fix: hold a refcount on the task while
+        // registered so a sender that captures the pointer
+        // mid-`wake()` can't have it freed underneath. Matched by
+        // ref_dec in wake/clear/Drop.
+        // SAFETY: caller (RecvFut::poll) just received task_ptr from
+        // the active receiver task whose refcount is >= 1.
+        unsafe { crate::task::ref_inc(task_ptr) };
+
+        // Release any prior registration's ref. Always check prev_ptr —
+        // not gated on `prev == STORED` — because a sender's `wake()` CAS
+        // may have transitioned state STORED→EMPTY without yet taking
+        // the task_ptr (the swap is the second step). In that race
+        // window, prev_ptr is still non-null even though state was
+        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
+        //
+        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
+        // we own that ref now and must release it.
+        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
+        if !prev_ptr.is_null() {
+            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
+        }
+
+        self.state.store(STORED, Ordering::Release);
+    }
+
     fn try_register_local(&self, waker: &Waker) -> bool {
         crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-            debug_assert_ne!(prev, REGISTERING);
-            self.task_ptr.store(task_ptr, Ordering::Relaxed);
-            self.state.store(STORED, Ordering::Release);
+            self.register(task_ptr);
             true
         })
     }
@@ -80,8 +107,17 @@ impl RxWakerSlot {
         {
             let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
             if !task_ptr.is_null() {
+                // SAFETY: task_ptr is alive because `try_register_local`
+                // ref_inc'd before storing — that ref keeps the task
+                // allocated through the dispatch (see BUG-2 #168).
                 let ctx = unsafe { &*self.cross_ctx };
                 unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
+
+                // BUG-2 fix: release the ref `try_register_local`
+                // acquired. AFTER wake_task_cross_thread so the task is
+                // alive for its deref.
+                // SAFETY: we own the ref from `try_register_local`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
                 return true;
             }
         }
@@ -98,8 +134,55 @@ impl RxWakerSlot {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
-            self.task_ptr
-                .store(std::ptr::null_mut(), Ordering::Release);
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // BUG-2 fix: release the ref `try_register_local` acquired.
+                // SAFETY: we own the ref.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+impl Drop for RxWakerSlot {
+    fn drop(&mut self) {
+        // BUG-2 (#168) fix: if still registered when dropped, release
+        // our ref. See mpsc.rs for the full rationale.
+        if *self.state.get_mut() == STORED {
+            let task_ptr = *self.task_ptr.get_mut();
+            if !task_ptr.is_null() {
+                // SAFETY: we own the ref from `try_register_local`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+/// Release the slot's ref on `task_ptr`. If terminal, route to executor
+/// via the cross-thread queue. See `mpsc::release_slot_ref` for design
+/// notes — duplicated here to keep the PR focused on the fix.
+///
+/// # Safety
+///
+/// `task_ptr` must point to a task on which `try_register_local`
+/// previously called `ref_inc`. `cross_ctx` must be valid.
+unsafe fn release_slot_ref(
+    task_ptr: *mut u8,
+    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+) {
+    match unsafe { crate::task::ref_dec(task_ptr) } {
+        crate::task::FreeAction::Retain => {}
+        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
+            // SAFETY: cross_ctx is valid (caller guarantee).
+            let ctx = unsafe { &*cross_ctx };
+            // SAFETY: terminal but not yet freed (we own the last ref).
+            if unsafe { crate::task::try_set_queued(task_ptr) } {
+                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
+                unsafe { ctx.queue.push(task_ptr) };
+                if ctx.parked.load(Ordering::Acquire) {
+                    let _ = ctx.mio_waker.wake();
+                }
+            }
         }
     }
 }
@@ -931,5 +1014,184 @@ mod tests {
         try_send(&mut tx1, b"more");
         let msg = rx.try_recv().unwrap();
         assert_eq!(&*msg, b"more");
+    }
+}
+
+// =============================================================================
+// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// =============================================================================
+//
+// See `mpsc.rs::uaf_tests` for the full rationale. This file's
+// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+#[cfg(test)]
+mod uaf_tests {
+    use super::*;
+    use crate::cross_wake::wake_task_cross_thread;
+    use crate::task::{self, FreeAction, Task};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::task::{Context, Poll};
+
+    struct UafNoop;
+    impl Future for UafNoop {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Ready(())
+        }
+    }
+
+    fn make_uaf_task() -> *mut u8 {
+        let task = Box::new(Task::new_boxed(UafNoop, 0));
+        Box::into_raw(task) as *mut u8
+    }
+
+    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
+        let poll = mio::Poll::new().unwrap();
+        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
+        Arc::new(crate::cross_wake::CrossWakeContext {
+            queue: crate::cross_wake::CrossWakeQueue::new(),
+            mio_waker,
+            parked: AtomicBool::new(false),
+        })
+    }
+
+    #[test]
+    fn waker_slot_uaf_when_task_freed_mid_dispatch() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+
+        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
+            FreeAction::FreeBox => {
+                unsafe { task::free_task(task_ptr) };
+                true
+            }
+            FreeAction::Retain => false,
+            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
+        };
+
+        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
+
+        if !pre_fix {
+            match unsafe { task::ref_dec(captured) } {
+                FreeAction::FreeBox => unsafe { task::free_task(captured) },
+                _ => panic!("post-fix cleanup must terminate the box task"),
+            }
+        }
+
+        drop(slot);
+    }
+
+    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
+    /// because `register` skips ref_inc and there's no Drop impl. PASSES
+    /// post-fix because register ref_incs and Drop ref_decs.
+    #[test]
+    fn slot_drop_releases_ref_when_still_registered() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+        let after_register = unsafe { task::ref_count(task_ptr) };
+
+        drop(slot);
+        let after_drop = unsafe { task::ref_count(task_ptr) };
+
+        assert_eq!(
+            after_register,
+            after_drop + 1,
+            "Post-fix Drop must release the ref that register acquired."
+        );
+        assert_eq!(
+            after_register,
+            baseline_refcount + 1,
+            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
+        );
+
+        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
+        let action = unsafe { task::ref_dec(task_ptr) };
+        match action {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+
+    /// Race regression for John's review item 1 (BUG-2 follow-up).
+    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
+    /// for the full design notes.
+    #[test]
+    fn register_during_wake_does_not_leak_ref() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "initial register must take a ref"
+        );
+
+        // Wake first half: CAS only.
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+
+        // Race: re-register during the wake window.
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
+        );
+
+        // Wake second half: swap + release.
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
+        );
+
+        drop(slot);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "Drop on STORED-but-null slot is a no-op for refcount"
+        );
+
+        match unsafe { task::ref_dec(task_ptr) } {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox, got {other:?}"),
+        }
     }
 }

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -64,6 +64,10 @@ impl RxWakerSlot {
 
     /// Register the receiver's task pointer. Single-registerer only.
     fn register(&self, task_ptr: *mut u8) {
+        debug_assert!(
+            !task_ptr.is_null(),
+            "RxWakerSlot::register called with null task_ptr"
+        );
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
 
@@ -72,7 +76,8 @@ impl RxWakerSlot {
         // mid-`wake()` can't have it freed underneath. Matched by
         // ref_dec in wake/clear/Drop.
         // SAFETY: caller (RecvFut::poll) just received task_ptr from
-        // the active receiver task whose refcount is >= 1.
+        // the active receiver task whose refcount is >= 1; the
+        // debug_assert above catches the null case in development.
         unsafe { crate::task::ref_inc(task_ptr) };
 
         // Release any prior registration's ref. Always check prev_ptr —
@@ -1076,8 +1081,19 @@ mod uaf_tests {
 
         let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
             FreeAction::FreeBox => {
-                unsafe { task::free_task(task_ptr) };
-                true
+                // PRE-FIX path: under regular cargo test, fail early
+                // (avoid segfault from the deref below). Under miri,
+                // trigger the UAF so the diagnostic trace fires.
+                #[cfg(not(miri))]
+                panic!(
+                    "BUG-2 regression detected: register skipped ref_inc. \
+                     Run under miri for the full UAF trace."
+                );
+                #[cfg(miri)]
+                {
+                    unsafe { task::free_task(task_ptr) };
+                    true
+                }
             }
             FreeAction::Retain => false,
             FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -58,7 +58,28 @@ impl RxWakerSlot {
     fn register(&self, task_ptr: *mut u8) {
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
-        self.task_ptr.store(task_ptr, Ordering::Relaxed);
+
+        // BUG-2 (#168) fix: hold a refcount on the task while registered
+        // so a sender that captures the pointer mid-`wake()` can't have
+        // it freed underneath. Matched by `ref_dec` in wake/clear/Drop.
+        // SAFETY: caller (RecvFut::poll) just received task_ptr from the
+        // active receiver task whose refcount is >= 1.
+        unsafe { crate::task::ref_inc(task_ptr) };
+
+        // Release any prior registration's ref. Always check prev_ptr —
+        // not gated on `prev == STORED` — because a sender's `wake()` CAS
+        // may have transitioned state STORED→EMPTY without yet taking
+        // the task_ptr (the swap is the second step). In that race
+        // window, prev_ptr is still non-null even though state was
+        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
+        //
+        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
+        // we own that ref now and must release it.
+        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
+        if !prev_ptr.is_null() {
+            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
+        }
+
         self.state.store(STORED, Ordering::Release);
     }
 
@@ -77,8 +98,16 @@ impl RxWakerSlot {
         {
             let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
             if !task_ptr.is_null() {
+                // SAFETY: task_ptr is alive because `register` ref_inc'd
+                // before storing — that ref keeps the task allocated
+                // through the dispatch (see BUG-2 #168).
                 let ctx = unsafe { &*self.cross_ctx };
                 unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
+
+                // BUG-2 fix: release the ref `register` acquired. AFTER
+                // wake_task_cross_thread so the task is alive for its deref.
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
                 return true;
             }
         }
@@ -98,8 +127,58 @@ impl RxWakerSlot {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
-            self.task_ptr
-                .store(std::ptr::null_mut(), Ordering::Release);
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // BUG-2 fix: release the ref `register` acquired.
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+impl Drop for RxWakerSlot {
+    fn drop(&mut self) {
+        // BUG-2 (#168) fix: if still registered when dropped, release
+        // our ref. See mpsc.rs for the full rationale.
+        if *self.state.get_mut() == STORED {
+            let task_ptr = *self.task_ptr.get_mut();
+            if !task_ptr.is_null() {
+                // SAFETY: we own the ref from `register`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+/// Release the slot's ref on `task_ptr`. If terminal, route the pointer
+/// back to the executor via the cross-thread queue (mirrors the pattern
+/// in `tokio_compat::cross_task_wake`). See `mpsc::release_slot_ref`
+/// for the design notes — this is the same code, kept inline rather
+/// than extracted into `channel/common.rs` to minimize PR churn.
+///
+/// # Safety
+///
+/// `task_ptr` must point to a task on which `register` previously called
+/// `ref_inc`. `cross_ctx` must point to a valid `CrossWakeContext`.
+unsafe fn release_slot_ref(
+    task_ptr: *mut u8,
+    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+) {
+    match unsafe { crate::task::ref_dec(task_ptr) } {
+        crate::task::FreeAction::Retain => {}
+        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
+            // SAFETY: cross_ctx is valid (caller guarantee).
+            let ctx = unsafe { &*cross_ctx };
+            // SAFETY: task_ptr was alive until ref_dec; for a terminal
+            // result it's still alive (we haven't freed it ourselves).
+            if unsafe { crate::task::try_set_queued(task_ptr) } {
+                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
+                unsafe { ctx.queue.push(task_ptr) };
+                if ctx.parked.load(Ordering::Acquire) {
+                    let _ = ctx.mio_waker.wake();
+                }
+            }
         }
     }
 }
@@ -629,5 +708,184 @@ mod tests {
 
         // Dropping receiver is clean.
         drop(rx);
+    }
+}
+
+// =============================================================================
+// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// =============================================================================
+//
+// See `mpsc.rs::uaf_tests` for the full rationale. This file's
+// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+#[cfg(test)]
+mod uaf_tests {
+    use super::*;
+    use crate::cross_wake::wake_task_cross_thread;
+    use crate::task::{self, FreeAction, Task};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::task::{Context, Poll};
+
+    struct UafNoop;
+    impl Future for UafNoop {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Ready(())
+        }
+    }
+
+    fn make_uaf_task() -> *mut u8 {
+        let task = Box::new(Task::new_boxed(UafNoop, 0));
+        Box::into_raw(task) as *mut u8
+    }
+
+    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
+        let poll = mio::Poll::new().unwrap();
+        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
+        Arc::new(crate::cross_wake::CrossWakeContext {
+            queue: crate::cross_wake::CrossWakeQueue::new(),
+            mio_waker,
+            parked: AtomicBool::new(false),
+        })
+    }
+
+    #[test]
+    fn waker_slot_uaf_when_task_freed_mid_dispatch() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+
+        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
+            FreeAction::FreeBox => {
+                unsafe { task::free_task(task_ptr) };
+                true
+            }
+            FreeAction::Retain => false,
+            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
+        };
+
+        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
+
+        if !pre_fix {
+            match unsafe { task::ref_dec(captured) } {
+                FreeAction::FreeBox => unsafe { task::free_task(captured) },
+                _ => panic!("post-fix cleanup must terminate the box task"),
+            }
+        }
+
+        drop(slot);
+    }
+
+    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
+    /// because `register` skips ref_inc and there's no Drop impl. PASSES
+    /// post-fix because register ref_incs and Drop ref_decs.
+    #[test]
+    fn slot_drop_releases_ref_when_still_registered() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+        let after_register = unsafe { task::ref_count(task_ptr) };
+
+        drop(slot);
+        let after_drop = unsafe { task::ref_count(task_ptr) };
+
+        assert_eq!(
+            after_register,
+            after_drop + 1,
+            "Post-fix Drop must release the ref that register acquired."
+        );
+        assert_eq!(
+            after_register,
+            baseline_refcount + 1,
+            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
+        );
+
+        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
+        let action = unsafe { task::ref_dec(task_ptr) };
+        match action {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+
+    /// Race regression for John's review item 1 (BUG-2 follow-up).
+    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
+    /// for the full design notes.
+    #[test]
+    fn register_during_wake_does_not_leak_ref() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "initial register must take a ref"
+        );
+
+        // Wake first half: CAS only.
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+
+        // Race: re-register during the wake window.
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
+        );
+
+        // Wake second half: swap + release.
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
+        );
+
+        drop(slot);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "Drop on STORED-but-null slot is a no-op for refcount"
+        );
+
+        match unsafe { task::ref_dec(task_ptr) } {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox, got {other:?}"),
+        }
     }
 }

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -56,6 +56,10 @@ impl RxWakerSlot {
     }
 
     fn register(&self, task_ptr: *mut u8) {
+        debug_assert!(
+            !task_ptr.is_null(),
+            "RxWakerSlot::register called with null task_ptr"
+        );
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
 
@@ -63,7 +67,8 @@ impl RxWakerSlot {
         // so a sender that captures the pointer mid-`wake()` can't have
         // it freed underneath. Matched by `ref_dec` in wake/clear/Drop.
         // SAFETY: caller (RecvFut::poll) just received task_ptr from the
-        // active receiver task whose refcount is >= 1.
+        // active receiver task whose refcount is >= 1; the debug_assert
+        // above catches the null case in development.
         unsafe { crate::task::ref_inc(task_ptr) };
 
         // Release any prior registration's ref. Always check prev_ptr —
@@ -770,8 +775,19 @@ mod uaf_tests {
 
         let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
             FreeAction::FreeBox => {
-                unsafe { task::free_task(task_ptr) };
-                true
+                // PRE-FIX path: under regular cargo test, fail early
+                // (avoid segfault from the deref below). Under miri,
+                // trigger the UAF so the diagnostic trace fires.
+                #[cfg(not(miri))]
+                panic!(
+                    "BUG-2 regression detected: register skipped ref_inc. \
+                     Run under miri for the full UAF trace."
+                );
+                #[cfg(miri)]
+                {
+                    unsafe { task::free_task(task_ptr) };
+                    true
+                }
             }
             FreeAction::Retain => false,
             FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -59,12 +59,39 @@ impl RxWakerSlot {
         }
     }
 
+    /// Register the receiver's task pointer. Single-registerer only.
+    fn register(&self, task_ptr: *mut u8) {
+        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
+        debug_assert_ne!(prev, REGISTERING);
+
+        // BUG-2 (#168) fix: hold a refcount on the task while
+        // registered so a sender that captures the pointer
+        // mid-`wake()` can't have it freed underneath. Matched by
+        // ref_dec in wake/clear/Drop.
+        // SAFETY: caller (RecvFut::poll) just received task_ptr from
+        // the active receiver task whose refcount is >= 1.
+        unsafe { crate::task::ref_inc(task_ptr) };
+
+        // Release any prior registration's ref. Always check prev_ptr —
+        // not gated on `prev == STORED` — because a sender's `wake()` CAS
+        // may have transitioned state STORED→EMPTY without yet taking
+        // the task_ptr (the swap is the second step). In that race
+        // window, prev_ptr is still non-null even though state was
+        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
+        //
+        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
+        // we own that ref now and must release it.
+        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
+        if !prev_ptr.is_null() {
+            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
+        }
+
+        self.state.store(STORED, Ordering::Release);
+    }
+
     fn try_register_local(&self, waker: &Waker) -> bool {
         crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-            debug_assert_ne!(prev, REGISTERING);
-            self.task_ptr.store(task_ptr, Ordering::Relaxed);
-            self.state.store(STORED, Ordering::Release);
+            self.register(task_ptr);
             true
         })
     }
@@ -77,8 +104,17 @@ impl RxWakerSlot {
         {
             let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
             if !task_ptr.is_null() {
+                // SAFETY: task_ptr is alive because `try_register_local`
+                // ref_inc'd before storing — that ref keeps the task
+                // allocated through the dispatch (see BUG-2 #168).
                 let ctx = unsafe { &*self.cross_ctx };
                 unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
+
+                // BUG-2 fix: release the ref `try_register_local`
+                // acquired. AFTER wake_task_cross_thread so the task is
+                // alive for its deref.
+                // SAFETY: we own the ref from `try_register_local`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
                 return true;
             }
         }
@@ -95,8 +131,55 @@ impl RxWakerSlot {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
-            self.task_ptr
-                .store(std::ptr::null_mut(), Ordering::Release);
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // BUG-2 fix: release the ref `try_register_local` acquired.
+                // SAFETY: we own the ref.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+impl Drop for RxWakerSlot {
+    fn drop(&mut self) {
+        // BUG-2 (#168) fix: if still registered when dropped, release
+        // our ref. See mpsc.rs for the full rationale.
+        if *self.state.get_mut() == STORED {
+            let task_ptr = *self.task_ptr.get_mut();
+            if !task_ptr.is_null() {
+                // SAFETY: we own the ref from `try_register_local`.
+                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
+            }
+        }
+    }
+}
+
+/// Release the slot's ref on `task_ptr`. If terminal, route to executor
+/// via the cross-thread queue. See `mpsc::release_slot_ref` for design
+/// notes — duplicated here to keep the PR focused on the fix.
+///
+/// # Safety
+///
+/// `task_ptr` must point to a task on which `try_register_local`
+/// previously called `ref_inc`. `cross_ctx` must be valid.
+unsafe fn release_slot_ref(
+    task_ptr: *mut u8,
+    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+) {
+    match unsafe { crate::task::ref_dec(task_ptr) } {
+        crate::task::FreeAction::Retain => {}
+        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
+            // SAFETY: cross_ctx is valid (caller guarantee).
+            let ctx = unsafe { &*cross_ctx };
+            // SAFETY: terminal but not yet freed (we own the last ref).
+            if unsafe { crate::task::try_set_queued(task_ptr) } {
+                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
+                unsafe { ctx.queue.push(task_ptr) };
+                if ctx.parked.load(Ordering::Acquire) {
+                    let _ = ctx.mio_waker.wake();
+                }
+            }
         }
     }
 }
@@ -741,5 +824,184 @@ mod tests {
 
         let msg = rx.try_recv().unwrap();
         assert_eq!(&*msg, b"after_abort");
+    }
+}
+
+// =============================================================================
+// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// =============================================================================
+//
+// See `mpsc.rs::uaf_tests` for the full rationale. This file's
+// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+#[cfg(test)]
+mod uaf_tests {
+    use super::*;
+    use crate::cross_wake::wake_task_cross_thread;
+    use crate::task::{self, FreeAction, Task};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::task::{Context, Poll};
+
+    struct UafNoop;
+    impl Future for UafNoop {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Ready(())
+        }
+    }
+
+    fn make_uaf_task() -> *mut u8 {
+        let task = Box::new(Task::new_boxed(UafNoop, 0));
+        Box::into_raw(task) as *mut u8
+    }
+
+    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
+        let poll = mio::Poll::new().unwrap();
+        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
+        Arc::new(crate::cross_wake::CrossWakeContext {
+            queue: crate::cross_wake::CrossWakeQueue::new(),
+            mio_waker,
+            parked: AtomicBool::new(false),
+        })
+    }
+
+    #[test]
+    fn waker_slot_uaf_when_task_freed_mid_dispatch() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+
+        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
+            FreeAction::FreeBox => {
+                unsafe { task::free_task(task_ptr) };
+                true
+            }
+            FreeAction::Retain => false,
+            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
+        };
+
+        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
+
+        if !pre_fix {
+            match unsafe { task::ref_dec(captured) } {
+                FreeAction::FreeBox => unsafe { task::free_task(captured) },
+                _ => panic!("post-fix cleanup must terminate the box task"),
+            }
+        }
+
+        drop(slot);
+    }
+
+    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
+    /// because `register` skips ref_inc and there's no Drop impl. PASSES
+    /// post-fix because register ref_incs and Drop ref_decs.
+    #[test]
+    fn slot_drop_releases_ref_when_still_registered() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+        let after_register = unsafe { task::ref_count(task_ptr) };
+
+        drop(slot);
+        let after_drop = unsafe { task::ref_count(task_ptr) };
+
+        assert_eq!(
+            after_register,
+            after_drop + 1,
+            "Post-fix Drop must release the ref that register acquired."
+        );
+        assert_eq!(
+            after_register,
+            baseline_refcount + 1,
+            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
+        );
+
+        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
+        let action = unsafe { task::ref_dec(task_ptr) };
+        match action {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+
+    /// Race regression for John's review item 1 (BUG-2 follow-up).
+    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
+    /// for the full design notes.
+    #[test]
+    fn register_during_wake_does_not_leak_ref() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline, 1);
+
+        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "initial register must take a ref"
+        );
+
+        // Wake first half: CAS only.
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        );
+
+        // Race: re-register during the wake window.
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
+        );
+
+        // Wake second half: swap + release.
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
+        );
+
+        drop(slot);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "Drop on STORED-but-null slot is a no-op for refcount"
+        );
+
+        match unsafe { task::ref_dec(task_ptr) } {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox, got {other:?}"),
+        }
     }
 }

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -61,6 +61,10 @@ impl RxWakerSlot {
 
     /// Register the receiver's task pointer. Single-registerer only.
     fn register(&self, task_ptr: *mut u8) {
+        debug_assert!(
+            !task_ptr.is_null(),
+            "RxWakerSlot::register called with null task_ptr"
+        );
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
 
@@ -69,7 +73,8 @@ impl RxWakerSlot {
         // mid-`wake()` can't have it freed underneath. Matched by
         // ref_dec in wake/clear/Drop.
         // SAFETY: caller (RecvFut::poll) just received task_ptr from
-        // the active receiver task whose refcount is >= 1.
+        // the active receiver task whose refcount is >= 1; the
+        // debug_assert above catches the null case in development.
         unsafe { crate::task::ref_inc(task_ptr) };
 
         // Release any prior registration's ref. Always check prev_ptr —
@@ -886,8 +891,19 @@ mod uaf_tests {
 
         let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
             FreeAction::FreeBox => {
-                unsafe { task::free_task(task_ptr) };
-                true
+                // PRE-FIX path: under regular cargo test, fail early
+                // (avoid segfault from the deref below). Under miri,
+                // trigger the UAF so the diagnostic trace fires.
+                #[cfg(not(miri))]
+                panic!(
+                    "BUG-2 regression detected: register skipped ref_inc. \
+                     Run under miri for the full UAF trace."
+                );
+                #[cfg(miri)]
+                {
+                    unsafe { task::free_task(task_ptr) };
+                    true
+                }
             }
             FreeAction::Retain => false,
             FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -459,7 +459,6 @@ pub(crate) unsafe fn ref_dec(ptr: *mut u8) -> FreeAction {
 /// # Safety
 ///
 /// `ptr` must point to a live `Task<F>`.
-#[allow(dead_code)]
 #[inline]
 pub(crate) unsafe fn ref_count(ptr: *mut u8) -> usize {
     (unsafe { state_load(ptr) } & REF_MASK) >> 6
@@ -1172,7 +1171,11 @@ mod tests {
             assert_eq!(action, FreeAction::FreeSlab);
 
             let s = state_load(ptr);
-            assert_eq!(s, COMPLETED | SLAB_ALLOCATED, "terminal state must be COMPLETED | SLAB_ALLOCATED");
+            assert_eq!(
+                s,
+                COMPLETED | SLAB_ALLOCATED,
+                "terminal state must be COMPLETED | SLAB_ALLOCATED"
+            );
             assert_eq!(s, 33);
             assert!(is_terminal(ptr));
 
@@ -1354,7 +1357,11 @@ mod tests {
 
             // Drop 9 waker refs — all Retain
             for i in 0..9 {
-                assert_eq!(ref_dec(ptr), FreeAction::Retain, "ref_dec #{i} should Retain");
+                assert_eq!(
+                    ref_dec(ptr),
+                    FreeAction::Retain,
+                    "ref_dec #{i} should Retain"
+                );
             }
             assert_eq!(ref_count(ptr), 1);
 


### PR DESCRIPTION
## Summary

Fix BUG-2 (#168): cross-thread channel wake path UAF. Receiver waker
slot stored a raw task pointer with no refcount, so a sender that
captured the pointer mid-`wake()` could deref freed memory if the task
completed during the dispatch window. Confirmed by miri tree-borrows
with full UAF trace; fix verified by miri post-fix clean across all
four channel implementations.

Also addresses follow-up items found during John's review (race
condition the original fix missed) and Copilot's review (CI hygiene +
defensive assertion).

Closes #168

## What changed

### Original BUG-2 fix

`RxWakerSlot` now holds a refcount on the registered task so it can't
be freed mid-dispatch:

- **`register`**: `task::ref_inc(task_ptr)` after the REGISTERING swap.
- **`wake`**: `release_slot_ref` AFTER `wake_task_cross_thread` returns
  (the "after" is critical — the ref keeps the task alive across the
  deref inside it).
- **`clear`**: capture pointer via swap, then `release_slot_ref`.
- **`Drop for RxWakerSlot`**: if `state == STORED`, capture pointer and
  release. Handles channel-dropped-while-still-registered.
- **`release_slot_ref` helper**: `ref_dec`; on terminal action, route
  to executor via cross-thread queue (`try_set_queued` + `queue.push`
  + conditional `mio_waker.wake`). Same pattern as
  `tokio_compat::cross_task_wake`.

Applied uniformly to all four channels: `mpsc.rs`, `spsc.rs`,
`mpsc_bytes.rs`, `spsc_bytes.rs`. For the bytes variants, extracted a
`register(&self, task_ptr: *mut u8)` method to mirror the typed-channel
shape (pure refactor, no behavior change in the extraction).

### Follow-up: race fix from John's review

John caught a race in `register()` that the original fix didn't
handle. The gate `if prev == STORED && !prev_ptr.is_null()` was wrong:
wake's CAS may transition state STORED→EMPTY before its task_ptr swap
takes the pointer, so during the race window prev_ptr is still
non-null even though state was EMPTY when register observes it.
Skipping the release leaks the original ref.

Fix: drop the `prev == STORED` part of the gate. Always release
non-null prev_ptr. Applied to all four channel files.

### Follow-up: tightened test coverage

Added `register_during_wake_does_not_leak_ref` to all four channels'
`uaf_tests`. Drives wake's two halves manually with re-register
sandwiched between, asserts refcount returns to baseline at each
checkpoint. Carl verified the test would have caught the regression
by temporarily reverting the gate fix in mpsc.rs only — mpsc test
failed exactly at the documented assertion (left: 3, right: 2),
the other three continued passing (per-file isolation).

Strengthened `slot_drop_releases_ref_when_still_registered` in all
four channels with explicit `assert_eq!(ref_count, expected)`
assertions before/after Drop. Catches leaks and double-frees
regardless of `-Zmiri-ignore-leaks`.

Removed `#[allow(dead_code)]` on `task::ref_count` — actively used
by the strengthened tests.

### Follow-up: CI hygiene from Copilot's review

**Defensive null-check on register:** Added
`debug_assert!(!task_ptr.is_null())` at the top of `register()` in
all four channel files. The function calls unsafe `ref_inc(task_ptr)`
internally; the debug_assert backs the safety contract documented in
the comment.

**cfg(miri) gating on UAF tests:** The `waker_slot_uaf_when_task_freed_mid_dispatch`
tests deliberately deref freed memory under the FreeBox branch to
trigger the UAF for miri. Under regular `cargo test` (without miri),
that deref would manifest as a segfault — flaky CI, no diagnostic
value. Restructured to:

- **Under regular `cargo test`:** if the BUG-2 fix regresses
  (`complete_and_unref` returns `FreeBox` instead of `Retain`), the
  test panics immediately with a clear message: `"BUG-2 regression
  detected: register skipped ref_inc. Run under miri for the full
  UAF trace."` No segfault risk.
- **Under `cargo +nightly miri test`:** original UAF path runs
  (free → wake_task_cross_thread deref), miri produces its diagnostic
  trace exactly as before. The BUG-2 proof is preserved.

## Test coverage

12 white-box `uaf_tests` (3 per channel × 4 channels):

- `waker_slot_uaf_when_task_freed_mid_dispatch` — original UAF repro
  (cfg(miri)-gated regression path)
- `slot_drop_releases_ref_when_still_registered` — Drop impl,
  strengthened with refcount assertions
- `register_during_wake_does_not_leak_ref` — race regression test for
  John's catch (manually orchestrated wake/register interleave)

All 12 pass under both regular `cargo test` and miri tree-borrows.

## Verification

| Check | Result |
|---|---|
| `cargo build -p nexus-async-rt --lib` | clean |
| `cargo test -p nexus-async-rt --lib uaf_tests` | 12/12 pass |
| `MIRIFLAGS=...tree-borrows... cargo +nightly miri test --lib uaf_tests` | 12/12 pass |
| `cargo test -p nexus-async-rt` (full debug + release + all-features) | all green |
| `cargo test --test channel_latency --release -- --ignored` | 10/10 (SIGABRT canary clean) |
| `MIRIFLAGS=... miri test --test miri_channel` | 18/18 pass |
| `MIRIFLAGS=... miri test --test miri_task` | 28/28 pass |
| `MIRIFLAGS=... miri test --test miri_alloc` | 4/4 pass |
| `cargo clippy -p nexus-async-rt --all-features --lib -- -D warnings` | clean |
| Pre-fix regression check: revert gate in mpsc.rs only | mpsc test FAILS at documented assertion; other 3 continue passing |

Pre-existing baseline issues in unrelated files (clippy `--tests` and
`fmt` drift in `src/channel/local.rs`, `src/backoff.rs`,
`#[cfg(test)] mod tests` in `src/runtime.rs` lines 854+) are unchanged.
Worth a separate cleanup PR.

## Performance impact

No measurable regression. The fix adds one cached atomic per side
(`ref_inc` in `register`, `ref_dec` in `wake`/`clear`/`Drop`).
Theoretical cost: ~1-2 ns per send/recv pair under cache-hit
conditions — below the channel_latency benchmark's measurement
resolution (~10 ns floor at p50 on this machine).

Detailed benchmark numbers in `.claude/feedback.md`.

## Files touched

**Modified (logic):**
- `nexus-async-rt/src/channel/mpsc.rs` — RxWakerSlot fix + 3 uaf_tests
- `nexus-async-rt/src/channel/spsc.rs` — same fix + 3 uaf_tests
- `nexus-async-rt/src/channel/mpsc_bytes.rs` — register extraction +
  same fix + 3 uaf_tests
- `nexus-async-rt/src/channel/spsc_bytes.rs` — register extraction +
  same fix + 3 uaf_tests
- `nexus-async-rt/src/task.rs` — removed `#[allow(dead_code)]` on
  `ref_count`; +12 lines of pre-existing fmt drift cleanup

**New:** none.

## Review trail

- Plan: `.claude/plan.md`
- Carl's pre-impl analysis + post-impl summary: `.claude/feedback.md`
- Martin + John reviews + Copilot follow-up: `.claude/review.md`
- Original audit: `.claude/audit-2026-04-20.md` § BUG-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)