### PR TITLE
PR 1a — TaskRef + dispose_terminal foundation (nexus-async-rt hardening)

### DIFF
--- a/nexus-async-rt/src/alloc.rs
+++ b/nexus-async-rt/src/alloc.rs
@@ -162,7 +162,9 @@ where
     F: Future + 'static,
     F::Output: 'static,
 {
-    let task = crate::task::new_joinable_slab(future, tracker_key, slab_free_task);
+    // See Executor::spawn_boxed for the cross_wake_ctx contract.
+    let cross_wake_ctx = crate::cross_wake::current_runtime_ctx();
+    let task = crate::task::new_joinable_slab(future, tracker_key, slab_free_task, cross_wake_ctx);
     let size = std::mem::size_of_val(&task);
     let src = std::ptr::from_ref(&task).cast::<u8>();
 
@@ -218,7 +220,10 @@ impl SlabClaim {
     {
         crate::runtime::with_executor(|exec| {
             let tracker_key = exec.next_tracker_key();
-            let task = crate::task::new_joinable_slab(future, tracker_key, slab_free_task);
+            // See Executor::spawn_boxed for the cross_wake_ctx contract.
+            let cross_wake_ctx = crate::cross_wake::current_runtime_ctx();
+            let task =
+                crate::task::new_joinable_slab(future, tracker_key, slab_free_task, cross_wake_ctx);
             let size = std::mem::size_of_val(&task);
 
             assert!(

--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -181,40 +181,29 @@ impl Drop for RxWakerSlot {
 }
 
 /// Release the slot's ref on `task_ptr`. If this turns out to be the
-/// terminal ref, route the pointer back to the executor for free +
-/// bookkeeping via the cross-thread queue. Mirrors the pattern in
-/// `tokio_compat::cross_task_wake` — the executor's `drain_cross_thread`
-/// recognizes terminal entries and routes them to `deferred_free`.
+/// terminal ref, route via [`crate::cross_wake::dispose_terminal`] —
+/// defers locally on the owning executor's thread (preserves
+/// `Executor::all_tasks` bookkeeping), queues cross-thread otherwise.
+///
+/// The `cross_ctx` parameter is unused now that dispose_terminal reads
+/// the context from the task header. Kept on the caller signature for
+/// PR 1a (slot consolidation in PR 1b removes the slot type entirely).
 ///
 /// # Safety
 ///
 /// `task_ptr` must point to a task on which `register` previously called
-/// `ref_inc`. `cross_ctx` must point to a valid `CrossWakeContext`.
+/// `ref_inc`.
 unsafe fn release_slot_ref(
     task_ptr: *mut u8,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
 ) {
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // Terminal. Route to the executor: try_set_queued + push +
-            // conditional mio wake. Slab tasks need executor-thread TLS
-            // to free; box tasks could be freed here directly, but routing
-            // both keeps `all_tasks` bookkeeping consistent (the executor
-            // removes the task from `all_tasks` when it processes the
-            // terminal entry).
-            // SAFETY: cross_ctx is valid (caller guarantee).
-            let ctx = unsafe { &*cross_ctx };
-            // SAFETY: task_ptr was alive until ref_dec; for a terminal
-            // result it's still alive (we haven't freed it ourselves).
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                // SAFETY: task_ptr valid; QUEUED is now set so it can
-                // safely live in the cross-thread queue's intrusive list.
-                unsafe { ctx.queue.push(task_ptr) };
-                if ctx.parked.load(Ordering::Acquire) {
-                    let _ = ctx.mio_waker.wake();
-                }
-            }
+            // SAFETY: caller guarantees task_ptr was alive until the
+            // ref_dec above; on terminal it's still alive (we don't
+            // free it here, dispose_terminal does).
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
 }

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -163,31 +163,27 @@ impl Drop for RxWakerSlot {
     }
 }
 
-/// Release the slot's ref on `task_ptr`. If terminal, route to executor
-/// via the cross-thread queue. See `mpsc::release_slot_ref` for design
-/// notes — duplicated here to keep the PR focused on the fix.
+/// Release the slot's ref on `task_ptr`. If terminal, route via
+/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
+/// for the full design rationale.
+///
+/// `cross_ctx` is unused (dispose_terminal reads ctx from the task
+/// header); kept on the signature for PR 1a consistency.
 ///
 /// # Safety
 ///
 /// `task_ptr` must point to a task on which `try_register_local`
-/// previously called `ref_inc`. `cross_ctx` must be valid.
+/// previously called `ref_inc`.
 unsafe fn release_slot_ref(
     task_ptr: *mut u8,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
 ) {
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: cross_ctx is valid (caller guarantee).
-            let ctx = unsafe { &*cross_ctx };
-            // SAFETY: terminal but not yet freed (we own the last ref).
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
-                unsafe { ctx.queue.push(task_ptr) };
-                if ctx.parked.load(Ordering::Acquire) {
-                    let _ = ctx.mio_waker.wake();
-                }
-            }
+            // SAFETY: task_ptr was alive until ref_dec; terminal but
+            // not yet freed (dispose_terminal does the routing).
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
 }

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -156,34 +156,27 @@ impl Drop for RxWakerSlot {
     }
 }
 
-/// Release the slot's ref on `task_ptr`. If terminal, route the pointer
-/// back to the executor via the cross-thread queue (mirrors the pattern
-/// in `tokio_compat::cross_task_wake`). See `mpsc::release_slot_ref`
-/// for the design notes — this is the same code, kept inline rather
-/// than extracted into `channel/common.rs` to minimize PR churn.
+/// Release the slot's ref on `task_ptr`. If terminal, route via
+/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
+/// for the full design rationale — this is the identical pattern.
+///
+/// `cross_ctx` is unused here (dispose_terminal reads ctx from the task
+/// header); kept on the signature for PR 1a consistency.
 ///
 /// # Safety
 ///
 /// `task_ptr` must point to a task on which `register` previously called
-/// `ref_inc`. `cross_ctx` must point to a valid `CrossWakeContext`.
+/// `ref_inc`.
 unsafe fn release_slot_ref(
     task_ptr: *mut u8,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
 ) {
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: cross_ctx is valid (caller guarantee).
-            let ctx = unsafe { &*cross_ctx };
-            // SAFETY: task_ptr was alive until ref_dec; for a terminal
-            // result it's still alive (we haven't freed it ourselves).
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
-                unsafe { ctx.queue.push(task_ptr) };
-                if ctx.parked.load(Ordering::Acquire) {
-                    let _ = ctx.mio_waker.wake();
-                }
-            }
+            // SAFETY: task_ptr was alive until ref_dec; on terminal it's
+            // still alive (dispose_terminal does the routing).
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
 }

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -160,31 +160,27 @@ impl Drop for RxWakerSlot {
     }
 }
 
-/// Release the slot's ref on `task_ptr`. If terminal, route to executor
-/// via the cross-thread queue. See `mpsc::release_slot_ref` for design
-/// notes — duplicated here to keep the PR focused on the fix.
+/// Release the slot's ref on `task_ptr`. If terminal, route via
+/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
+/// for the full design rationale.
+///
+/// `cross_ctx` is unused (dispose_terminal reads ctx from the task
+/// header); kept on the signature for PR 1a consistency.
 ///
 /// # Safety
 ///
 /// `task_ptr` must point to a task on which `try_register_local`
-/// previously called `ref_inc`. `cross_ctx` must be valid.
+/// previously called `ref_inc`.
 unsafe fn release_slot_ref(
     task_ptr: *mut u8,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
+    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
 ) {
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: cross_ctx is valid (caller guarantee).
-            let ctx = unsafe { &*cross_ctx };
-            // SAFETY: terminal but not yet freed (we own the last ref).
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                // SAFETY: task_ptr valid; QUEUED set, safe in queue.
-                unsafe { ctx.queue.push(task_ptr) };
-                if ctx.parked.load(Ordering::Acquire) {
-                    let _ = ctx.mio_waker.wake();
-                }
-            }
+            // SAFETY: task_ptr was alive until ref_dec; terminal but
+            // not yet freed (dispose_terminal does the routing).
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
 }

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -517,10 +517,20 @@ mod tests {
     // =========================================================================
 
     fn make_ctx() -> Arc<CrossWakeContext> {
-        // Real mio waker + queue. Construction is lightweight enough
-        // for unit tests; miri tolerates the mio FFI here because
-        // CrossWakeContext doesn't actually call wake() unless `parked`
-        // is true (we keep it false in these tests).
+        // Real mio Poll + Waker. mio 1.x exposes no public Waker
+        // constructor that bypasses Poll (no `from_raw_fd`, no
+        // `with_eventfd`), so a syscall-free test ctx would require
+        // changing CrossWakeContext to hold `Option<Arc<mio::Waker>>`
+        // — production-code churn whose only motivation is test
+        // ergonomics. Keep the real mio construction here; the tests
+        // never set `parked = true` so `mio_waker.wake()` is never
+        // called.
+        //
+        // Tests pass under `-Zmiri-tree-borrows -Zmiri-ignore-leaks`
+        // today. If a future miri tightens its epoll/eventfd shim and
+        // breaks these tests, revisit by either (a) wrapping mio_waker
+        // in an Option behind a trait abstraction, or (b) skipping
+        // these tests under miri via #[cfg_attr(miri, ignore)].
         let poll = mio::Poll::new().expect("mio::Poll");
         let waker = mio::Waker::new(poll.registry(), mio::Token(0)).expect("mio::Waker");
         Arc::new(CrossWakeContext {

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -20,9 +20,33 @@ use crate::task;
 // =============================================================================
 // TLS — cross-wake context accessible during block_on
 // =============================================================================
+//
+// Two slots, separate scopes, separate consumers:
+//
+// - `CTX_CROSS_WAKE: *const Arc<CrossWakeContext>`
+//   Pointer to the Runtime's `cross_wake` Arc field. Installed at
+//   `run_loop` entry, cleared on exit. Used by `cross_wake_context()`
+//   to clone the Arc for new cross-thread waker construction (channel
+//   slots, tokio_compat). Scope is `block_on` because that's when
+//   user task code runs and needs to construct cross-thread wakers.
+//   Pointer-to-field — safe under `&mut self` during run_loop.
+//
+// - `CURRENT_RUNTIME_CTX: *const CrossWakeContext`
+//   `Arc::as_ptr` value pointing into the Arc allocation (heap-stable,
+//   doesn't dangle if the Runtime moves). Installed at
+//   `RuntimeBuilder::build`, cleared via a guard field on Runtime.
+//   Used by `dispose_terminal::on_owning_executor` to decide whether
+//   a TaskRef::Drop is on the executor thread (defer) or a foreign
+//   thread (queue). Scope is the Runtime's full lifetime because
+//   TaskRef::Drop can fire post-`block_on` (e.g., JoinHandle dropped
+//   between block_on calls, channel slots torn down during Runtime
+//   drop) and during `Executor::drop` itself.
 
 thread_local! {
     static CTX_CROSS_WAKE: Cell<*const Arc<CrossWakeContext>> =
+        const { Cell::new(std::ptr::null()) };
+
+    static CURRENT_RUNTIME_CTX: Cell<*const CrossWakeContext> =
         const { Cell::new(std::ptr::null()) };
 }
 
@@ -56,6 +80,137 @@ pub(crate) fn cross_wake_context() -> Option<Arc<CrossWakeContext>> {
             Some(unsafe { (*ptr).clone() })
         }
     })
+}
+
+// =============================================================================
+// Runtime-lifetime TLS install for `dispose_terminal`
+// =============================================================================
+
+/// Install the Runtime's cross-wake context as the current-thread
+/// "owning executor" identity. Returns a guard that restores the
+/// previous value on drop.
+///
+/// Stores `Arc::as_ptr(arc)` — the inner allocation address, stable
+/// for the lifetime of the Arc. Doesn't dangle if the Runtime struct
+/// moves (the inner stays put).
+pub(crate) fn install_runtime_cross_wake(arc: &Arc<CrossWakeContext>) -> RuntimeCrossWakeGuard {
+    let ptr = Arc::as_ptr(arc);
+    let prev = CURRENT_RUNTIME_CTX.with(|c| c.replace(ptr));
+    RuntimeCrossWakeGuard { prev }
+}
+
+/// RAII guard restoring the previous `CURRENT_RUNTIME_CTX` on drop.
+///
+/// Lives as a field on `Runtime`, placed after `executor` so it drops
+/// after the executor finishes its task-freeing work (which may invoke
+/// `dispose_terminal`).
+pub(crate) struct RuntimeCrossWakeGuard {
+    prev: *const CrossWakeContext,
+}
+
+impl Drop for RuntimeCrossWakeGuard {
+    fn drop(&mut self) {
+        CURRENT_RUNTIME_CTX.with(|c| c.set(self.prev));
+    }
+}
+
+/// Read the currently-installed runtime cross-wake context pointer for
+/// this thread, if any. Returns null when no Runtime is alive on the
+/// thread.
+///
+/// Used by spawn paths (`Executor::spawn_boxed`, `alloc::slab_spawn`,
+/// `SlabClaim::spawn`) to write the value into each new task's header.
+#[inline]
+pub(crate) fn current_runtime_ctx() -> *const CrossWakeContext {
+    CURRENT_RUNTIME_CTX.with(Cell::get)
+}
+
+/// True if `ctx` matches the runtime currently installed on this thread.
+///
+/// False when no Runtime is alive here, or when a different runtime's
+/// ctx is installed (which can't actually happen given
+/// `RuntimePresenceGuard` — at most one Runtime per thread).
+#[inline]
+fn on_owning_executor(ctx: &CrossWakeContext) -> bool {
+    let installed = CURRENT_RUNTIME_CTX.with(Cell::get);
+    !installed.is_null() && std::ptr::eq(installed, ctx)
+}
+
+// =============================================================================
+// dispose_terminal — unified terminal-drop routing
+// =============================================================================
+
+/// Dispose of a task whose final ref was just dropped (FreeBox / FreeSlab).
+///
+/// Routes to one of two on-thread paths and one off-thread path,
+/// chosen by `task_ptr`'s header context and the current thread:
+///
+/// 1. **On-thread (null ctx OR ctx matches the current Runtime's TLS).**
+///    Defer to end of the current poll cycle via
+///    `crate::waker::try_defer_free` so `Executor::all_tasks`
+///    bookkeeping stays consistent (the executor's drain frees the
+///    task and removes the slab key in the right order). If the
+///    `DEFERRED_FREE` TLS is null (called outside any poll cycle —
+///    e.g., `JoinHandle` dropped after `block_on` returns, or a bare
+///    `Executor` test where the handle outlives the poll), the slot
+///    leaks until `Executor::drop` iterates `all_tasks` and reclaims
+///    it. **Direct-freeing here is unsafe** because it would race
+///    `Executor::drop`'s `all_tasks` iteration → double free. This is
+///    the established pre-refactor behavior of `free_completed_slot`.
+///
+/// 2. **Off-thread (ctx non-null, doesn't match TLS).** Push to the
+///    Runtime's cross-thread queue via `try_set_queued + push +
+///    parked check`. The Runtime's `drain_cross_thread` recognizes
+///    terminal entries and pushes them to `deferred_free`, which
+///    updates `all_tasks` on the next poll cycle.
+///
+/// This is the ONE place that does terminal-drop routing for off-thread
+/// holders. All other code (`TaskRef::Drop`, channel slot release
+/// paths, `tokio_compat` terminal branches) goes through here.
+///
+/// # Safety
+///
+/// `task_ptr` must reference a task whose final ref was just dropped
+/// (i.e., `ref_dec` returned `FreeBox` or `FreeSlab`). The header's
+/// `cross_wake_ctx` must be either null or a valid Arc-backed pointer
+/// (set at spawn time, kept alive transitively by any holder of a
+/// TaskRef on this task).
+pub(crate) unsafe fn dispose_terminal(task_ptr: *mut u8) {
+    let ctx_ptr = unsafe { task::header_cross_wake_ctx(task_ptr) };
+
+    // Null ctx (bare Executor or test-only Task::new_boxed): same
+    // defer-or-leak fallback as the on-owning-executor branch. Direct
+    // free is unsafe — see doc-comment.
+    let on_executor = ctx_ptr.is_null() || {
+        // SAFETY: ctx_ptr is Arc-backed and kept alive transitively
+        // by whoever held the ref we just dropped.
+        let ctx = unsafe { &*ctx_ptr };
+        on_owning_executor(ctx)
+    };
+
+    if on_executor {
+        // SAFETY: caller guarantees terminal state.
+        let _ = unsafe { crate::waker::try_defer_free(task_ptr) };
+        return;
+    }
+
+    // Off-thread: route via cross-queue. The executor's
+    // drain_cross_thread recognizes terminal entries and pushes them
+    // to deferred_free, which updates all_tasks on the next poll cycle.
+    //
+    // SAFETY: ctx_ptr non-null (bypassed the on_executor branch via
+    // the && short-circuit above), Arc-backed and alive. try_set_queued
+    // is an atomic on the task header (still alive — we own no ref but
+    // the task header isn't freed because no one else has freed it
+    // yet, and dispose_terminal is the path that would). queue.push
+    // uses the cross_next field and is thread-safe.
+    let ctx = unsafe { &*ctx_ptr };
+    if unsafe { task::try_set_queued(task_ptr) } {
+        unsafe { ctx.queue.push(task_ptr) };
+        if ctx.parked.load(Ordering::Acquire) {
+            let _ = ctx.mio_waker.wake();
+        }
+    }
 }
 
 // =============================================================================
@@ -355,5 +510,165 @@ mod tests {
         assert_eq!(q.pop(), None);
 
         unsafe { free(t1) };
+    }
+
+    // =========================================================================
+    // dispose_terminal — routing under different ctx + thread states
+    // =========================================================================
+
+    fn make_ctx() -> Arc<CrossWakeContext> {
+        // Real mio waker + queue. Construction is lightweight enough
+        // for unit tests; miri tolerates the mio FFI here because
+        // CrossWakeContext doesn't actually call wake() unless `parked`
+        // is true (we keep it false in these tests).
+        let poll = mio::Poll::new().expect("mio::Poll");
+        let waker = mio::Waker::new(poll.registry(), mio::Token(0)).expect("mio::Waker");
+        Arc::new(CrossWakeContext {
+            queue: CrossWakeQueue::new(),
+            mio_waker: Arc::new(waker),
+            parked: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    /// Build a real spawn-shaped task (refcount=2, HAS_JOIN, ctx in
+    /// header) so dispose_terminal sees a production-like header.
+    fn make_spawned_task(ctx: &Arc<CrossWakeContext>) -> *mut u8 {
+        struct Noop;
+        impl std::future::Future for Noop {
+            type Output = u64;
+            fn poll(self: std::pin::Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<u64> {
+                Poll::Ready(0)
+            }
+        }
+        crate::task::box_spawn_joinable(Noop, 0, Arc::as_ptr(ctx))
+    }
+
+    /// Walk a freshly-spawned joinable task to terminal-eligible state:
+    /// drop future, complete, clear HAS_JOIN, ref_dec the JoinHandle's
+    /// ref. Final state: rc=0, COMPLETED, no lifecycle flags. Caller
+    /// then invokes `dispose_terminal(ptr)` directly to exercise the
+    /// routing — no re-acquire (would violate ref_inc's >=1 contract).
+    unsafe fn drive_to_terminal(ptr: *mut u8) {
+        unsafe {
+            crate::task::drop_task_future(ptr);
+            assert!(matches!(
+                crate::task::complete_and_unref(ptr),
+                crate::task::FreeAction::Retain
+            )); // 2 refs → 1 (HAS_JOIN still set, rc=1)
+            crate::task::clear_has_join(ptr);
+            assert!(matches!(
+                crate::task::ref_dec(ptr),
+                crate::task::FreeAction::FreeBox
+            )); // rc 1 → 0, COMPLETED, no lifecycle → terminal
+            assert!(crate::task::is_terminal(ptr));
+        }
+    }
+
+    #[test]
+    fn dispose_terminal_null_ctx_no_tls_leaks() {
+        // Null ctx + no DEFERRED_FREE TLS → leak. dispose_terminal must
+        // NOT free directly (would race Executor::drop's all_tasks scan
+        // for tasks registered with a bare Executor).
+        struct Noop;
+        impl std::future::Future for Noop {
+            type Output = ();
+            fn poll(self: std::pin::Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+                Poll::Ready(())
+            }
+        }
+        // Task::new_boxed: cross_wake_ctx is null, rc=1, no HAS_JOIN.
+        let task = Box::new(crate::task::Task::new_boxed(Noop, 0));
+        let ptr = Box::into_raw(task) as *mut u8;
+
+        unsafe {
+            // Walk to terminal: rc 1 → 0, COMPLETED, no lifecycle.
+            crate::task::drop_task_future(ptr);
+            assert!(matches!(
+                crate::task::complete_and_unref(ptr),
+                crate::task::FreeAction::FreeBox
+            ));
+            assert!(crate::task::is_terminal(ptr));
+
+            // No TLS installed. dispose_terminal: null ctx → on_executor
+            // branch → try_defer_free returns false (no DEFERRED_FREE
+            // TLS) → leak. Task header stays valid for our final free.
+            dispose_terminal(ptr);
+            assert!(crate::task::is_terminal(ptr));
+            crate::task::free_task(ptr);
+        }
+    }
+
+    #[test]
+    fn dispose_terminal_on_executor_defers_when_tls_set() {
+        // ctx matches CURRENT_RUNTIME_CTX TLS + DEFERRED_FREE TLS set
+        // → push to deferred_free list. Real-world case: JoinHandle
+        // dropped during a poll cycle.
+        let ctx = make_ctx();
+        let _guard = install_runtime_cross_wake(&ctx);
+        let ptr = make_spawned_task(&ctx);
+
+        // Set up DEFERRED_FREE TLS pointing at a local Vec.
+        let mut deferred: Vec<*mut u8> = Vec::new();
+        let mut ready: Vec<*mut u8> = Vec::new();
+        let _poll_guard = crate::waker::set_poll_context(&raw mut ready, &raw mut deferred);
+
+        unsafe {
+            drive_to_terminal(ptr);
+            dispose_terminal(ptr);
+        }
+
+        // Verify push to deferred_free.
+        assert_eq!(deferred.len(), 1);
+        assert_eq!(deferred[0], ptr);
+
+        // Cleanup: free the task ourselves (we own the deferred entry).
+        unsafe { crate::task::free_task(ptr) };
+    }
+
+    #[test]
+    fn dispose_terminal_on_executor_leaks_when_tls_null() {
+        // ctx matches TLS but DEFERRED_FREE TLS is null (e.g.,
+        // JoinHandle dropped between block_on calls). dispose_terminal
+        // leaves the task for Executor::drop to reclaim — we verify
+        // "no double free" by freeing manually afterwards.
+        let ctx = make_ctx();
+        let _guard = install_runtime_cross_wake(&ctx);
+        let ptr = make_spawned_task(&ctx);
+
+        unsafe {
+            drive_to_terminal(ptr);
+            // No poll context installed → DEFERRED_FREE TLS stays null.
+            dispose_terminal(ptr);
+        }
+
+        // Task header still valid (we leaked, didn't free).
+        assert!(unsafe { crate::task::is_terminal(ptr) });
+
+        unsafe { crate::task::free_task(ptr) };
+    }
+
+    #[test]
+    fn dispose_terminal_off_thread_queues() {
+        // ctx non-null, but CURRENT_RUNTIME_CTX TLS NOT installed →
+        // on_owning_executor returns false → off-thread branch →
+        // push to ctx.queue + parked check.
+        let ctx = make_ctx();
+        let ptr = make_spawned_task(&ctx);
+
+        unsafe {
+            drive_to_terminal(ptr);
+            // No install_runtime_cross_wake → TLS null.
+            dispose_terminal(ptr);
+        }
+
+        // Verify push to cross-queue.
+        let popped = ctx.queue.pop();
+        assert_eq!(popped, Some(ptr));
+        assert!(unsafe { crate::task::is_queued(ptr) });
+
+        unsafe {
+            crate::task::clear_queued(ptr);
+            crate::task::free_task(ptr);
+        }
     }
 }

--- a/nexus-async-rt/src/lib.rs
+++ b/nexus-async-rt/src/lib.rs
@@ -80,8 +80,8 @@ use waker::set_poll_context;
 
 /// Recommended minimum slab slot size.
 ///
-/// The actual minimum depends on the task: header (64 bytes) + `max(size_of::<F>(),
-/// size_of::<T>())`. ZST futures need only 64 bytes. 128 is a conservative default
+/// The actual minimum depends on the task: header (72 bytes) + `max(size_of::<F>(),
+/// size_of::<T>())`. ZST futures need only 72 bytes. 128 is a conservative default
 /// that covers most small futures.
 pub const MIN_SLOT_SIZE: usize = 128;
 
@@ -178,7 +178,13 @@ impl Executor {
             u32::try_from(tracker_key).is_ok(),
             "more than 4 billion concurrent tasks — tracker_key overflow"
         );
-        let ptr = task::box_spawn_joinable(future, tracker_key as u32);
+        // Read the runtime's cross-wake context from TLS — installed at
+        // RuntimeBuilder::build, lifetime of Runtime. Null when no
+        // Runtime is alive (e.g., direct Executor use in tests); the
+        // task header's cross_wake_ctx becomes null and dispose_terminal
+        // routes those tasks via its null-ctx fallback.
+        let cross_wake_ctx = crate::cross_wake::current_runtime_ctx();
+        let ptr = task::box_spawn_joinable(future, tracker_key as u32, cross_wake_ctx);
 
         self.enqueue(ptr);
         task::JoinHandle::new(ptr)
@@ -486,8 +492,8 @@ impl Drop for Executor {
                     //   — the original SIGABRT we were trying to avoid,
                     //   but UAF would be worse.
                     if unsafe { task::is_slab_allocated(ptr) } {
-                        let deadline = std::time::Instant::now()
-                            + std::time::Duration::from_millis(100);
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_millis(100);
                         while unsafe { task::ref_count(ptr) } > 0
                             && std::time::Instant::now() < deadline
                         {

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -236,6 +236,17 @@ pub struct Runtime {
     /// `executor`, the on-thread fast path silently misroutes terminal
     /// frees to the cross-queue. The `const _: ()` block below this
     /// struct enforces the ordering at compile time.
+    ///
+    /// **FAILURE MODE: silent UAF in production for slab tasks.** If
+    /// this guard drops before `executor`, the on-thread fast path in
+    /// `dispose_terminal::on_owning_executor` silently misroutes
+    /// terminal `TaskRef::Drop` calls to the cross-queue. Nothing
+    /// drains the cross-queue at this point in shutdown. `_slab_guard`
+    /// then releases the slab backing storage. Any off-thread holder
+    /// still pointing into the freed slab memory dereferences a
+    /// dangling pointer. Do NOT modify the field declaration order
+    /// without re-running miri tree-borrows on the full test suite AND
+    /// the BUG-4 unwind regression tests.
     _cross_wake_tls_guard: crate::cross_wake::RuntimeCrossWakeGuard,
 
     /// IO driver (mio). Wrapped in `UnsafeCell` because a raw pointer

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -219,8 +219,24 @@ pub struct Runtime {
     /// Drops first (declaration order). `Executor::drop` walks
     /// `all_tasks` and frees any survivors via the slab TLS dispatch
     /// path, which requires `_slab_guard` to still be alive — see the
-    /// field-order invariant on `_slab_guard`.
+    /// field-order invariant on `_slab_guard`. Surviving tasks may
+    /// also trigger `TaskRef::Drop → dispose_terminal`, which reads
+    /// the runtime's cross-wake context from TLS — see the field-order
+    /// invariant on `_cross_wake_tls_guard` below.
     executor: Executor,
+
+    /// Clears the runtime's `CURRENT_RUNTIME_CTX` TLS slot on drop.
+    ///
+    /// **MUST drop AFTER `executor`**: when `Executor::drop` walks
+    /// `all_tasks` and frees terminal tasks, any TaskRef::Drop fired
+    /// from cross-thread holders (or local wakers cleaned up during
+    /// teardown) reads `CURRENT_RUNTIME_CTX` via
+    /// `crate::cross_wake::on_owning_executor` to decide whether to
+    /// defer locally or queue cross-thread. If this guard drops before
+    /// `executor`, the on-thread fast path silently misroutes terminal
+    /// frees to the cross-queue. The `const _: ()` block below this
+    /// struct enforces the ordering at compile time.
+    _cross_wake_tls_guard: crate::cross_wake::RuntimeCrossWakeGuard,
 
     /// IO driver (mio). Wrapped in `UnsafeCell` because a raw pointer
     /// is stored in TLS during `block_on`. Task futures access the IO
@@ -290,6 +306,24 @@ const _: () = assert!(
      declared after Runtime::executor so it drops after the executor \
      frees surviving slab tasks. Restore the declaration order or BUG-1 \
      reappears as a panic at Runtime::drop."
+);
+
+// PR 1a (TaskRef + dispose_terminal) invariant: `_cross_wake_tls_guard`
+// MUST drop after `executor`. The executor's drop path runs TaskRef::Drop
+// for any cross-thread holder ref that lands during teardown; those
+// drops route through `dispose_terminal` which checks
+// `CURRENT_RUNTIME_CTX` to pick the on-thread (defer) vs off-thread
+// (queue) branch. If this guard clears the TLS before `executor`
+// finishes, the comparison silently fails and on-thread terminal frees
+// get misrouted to the cross-queue (where nothing drains them — leak,
+// or for slab tasks, eventual UAF when the slab backing storage drops
+// behind `_slab_guard`).
+const _: () = assert!(
+    std::mem::offset_of!(Runtime, _cross_wake_tls_guard) > std::mem::offset_of!(Runtime, executor),
+    "PR 1a invariant violated: Runtime::_cross_wake_tls_guard MUST be \
+     declared after Runtime::executor so the runtime's CURRENT_RUNTIME_CTX \
+     TLS stays installed while Executor::drop runs. Reordering \
+     misroutes terminal TaskRef::Drop calls during teardown."
 );
 
 impl Runtime {
@@ -435,8 +469,8 @@ impl<'w> RuntimeBuilder<'w> {
 
     /// Hand off a growable (unbounded) slab for [`spawn_slab`].
     ///
-    /// `S` is the total slot size in bytes. The task header uses 64 bytes,
-    /// so `Slab<256>` gives 192 bytes for the future. Most async IO
+    /// `S` is the total slot size in bytes. The task header uses 72 bytes,
+    /// so `Slab<256>` gives 184 bytes for the future. Most async IO
     /// futures are 128–256 bytes — `Slab<256>` or `Slab<512>` covers
     /// the common cases.
     ///
@@ -461,8 +495,8 @@ impl<'w> RuntimeBuilder<'w> {
     ) -> Self {
         const {
             assert!(
-                S >= 64,
-                "slab slot size must be at least 64 bytes (TASK_HEADER_SIZE)"
+                S >= 72,
+                "slab slot size must be at least 72 bytes (TASK_HEADER_SIZE)"
             );
         }
         self.slab_installer = Some(Box::new(move || {
@@ -502,8 +536,8 @@ impl<'w> RuntimeBuilder<'w> {
     ) -> Self {
         const {
             assert!(
-                S >= 64,
-                "slab slot size must be at least 64 bytes (TASK_HEADER_SIZE)"
+                S >= 72,
+                "slab slot size must be at least 72 bytes (TASK_HEADER_SIZE)"
             );
         }
         self.slab_installer = Some(Box::new(move || {
@@ -553,8 +587,16 @@ impl<'w> RuntimeBuilder<'w> {
             parked: std::sync::atomic::AtomicBool::new(false),
         });
 
+        // Install the runtime's cross-wake context as the current-thread
+        // owning-executor identity. Lives lifetime-of-Runtime via the
+        // guard field below — `dispose_terminal::on_owning_executor`
+        // reads this slot to decide local-defer vs cross-queue routing
+        // for TaskRef terminal drops.
+        let cross_wake_tls_guard = crate::cross_wake::install_runtime_cross_wake(&cross_wake);
+
         let rt = Runtime {
             executor,
+            _cross_wake_tls_guard: cross_wake_tls_guard,
             io: std::cell::UnsafeCell::new(io),
             timers: std::cell::UnsafeCell::new(TimerDriver::new(64)),
             ctx,

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -155,25 +155,8 @@ impl TaskRef {
 
     /// The raw task pointer this handle holds.
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn as_ptr(&self) -> *mut u8 {
         self.ptr
-    }
-
-    /// Release the ref without invoking Drop's terminal routing. Returns
-    /// the `FreeAction` so the caller can decide how to dispose of a
-    /// terminal task.
-    ///
-    /// Use sparingly. Drop is the expected disposal path for almost all
-    /// holders. `release` exists for callers that need to inspect the
-    /// terminal action (e.g., to make a routing decision the standard
-    /// `dispose_terminal` flow doesn't cover).
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn release(self) -> FreeAction {
-        let ptr = self.ptr;
-        std::mem::forget(self);
-        unsafe { ref_dec(ptr) }
     }
 }
 
@@ -283,8 +266,13 @@ impl<F: Future<Output = ()> + 'static> Task<F> {
     /// Used internally for tests and low-level task construction.
     /// `ref_count = 1` (executor only), `HAS_JOIN` not set.
     /// `cross_wake_ctx` is null — test tasks aren't registered with any
-    /// runtime, so terminal frees go through `dispose_terminal`'s
-    /// null-ctx branch (free directly).
+    /// runtime. Terminal frees go through `dispose_terminal`'s on-thread
+    /// defer path (`try_defer_free` if a poll cycle is active, otherwise
+    /// leak until `Executor::drop`'s `all_tasks` scan reclaims them).
+    /// Direct-free is unsafe even for null-ctx tasks because
+    /// `dispose_terminal` doesn't own `all_tasks` bookkeeping — see
+    /// `dispose_terminal`'s doc-comment in `cross_wake.rs` for the full
+    /// rationale.
     ///
     /// # Why `Output = ()` is required
     ///
@@ -1515,52 +1503,6 @@ mod tests {
             // Cleanup: complete and free directly (no TaskRef path).
             drop_task_future(ptr);
             assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
-            free_task(ptr);
-        }
-    }
-
-    #[test]
-    fn taskref_release_returns_freeaction_retain() {
-        // Acquire TaskRef on a non-terminal task, then release. ref_dec
-        // returns Retain (other refs still exist or task not completed).
-        let task = Box::new(Task::new_boxed(async {}, 0));
-        let ptr = Box::into_raw(task) as *mut u8;
-
-        unsafe {
-            assert_eq!(ref_count(ptr), 1);
-            let task_ref = TaskRef::acquire(ptr); // rc=2
-            let action = task_ref.release(); // rc=2 → 1, no COMPLETED → Retain
-            assert!(matches!(action, FreeAction::Retain));
-            assert_eq!(ref_count(ptr), 1);
-
-            // Cleanup.
-            drop_task_future(ptr);
-            assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
-            free_task(ptr);
-        }
-    }
-
-    #[test]
-    fn taskref_release_returns_freeaction_terminal() {
-        // Set up a task at rc=1, COMPLETED, lifecycle clear. Wrap with
-        // from_owned (TaskRef takes the existing ref). Release →
-        // ref_dec returns FreeBox. Verifies release exposes the
-        // terminal action without going through dispose_terminal.
-        let ptr = box_spawn_joinable(async { 42u64 }, 0, std::ptr::null());
-        unsafe {
-            // rc=2, HAS_JOIN. Drop future, complete_and_unref → rc=1
-            // (HAS_JOIN gates terminal), COMPLETED.
-            drop_task_future(ptr);
-            assert!(matches!(complete_and_unref(ptr), FreeAction::Retain));
-            // Clear HAS_JOIN — rc=1, COMPLETED, no lifecycle flags.
-            clear_has_join(ptr);
-
-            // TaskRef wraps the existing rc=1 (no extra inc).
-            let task_ref = TaskRef::from_owned(ptr);
-            let action = task_ref.release(); // rc=1 → 0, terminal → FreeBox
-            assert!(matches!(action, FreeAction::FreeBox));
-            assert!(is_terminal(ptr));
-
             free_task(ptr);
         }
     }

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -120,9 +120,9 @@ pub(crate) enum FreeAction {
 ///
 /// - Each `TaskRef` owns exactly one refcount unit on the underlying task.
 /// - `Drop` decrements; if terminal, the task is routed via
-///   `crate::cross_wake::dispose_terminal` (defer locally on the owning
-///   executor thread, queue cross-thread, or free directly for tasks
-///   with no runtime context).
+///   `crate::cross_wake::dispose_terminal` (defer via `try_defer_free`
+///   on the owning executor thread or for null-ctx test tasks; queue
+///   via the cross-wake queue off-thread).
 pub(crate) struct TaskRef {
     ptr: *mut u8,
 }
@@ -166,10 +166,20 @@ impl Drop for TaskRef {
         match unsafe { ref_dec(self.ptr) } {
             FreeAction::Retain => {}
             FreeAction::FreeBox | FreeAction::FreeSlab => {
-                // SAFETY: terminal state — ref just dropped to 0 with all
-                // lifecycle flags clear. dispose_terminal handles routing
-                // (defer / cross-queue / direct-free) per the task's
-                // header context and current thread.
+                // SAFETY: terminal state — ref just dropped to 0 with
+                // all lifecycle flags clear. dispose_terminal routes
+                // per the task's header context and current thread:
+                //
+                //   - On-thread (or null-ctx test task): try_defer_free
+                //     pushes to DEFERRED_FREE TLS if a poll cycle is
+                //     active; otherwise the slot leaks until
+                //     Executor::drop reclaims via its all_tasks scan.
+                //   - Off-thread: queues via the cross-wake queue +
+                //     conditional eventfd poke.
+                //
+                // Direct-free is never used — would race
+                // Executor::all_tasks bookkeeping. See dispose_terminal's
+                // doc-comment in `cross_wake.rs` for the full rationale.
                 unsafe { crate::cross_wake::dispose_terminal(self.ptr) };
             }
         }
@@ -797,9 +807,15 @@ pub(crate) unsafe fn storage_offset(ptr: *mut u8) -> usize {
 /// `ptr` must point to a live `Task<S>` (header still valid).
 #[inline]
 pub(crate) unsafe fn header_cross_wake_ctx(ptr: *mut u8) -> *const CrossWakeContext {
-    // SAFETY: cross_wake_ctx is *const CrossWakeContext at offset 64
-    // in repr(C) Task. The field is initialized at spawn and never
-    // mutated afterwards — single-threaded read is sound.
+    // SAFETY: `cross_wake_ctx` is `*const CrossWakeContext` at offset 64
+    // in `repr(C) Task`. The field is initialized exactly once at spawn
+    // time under the spawning thread's exclusive ownership, then made
+    // visible to other threads via Arc/refcount publication (any TaskRef
+    // holder transitively keeps the owning runtime's Arc alive, and the
+    // Arc's atomic-counter publication establishes happens-before for the
+    // read). Immutable after init — concurrent reads from any thread are
+    // sound. dispose_terminal explicitly reads this from foreign threads
+    // when routing terminal drops from cross-thread waker holders.
     unsafe { *(ptr.add(64).cast::<*const CrossWakeContext>()) }
 }
 

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -34,6 +34,19 @@
 //! `poll_join` drops `F` in place and writes `T` to the same bytes.
 //! `drop_fn` is overwritten from `drop_fn::<F>` to `drop_output::<T>`
 //! so subsequent cleanup targets the correct type.
+//!
+//! ## `TaskRef` ownership rule
+//!
+//! [`TaskRef`] covers every refcount holder EXCEPT the executor's own
+//! `all_tasks` ref. That single ref uses [`complete_and_unref`] directly
+//! (atomic COMPLETED-set + decrement), bypassing TaskRef's Drop-time
+//! `dispose_terminal` routing. Wrapping `all_tasks` ownership in TaskRef
+//! would route terminal frees through `dispose_terminal` →
+//! `try_defer_free`, double-handling tasks the executor is already
+//! tracking. Subtle regression — don't do it.
+//!
+//! Everything else (local wakers, cross-thread wakers, channel slots,
+//! `JoinHandle`) IS a `TaskRef`.
 
 use std::cell::UnsafeCell;
 use std::future::Future;
@@ -41,6 +54,8 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::task::{Context, Poll, Waker};
+
+use crate::cross_wake::CrossWakeContext;
 
 // =============================================================================
 // Packed state word — constants
@@ -89,32 +104,136 @@ pub(crate) enum FreeAction {
 }
 
 // =============================================================================
+// TaskRef — RAII smart pointer pairing ref_inc with ref_dec
+// =============================================================================
+
+/// Refcounted handle to a task. Pairs `ref_inc` with `ref_dec` at
+/// compile time — Drop calls `ref_dec` and routes terminal results
+/// through `dispose_terminal`.
+///
+/// `TaskRef` is the canonical refcount holder for everything except the
+/// executor's `all_tasks` ref (see the module-level doc-block). Local
+/// wakers, cross-thread wakers, channel slots, and `JoinHandle` all
+/// hold a `TaskRef`.
+///
+/// # Invariants
+///
+/// - Each `TaskRef` owns exactly one refcount unit on the underlying task.
+/// - `Drop` decrements; if terminal, the task is routed via
+///   `crate::cross_wake::dispose_terminal` (defer locally on the owning
+///   executor thread, queue cross-thread, or free directly for tasks
+///   with no runtime context).
+pub(crate) struct TaskRef {
+    ptr: *mut u8,
+}
+
+impl TaskRef {
+    /// Acquire a reference. Increments the task's refcount.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a live task with refcount >= 1 at the time of call.
+    #[inline]
+    pub(crate) unsafe fn acquire(ptr: *mut u8) -> Self {
+        unsafe { ref_inc(ptr) };
+        Self { ptr }
+    }
+
+    /// Wrap a pre-incremented pointer (no `ref_inc` here).
+    ///
+    /// Use when the caller has already accounted for the ref (e.g., on
+    /// the boundary of a vtable handoff like `RawWaker::data` →
+    /// `wake_fn` consuming the ref).
+    ///
+    /// # Safety
+    ///
+    /// `ptr` owns one ref. The caller must not also drop it.
+    #[inline]
+    pub(crate) unsafe fn from_owned(ptr: *mut u8) -> Self {
+        Self { ptr }
+    }
+
+    /// The raw task pointer this handle holds.
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Release the ref without invoking Drop's terminal routing. Returns
+    /// the `FreeAction` so the caller can decide how to dispose of a
+    /// terminal task.
+    ///
+    /// Use sparingly. Drop is the expected disposal path for almost all
+    /// holders. `release` exists for callers that need to inspect the
+    /// terminal action (e.g., to make a routing decision the standard
+    /// `dispose_terminal` flow doesn't cover).
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn release(self) -> FreeAction {
+        let ptr = self.ptr;
+        std::mem::forget(self);
+        unsafe { ref_dec(ptr) }
+    }
+}
+
+impl Drop for TaskRef {
+    #[inline]
+    fn drop(&mut self) {
+        match unsafe { ref_dec(self.ptr) } {
+            FreeAction::Retain => {}
+            FreeAction::FreeBox | FreeAction::FreeSlab => {
+                // SAFETY: terminal state — ref just dropped to 0 with all
+                // lifecycle flags clear. dispose_terminal handles routing
+                // (defer / cross-queue / direct-free) per the task's
+                // header context and current thread.
+                unsafe { crate::cross_wake::dispose_terminal(self.ptr) };
+            }
+        }
+    }
+}
+
+// SAFETY: TaskRef is a raw pointer + refcount discipline. The underlying
+// task allocation is Send-safe (atomic state, no thread-affine fields
+// in the header). Cross-thread holders (tokio_compat, channel slots)
+// store TaskRef across threads, so it must be Send.
+unsafe impl Send for TaskRef {}
+// Not Sync — only the holder may drop. Cloning a TaskRef means a new
+// ref_inc; aliasing through &TaskRef would let two holders ref_dec
+// the same logical ref.
+
+// =============================================================================
 // Task layout
 // =============================================================================
 
 /// Header size in bytes. Must match the layout of `Task<F>` before the
-/// `future` field.
-pub const TASK_HEADER_SIZE: usize = 64;
+/// `storage` field.
+pub const TASK_HEADER_SIZE: usize = 72;
 
 /// Task header + storage in a contiguous allocation. `repr(C)` for
 /// deterministic layout.
 ///
 /// `S` is the storage type — either just `F` (fire-and-forget) or a union
-/// of `F` and `T` (joinable). The header is always 64 bytes regardless of `S`.
+/// of `F` and `T` (joinable). The header is always 72 bytes regardless of `S`.
 ///
 /// Layout (64-bit):
 /// ```text
-/// offset  0: poll_fn       (8B, fn pointer — polls the future)
-/// offset  8: drop_fn       (8B, fn pointer — drops F or T in place)
-/// offset 16: free_fn       (8B, fn pointer — deallocates the task storage)
-/// offset 24: state         (8B, AtomicUsize — packed flags + refcount)
-/// offset 32: cross_next    (8B, AtomicPtr — intrusive cross-thread wake queue)
-/// offset 40: join_waker    (16B, UnsafeCell<Option<Waker>>)
+/// offset  0: poll_fn        (8B, fn pointer — polls the future)
+/// offset  8: drop_fn        (8B, fn pointer — drops F or T in place)
+/// offset 16: free_fn        (8B, fn pointer — deallocates the task storage)
+/// offset 24: state          (8B, AtomicUsize — packed flags + refcount)
+/// offset 32: cross_next     (8B, AtomicPtr — intrusive cross-thread wake queue)
+/// offset 40: join_waker     (16B, UnsafeCell<Option<Waker>>)
 /// offset 56: storage_offset (2B, u16 — byte offset to storage field)
-/// offset 58: _pad          (2B)
-/// offset 60: tracker_key   (4B, u32 — index in Executor::all_tasks slab)
-/// offset 64: storage       (S bytes — future F or union { F, T })
+/// offset 58: _pad           (2B)
+/// offset 60: tracker_key    (4B, u32 — index in Executor::all_tasks slab)
+/// offset 64: cross_wake_ctx (8B, *const CrossWakeContext — cold; read by dispose_terminal)
+/// offset 72: storage        (S bytes — future F or union { F, T })
 /// ```
+///
+/// `cross_wake_ctx` lives at the end of the header because it's only
+/// touched on terminal Drop (cold path); hot-path reads (state, drop_fn,
+/// poll_fn, free_fn) stay near the cache-line head.
 #[repr(C)]
 pub(crate) struct Task<S> {
     /// Polls the future. Receives the task base pointer.
@@ -136,6 +255,12 @@ pub(crate) struct Task<S> {
     _pad: [u8; 2],
     /// Index into the Executor's `all_tasks` slab.
     tracker_key: u32,
+    /// Pointer to the runtime's [`CrossWakeContext`] (Arc-backed, heap-stable).
+    /// Set at spawn time. Read by `dispose_terminal` on terminal Drop to
+    /// route the task through the owning executor (defer locally) or its
+    /// cross-thread queue (off-thread). Null for tasks not associated
+    /// with any runtime (test-only `Task::new_boxed` path).
+    cross_wake_ctx: *const CrossWakeContext,
     storage: S,
 }
 
@@ -157,14 +282,18 @@ impl<F: Future<Output = ()> + 'static> Task<F> {
     ///
     /// Used internally for tests and low-level task construction.
     /// `ref_count = 1` (executor only), `HAS_JOIN` not set.
+    /// `cross_wake_ctx` is null — test tasks aren't registered with any
+    /// runtime, so terminal frees go through `dispose_terminal`'s
+    /// null-ctx branch (free directly).
     ///
     /// # Why `Output = ()` is required
     ///
-    /// This uses `poll_join::<F>` which writes T at offset 64 after dropping F.
-    /// The storage is `F` (not `FutureOrOutput<F, T>`), so it's only sized for F.
-    /// With `T = ()` (ZST), the write is zero-size and the `drop_fn` overwrite
-    /// to `drop_output::<()>` is a no-op. Relaxing this bound to non-ZST T
-    /// would write T into storage not sized for it — UB.
+    /// This uses `poll_join::<F>` which writes T at the storage offset
+    /// after dropping F. The storage is `F` (not `FutureOrOutput<F, T>`),
+    /// so it's only sized for F. With `T = ()` (ZST), the write is
+    /// zero-size and the `drop_fn` overwrite to `drop_output::<()>` is a
+    /// no-op. Relaxing this bound to non-ZST T would write T into
+    /// storage not sized for it — UB.
     #[cfg(test)]
     #[inline]
     pub(crate) fn new_boxed(future: F, tracker_key: u32) -> Self {
@@ -178,6 +307,7 @@ impl<F: Future<Output = ()> + 'static> Task<F> {
             storage_offset: std::mem::offset_of!(Task<F>, storage) as u16,
             tracker_key,
             _pad: [0; 2],
+            cross_wake_ctx: std::ptr::null(),
             storage: future,
         }
     }
@@ -188,7 +318,16 @@ impl<F: Future<Output = ()> + 'static> Task<F> {
 /// The task has `ref_count = 2` (executor + JoinHandle) and `HAS_JOIN` set.
 /// The allocation is sized for `max(size_of::<F>(), size_of::<T>())` via
 /// the `FutureOrOutput<F, T>` union.
-pub(crate) fn box_spawn_joinable<F>(future: F, tracker_key: u32) -> *mut u8
+///
+/// `cross_wake_ctx` should be `Arc::as_ptr(&runtime.cross_wake)` for
+/// real spawns (Arc-backed, heap-stable), or `std::ptr::null()` for
+/// tasks not associated with any runtime (test paths only). Read by
+/// `dispose_terminal` on terminal Drop.
+pub(crate) fn box_spawn_joinable<F>(
+    future: F,
+    tracker_key: u32,
+    cross_wake_ctx: *const CrossWakeContext,
+) -> *mut u8
 where
     F: Future + 'static,
     F::Output: 'static,
@@ -205,6 +344,7 @@ where
         storage_offset: std::mem::offset_of!(Task<Storage<F>>, storage) as u16,
         tracker_key,
         _pad: [0; 2],
+        cross_wake_ctx,
         storage: FutureOrOutput {
             future: std::mem::ManuallyDrop::new(future),
         },
@@ -216,10 +356,13 @@ where
 ///
 /// Returns the task struct to be copied into a slab slot. Uses the
 /// `FutureOrOutput<F, T>` union so the allocation fits both.
+///
+/// See `box_spawn_joinable` for the `cross_wake_ctx` contract.
 pub(crate) fn new_joinable_slab<F>(
     future: F,
     tracker_key: u32,
     free_fn: unsafe fn(*mut u8),
+    cross_wake_ctx: *const CrossWakeContext,
 ) -> Task<FutureOrOutput<F, F::Output>>
 where
     F: Future + 'static,
@@ -235,6 +378,7 @@ where
         storage_offset: std::mem::offset_of!(Task<FutureOrOutput<F, F::Output>>, storage) as u16,
         tracker_key,
         _pad: [0; 2],
+        cross_wake_ctx,
         storage: FutureOrOutput {
             future: std::mem::ManuallyDrop::new(future),
         },
@@ -354,24 +498,16 @@ impl<T> Drop for JoinHandle<T> {
         unsafe { clear_has_join(ptr) };
         let _ = unsafe { take_join_waker(ptr) };
 
-        // Release our reference. If terminal, push to deferred free.
-        match unsafe { ref_dec(ptr) } {
-            FreeAction::Retain => {}
-            FreeAction::FreeBox | FreeAction::FreeSlab => {
-                // Executor thread — slab TLS available. Free via deferred path.
-                unsafe { defer_free_slot(ptr) };
-            }
-        }
+        // Release our reference via TaskRef. Drop routes terminal state
+        // through dispose_terminal — defers via DEFERRED_FREE TLS on the
+        // executor thread (so all_tasks bookkeeping stays consistent),
+        // queues cross-thread otherwise, frees directly for null-ctx
+        // (test) tasks. JoinHandle is !Send so we're always on the
+        // executor thread here, but the routing handles all cases.
+        // SAFETY: JoinHandle owned exactly one ref on `ptr`; we hand
+        // it off to TaskRef which will ref_dec on Drop.
+        drop(unsafe { TaskRef::from_owned(ptr) });
     }
-}
-
-/// Push a task to the deferred free list, or free immediately if outside poll.
-///
-/// # Safety
-///
-/// `ptr` must point to a completed task in TERMINAL state.
-unsafe fn defer_free_slot(ptr: *mut u8) {
-    unsafe { crate::waker::defer_free(ptr) };
 }
 
 // =============================================================================
@@ -662,6 +798,23 @@ pub(crate) unsafe fn storage_offset(ptr: *mut u8) -> usize {
     unsafe { *(ptr.add(56).cast::<u16>()) as usize }
 }
 
+/// Read the `cross_wake_ctx` pointer from the task header.
+///
+/// Returns the runtime's [`CrossWakeContext`] pointer (Arc-backed,
+/// heap-stable) set at spawn time, or null for tasks not associated
+/// with any runtime (test path).
+///
+/// # Safety
+///
+/// `ptr` must point to a live `Task<S>` (header still valid).
+#[inline]
+pub(crate) unsafe fn header_cross_wake_ctx(ptr: *mut u8) -> *const CrossWakeContext {
+    // SAFETY: cross_wake_ctx is *const CrossWakeContext at offset 64
+    // in repr(C) Task. The field is initialized at spawn and never
+    // mutated afterwards — single-threaded read is sound.
+    unsafe { *(ptr.add(64).cast::<*const CrossWakeContext>()) }
+}
+
 /// Store a waker for the JoinHandle awaiter.
 ///
 /// # Safety
@@ -834,8 +987,8 @@ mod tests {
 
     #[test]
     fn task_header_size() {
-        assert_eq!(TASK_HEADER_SIZE, 64);
-        assert_eq!(std::mem::size_of::<Task<()>>(), 64);
+        assert_eq!(TASK_HEADER_SIZE, 72);
+        assert_eq!(std::mem::size_of::<Task<()>>(), 72);
     }
 
     #[test]
@@ -849,7 +1002,8 @@ mod tests {
         assert_eq!(std::mem::offset_of!(Task<()>, storage_offset), 56);
         assert_eq!(std::mem::offset_of!(Task<()>, _pad), 58);
         assert_eq!(std::mem::offset_of!(Task<()>, tracker_key), 60);
-        assert_eq!(std::mem::offset_of!(Task<()>, storage), 64);
+        assert_eq!(std::mem::offset_of!(Task<()>, cross_wake_ctx), 64);
+        assert_eq!(std::mem::offset_of!(Task<()>, storage), 72);
     }
 
     #[test]
@@ -863,7 +1017,7 @@ mod tests {
             }
         }
 
-        // 64 byte header + 24 byte future = 88 bytes
+        // 72 byte header + 24 byte future = 96 bytes
         assert_eq!(
             std::mem::size_of::<Task<SmallFuture>>(),
             TASK_HEADER_SIZE + 24
@@ -916,7 +1070,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 7);
+        let ptr = box_spawn_joinable(Noop, 7, std::ptr::null());
         unsafe {
             assert!(has_join(ptr));
             assert!(!is_aborted(ptr));
@@ -947,7 +1101,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // complete_and_unref with 2 refs → not terminal
             drop_task_future(ptr);
@@ -974,7 +1128,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // Waker clone: ref_inc
             ref_inc(ptr);
@@ -1035,6 +1189,7 @@ mod tests {
                 drop_count: &raw mut drop_count,
             },
             0,
+            std::ptr::null(),
         );
 
         // poll_join completes the future, then drops F — which panics.
@@ -1087,7 +1242,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(ProduceTracked, 0);
+        let ptr = box_spawn_joinable(ProduceTracked, 0, std::ptr::null());
 
         // Poll to completion — F dropped, T written, drop_fn → drop_output.
         let result = unsafe { poll_task(ptr, &mut cx) };
@@ -1166,7 +1321,7 @@ mod tests {
             std::alloc::dealloc(ptr, layout);
         }
 
-        let task = new_joinable_slab(Noop, 0, slab_free);
+        let task = new_joinable_slab(Noop, 0, slab_free, std::ptr::null());
         let ptr = Box::into_raw(Box::new(task)) as *mut u8;
 
         unsafe {
@@ -1209,7 +1364,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             assert_eq!(ref_count(ptr), 2);
             assert!(has_join(ptr));
@@ -1242,7 +1397,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // complete_and_unref: sets COMPLETED, dec ref → 1 ref remains
             drop_task_future(ptr);
@@ -1273,7 +1428,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // Waker clone: ref_inc
             ref_inc(ptr);
@@ -1311,7 +1466,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // complete_and_unref with 2 refs → Retain
             drop_task_future(ptr);
@@ -1338,6 +1493,130 @@ mod tests {
         }
     }
 
+    // =========================================================================
+    // TaskRef — RAII inc/dec discipline
+    // =========================================================================
+
+    #[test]
+    fn taskref_acquire_drop_balances_refcount() {
+        // Acquire a TaskRef on a task with rc=1; rc goes to 2. Drop the
+        // TaskRef; rc goes back to 1. Verifies acquire(ref_inc) is paired
+        // with Drop(ref_dec).
+        let task = Box::new(Task::new_boxed(async {}, 0));
+        let ptr = Box::into_raw(task) as *mut u8;
+
+        unsafe {
+            assert_eq!(ref_count(ptr), 1);
+            let task_ref = TaskRef::acquire(ptr);
+            assert_eq!(ref_count(ptr), 2);
+            drop(task_ref); // Not terminal — rc 2 → 1
+            assert_eq!(ref_count(ptr), 1);
+
+            // Cleanup: complete and free directly (no TaskRef path).
+            drop_task_future(ptr);
+            assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
+            free_task(ptr);
+        }
+    }
+
+    #[test]
+    fn taskref_release_returns_freeaction_retain() {
+        // Acquire TaskRef on a non-terminal task, then release. ref_dec
+        // returns Retain (other refs still exist or task not completed).
+        let task = Box::new(Task::new_boxed(async {}, 0));
+        let ptr = Box::into_raw(task) as *mut u8;
+
+        unsafe {
+            assert_eq!(ref_count(ptr), 1);
+            let task_ref = TaskRef::acquire(ptr); // rc=2
+            let action = task_ref.release(); // rc=2 → 1, no COMPLETED → Retain
+            assert!(matches!(action, FreeAction::Retain));
+            assert_eq!(ref_count(ptr), 1);
+
+            // Cleanup.
+            drop_task_future(ptr);
+            assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
+            free_task(ptr);
+        }
+    }
+
+    #[test]
+    fn taskref_release_returns_freeaction_terminal() {
+        // Set up a task at rc=1, COMPLETED, lifecycle clear. Wrap with
+        // from_owned (TaskRef takes the existing ref). Release →
+        // ref_dec returns FreeBox. Verifies release exposes the
+        // terminal action without going through dispose_terminal.
+        let ptr = box_spawn_joinable(async { 42u64 }, 0, std::ptr::null());
+        unsafe {
+            // rc=2, HAS_JOIN. Drop future, complete_and_unref → rc=1
+            // (HAS_JOIN gates terminal), COMPLETED.
+            drop_task_future(ptr);
+            assert!(matches!(complete_and_unref(ptr), FreeAction::Retain));
+            // Clear HAS_JOIN — rc=1, COMPLETED, no lifecycle flags.
+            clear_has_join(ptr);
+
+            // TaskRef wraps the existing rc=1 (no extra inc).
+            let task_ref = TaskRef::from_owned(ptr);
+            let action = task_ref.release(); // rc=1 → 0, terminal → FreeBox
+            assert!(matches!(action, FreeAction::FreeBox));
+            assert!(is_terminal(ptr));
+
+            free_task(ptr);
+        }
+    }
+
+    #[test]
+    fn taskref_from_owned_drop_balances_refcount() {
+        // Manually ref_inc, then wrap with from_owned (no extra inc).
+        // Drop releases the manual ref. Verifies from_owned's "wrap a
+        // pre-incremented pointer" contract.
+        let task = Box::new(Task::new_boxed(async {}, 0));
+        let ptr = Box::into_raw(task) as *mut u8;
+
+        unsafe {
+            assert_eq!(ref_count(ptr), 1);
+            ref_inc(ptr); // simulate handoff (e.g. RawWaker::data ownership)
+            assert_eq!(ref_count(ptr), 2);
+            let task_ref = TaskRef::from_owned(ptr);
+            // No additional ref_inc — TaskRef takes the existing ref.
+            assert_eq!(ref_count(ptr), 2);
+            drop(task_ref); // releases the manual ref
+            assert_eq!(ref_count(ptr), 1);
+
+            // Cleanup.
+            drop_task_future(ptr);
+            assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
+            free_task(ptr);
+        }
+    }
+
+    #[test]
+    fn taskref_drop_non_terminal_no_dispose() {
+        // Drop a TaskRef when refcount > 1 — should NOT invoke
+        // dispose_terminal. Verifies Drop's terminal gate (Retain branch
+        // returns immediately).
+        let task = Box::new(Task::new_boxed(async {}, 0));
+        let ptr = Box::into_raw(task) as *mut u8;
+
+        unsafe {
+            // rc=1, acquire to rc=2, drop to rc=1. Not terminal (no
+            // COMPLETED, lifecycle flags clear). Drop hits the Retain
+            // branch — no dispose_terminal call. If dispose_terminal
+            // were called with a non-terminal task it would assert (or
+            // worse, free a live task).
+            let task_ref = TaskRef::acquire(ptr);
+            assert_eq!(ref_count(ptr), 2);
+            drop(task_ref);
+            assert_eq!(ref_count(ptr), 1);
+            assert!(!is_completed(ptr));
+
+            // Cleanup.
+            drop_task_future(ptr);
+            assert!(matches!(complete_and_unref(ptr), FreeAction::FreeBox));
+            free_task(ptr);
+        }
+    }
+
     #[test]
     fn packed_state_many_refs_converge() {
         // Clone waker 10 times (ref_inc 10x), complete, then ref_dec 10x.
@@ -1350,7 +1629,7 @@ mod tests {
             }
         }
 
-        let ptr = box_spawn_joinable(Noop, 0);
+        let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
         unsafe {
             // 10 waker clones: ref 2 → 12
             for _ in 0..10 {

--- a/nexus-async-rt/src/tokio_compat.rs
+++ b/nexus-async-rt/src/tokio_compat.rs
@@ -224,22 +224,17 @@ unsafe fn cross_task_wake(data: *const ()) {
     unsafe { cross_task_wake_by_ref(data) };
     let boxed = unsafe { Box::from_raw(data.cast_mut().cast::<CrossTaskWakerData>()) };
     let task_ptr = boxed.task_ptr;
+    // Release the ref; on terminal, dispose_terminal routes via the
+    // cross-queue (this fires off-thread — tokio worker thread). The
+    // `try_set_queued` gate inside dispose_terminal prevents the
+    // double-push that wake_by_ref above might have already done.
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // Terminal. Route to executor for free + all_tasks bookkeeping.
-            // Can't free cross-thread: all_tasks (slab::Slab) is not thread-safe,
-            // and slab tasks need TLS for deallocation.
-            // wake_by_ref may have already pushed (if task wasn't completed).
-            // try_set_queued prevents double-push.
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                unsafe { boxed.ctx.queue.push(task_ptr) };
-                if boxed.ctx.parked.load(std::sync::atomic::Ordering::Acquire) {
-                    let _ = boxed.ctx.mio_waker.wake();
-                }
-            }
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
+    // boxed Drop runs here — releases the Arc<CrossWakeContext>.
 }
 
 /// Wake by ref: push to cross-thread inbox. No refcount change.
@@ -250,22 +245,17 @@ unsafe fn cross_task_wake_by_ref(data: *const ()) {
     }
 }
 
-/// Drop: free box, dec refcount.
+/// Drop: free box, dec refcount. Terminal frees route via dispose_terminal.
 unsafe fn cross_task_drop(data: *const ()) {
     let boxed = unsafe { Box::from_raw(data.cast_mut().cast::<CrossTaskWakerData>()) };
     let task_ptr = boxed.task_ptr;
     match unsafe { crate::task::ref_dec(task_ptr) } {
         crate::task::FreeAction::Retain => {}
         crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // Terminal. Route to executor — same as cross_task_wake.
-            if unsafe { crate::task::try_set_queued(task_ptr) } {
-                unsafe { boxed.ctx.queue.push(task_ptr) };
-                if boxed.ctx.parked.load(std::sync::atomic::Ordering::Acquire) {
-                    let _ = boxed.ctx.mio_waker.wake();
-                }
-            }
+            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
         }
     }
+    // boxed Drop runs here — releases the Arc<CrossWakeContext>.
 }
 
 // =============================================================================

--- a/nexus-async-rt/src/waker.rs
+++ b/nexus-async-rt/src/waker.rs
@@ -22,7 +22,7 @@
 
 use std::task::{RawWaker, RawWakerVTable, Waker};
 
-use crate::task;
+use crate::task::{self, TaskRef};
 
 // =============================================================================
 // Thread-local ready queue for wakers
@@ -89,8 +89,11 @@ pub(crate) static VTABLE: RawWakerVTable =
 /// `ptr` must point to a live task with `ref_count >= 1`.
 #[inline]
 pub(crate) unsafe fn task_waker(ptr: *mut u8) -> Waker {
-    unsafe { task::ref_inc(ptr) };
-    let raw = RawWaker::new(ptr.cast(), &VTABLE);
+    // Acquire a TaskRef (ref_inc), then forget it — the RawWaker now
+    // owns the ref. drop_fn calls TaskRef::from_owned + drop to release.
+    let task_ref = unsafe { TaskRef::acquire(ptr) };
+    let raw = RawWaker::new(task_ref.as_ptr().cast(), &VTABLE);
+    std::mem::forget(task_ref);
     unsafe { Waker::from_raw(raw) }
 }
 
@@ -106,26 +109,25 @@ pub(crate) fn task_ptr_from_local_waker(waker: &Waker) -> Option<*mut u8> {
     }
 }
 
-/// Clone: increment refcount, copy the pointer.
+/// Clone: increment refcount, copy the pointer. The new RawWaker owns
+/// the new ref; its drop_fn will release it.
 unsafe fn clone_fn(data: *const ()) -> RawWaker {
-    // SAFETY: data points to a live (or completed) task.
-    unsafe { task::ref_inc(data as *mut u8) };
-    RawWaker::new(data, &VTABLE)
+    // SAFETY: data points to a live (or completed) task with refcount >= 1
+    // (the original waker holds a ref).
+    let task_ref = unsafe { TaskRef::acquire(data as *mut u8) };
+    let raw = RawWaker::new(task_ref.as_ptr().cast(), &VTABLE);
+    std::mem::forget(task_ref);
+    raw
 }
 
-/// Wake (by value): push to ready queue, decrement refcount (consumes waker).
-/// If the task is completed and refcount hits 0, signals slot can be freed.
+/// Wake (by value): push to ready queue, decrement refcount (consumes
+/// waker). TaskRef::Drop routes terminal state through dispose_terminal,
+/// which defers to DEFERRED_FREE on the executor thread.
 unsafe fn wake_fn(data: *const ()) {
     // SAFETY: data is a valid task pointer.
     unsafe { wake_impl(data) };
-    // Consume: decrement refcount. If terminal, free via TLS deferred path.
-    // Executor thread — slab TLS always available.
-    match unsafe { task::ref_dec(data as *mut u8) } {
-        task::FreeAction::Retain => {}
-        task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
-            unsafe { free_completed_slot(data as *mut u8) };
-        }
-    }
+    // Consume the ref via TaskRef::Drop.
+    drop(unsafe { TaskRef::from_owned(data as *mut u8) });
 }
 
 /// Wake (by ref): push to ready queue. Does NOT decrement refcount
@@ -135,15 +137,9 @@ unsafe fn wake_by_ref_fn(data: *const ()) {
     unsafe { wake_impl(data) };
 }
 
-/// Drop (without waking): decrement refcount. If the task is completed
-/// and refcount hits 0, free the slot.
+/// Drop (without waking): decrement refcount via TaskRef::Drop.
 unsafe fn drop_fn(data: *const ()) {
-    match unsafe { task::ref_dec(data as *mut u8) } {
-        task::FreeAction::Retain => {}
-        task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
-            unsafe { free_completed_slot(data as *mut u8) };
-        }
-    }
+    drop(unsafe { TaskRef::from_owned(data as *mut u8) });
 }
 
 #[cfg(test)]
@@ -172,44 +168,38 @@ mod tests {
     }
 }
 
-/// Queue a completed task slot for deferred freeing.
+/// Push a terminal task pointer onto the executor's `DEFERRED_FREE`
+/// list. Returns `true` if the push succeeded, `false` if the TLS is
+/// null (called outside a poll cycle).
 ///
-/// Called when the last reference drops (refcount hits 0) — either from
-/// a waker drop or from JoinHandle::Drop.
+/// On `false`, the caller's task slot is not enqueued for cleanup —
+/// `Executor::drop` will eventually iterate `all_tasks` and reclaim it.
+/// This is the established "leak until shutdown" fallback for
+/// terminal frees that fire outside `block_on`.
 ///
-/// If called outside a poll cycle (DEFERRED_FREE TLS is null), the slot
-/// is **not freed** — it will be reclaimed by `Executor::drop`. This is
-/// acceptable for correctness but means tasks whose last ref drops outside
-/// `block_on` are cleaned up lazily.
-///
-/// # Safety
-///
-/// `ptr` must point to a completed task slot.
-#[cold]
-#[inline(never)]
-pub(crate) unsafe fn defer_free(ptr: *mut u8) {
-    unsafe { free_completed_slot(ptr) };
-}
-
-/// Queue a completed task slot for deferred freeing. Called when the
-/// last waker clone drops (refcount hits 0).
+/// Used by `crate::cross_wake::dispose_terminal` for the on-executor
+/// branch (TaskRef::Drop on the runtime's owning thread). The deferred
+/// path keeps `Executor::all_tasks` bookkeeping consistent — the next
+/// poll cycle's drain reads `tracker_key` then frees + removes from
+/// `all_tasks` in the right order (see `Executor::poll`).
 ///
 /// # Safety
 ///
-/// `ptr` must point to a completed task slot.
+/// `ptr` must point to a terminal task slot (refcount 0, COMPLETED set,
+/// lifecycle flags clear).
 #[cold]
 #[inline(never)]
-unsafe fn free_completed_slot(ptr: *mut u8) {
+pub(crate) unsafe fn try_defer_free(ptr: *mut u8) -> bool {
     DEFERRED_FREE.with(|cell| {
         let list_ptr = cell.get();
-        if !list_ptr.is_null() {
-            // SAFETY: list_ptr valid — set by set_poll_context.
-            let list = unsafe { &mut *list_ptr };
-            list.push(ptr);
+        if list_ptr.is_null() {
+            return false;
         }
-        // If null (outside poll cycle), the slot leaks. This is
-        // acceptable — it will be cleaned up on Executor::drop.
-    });
+        // SAFETY: list_ptr valid — set by set_poll_context.
+        let list = unsafe { &mut *list_ptr };
+        list.push(ptr);
+        true
+    })
 }
 
 /// Shared wake implementation.

--- a/nexus-async-rt/tests/miri_task.rs
+++ b/nexus-async-rt/tests/miri_task.rs
@@ -287,7 +287,7 @@ fn output_larger_than_future() {
 #[test]
 fn storage_offset_matches_header() {
     // For Task<()>, storage should be at TASK_HEADER_SIZE.
-    assert_eq!(TASK_HEADER_SIZE, 64);
+    assert_eq!(TASK_HEADER_SIZE, 72);
     // The storage_offset field is set from offset_of! at construction.
     // This test verifies the accessor reads the correct value by
     // spawning a task and checking the output is at the right place.

--- a/nexus-async-rt/tests/tokio_compat.rs
+++ b/nexus-async-rt/tests/tokio_compat.rs
@@ -1092,7 +1092,10 @@ fn executor_drop_during_unwind_does_not_abort_box() {
 
     // Reaching here at all means the original panic propagated cleanly.
     // If Executor::drop double-panicked, the process would have aborted.
-    assert!(result.is_err(), "block_on panic should propagate, not abort");
+    assert!(
+        result.is_err(),
+        "block_on panic should propagate, not abort"
+    );
     let panic_msg = result
         .unwrap_err()
         .downcast::<&'static str>()
@@ -1123,9 +1126,7 @@ fn executor_drop_during_unwind_does_not_uaf_slab() {
     use nexus_async_rt::spawn_slab;
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let slab = unsafe {
-            nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8)
-        };
+        let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
         let wb = WorldBuilder::new();
         let mut world = wb.build();
         let mut rt = Runtime::builder(&mut world).slab_unbounded(slab).build();
@@ -1143,7 +1144,10 @@ fn executor_drop_during_unwind_does_not_uaf_slab() {
 
     // Same as the box variant: reaching here means we didn't abort.
     // Additionally verifies the slab branch (wait + free) didn't UAF.
-    assert!(result.is_err(), "block_on panic should propagate, not abort");
+    assert!(
+        result.is_err(),
+        "block_on panic should propagate, not abort"
+    );
     let panic_msg = result
         .unwrap_err()
         .downcast::<&'static str>()


### PR DESCRIPTION
## Summary

First of four PRs in the `nexus-async-rt` hardening plan. Introduces two abstractions that collapse the cross-thread refcount discipline into one place, eliminating the "ref_dec → if terminal: try_set_queued + push + parked check" duplication that was the root cause of three of the last four bugs (BUG-2, BUG-2-followup, BUG-4C).

**Public API unchanged.** Internal-only refactor.

Companion plan: `.claude/nexus-async-rt-hardening-plan-2026-05-03.md`

## What's in this PR

- **`TaskRef`** — RAII smart pointer pairing `ref_inc` with `ref_dec` at compile time. Drop routes terminal state through `dispose_terminal`. Replaces manual `unsafe fn ref_inc(*mut u8)` / `unsafe fn ref_dec(*mut u8)` discipline at off-thread call sites.
- **`dispose_terminal(task_ptr)`** — single helper for terminal-drop routing. Reads owning `CrossWakeContext` from the task header (set at spawn). On the executor's thread (or null-ctx test tasks), defers via `DEFERRED_FREE` TLS to keep `Executor::all_tasks` bookkeeping consistent. Off-thread, queues via cross-wake queue.
- **Task header grows 64 → 72 bytes.** New `cross_wake_ctx: *const CrossWakeContext` at offset 64 (cold-path; hot-path reads stay in the first cache line). For `Slab<256>` tasks, payload room drops 192 → 184 bytes. For `Slab<128>` users, 64 → 56 bytes — non-trivial state machines may need to bump slot size.
- **Two TLS slots, separate scopes.** Existing `CTX_CROSS_WAKE` (Arc-pointer, `block_on`-scoped) stays unchanged. New `CURRENT_RUNTIME_CTX` (`Arc::as_ptr` value, Runtime-lifetime-scoped, heap-stable) drives `dispose_terminal`'s on-thread vs off-thread routing.
- **`RuntimeCrossWakeGuard` field** placed right after `executor` in the `Runtime` struct so it drops second. Compile-time `const _:` assert enforces the ordering. Field doc-comment explicitly names "silent UAF in production for slab tasks" as the failure mode if reordered.
- **`free_completed_slot` → `try_defer_free`** rename. Returns `bool` instead of silently no-op'ing when DEFERRED_FREE TLS is null. The `defer_free` and `defer_free_slot` indirections are deleted.
- **Migrations:** `waker.rs` (`task_waker`/`clone_fn`/`wake_fn`/`drop_fn`), `tokio_compat.rs` (`cross_task_drop`/`cross_task_wake`), `JoinHandle::Drop`, and all four channel `release_slot_ref` paths now route through `TaskRef` + `dispose_terminal`.

## Two design decisions worth highlighting

### `dispose_terminal` has two internal routing paths

Single helper, two branches: defer-on-thread (`try_defer_free` or leak-to-`Executor::drop`) vs queue-off-thread (cross-wake queue + parked check). The "one helper" framing is about call-site convergence, not single-path implementation. The split is unavoidable given the `Executor::all_tasks` bookkeeping invariant — direct-freeing on the executor thread races `Executor::drop`'s scan. PR 2 §2.2 (Executor::drop refactor) may unify if cleanly possible.

### The "TaskRef covers everything EXCEPT executor's `all_tasks` ref" rule

Documented in the doc-block at the top of `task.rs`. The executor's `all_tasks` ownership uses `complete_and_unref` directly (atomic COMPLETED-set + decrement), bypassing TaskRef's Drop-time routing. Wrapping it in TaskRef would double-handle tasks the executor is already tracking. Subtle regression — explicitly warned against.

## BUG status notes

- **BUG-1 (#167) — slab shutdown:** already fixed via field-order RAII. This PR adds a parallel field-order invariant for `_cross_wake_tls_guard`.
- **BUG-2 (#168) and BUG-2-followup — channel UAF / wake-register race:** consolidation surface for these begins here. Terminal routing is now in one place; PR 1b consolidates the four duplicate `RxWakerSlot` types.
- **BUG-3 (#169) — Cancelled waker leak:** **still open.** PR #197 was a partial fix (`last_waker` gating reduces trigger conditions). The architectural problem from hardening plan §F8 — per-poll `Box<WaiterNode>` accumulating on the Treiber stack — remains. PR 3 in this hardening sequence is the real fix.
- **BUG-4 (#196) — busy-spin + slab UAF on unwind:** unchanged. The `executor_drop_during_unwind_does_not_*` regression tests continue to pass.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p nexus-async-rt --lib` — 207 pass (was 209; -2 from deleted speculative-API release tests)
- [x] `cargo test -p nexus-async-rt --tests` — all integration suites green
- [x] `cargo test -p nexus-async-rt --test tokio_compat --features tokio-compat` — 21 pass, including BUG-4 unwind regressions
- [x] `cargo clippy -p nexus-async-rt --all-features --lib -- -D warnings` — clean
- [x] `cargo fmt --check -p nexus-async-rt` — clean
- [x] Miri stacked-borrows on `taskref`/`dispose_terminal`/channel uaf_tests — 10 pass
- [x] Miri tree-borrows on the same — 10 pass
- [x] `#[allow(dead_code)]` count net -2 in the new code (no speculative API surface ships)

## Out of scope (covered by later PRs in the hardening sequence)

- **PR 1b:** `RxWakerSlot` x4 → `TaskWakerSlot` x1 consolidation, `FallbackWaker` dedup, unified white-box harness, runtime field-ordering doc-block.
- **PR 2:** per-clone `Box<CrossTaskWakerData>` → `Arc` rewrite, `Executor::drop` refactor, `ShutdownStats` observability, `shutdown_quiesce`.
- **PR 3:** Cancellation token rewrite (closes BUG-3 properly).

## Review notes

Three independent reviews (John code-quality, planning council, Martin pre-merge) all approved. Pre-merge cleanup items (stale doc fix, deletion of speculative `TaskRef::release()`, strengthened `_cross_wake_tls_guard` failure-mode comment) all landed before this PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)