### PR TITLE
async rt refactor part 1b

### DIFF
--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -25,188 +25,11 @@ use std::cell::UnsafeCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 use std::task::{Context, Poll, Waker};
 
 use super::{RecvError, SendError, TryRecvError, TrySendError};
-
-// =============================================================================
-// Receiver WakerSlot — zero-alloc, lives in Inner
-// =============================================================================
-
-/// Pre-allocated slot for the receiver's cross-thread waker.
-/// Lives inside `Inner`, pointed to by `RawWaker::data`. No Box.
-struct RxWakerSlot {
-    /// Task pointer to wake. Written by receiver, read by senders.
-    task_ptr: AtomicPtr<u8>,
-    /// Raw pointer to the `CrossWakeContext`. Set once at channel creation.
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
-    /// State: EMPTY / STORED / REGISTERING.
-    state: AtomicU8,
-}
-
-const EMPTY: u8 = 0;
-const STORED: u8 = 1;
-const REGISTERING: u8 = 2;
-
-// SAFETY: All fields are atomic or immutable after creation.
-unsafe impl Send for RxWakerSlot {}
-unsafe impl Sync for RxWakerSlot {}
-
-impl RxWakerSlot {
-    fn new(cross_ctx: *const crate::cross_wake::CrossWakeContext) -> Self {
-        Self {
-            task_ptr: AtomicPtr::new(std::ptr::null_mut()),
-            cross_ctx,
-            state: AtomicU8::new(EMPTY),
-        }
-    }
-
-    /// Register the receiver's task pointer. Called by RecvFut::poll.
-    /// Single-registerer only.
-    fn register(&self, task_ptr: *mut u8) {
-        debug_assert!(
-            !task_ptr.is_null(),
-            "RxWakerSlot::register called with null task_ptr — \
-             contract violation by caller (typically RecvFut::poll)"
-        );
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING, "concurrent register on RxWakerSlot");
-
-        // BUG-2 (#168) fix: hold a refcount on the task while registered
-        // so a sender that captures the pointer mid-`wake()` can't have
-        // it freed underneath. The matching `ref_dec` happens in `wake`
-        // (after `wake_task_cross_thread` returns), `clear`, or `Drop`.
-        // SAFETY: caller (RecvFut::poll) just received task_ptr from the
-        // active receiver task whose refcount is >= 1; the debug_assert
-        // above catches the null case in development.
-        unsafe { crate::task::ref_inc(task_ptr) };
-
-        // Release any prior registration's ref. Always check prev_ptr —
-        // not gated on `prev == STORED` — because a sender's `wake()`
-        // CAS may have transitioned state STORED→EMPTY without yet
-        // taking the task_ptr (the swap is the second step). In that
-        // race window, prev_ptr is still non-null even though state was
-        // EMPTY when we observed it. Skipping the release leaks the
-        // ref. (BUG-2 follow-up — found by John in PR review.)
-        //
-        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
-        // we own that ref now and must release it. wake/clear/Drop
-        // operate on the new pointer we just stored — both refs are
-        // tracked correctly in all interleavings.
-        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
-        if !prev_ptr.is_null() {
-            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
-        }
-
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    /// Try to register a local runtime waker. Returns true if the waker
-    /// is a local runtime waker and was registered via the zero-alloc
-    /// slot. Returns false for foreign wakers (caller should fall back
-    /// to the AtomicWaker slot on Inner).
-    fn try_register_local(&self, waker: &Waker) -> bool {
-        crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            self.register(task_ptr);
-            true
-        })
-    }
-
-    /// Wake the receiver if registered. Called by senders from any thread.
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // Push to cross-thread inbox + conditional eventfd poke.
-                // SAFETY: cross_ctx is valid for the lifetime of the channel.
-                // task_ptr is alive because `register` ref_inc'd before
-                // storing — that ref keeps the task allocated through the
-                // dispatch (see BUG-2 #168).
-                let ctx = unsafe { &*self.cross_ctx };
-                unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
-
-                // BUG-2 fix: release the ref `register` acquired. Must
-                // happen AFTER `wake_task_cross_thread` returns so the
-                // task is alive for the deref inside it.
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-
-    fn clear(&self) {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // BUG-2 fix: release the ref `register` acquired.
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-impl Drop for RxWakerSlot {
-    fn drop(&mut self) {
-        // BUG-2 (#168) fix: if still registered when dropped, release
-        // our ref. Slot drops when the channel `Inner` drops — both
-        // sides of the channel are gone, so any registered receiver
-        // task can no longer be woken via this slot. Releasing the ref
-        // here matches the wake/clear release paths.
-        //
-        // &mut self gives exclusive access; no concurrent mutator.
-        if *self.state.get_mut() == STORED {
-            let task_ptr = *self.task_ptr.get_mut();
-            if !task_ptr.is_null() {
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-/// Release the slot's ref on `task_ptr`. If this turns out to be the
-/// terminal ref, route via [`crate::cross_wake::dispose_terminal`] —
-/// defers locally on the owning executor's thread (preserves
-/// `Executor::all_tasks` bookkeeping), queues cross-thread otherwise.
-///
-/// The `cross_ctx` parameter is unused now that dispose_terminal reads
-/// the context from the task header. Kept on the caller signature for
-/// PR 1a (slot consolidation in PR 1b removes the slot type entirely).
-///
-/// # Safety
-///
-/// `task_ptr` must point to a task on which `register` previously called
-/// `ref_inc`.
-unsafe fn release_slot_ref(
-    task_ptr: *mut u8,
-    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
-) {
-    match unsafe { crate::task::ref_dec(task_ptr) } {
-        crate::task::FreeAction::Retain => {}
-        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: caller guarantees task_ptr was alive until the
-            // ref_dec above; on terminal it's still alive (we don't
-            // free it here, dispose_terminal does).
-            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
-        }
-    }
-}
+use crate::cross_wake::{FallbackWaker, TaskWakerSlot};
 
 // =============================================================================
 // Sender WakerNode — intrusive list, zero-alloc on park
@@ -370,60 +193,8 @@ impl SenderWaitList {
     }
 }
 
-// =============================================================================
-// Legacy AtomicWaker for root future / foreign wakers
-// =============================================================================
-
-/// Fallback waker storage for non-runtime wakers (root future, foreign).
-/// Used when `RxWakerSlot::try_register_local` returns false.
-struct FallbackWaker {
-    state: AtomicU8,
-    waker: UnsafeCell<Option<Waker>>,
-}
-
-unsafe impl Send for FallbackWaker {}
-unsafe impl Sync for FallbackWaker {}
-
-impl FallbackWaker {
-    fn new() -> Self {
-        Self {
-            state: AtomicU8::new(EMPTY),
-            waker: UnsafeCell::new(None),
-        }
-    }
-
-    fn register(&self, waker: &Waker) {
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-        unsafe { *self.waker.get() = Some(waker.clone()) };
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let waker = unsafe { (*self.waker.get()).take() };
-            if let Some(w) = waker {
-                w.wake();
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-}
-
-impl Drop for FallbackWaker {
-    fn drop(&mut self) {
-        *self.waker.get_mut() = None;
-    }
-}
+// `FallbackWaker` (for root future / foreign wakers) is now shared from
+// `crate::cross_wake`. See PR 1b.
 
 // =============================================================================
 // Shared state
@@ -436,7 +207,7 @@ struct Inner<T> {
 
     /// Zero-alloc receiver waker slot. Senders read this to wake the
     /// receiver via the cross-thread inbox.
-    rx_slot: RxWakerSlot,
+    rx_slot: TaskWakerSlot,
 
     /// Fallback for non-runtime wakers (root future, foreign runtimes).
     rx_fallback: FallbackWaker,
@@ -445,7 +216,7 @@ struct Inner<T> {
     tx_waiters: SenderWaitList,
 
     /// Keeps the CrossWakeContext alive for the lifetime of the channel.
-    /// `RxWakerSlot::cross_ctx` is a raw pointer derived from this Arc.
+    /// `TaskWakerSlot::cross_ctx` is a raw pointer derived from this Arc.
     _cross_wake_owner: Arc<crate::cross_wake::CrossWakeContext>,
 
     /// Number of live Sender handles.
@@ -493,7 +264,7 @@ pub fn channel<T: Send>(capacity: usize) -> (Sender<T>, Receiver<T>) {
 
     let (producer, consumer) = nexus_queue::mpsc::ring_buffer(capacity);
 
-    let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+    let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
     let inner = Arc::new(Inner {
         producer,
@@ -764,7 +535,7 @@ mod tests {
         });
 
         let (producer, consumer) = nexus_queue::mpsc::ring_buffer(capacity);
-        let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
         let inner = Arc::new(Inner {
             producer,
@@ -1029,319 +800,30 @@ mod tests {
 }
 
 // =============================================================================
-// BUG-2 (#168) — verify use-after-free in the cross-thread wake path
+// BUG-2 (#168) — cross-thread wake-path UAF regression tests
 // =============================================================================
 //
-// Hypothesis: `RxWakerSlot::register` stores `task_ptr` without calling
-// `task::ref_inc`. A sender that wins the wake CAS captures the pointer,
-// then dereferences it inside `wake_task_cross_thread` (`is_completed`,
-// `try_set_queued`, `queue.push`). If the task completes and is freed
-// in the gap between CAS and deref — typically because a `select!`
-// resolved on a different arm — the deref hits freed memory.
-//
-// The white-box test below orchestrates the race deterministically:
-// it CAS-claims the slot itself, completes-and-frees the task, and THEN
-// calls `wake_task_cross_thread`. Run under tree-borrows miri to expose
-// the UAF.
-//
-// Run pre-fix (UAF expected):
-//   MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-ignore-leaks" \
-//     cargo +nightly miri test -p nexus-async-rt --lib uaf_tests
-//
-// After the fix (`register` ref_incs, `wake`/`clear`/`Drop` ref_dec),
-// this same test runs clean under miri because the slot's ref keeps
-// the task alive across the dispatch window.
+// Tests live in `crate::cross_wake::uaf_scenarios` (one canonical body
+// per scenario, shared across all four channels). These per-channel
+// `#[test]` wrappers exist for `cargo test mpsc::uaf_tests` output
+// visibility and to verify the consolidated `TaskWakerSlot` works
+// identically across channel modules.
 #[cfg(test)]
 mod uaf_tests {
-    use super::*;
-    use crate::cross_wake::wake_task_cross_thread;
-    use crate::task::{self, FreeAction, Task};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
+    use crate::cross_wake::uaf_scenarios as h;
 
-    struct UafNoop;
-    impl Future for UafNoop {
-        type Output = ();
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
-            Poll::Ready(())
-        }
-    }
-
-    fn make_uaf_task() -> *mut u8 {
-        // Refcount = 1 (single executor-style ref) per Task::new_boxed.
-        let task = Box::new(Task::new_boxed(UafNoop, 0));
-        Box::into_raw(task) as *mut u8
-    }
-
-    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
-        let poll = mio::Poll::new().unwrap();
-        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
-        Arc::new(crate::cross_wake::CrossWakeContext {
-            queue: crate::cross_wake::CrossWakeQueue::new(),
-            mio_waker,
-            parked: AtomicBool::new(false),
-        })
-    }
-
-    /// Reproduces BUG-2: sender derefs the task pointer after the
-    /// receiver task has been freed.
-    ///
-    /// Pre-fix: the call to `wake_task_cross_thread(captured, ...)`
-    /// reads task state from freed memory. Tree-borrows miri flags
-    /// this. The exact failure surface depends on which read miri
-    /// trips on first (`is_completed` is the first deref).
-    ///
-    /// Post-fix: `register` ref_incs (refcount goes 1→2), so
-    /// `complete_and_unref` returns `Retain` instead of `FreeBox`. The
-    /// task allocation is alive when the sender derefs it; the deref
-    /// reads `COMPLETED` and the function returns early. The slot's
-    /// `Drop` then releases the final ref, freeing the task cleanly.
     #[test]
     fn waker_slot_uaf_when_task_freed_mid_dispatch() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        // Sanity: starting refcount is 1 (Task::new_boxed initial state).
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            1,
-            "make_uaf_task should produce refcount=1"
-        );
-
-        // Construct the slot pointing at the cross-wake context, then
-        // register the task pointer — this is the operation under test.
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-
-        // Mirror the sender's first half of `slot.wake()`: CAS state
-        // STORED→EMPTY, swap the pointer out. After this, the sender
-        // owns the captured pointer and is about to call
-        // `wake_task_cross_thread`.
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok(),
-            "slot was registered; CAS STORED→EMPTY must succeed"
-        );
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-
-        // Simulate "select resolved on the other arm during the
-        // dispatch window": the executor calls `complete_and_unref` on
-        // the task, which atomically sets COMPLETED and decrements the
-        // executor's ref. Pre-fix this is the last ref → FreeBox.
-        // Post-fix the slot still holds a ref → Retain.
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-
-        // Track which path we're on — the test must clean up differently
-        // pre-fix vs post-fix. Pre-fix: task is already freed below.
-        // Post-fix: task is still alive (slot's ref); we must release it
-        // ourselves at the end since the slot's `state` is EMPTY (we
-        // CAS'd it above), so any future `Drop`-time release won't fire.
-        let pre_fix = match action {
-            FreeAction::FreeBox => {
-                // PRE-FIX path: register skipped the ref_inc, so the
-                // executor's complete_and_unref produced terminal. Under
-                // regular `cargo test`, fail early — the deref below
-                // would manifest as a segfault rather than a clean
-                // assertion failure. Under `cargo +nightly miri test`,
-                // proceed to trigger the UAF so miri can produce its
-                // diagnostic trace (the original BUG-2 proof).
-                #[cfg(not(miri))]
-                panic!(
-                    "BUG-2 regression detected: register skipped ref_inc, \
-                     so complete_and_unref produced FreeBox instead of \
-                     Retain. Run under miri for the full UAF trace."
-                );
-                #[cfg(miri)]
-                {
-                    unsafe { task::free_task(task_ptr) };
-                    true
-                }
-            }
-            FreeAction::Retain => false,
-            FreeAction::FreeSlab => {
-                panic!("box-allocated test task must not produce FreeSlab");
-            }
-        };
-
-        // Sender continues with the captured pointer.
-        // PRE-FIX: derefs freed memory → tree-borrows UAF.
-        // POST-FIX: derefs alive task, observes COMPLETED, returns early.
-        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
-
-        if !pre_fix {
-            // POST-FIX cleanup: release the slot's captured ref. In real
-            // code this is the ref_dec that `wake()` does after
-            // `wake_task_cross_thread` returns.
-            match unsafe { task::ref_dec(captured) } {
-                FreeAction::FreeBox => unsafe { task::free_task(captured) },
-                FreeAction::Retain | FreeAction::FreeSlab => {
-                    panic!("post-fix cleanup must terminate the box task")
-                }
-            }
-        }
-
-        // Drop the slot. State is EMPTY (CAS'd above), so any
-        // `Drop`-time release path is a no-op for this scenario.
-        drop(slot);
+        h::waker_slot_uaf_when_task_freed_mid_dispatch();
     }
 
-    /// Companion test: when a registered slot is dropped without ever
-    /// being woken or cleared, the slot's `Drop` must release its ref.
-    /// Otherwise the task allocation leaks.
-    ///
-    /// **Sensitive to the fix via explicit refcount assertions.** This
-    /// test FAILS pre-fix because no `Drop` impl exists on `RxWakerSlot`,
-    /// so `register` doesn't take a ref and Drop doesn't release one.
-    /// PASSES post-fix because `register` ref_incs and Drop ref_decs.
     #[test]
     fn slot_drop_releases_ref_when_still_registered() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        // Mark the task COMPLETED first via complete_and_unref. Bump the
-        // ref to 2 so complete_and_unref returns Retain (rather than
-        // freeing). After: refcount = 1, COMPLETED set.
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-        // Post-fix: register ref_inc → refcount = 2.
-        // Pre-fix: register did NOT ref_inc → refcount = 1.
-        let after_register = unsafe { task::ref_count(task_ptr) };
-
-        // Drop the slot WITHOUT calling wake() or clear().
-        // Post-fix: Drop sees state == STORED, ref_dec → refcount = 1, returns Retain.
-        // Pre-fix: no Drop impl → refcount unchanged.
-        drop(slot);
-        let after_drop = unsafe { task::ref_count(task_ptr) };
-
-        // **The strengthened assertion**: register-then-drop must net to
-        // zero change in refcount. Pre-fix register doesn't take a ref AND
-        // Drop doesn't release one, so this ALSO nets to zero — but the
-        // explicit `register-took-a-ref` check below catches the regression.
-        assert_eq!(
-            after_register,
-            after_drop + 1,
-            "Post-fix Drop must release the ref that register acquired. \
-             If this fires pre-fix (register skipped ref_inc), there's no \
-             Drop ref_dec to compensate, so the net is 0 instead of -1."
-        );
-        assert_eq!(
-            after_register,
-            baseline_refcount + 1,
-            "Post-fix register must bump refcount by 1. If this fires \
-             pre-fix, register skipped ref_inc — that's BUG-2's root cause."
-        );
-
-        // Cleanup: refcount is 1 (post-fix or pre-fix), COMPLETED set.
-        // Final ref_dec should return FreeBox; free the allocation.
-        let action = unsafe { task::ref_dec(task_ptr) };
-        match action {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
-        }
+        h::slot_drop_releases_ref_when_still_registered();
     }
 
-    /// Race regression for John's review item 1 (BUG-2 follow-up).
-    ///
-    /// `register()` previously gated the prev-ref release on
-    /// `prev == STORED && !prev_ptr.is_null()`. That gate was wrong:
-    /// a sender's `wake()` first CAS's state STORED→EMPTY, THEN swaps
-    /// `task_ptr`. If a re-register interleaves between those two
-    /// steps it observes `prev == EMPTY` (CAS happened) but
-    /// `prev_ptr` is still non-null (swap hasn't happened) — the gate
-    /// skipped releasing the old ref, leaking it.
-    ///
-    /// The fix removes the `prev == STORED` part of the gate; we now
-    /// always release a non-null prev_ptr.
-    ///
-    /// This test drives the interleave manually and asserts refcount
-    /// returns to baseline. Pre-fix it lands at baseline+1 (leak).
     #[test]
     fn register_during_wake_does_not_leak_ref() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        // Bump the ref so the test's manual ref_decs don't trigger
-        // free mid-test. After complete_and_unref, refcount = 1 with
-        // COMPLETED set — this is our baseline.
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline, 1, "baseline must be 1 (executor-style ref)");
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-
-        // ---- T0: initial register ----
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "initial register must take a ref (slot owns +1)"
-        );
-
-        // ---- T1 wake (first half): CAS only, do NOT swap task_ptr yet ----
-        // Mirrors the entry of `wake()` paused mid-function. After
-        // this, state is EMPTY but task_ptr still points at task_ptr.
-        let cas_ok = slot
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok();
-        assert!(cas_ok, "wake's CAS must succeed when state is STORED");
-
-        // ---- T2: re-register (the race) ----
-        // Mirrors RecvFut::poll re-registering after a wake from
-        // another source (timer, parent select arm fired). Same task
-        // — same task_ptr. Pre-fix: register's gate sees prev==EMPTY,
-        // skips the release, leaks the old ref. Post-fix: release fires.
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "race register must NET to baseline+1 (slot still owns one ref). \
-             Pre-fix the gate skipped the release of the original; this \
-             assertion would fire baseline+2 — the leak."
-        );
-
-        // ---- T1 wake (second half): swap task_ptr, release ----
-        // Skip wake_task_cross_thread — we're testing refcount balance,
-        // not the dispatch path. release_slot_ref is the operation
-        // wake() performs after the dispatch.
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
-
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "after wake's release, slot owes 0 refs to task. Pre-fix \
-             this is baseline+1 (the leaked original)."
-        );
-
-        // ---- Cleanup ----
-        // After the race, slot is in (state=STORED, task_ptr=null).
-        // Drop sees state=STORED but task_ptr is null, so it releases
-        // nothing — confirms the Drop impl correctly handles this
-        // benign "post-race" inconsistency.
-        drop(slot);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "Drop on a STORED-but-null-task_ptr slot must be a no-op for refcount"
-        );
-
-        // Final ref_dec → FreeBox.
-        match unsafe { task::ref_dec(task_ptr) } {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
-        }
+        h::register_during_wake_does_not_leak_ref();
     }
 }

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -31,210 +31,12 @@
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::task::{Poll, Waker};
 
 use std::ops::{Deref, DerefMut};
 
-// =============================================================================
-// Waker primitives (same pattern as spsc_bytes / mpsc typed)
-// =============================================================================
-
-const EMPTY: u8 = 0;
-const STORED: u8 = 1;
-const REGISTERING: u8 = 2;
-
-struct RxWakerSlot {
-    task_ptr: std::sync::atomic::AtomicPtr<u8>,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
-    state: AtomicU8,
-}
-
-unsafe impl Send for RxWakerSlot {}
-unsafe impl Sync for RxWakerSlot {}
-
-impl RxWakerSlot {
-    fn new(cross_ctx: *const crate::cross_wake::CrossWakeContext) -> Self {
-        Self {
-            task_ptr: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            cross_ctx,
-            state: AtomicU8::new(EMPTY),
-        }
-    }
-
-    /// Register the receiver's task pointer. Single-registerer only.
-    fn register(&self, task_ptr: *mut u8) {
-        debug_assert!(
-            !task_ptr.is_null(),
-            "RxWakerSlot::register called with null task_ptr"
-        );
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-
-        // BUG-2 (#168) fix: hold a refcount on the task while
-        // registered so a sender that captures the pointer
-        // mid-`wake()` can't have it freed underneath. Matched by
-        // ref_dec in wake/clear/Drop.
-        // SAFETY: caller (RecvFut::poll) just received task_ptr from
-        // the active receiver task whose refcount is >= 1; the
-        // debug_assert above catches the null case in development.
-        unsafe { crate::task::ref_inc(task_ptr) };
-
-        // Release any prior registration's ref. Always check prev_ptr —
-        // not gated on `prev == STORED` — because a sender's `wake()` CAS
-        // may have transitioned state STORED→EMPTY without yet taking
-        // the task_ptr (the swap is the second step). In that race
-        // window, prev_ptr is still non-null even though state was
-        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
-        //
-        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
-        // we own that ref now and must release it.
-        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
-        if !prev_ptr.is_null() {
-            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
-        }
-
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn try_register_local(&self, waker: &Waker) -> bool {
-        crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            self.register(task_ptr);
-            true
-        })
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // SAFETY: task_ptr is alive because `try_register_local`
-                // ref_inc'd before storing — that ref keeps the task
-                // allocated through the dispatch (see BUG-2 #168).
-                let ctx = unsafe { &*self.cross_ctx };
-                unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
-
-                // BUG-2 fix: release the ref `try_register_local`
-                // acquired. AFTER wake_task_cross_thread so the task is
-                // alive for its deref.
-                // SAFETY: we own the ref from `try_register_local`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-
-    fn clear(&self) {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // BUG-2 fix: release the ref `try_register_local` acquired.
-                // SAFETY: we own the ref.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-impl Drop for RxWakerSlot {
-    fn drop(&mut self) {
-        // BUG-2 (#168) fix: if still registered when dropped, release
-        // our ref. See mpsc.rs for the full rationale.
-        if *self.state.get_mut() == STORED {
-            let task_ptr = *self.task_ptr.get_mut();
-            if !task_ptr.is_null() {
-                // SAFETY: we own the ref from `try_register_local`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-/// Release the slot's ref on `task_ptr`. If terminal, route via
-/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
-/// for the full design rationale.
-///
-/// `cross_ctx` is unused (dispose_terminal reads ctx from the task
-/// header); kept on the signature for PR 1a consistency.
-///
-/// # Safety
-///
-/// `task_ptr` must point to a task on which `try_register_local`
-/// previously called `ref_inc`.
-unsafe fn release_slot_ref(
-    task_ptr: *mut u8,
-    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
-) {
-    match unsafe { crate::task::ref_dec(task_ptr) } {
-        crate::task::FreeAction::Retain => {}
-        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: task_ptr was alive until ref_dec; terminal but
-            // not yet freed (dispose_terminal does the routing).
-            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
-        }
-    }
-}
-
-struct FallbackWaker {
-    state: AtomicU8,
-    waker: UnsafeCell<Option<Waker>>,
-}
-
-unsafe impl Send for FallbackWaker {}
-unsafe impl Sync for FallbackWaker {}
-
-impl FallbackWaker {
-    fn new() -> Self {
-        Self {
-            state: AtomicU8::new(EMPTY),
-            waker: UnsafeCell::new(None),
-        }
-    }
-
-    fn register(&self, waker: &Waker) {
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-        unsafe { *self.waker.get() = Some(waker.clone()) };
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            if let Some(w) = unsafe { (*self.waker.get()).take() } {
-                w.wake();
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-}
-
-impl Drop for FallbackWaker {
-    fn drop(&mut self) {
-        *self.waker.get_mut() = None;
-    }
-}
+use crate::cross_wake::{FallbackWaker, TaskWakerSlot};
 
 // =============================================================================
 // Sender waiter list (intrusive, same pattern as mpsc typed)
@@ -398,7 +200,7 @@ impl SenderWaitList {
 // =============================================================================
 
 struct Inner {
-    rx_slot: RxWakerSlot,
+    rx_slot: TaskWakerSlot,
     rx_fallback: FallbackWaker,
     tx_waiters: SenderWaitList,
     _cross_wake_owner: Arc<crate::cross_wake::CrossWakeContext>,
@@ -576,7 +378,7 @@ pub fn channel(capacity: usize) -> (Sender, Receiver) {
         .expect("mpsc_bytes::channel() requires runtime context");
 
     let (producer, consumer) = nexus_logbuf::queue::mpsc::new(capacity);
-    let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+    let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
     let inner = Arc::new(Inner {
         rx_slot,
@@ -826,7 +628,7 @@ mod tests {
         });
 
         let (producer, consumer) = nexus_logbuf::queue::mpsc::new(capacity);
-        let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
         let inner = Arc::new(Inner {
             rx_slot,
@@ -1019,191 +821,30 @@ mod tests {
 }
 
 // =============================================================================
-// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// BUG-2 (#168) — cross-thread wake-path UAF regression tests
 // =============================================================================
 //
-// See `mpsc.rs::uaf_tests` for the full rationale. This file's
-// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+// Tests live in `crate::cross_wake::uaf_scenarios` (one canonical body
+// per scenario, shared across all four channels). These per-channel
+// `#[test]` wrappers exist for `cargo test mpsc_bytes::uaf_tests`
+// output visibility and to verify the consolidated `TaskWakerSlot`
+// works identically across channel modules.
 #[cfg(test)]
 mod uaf_tests {
-    use super::*;
-    use crate::cross_wake::wake_task_cross_thread;
-    use crate::task::{self, FreeAction, Task};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
-    use std::task::{Context, Poll};
-
-    struct UafNoop;
-    impl Future for UafNoop {
-        type Output = ();
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
-            Poll::Ready(())
-        }
-    }
-
-    fn make_uaf_task() -> *mut u8 {
-        let task = Box::new(Task::new_boxed(UafNoop, 0));
-        Box::into_raw(task) as *mut u8
-    }
-
-    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
-        let poll = mio::Poll::new().unwrap();
-        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
-        Arc::new(crate::cross_wake::CrossWakeContext {
-            queue: crate::cross_wake::CrossWakeQueue::new(),
-            mio_waker,
-            parked: AtomicBool::new(false),
-        })
-    }
+    use crate::cross_wake::uaf_scenarios as h;
 
     #[test]
     fn waker_slot_uaf_when_task_freed_mid_dispatch() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-
-        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
-            FreeAction::FreeBox => {
-                // PRE-FIX path: under regular cargo test, fail early
-                // (avoid segfault from the deref below). Under miri,
-                // trigger the UAF so the diagnostic trace fires.
-                #[cfg(not(miri))]
-                panic!(
-                    "BUG-2 regression detected: register skipped ref_inc. \
-                     Run under miri for the full UAF trace."
-                );
-                #[cfg(miri)]
-                {
-                    unsafe { task::free_task(task_ptr) };
-                    true
-                }
-            }
-            FreeAction::Retain => false,
-            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
-        };
-
-        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
-
-        if !pre_fix {
-            match unsafe { task::ref_dec(captured) } {
-                FreeAction::FreeBox => unsafe { task::free_task(captured) },
-                _ => panic!("post-fix cleanup must terminate the box task"),
-            }
-        }
-
-        drop(slot);
+        h::waker_slot_uaf_when_task_freed_mid_dispatch();
     }
 
-    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
-    /// because `register` skips ref_inc and there's no Drop impl. PASSES
-    /// post-fix because register ref_incs and Drop ref_decs.
     #[test]
     fn slot_drop_releases_ref_when_still_registered() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-        let after_register = unsafe { task::ref_count(task_ptr) };
-
-        drop(slot);
-        let after_drop = unsafe { task::ref_count(task_ptr) };
-
-        assert_eq!(
-            after_register,
-            after_drop + 1,
-            "Post-fix Drop must release the ref that register acquired."
-        );
-        assert_eq!(
-            after_register,
-            baseline_refcount + 1,
-            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
-        );
-
-        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
-        let action = unsafe { task::ref_dec(task_ptr) };
-        match action {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
-        }
+        h::slot_drop_releases_ref_when_still_registered();
     }
 
-    /// Race regression for John's review item 1 (BUG-2 follow-up).
-    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
-    /// for the full design notes.
     #[test]
     fn register_during_wake_does_not_leak_ref() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "initial register must take a ref"
-        );
-
-        // Wake first half: CAS only.
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-
-        // Race: re-register during the wake window.
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
-        );
-
-        // Wake second half: swap + release.
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
-        );
-
-        drop(slot);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "Drop on STORED-but-null slot is a no-op for refcount"
-        );
-
-        match unsafe { task::ref_dec(task_ptr) } {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox, got {other:?}"),
-        }
+        h::register_during_wake_does_not_leak_ref();
     }
 }

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -27,208 +27,16 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::task::{Context, Poll, Waker};
 
 use super::{RecvError, SendError, TryRecvError, TrySendError};
+use crate::cross_wake::{FallbackWaker, TaskWakerSlot};
 
-// =============================================================================
-// Waker primitives (shared with mpsc pattern)
-// =============================================================================
-
+// Local state constants used by `TxWakerSlot` below. (RxWakerSlot's
+// constants moved to `cross_wake` with the slot consolidation in PR
+// 1b. TxWakerSlot is single-sender / single-receiver — out of scope
+// for the cross-thread slot consolidation since it's not duplicated
+// across all channels — and keeps its own copy.)
 const EMPTY: u8 = 0;
 const STORED: u8 = 1;
 const REGISTERING: u8 = 2;
-
-/// Zero-alloc receiver waker slot. Lives in Inner.
-struct RxWakerSlot {
-    task_ptr: std::sync::atomic::AtomicPtr<u8>,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
-    state: AtomicU8,
-}
-
-unsafe impl Send for RxWakerSlot {}
-unsafe impl Sync for RxWakerSlot {}
-
-impl RxWakerSlot {
-    fn new(cross_ctx: *const crate::cross_wake::CrossWakeContext) -> Self {
-        Self {
-            task_ptr: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            cross_ctx,
-            state: AtomicU8::new(EMPTY),
-        }
-    }
-
-    fn register(&self, task_ptr: *mut u8) {
-        debug_assert!(
-            !task_ptr.is_null(),
-            "RxWakerSlot::register called with null task_ptr"
-        );
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-
-        // BUG-2 (#168) fix: hold a refcount on the task while registered
-        // so a sender that captures the pointer mid-`wake()` can't have
-        // it freed underneath. Matched by `ref_dec` in wake/clear/Drop.
-        // SAFETY: caller (RecvFut::poll) just received task_ptr from the
-        // active receiver task whose refcount is >= 1; the debug_assert
-        // above catches the null case in development.
-        unsafe { crate::task::ref_inc(task_ptr) };
-
-        // Release any prior registration's ref. Always check prev_ptr —
-        // not gated on `prev == STORED` — because a sender's `wake()` CAS
-        // may have transitioned state STORED→EMPTY without yet taking
-        // the task_ptr (the swap is the second step). In that race
-        // window, prev_ptr is still non-null even though state was
-        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
-        //
-        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
-        // we own that ref now and must release it.
-        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
-        if !prev_ptr.is_null() {
-            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
-        }
-
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn try_register_local(&self, waker: &Waker) -> bool {
-        crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            self.register(task_ptr);
-            true
-        })
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // SAFETY: task_ptr is alive because `register` ref_inc'd
-                // before storing — that ref keeps the task allocated
-                // through the dispatch (see BUG-2 #168).
-                let ctx = unsafe { &*self.cross_ctx };
-                unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
-
-                // BUG-2 fix: release the ref `register` acquired. AFTER
-                // wake_task_cross_thread so the task is alive for its deref.
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-
-    /// Clear the stored waker if one exists. Used by RecvFut::Drop to
-    /// prevent use-after-free when the recv task completes while a
-    /// sender on another thread may try to wake through the stale ptr.
-    fn clear(&self) {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // BUG-2 fix: release the ref `register` acquired.
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-impl Drop for RxWakerSlot {
-    fn drop(&mut self) {
-        // BUG-2 (#168) fix: if still registered when dropped, release
-        // our ref. See mpsc.rs for the full rationale.
-        if *self.state.get_mut() == STORED {
-            let task_ptr = *self.task_ptr.get_mut();
-            if !task_ptr.is_null() {
-                // SAFETY: we own the ref from `register`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-/// Release the slot's ref on `task_ptr`. If terminal, route via
-/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
-/// for the full design rationale — this is the identical pattern.
-///
-/// `cross_ctx` is unused here (dispose_terminal reads ctx from the task
-/// header); kept on the signature for PR 1a consistency.
-///
-/// # Safety
-///
-/// `task_ptr` must point to a task on which `register` previously called
-/// `ref_inc`.
-unsafe fn release_slot_ref(
-    task_ptr: *mut u8,
-    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
-) {
-    match unsafe { crate::task::ref_dec(task_ptr) } {
-        crate::task::FreeAction::Retain => {}
-        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: task_ptr was alive until ref_dec; on terminal it's
-            // still alive (dispose_terminal does the routing).
-            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
-        }
-    }
-}
-
-/// Fallback waker for non-runtime wakers (root future).
-struct FallbackWaker {
-    state: AtomicU8,
-    waker: UnsafeCell<Option<Waker>>,
-}
-
-unsafe impl Send for FallbackWaker {}
-unsafe impl Sync for FallbackWaker {}
-
-impl FallbackWaker {
-    fn new() -> Self {
-        Self {
-            state: AtomicU8::new(EMPTY),
-            waker: UnsafeCell::new(None),
-        }
-    }
-
-    fn register(&self, waker: &Waker) {
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-        unsafe { *self.waker.get() = Some(waker.clone()) };
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            if let Some(w) = unsafe { (*self.waker.get()).take() } {
-                w.wake();
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-}
-
-impl Drop for FallbackWaker {
-    fn drop(&mut self) {
-        *self.waker.get_mut() = None;
-    }
-}
 
 /// Sender waker slot — single sender, no intrusive list needed.
 struct TxWakerSlot {
@@ -289,7 +97,7 @@ struct Inner<T> {
     producer: nexus_queue::spsc::Producer<T>,
     consumer: nexus_queue::spsc::Consumer<T>,
 
-    rx_slot: RxWakerSlot,
+    rx_slot: TaskWakerSlot,
     rx_fallback: FallbackWaker,
     tx_waker: TxWakerSlot,
 
@@ -338,7 +146,7 @@ pub fn channel<T: Send>(capacity: usize) -> (Sender<T>, Receiver<T>) {
 
     let (producer, consumer) = nexus_queue::spsc::ring_buffer(capacity);
 
-    let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+    let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
     let inner = Arc::new(Inner {
         producer,
@@ -504,7 +312,7 @@ pub struct RecvFut<'a, T> {
 
 impl<T> Drop for RecvFut<'_, T> {
     fn drop(&mut self) {
-        // Clear the RxWakerSlot to prevent use-after-free: if a sender on
+        // Clear the TaskWakerSlot to prevent use-after-free: if a sender on
         // another thread calls wake() after this recv future is dropped,
         // it would read a dangling task pointer. The CAS ensures mutual
         // exclusion with the sender's wake() CAS on the same slot.
@@ -570,7 +378,7 @@ mod tests {
         });
 
         let (producer, consumer) = nexus_queue::spsc::ring_buffer(capacity);
-        let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
         let inner = Arc::new(Inner {
             producer,
@@ -710,191 +518,30 @@ mod tests {
 }
 
 // =============================================================================
-// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// BUG-2 (#168) — cross-thread wake-path UAF regression tests
 // =============================================================================
 //
-// See `mpsc.rs::uaf_tests` for the full rationale. This file's
-// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+// Tests live in `crate::cross_wake::uaf_scenarios` (one canonical body
+// per scenario, shared across all four channels). These per-channel
+// `#[test]` wrappers exist for `cargo test spsc::uaf_tests` output
+// visibility and to verify the consolidated `TaskWakerSlot` works
+// identically across channel modules.
 #[cfg(test)]
 mod uaf_tests {
-    use super::*;
-    use crate::cross_wake::wake_task_cross_thread;
-    use crate::task::{self, FreeAction, Task};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
-    use std::task::{Context, Poll};
-
-    struct UafNoop;
-    impl Future for UafNoop {
-        type Output = ();
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
-            Poll::Ready(())
-        }
-    }
-
-    fn make_uaf_task() -> *mut u8 {
-        let task = Box::new(Task::new_boxed(UafNoop, 0));
-        Box::into_raw(task) as *mut u8
-    }
-
-    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
-        let poll = mio::Poll::new().unwrap();
-        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
-        Arc::new(crate::cross_wake::CrossWakeContext {
-            queue: crate::cross_wake::CrossWakeQueue::new(),
-            mio_waker,
-            parked: AtomicBool::new(false),
-        })
-    }
+    use crate::cross_wake::uaf_scenarios as h;
 
     #[test]
     fn waker_slot_uaf_when_task_freed_mid_dispatch() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-
-        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
-            FreeAction::FreeBox => {
-                // PRE-FIX path: under regular cargo test, fail early
-                // (avoid segfault from the deref below). Under miri,
-                // trigger the UAF so the diagnostic trace fires.
-                #[cfg(not(miri))]
-                panic!(
-                    "BUG-2 regression detected: register skipped ref_inc. \
-                     Run under miri for the full UAF trace."
-                );
-                #[cfg(miri)]
-                {
-                    unsafe { task::free_task(task_ptr) };
-                    true
-                }
-            }
-            FreeAction::Retain => false,
-            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
-        };
-
-        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
-
-        if !pre_fix {
-            match unsafe { task::ref_dec(captured) } {
-                FreeAction::FreeBox => unsafe { task::free_task(captured) },
-                _ => panic!("post-fix cleanup must terminate the box task"),
-            }
-        }
-
-        drop(slot);
+        h::waker_slot_uaf_when_task_freed_mid_dispatch();
     }
 
-    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
-    /// because `register` skips ref_inc and there's no Drop impl. PASSES
-    /// post-fix because register ref_incs and Drop ref_decs.
     #[test]
     fn slot_drop_releases_ref_when_still_registered() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-        let after_register = unsafe { task::ref_count(task_ptr) };
-
-        drop(slot);
-        let after_drop = unsafe { task::ref_count(task_ptr) };
-
-        assert_eq!(
-            after_register,
-            after_drop + 1,
-            "Post-fix Drop must release the ref that register acquired."
-        );
-        assert_eq!(
-            after_register,
-            baseline_refcount + 1,
-            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
-        );
-
-        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
-        let action = unsafe { task::ref_dec(task_ptr) };
-        match action {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
-        }
+        h::slot_drop_releases_ref_when_still_registered();
     }
 
-    /// Race regression for John's review item 1 (BUG-2 follow-up).
-    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
-    /// for the full design notes.
     #[test]
     fn register_during_wake_does_not_leak_ref() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "initial register must take a ref"
-        );
-
-        // Wake first half: CAS only.
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-
-        // Race: re-register during the wake window.
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
-        );
-
-        // Wake second half: swap + release.
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
-        );
-
-        drop(slot);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "Drop on STORED-but-null slot is a no-op for refcount"
-        );
-
-        match unsafe { task::ref_dec(task_ptr) } {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox, got {other:?}"),
-        }
+        h::register_during_wake_does_not_leak_ref();
     }
 }

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -33,205 +33,16 @@ use std::task::{Poll, Waker};
 
 use std::ops::{Deref, DerefMut};
 
-// =============================================================================
-// Waker primitives (same pattern as spsc typed channel)
-// =============================================================================
+use crate::cross_wake::{FallbackWaker, TaskWakerSlot};
 
+// Local state constants used by `TxWakerSlot` below. (TaskWakerSlot's
+// constants moved to `cross_wake` with the slot consolidation in PR
+// 1b. TxWakerSlot is single-sender / single-receiver — out of scope
+// for the cross-thread slot consolidation since it's not duplicated
+// across all channels — and keeps its own copy.)
 const EMPTY: u8 = 0;
 const STORED: u8 = 1;
 const REGISTERING: u8 = 2;
-
-struct RxWakerSlot {
-    task_ptr: std::sync::atomic::AtomicPtr<u8>,
-    cross_ctx: *const crate::cross_wake::CrossWakeContext,
-    state: AtomicU8,
-}
-
-unsafe impl Send for RxWakerSlot {}
-unsafe impl Sync for RxWakerSlot {}
-
-impl RxWakerSlot {
-    fn new(cross_ctx: *const crate::cross_wake::CrossWakeContext) -> Self {
-        Self {
-            task_ptr: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            cross_ctx,
-            state: AtomicU8::new(EMPTY),
-        }
-    }
-
-    /// Register the receiver's task pointer. Single-registerer only.
-    fn register(&self, task_ptr: *mut u8) {
-        debug_assert!(
-            !task_ptr.is_null(),
-            "RxWakerSlot::register called with null task_ptr"
-        );
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-
-        // BUG-2 (#168) fix: hold a refcount on the task while
-        // registered so a sender that captures the pointer
-        // mid-`wake()` can't have it freed underneath. Matched by
-        // ref_dec in wake/clear/Drop.
-        // SAFETY: caller (RecvFut::poll) just received task_ptr from
-        // the active receiver task whose refcount is >= 1; the
-        // debug_assert above catches the null case in development.
-        unsafe { crate::task::ref_inc(task_ptr) };
-
-        // Release any prior registration's ref. Always check prev_ptr —
-        // not gated on `prev == STORED` — because a sender's `wake()` CAS
-        // may have transitioned state STORED→EMPTY without yet taking
-        // the task_ptr (the swap is the second step). In that race
-        // window, prev_ptr is still non-null even though state was
-        // EMPTY. Skipping the release leaks the ref. (BUG-2 follow-up.)
-        //
-        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
-        // we own that ref now and must release it.
-        let prev_ptr = self.task_ptr.swap(task_ptr, Ordering::AcqRel);
-        if !prev_ptr.is_null() {
-            unsafe { release_slot_ref(prev_ptr, self.cross_ctx) };
-        }
-
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn try_register_local(&self, waker: &Waker) -> bool {
-        crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
-            self.register(task_ptr);
-            true
-        })
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // SAFETY: task_ptr is alive because `try_register_local`
-                // ref_inc'd before storing — that ref keeps the task
-                // allocated through the dispatch (see BUG-2 #168).
-                let ctx = unsafe { &*self.cross_ctx };
-                unsafe { crate::cross_wake::wake_task_cross_thread(task_ptr, ctx) };
-
-                // BUG-2 fix: release the ref `try_register_local`
-                // acquired. AFTER wake_task_cross_thread so the task is
-                // alive for its deref.
-                // SAFETY: we own the ref from `try_register_local`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-
-    fn clear(&self) {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-            if !task_ptr.is_null() {
-                // BUG-2 fix: release the ref `try_register_local` acquired.
-                // SAFETY: we own the ref.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-impl Drop for RxWakerSlot {
-    fn drop(&mut self) {
-        // BUG-2 (#168) fix: if still registered when dropped, release
-        // our ref. See mpsc.rs for the full rationale.
-        if *self.state.get_mut() == STORED {
-            let task_ptr = *self.task_ptr.get_mut();
-            if !task_ptr.is_null() {
-                // SAFETY: we own the ref from `try_register_local`.
-                unsafe { release_slot_ref(task_ptr, self.cross_ctx) };
-            }
-        }
-    }
-}
-
-/// Release the slot's ref on `task_ptr`. If terminal, route via
-/// [`crate::cross_wake::dispose_terminal`]. See `mpsc::release_slot_ref`
-/// for the full design rationale.
-///
-/// `cross_ctx` is unused (dispose_terminal reads ctx from the task
-/// header); kept on the signature for PR 1a consistency.
-///
-/// # Safety
-///
-/// `task_ptr` must point to a task on which `try_register_local`
-/// previously called `ref_inc`.
-unsafe fn release_slot_ref(
-    task_ptr: *mut u8,
-    _cross_ctx: *const crate::cross_wake::CrossWakeContext,
-) {
-    match unsafe { crate::task::ref_dec(task_ptr) } {
-        crate::task::FreeAction::Retain => {}
-        crate::task::FreeAction::FreeBox | crate::task::FreeAction::FreeSlab => {
-            // SAFETY: task_ptr was alive until ref_dec; terminal but
-            // not yet freed (dispose_terminal does the routing).
-            unsafe { crate::cross_wake::dispose_terminal(task_ptr) };
-        }
-    }
-}
-
-struct FallbackWaker {
-    state: AtomicU8,
-    waker: UnsafeCell<Option<Waker>>,
-}
-
-unsafe impl Send for FallbackWaker {}
-unsafe impl Sync for FallbackWaker {}
-
-impl FallbackWaker {
-    fn new() -> Self {
-        Self {
-            state: AtomicU8::new(EMPTY),
-            waker: UnsafeCell::new(None),
-        }
-    }
-
-    fn register(&self, waker: &Waker) {
-        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
-        debug_assert_ne!(prev, REGISTERING);
-        unsafe { *self.waker.get() = Some(waker.clone()) };
-        self.state.store(STORED, Ordering::Release);
-    }
-
-    fn wake(&self) -> bool {
-        if self
-            .state
-            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            if let Some(w) = unsafe { (*self.waker.get()).take() } {
-                w.wake();
-                return true;
-            }
-        }
-        false
-    }
-
-    fn has_waker(&self) -> bool {
-        self.state.load(Ordering::Acquire) == STORED
-    }
-}
-
-impl Drop for FallbackWaker {
-    fn drop(&mut self) {
-        *self.waker.get_mut() = None;
-    }
-}
 
 struct TxWakerSlot {
     state: AtomicU8,
@@ -286,7 +97,7 @@ impl Drop for TxWakerSlot {
 // =============================================================================
 
 struct Inner {
-    rx_slot: RxWakerSlot,
+    rx_slot: TaskWakerSlot,
     rx_fallback: FallbackWaker,
     tx_waker: TxWakerSlot,
     _cross_wake_owner: Arc<crate::cross_wake::CrossWakeContext>,
@@ -472,7 +283,7 @@ pub fn channel(capacity: usize) -> (Sender, Receiver) {
         .expect("spsc_bytes::channel() requires runtime context");
 
     let (producer, consumer) = nexus_logbuf::queue::spsc::new(capacity);
-    let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+    let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
     let inner = Arc::new(Inner {
         rx_slot,
@@ -686,7 +497,7 @@ mod tests {
         });
 
         let (producer, consumer) = nexus_logbuf::queue::spsc::new(capacity);
-        let rx_slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        let rx_slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
 
         let inner = Arc::new(Inner {
             rx_slot,
@@ -829,191 +640,30 @@ mod tests {
 }
 
 // =============================================================================
-// BUG-2 (#168) — UAF white-box test, same shape as mpsc.rs
+// BUG-2 (#168) — cross-thread wake-path UAF regression tests
 // =============================================================================
 //
-// See `mpsc.rs::uaf_tests` for the full rationale. This file's
-// `RxWakerSlot` shares the same fix and is verified by the same scenario.
+// Tests live in `crate::cross_wake::uaf_scenarios` (one canonical body
+// per scenario, shared across all four channels). These per-channel
+// `#[test]` wrappers exist for `cargo test spsc_bytes::uaf_tests`
+// output visibility and to verify the consolidated `TaskWakerSlot`
+// works identically across channel modules.
 #[cfg(test)]
 mod uaf_tests {
-    use super::*;
-    use crate::cross_wake::wake_task_cross_thread;
-    use crate::task::{self, FreeAction, Task};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
-    use std::task::{Context, Poll};
-
-    struct UafNoop;
-    impl Future for UafNoop {
-        type Output = ();
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
-            Poll::Ready(())
-        }
-    }
-
-    fn make_uaf_task() -> *mut u8 {
-        let task = Box::new(Task::new_boxed(UafNoop, 0));
-        Box::into_raw(task) as *mut u8
-    }
-
-    fn make_uaf_cross_ctx() -> Arc<crate::cross_wake::CrossWakeContext> {
-        let poll = mio::Poll::new().unwrap();
-        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
-        Arc::new(crate::cross_wake::CrossWakeContext {
-            queue: crate::cross_wake::CrossWakeQueue::new(),
-            mio_waker,
-            parked: AtomicBool::new(false),
-        })
-    }
+    use crate::cross_wake::uaf_scenarios as h;
 
     #[test]
     fn waker_slot_uaf_when_task_freed_mid_dispatch() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-
-        let pre_fix = match unsafe { task::complete_and_unref(task_ptr) } {
-            FreeAction::FreeBox => {
-                // PRE-FIX path: under regular cargo test, fail early
-                // (avoid segfault from the deref below). Under miri,
-                // trigger the UAF so the diagnostic trace fires.
-                #[cfg(not(miri))]
-                panic!(
-                    "BUG-2 regression detected: register skipped ref_inc. \
-                     Run under miri for the full UAF trace."
-                );
-                #[cfg(miri)]
-                {
-                    unsafe { task::free_task(task_ptr) };
-                    true
-                }
-            }
-            FreeAction::Retain => false,
-            FreeAction::FreeSlab => panic!("box test must not yield FreeSlab"),
-        };
-
-        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
-
-        if !pre_fix {
-            match unsafe { task::ref_dec(captured) } {
-                FreeAction::FreeBox => unsafe { task::free_task(captured) },
-                _ => panic!("post-fix cleanup must terminate the box task"),
-            }
-        }
-
-        drop(slot);
+        h::waker_slot_uaf_when_task_freed_mid_dispatch();
     }
 
-    /// Sensitive to the fix via explicit refcount assertions. FAILS pre-fix
-    /// because `register` skips ref_inc and there's no Drop impl. PASSES
-    /// post-fix because register ref_incs and Drop ref_decs.
     #[test]
     fn slot_drop_releases_ref_when_still_registered() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-        slot.register(task_ptr);
-        let after_register = unsafe { task::ref_count(task_ptr) };
-
-        drop(slot);
-        let after_drop = unsafe { task::ref_count(task_ptr) };
-
-        assert_eq!(
-            after_register,
-            after_drop + 1,
-            "Post-fix Drop must release the ref that register acquired."
-        );
-        assert_eq!(
-            after_register,
-            baseline_refcount + 1,
-            "Post-fix register must bump refcount by 1 — BUG-2 root cause."
-        );
-
-        // Cleanup: refcount = 1 + COMPLETED → final ref_dec yields FreeBox.
-        let action = unsafe { task::ref_dec(task_ptr) };
-        match action {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
-        }
+        h::slot_drop_releases_ref_when_still_registered();
     }
 
-    /// Race regression for John's review item 1 (BUG-2 follow-up).
-    /// See `mpsc.rs::uaf_tests::register_during_wake_does_not_leak_ref`
-    /// for the full design notes.
     #[test]
     fn register_during_wake_does_not_leak_ref() {
-        let cross_ctx = make_uaf_cross_ctx();
-        let task_ptr = make_uaf_task();
-
-        unsafe { task::ref_inc(task_ptr) };
-        let action = unsafe { task::complete_and_unref(task_ptr) };
-        assert!(matches!(action, FreeAction::Retain));
-        let baseline = unsafe { task::ref_count(task_ptr) };
-        assert_eq!(baseline, 1);
-
-        let slot = RxWakerSlot::new(Arc::as_ptr(&cross_ctx));
-
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "initial register must take a ref"
-        );
-
-        // Wake first half: CAS only.
-        assert!(
-            slot.state
-                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-        );
-
-        // Race: re-register during the wake window.
-        slot.register(task_ptr);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline + 1,
-            "race register must net to baseline+1; pre-fix this is baseline+2 (the leak)"
-        );
-
-        // Wake second half: swap + release.
-        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
-        assert_eq!(captured, task_ptr);
-        unsafe { release_slot_ref(captured, Arc::as_ptr(&cross_ctx)) };
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "post-wake refcount must be at baseline; pre-fix this is baseline+1"
-        );
-
-        drop(slot);
-        assert_eq!(
-            unsafe { task::ref_count(task_ptr) },
-            baseline,
-            "Drop on STORED-but-null slot is a no-op for refcount"
-        );
-
-        match unsafe { task::ref_dec(task_ptr) } {
-            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
-            other => panic!("expected FreeBox, got {other:?}"),
-        }
+        h::register_during_wake_does_not_leak_ref();
     }
 }

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -451,8 +451,8 @@ pub(crate) unsafe fn wake_task_cross_thread(task_ptr: *mut u8, ctx: &CrossWakeCo
 //    derefs `task_ptr` (`is_completed`); releasing first risks the deref
 //    hitting freed memory if our release was the terminal ref.
 
-/// Shared wakeslot state values. `pub(crate)` because both
-/// `TaskWakerSlot` and `FallbackWaker` use them.
+/// Shared wakeslot state values. Private to this module — both
+/// `TaskWakerSlot` and `FallbackWaker` (defined below) use them.
 const EMPTY: u8 = 0;
 const STORED: u8 = 1;
 const REGISTERING: u8 = 2;

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -413,6 +413,563 @@ pub(crate) unsafe fn wake_task_cross_thread(task_ptr: *mut u8, ctx: &CrossWakeCo
 }
 
 // =============================================================================
+// Shared waker slots — used by all channel modules
+// =============================================================================
+//
+// `TaskWakerSlot`: cross-thread receiver waker slot. Holds one refcount
+// unit on the registered task (TaskRef-equivalent semantics — the slot's
+// `task_ptr` field semantically owns one ref). Used by the receiver side
+// of every channel (`mpsc`, `spsc`, `mpsc_bytes`, `spsc_bytes`).
+//
+// `FallbackWaker`: storage for non-runtime wakers (root future, foreign
+// wakers). Used when `TaskWakerSlot::try_register_local` returns false.
+//
+// Pre-PR-1b these were duplicated across the four channel modules. PR
+// 1b consolidates to one definition each, shared via `pub(crate)` from
+// this module.
+//
+// **CRITICAL invariants** (any future change to these types must
+// preserve them — see PR 1a + PR 1b plans for context):
+//
+// 1. `TaskWakerSlot::register` ALWAYS releases `prev_ptr` when non-null,
+//    regardless of `state` value. A sender's `wake()` CAS may have
+//    transitioned state STORED→EMPTY without yet taking `task_ptr` (the
+//    swap is the second step). In that race window `prev_ptr` is
+//    non-null even though state was EMPTY when register observed it.
+//    Skipping the release leaks the ref. (BUG-2 follow-up — found by
+//    John in PR 1a review. The
+//    `register_during_wake_does_not_leak_ref` test orchestrates exactly
+//    this race.)
+//
+// 2. `TaskWakerSlot::wake` dispatches BEFORE releasing the ref:
+//    (a) CAS state STORED→EMPTY,
+//    (b) swap `task_ptr` to null (slot transfers ownership to caller),
+//    (c) call `wake_task_cross_thread` — uses the ref but doesn't
+//        consume it,
+//    (d) drop the TaskRef (via `from_owned`).
+//    Steps (c) and (d) MUST stay in this order. `wake_task_cross_thread`
+//    derefs `task_ptr` (`is_completed`); releasing first risks the deref
+//    hitting freed memory if our release was the terminal ref.
+
+/// Shared wakeslot state values. `pub(crate)` because both
+/// `TaskWakerSlot` and `FallbackWaker` use them.
+const EMPTY: u8 = 0;
+const STORED: u8 = 1;
+const REGISTERING: u8 = 2;
+
+/// Cross-thread receiver waker slot. Zero-alloc, lives in each channel's
+/// `Inner`, pointed to by `RawWaker::data`.
+///
+/// Holds one refcount unit on the registered task. Senders observe
+/// `task_ptr` and atomically swap it during `wake()`; the receiver
+/// registers/clears it during `RecvFut::poll`/`RecvFut::Drop`.
+pub(crate) struct TaskWakerSlot {
+    /// Task pointer to wake. Written by receiver, read by senders.
+    task_ptr: AtomicPtr<u8>,
+    /// Raw pointer to the `CrossWakeContext`. Set once at channel
+    /// creation. Used by `wake()` to enqueue the cross-thread wake.
+    /// NOT used for terminal-drop routing — the dropped TaskRef reads
+    /// ctx from the task header instead.
+    cross_ctx: *const CrossWakeContext,
+    /// State: EMPTY / STORED / REGISTERING. Coordinates concurrent
+    /// register/wake/clear access.
+    state: std::sync::atomic::AtomicU8,
+}
+
+// SAFETY: All fields are atomic or immutable after creation.
+unsafe impl Send for TaskWakerSlot {}
+unsafe impl Sync for TaskWakerSlot {}
+
+impl TaskWakerSlot {
+    pub(crate) fn new(cross_ctx: *const CrossWakeContext) -> Self {
+        Self {
+            task_ptr: AtomicPtr::new(std::ptr::null_mut()),
+            cross_ctx,
+            state: std::sync::atomic::AtomicU8::new(EMPTY),
+        }
+    }
+
+    /// Register the receiver's task pointer. Called by `RecvFut::poll`.
+    /// Single-registerer only.
+    pub(crate) fn register(&self, task_ptr: *mut u8) {
+        debug_assert!(
+            !task_ptr.is_null(),
+            "TaskWakerSlot::register called with null task_ptr — \
+             contract violation by caller (typically RecvFut::poll)"
+        );
+        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
+        debug_assert_ne!(prev, REGISTERING, "concurrent register on TaskWakerSlot");
+
+        // BUG-2 (#168) fix: hold a refcount on the task while registered
+        // so a sender that captures the pointer mid-`wake()` can't have
+        // it freed underneath. The matching `ref_dec` happens in `wake`
+        // (after `wake_task_cross_thread` returns), `clear`, or `Drop`.
+        // SAFETY: caller (RecvFut::poll) just received task_ptr from the
+        // active receiver task whose refcount is >= 1; the debug_assert
+        // above catches the null case in development.
+        let task_ref = unsafe { crate::task::TaskRef::acquire(task_ptr) };
+        let ptr = task_ref.as_ptr();
+        std::mem::forget(task_ref); // slot's AtomicPtr now owns the ref
+
+        // Release any prior registration's ref. Always check prev_ptr —
+        // not gated on `prev == STORED` — because a sender's `wake()`
+        // CAS may have transitioned state STORED→EMPTY without yet
+        // taking the task_ptr (the swap is the second step). In that
+        // race window, prev_ptr is still non-null even though state was
+        // EMPTY when we observed it. Skipping the release leaks the
+        // ref. (BUG-2 follow-up — found by John in PR review.)
+        //
+        // SAFETY: prev_ptr (if non-null) was registered with a ref_inc;
+        // we own that ref now and must release it via TaskRef::Drop →
+        // dispose_terminal. wake/clear/Drop operate on the new pointer
+        // we just stored — both refs are tracked correctly in all
+        // interleavings.
+        let prev_ptr = self.task_ptr.swap(ptr, Ordering::AcqRel);
+        if !prev_ptr.is_null() {
+            drop(unsafe { crate::task::TaskRef::from_owned(prev_ptr) });
+        }
+
+        self.state.store(STORED, Ordering::Release);
+    }
+
+    /// Try to register a local runtime waker. Returns true if the waker
+    /// is a local-runtime waker and was registered via the zero-alloc
+    /// slot. Returns false for foreign wakers (caller should fall back
+    /// to the `FallbackWaker` slot on Inner).
+    pub(crate) fn try_register_local(&self, waker: &std::task::Waker) -> bool {
+        crate::waker::task_ptr_from_local_waker(waker).is_some_and(|task_ptr| {
+            self.register(task_ptr);
+            true
+        })
+    }
+
+    /// Wake the receiver if registered. Called by senders from any
+    /// thread. Returns true if a wake was actually delivered.
+    ///
+    /// PRESERVES dispatch-before-release ordering — see CRITICAL
+    /// invariant 2 at the top of this section.
+    pub(crate) fn wake(&self) -> bool {
+        if self
+            .state
+            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // Push to cross-thread inbox + conditional eventfd poke.
+                // SAFETY: cross_ctx is valid for the lifetime of the
+                // channel. task_ptr is alive because `register`
+                // ref_inc'd before storing — that ref keeps the task
+                // allocated through the dispatch (see BUG-2 #168).
+                let ctx = unsafe { &*self.cross_ctx };
+                unsafe { wake_task_cross_thread(task_ptr, ctx) };
+
+                // BUG-2 fix: release the ref `register` acquired. Must
+                // happen AFTER `wake_task_cross_thread` returns so the
+                // task is alive for the deref inside it.
+                // SAFETY: we own the ref from `register`.
+                drop(unsafe { crate::task::TaskRef::from_owned(task_ptr) });
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn has_waker(&self) -> bool {
+        self.state.load(Ordering::Acquire) == STORED
+    }
+
+    /// Clear the stored waker if one exists. Used by `RecvFut::Drop` to
+    /// prevent use-after-free when the recv task completes while a
+    /// sender on another thread may try to wake through the stale ptr.
+    pub(crate) fn clear(&self) {
+        if self
+            .state
+            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            let task_ptr = self.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+            if !task_ptr.is_null() {
+                // BUG-2 fix: release the ref `register` acquired.
+                // SAFETY: we own the ref from `register`.
+                drop(unsafe { crate::task::TaskRef::from_owned(task_ptr) });
+            }
+        }
+    }
+}
+
+impl Drop for TaskWakerSlot {
+    fn drop(&mut self) {
+        // BUG-2 (#168) fix: if still registered when dropped, release
+        // our ref. Slot drops when channel `Inner` drops — both sides
+        // of the channel are gone, so any registered receiver task can
+        // no longer be woken via this slot. Releasing the ref here
+        // matches the wake/clear release paths.
+        //
+        // &mut self gives exclusive access; no concurrent mutator.
+        if *self.state.get_mut() == STORED {
+            let task_ptr = *self.task_ptr.get_mut();
+            if !task_ptr.is_null() {
+                // SAFETY: we own the ref from `register`.
+                drop(unsafe { crate::task::TaskRef::from_owned(task_ptr) });
+            }
+        }
+    }
+}
+
+/// Fallback waker storage for non-runtime wakers (root future, foreign).
+/// Used when `TaskWakerSlot::try_register_local` returns false.
+pub(crate) struct FallbackWaker {
+    state: std::sync::atomic::AtomicU8,
+    waker: UnsafeCell<Option<std::task::Waker>>,
+}
+
+unsafe impl Send for FallbackWaker {}
+unsafe impl Sync for FallbackWaker {}
+
+impl FallbackWaker {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: std::sync::atomic::AtomicU8::new(EMPTY),
+            waker: UnsafeCell::new(None),
+        }
+    }
+
+    pub(crate) fn register(&self, waker: &std::task::Waker) {
+        let prev = self.state.swap(REGISTERING, Ordering::Acquire);
+        debug_assert_ne!(prev, REGISTERING);
+        unsafe { *self.waker.get() = Some(waker.clone()) };
+        self.state.store(STORED, Ordering::Release);
+    }
+
+    pub(crate) fn wake(&self) -> bool {
+        if self
+            .state
+            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            let waker = unsafe { (*self.waker.get()).take() };
+            if let Some(w) = waker {
+                w.wake();
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn has_waker(&self) -> bool {
+        self.state.load(Ordering::Acquire) == STORED
+    }
+}
+
+impl Drop for FallbackWaker {
+    fn drop(&mut self) {
+        *self.waker.get_mut() = None;
+    }
+}
+
+// =============================================================================
+// Cross-thread waker test scenarios — shared by all four channels' uaf_tests
+// =============================================================================
+//
+// Pre-PR-1b: the 3 scenarios below were duplicated 4x (once per channel)
+// with channel-specific `RxWakerSlot` types. After consolidation to the
+// shared `TaskWakerSlot`, the bodies become identical — they all call
+// the same `TaskWakerSlot` API. This module owns the canonical bodies;
+// each channel's `mod uaf_tests` becomes 3 thin `#[test] fn` wrappers
+// calling these scenarios.
+//
+// Why in-crate (`#[cfg(test)] pub(crate) mod`) instead of an integration
+// test in `tests/cross_thread_harness.rs` (per PR 1b plan): the
+// scenarios poke `TaskWakerSlot` internal fields (`state`,
+// `task_ptr`) and call private helpers. Integration tests can only see
+// `pub` items, which would force unacceptable test-only public API
+// surface on `TaskWakerSlot`. The plan acknowledged this alternative
+// ("a shared `#[cfg(test)] mod` inside `cross_wake.rs`") — taking it
+// for the surface-leak reason.
+#[cfg(test)]
+pub(crate) mod uaf_scenarios {
+    use super::*;
+    use crate::task::{self, FreeAction, Task, TaskRef};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicBool;
+    use std::task::{Context, Poll};
+
+    struct UafNoop;
+    impl Future for UafNoop {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Ready(())
+        }
+    }
+
+    fn make_uaf_task() -> *mut u8 {
+        // Refcount = 1 (single executor-style ref) per Task::new_boxed.
+        let task = Box::new(Task::new_boxed(UafNoop, 0));
+        Box::into_raw(task) as *mut u8
+    }
+
+    fn make_uaf_cross_ctx() -> Arc<CrossWakeContext> {
+        let poll = mio::Poll::new().unwrap();
+        let mio_waker = Arc::new(mio::Waker::new(poll.registry(), mio::Token(usize::MAX)).unwrap());
+        Arc::new(CrossWakeContext {
+            queue: CrossWakeQueue::new(),
+            mio_waker,
+            parked: AtomicBool::new(false),
+        })
+    }
+
+    /// Reproduces BUG-2: sender derefs the task pointer after the
+    /// receiver task has been freed.
+    ///
+    /// Pre-fix: the call to `wake_task_cross_thread(captured, ...)`
+    /// reads task state from freed memory. Tree-borrows miri flags
+    /// this. The exact failure surface depends on which read miri
+    /// trips on first (`is_completed` is the first deref).
+    ///
+    /// Post-fix: `register` ref_incs (refcount goes 1→2), so
+    /// `complete_and_unref` returns `Retain` instead of `FreeBox`. The
+    /// task allocation is alive when the sender derefs it; the deref
+    /// reads `COMPLETED` and the function returns early. The slot's
+    /// `Drop` then releases the final ref, freeing the task cleanly.
+    pub(crate) fn waker_slot_uaf_when_task_freed_mid_dispatch() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Sanity: starting refcount is 1 (Task::new_boxed initial state).
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            1,
+            "make_uaf_task should produce refcount=1"
+        );
+
+        // Construct the slot pointing at the cross-wake context, then
+        // register the task pointer — this is the operation under test.
+        let slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+
+        // Mirror the sender's first half of `slot.wake()`: CAS state
+        // STORED→EMPTY, swap the pointer out. After this, the sender
+        // owns the captured pointer and is about to call
+        // `wake_task_cross_thread`.
+        assert!(
+            slot.state
+                .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok(),
+            "slot was registered; CAS STORED→EMPTY must succeed"
+        );
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+
+        // Simulate "select resolved on the other arm during the
+        // dispatch window": the executor calls `complete_and_unref` on
+        // the task, which atomically sets COMPLETED and decrements the
+        // executor's ref. Pre-fix this is the last ref → FreeBox.
+        // Post-fix the slot still holds a ref → Retain.
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+
+        // Track which path we're on — the test must clean up differently
+        // pre-fix vs post-fix. Pre-fix: task is already freed below.
+        // Post-fix: task is still alive (slot's ref); we must release it
+        // ourselves at the end since the slot's `state` is EMPTY (we
+        // CAS'd it above), so any future `Drop`-time release won't fire.
+        let pre_fix = match action {
+            FreeAction::FreeBox => {
+                #[cfg(not(miri))]
+                panic!(
+                    "BUG-2 regression detected: register skipped ref_inc, \
+                     so complete_and_unref produced FreeBox instead of \
+                     Retain. Run under miri for the full UAF trace."
+                );
+                #[cfg(miri)]
+                {
+                    unsafe { task::free_task(task_ptr) };
+                    true
+                }
+            }
+            FreeAction::Retain => false,
+            FreeAction::FreeSlab => {
+                panic!("box-allocated test task must not produce FreeSlab");
+            }
+        };
+
+        // Sender continues with the captured pointer.
+        // PRE-FIX: derefs freed memory → tree-borrows UAF.
+        // POST-FIX: derefs alive task, observes COMPLETED, returns early.
+        unsafe { wake_task_cross_thread(captured, &cross_ctx) };
+
+        if !pre_fix {
+            // POST-FIX cleanup: release the slot's captured ref via
+            // TaskRef. In real code this is `wake()`'s drop after
+            // wake_task_cross_thread returns.
+            drop(unsafe { TaskRef::from_owned(captured) });
+            // captured was the only remaining ref; now freed. Don't
+            // touch task_ptr again.
+            drop(slot);
+            return;
+        }
+
+        // PRE-FIX cleanup path (reachable only under miri).
+        drop(slot);
+    }
+
+    /// Companion: a registered slot dropped without wake/clear must
+    /// release its ref via Drop. Otherwise the task allocation leaks.
+    ///
+    /// **Sensitive to the fix via explicit refcount assertions.** Pre-fix
+    /// this FAILS because no `Drop` impl exists on `TaskWakerSlot`,
+    /// so `register` doesn't take a ref and Drop doesn't release one.
+    /// PASSES post-fix because `register` ref_incs and Drop ref_decs.
+    pub(crate) fn slot_drop_releases_ref_when_still_registered() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Mark the task COMPLETED first via complete_and_unref. Bump the
+        // ref to 2 so complete_and_unref returns Retain (rather than
+        // freeing). After: refcount = 1, COMPLETED set.
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline_refcount = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
+
+        let slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
+        slot.register(task_ptr);
+        // Post-fix: register ref_inc → refcount = 2.
+        // Pre-fix: register did NOT ref_inc → refcount = 1.
+        let after_register = unsafe { task::ref_count(task_ptr) };
+
+        // Drop the slot WITHOUT calling wake() or clear().
+        // Post-fix: Drop sees state == STORED, ref_dec → refcount = 1, returns Retain.
+        // Pre-fix: no Drop impl → refcount unchanged.
+        drop(slot);
+        let after_drop = unsafe { task::ref_count(task_ptr) };
+
+        // The strengthened assertion: register-then-drop must net to
+        // zero change in refcount. Pre-fix register doesn't take a ref AND
+        // Drop doesn't release one, so this ALSO nets to zero — but the
+        // explicit `register-took-a-ref` check below catches the regression.
+        assert_eq!(
+            after_register,
+            after_drop + 1,
+            "Post-fix Drop must release the ref that register acquired. \
+             If this fires pre-fix (register skipped ref_inc), there's no \
+             Drop ref_dec to compensate, so the net is 0 instead of -1."
+        );
+        assert_eq!(
+            after_register,
+            baseline_refcount + 1,
+            "Post-fix register must bump refcount by 1. If this fires \
+             pre-fix, register skipped ref_inc — that's BUG-2's root cause."
+        );
+
+        // Cleanup: refcount is 1 (post-fix or pre-fix), COMPLETED set.
+        // Final ref_dec should return FreeBox; free the allocation.
+        let action = unsafe { task::ref_dec(task_ptr) };
+        match action {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+
+    /// Race regression for the BUG-2 follow-up.
+    ///
+    /// `register()` previously gated the prev-ref release on
+    /// `prev == STORED && !prev_ptr.is_null()`. That gate was wrong:
+    /// a sender's `wake()` first CAS's state STORED→EMPTY, THEN swaps
+    /// `task_ptr`. If a re-register interleaves between those two
+    /// steps it observes `prev == EMPTY` (CAS happened) but
+    /// `prev_ptr` is still non-null (swap hasn't happened) — the gate
+    /// skipped releasing the old ref, leaking it.
+    ///
+    /// The fix removes the `prev == STORED` part of the gate; we now
+    /// always release a non-null prev_ptr.
+    ///
+    /// This test drives the interleave manually and asserts refcount
+    /// returns to baseline. Pre-fix it lands at baseline+1 (leak).
+    pub(crate) fn register_during_wake_does_not_leak_ref() {
+        let cross_ctx = make_uaf_cross_ctx();
+        let task_ptr = make_uaf_task();
+
+        // Bump the ref so the test's manual ref_decs don't trigger
+        // free mid-test. After complete_and_unref, refcount = 1 with
+        // COMPLETED set — this is our baseline.
+        unsafe { task::ref_inc(task_ptr) };
+        let action = unsafe { task::complete_and_unref(task_ptr) };
+        assert!(matches!(action, FreeAction::Retain));
+        let baseline = unsafe { task::ref_count(task_ptr) };
+        assert_eq!(baseline, 1, "baseline must be 1 (executor-style ref)");
+
+        let slot = TaskWakerSlot::new(Arc::as_ptr(&cross_ctx));
+
+        // ---- T0: initial register ----
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "initial register must take a ref (slot owns +1)"
+        );
+
+        // ---- T1 wake (first half): CAS only, do NOT swap task_ptr yet ----
+        // Mirrors the entry of `wake()` paused mid-function. After
+        // this, state is EMPTY but task_ptr still points at task_ptr.
+        let cas_ok = slot
+            .state
+            .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok();
+        assert!(cas_ok, "wake's CAS must succeed when state is STORED");
+
+        // ---- T2: re-register (the race) ----
+        // Mirrors RecvFut::poll re-registering after a wake from
+        // another source (timer, parent select arm fired). Same task
+        // — same task_ptr. Pre-fix: register's gate sees prev==EMPTY,
+        // skips the release, leaks the old ref. Post-fix: release fires.
+        slot.register(task_ptr);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline + 1,
+            "race register must NET to baseline+1 (slot still owns one ref). \
+             Pre-fix the gate skipped the release of the original; this \
+             assertion would fire baseline+2 — the leak."
+        );
+
+        // ---- T1 wake (second half): swap task_ptr, release ----
+        // Skip wake_task_cross_thread — we're testing refcount balance,
+        // not the dispatch path. Drop the captured TaskRef (matches
+        // wake's release-after-dispatch semantics).
+        let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
+        assert_eq!(captured, task_ptr);
+        drop(unsafe { TaskRef::from_owned(captured) });
+
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "after wake's release, slot owes 0 refs to task. Pre-fix \
+             this is baseline+1 (the leaked original)."
+        );
+
+        // ---- Cleanup ----
+        // After the race, slot is in (state=STORED, task_ptr=null).
+        // Drop sees state=STORED but task_ptr is null, so it releases
+        // nothing — confirms the Drop impl correctly handles this
+        // benign "post-race" inconsistency.
+        drop(slot);
+        assert_eq!(
+            unsafe { task::ref_count(task_ptr) },
+            baseline,
+            "Drop on a STORED-but-null-task_ptr slot must be a no-op for refcount"
+        );
+
+        // Final ref_dec → FreeBox.
+        match unsafe { task::ref_dec(task_ptr) } {
+            FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
+            other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
+        }
+    }
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -306,6 +306,80 @@ pub struct Runtime {
     _not_thread_safe: PhantomData<*const ()>,
 }
 
+// =============================================================================
+// Runtime field ordering — invariants
+// =============================================================================
+//
+// Field declaration order in `struct Runtime` is load-bearing. Each
+// field has a position relative to others enforced by the requirements
+// below. Rust's default layout doesn't guarantee declaration order,
+// but `#[repr(C)]` + the `const _: ()` asserts below catch any
+// reordering at compile time regardless of layout.
+//
+// Order (top → bottom = first → last drop):
+//
+//   executor              ← drops first; frees tasks
+//   _cross_wake_tls_guard ← drops second; clears CURRENT_RUNTIME_CTX TLS
+//   io                    ← UnsafeCell, no Drop concerns
+//   timers                ← UnsafeCell, no Drop concerns
+//   ctx                   ← WorldCtx, holds raw pointer to user's World
+//   event_time            ← Cell<Instant>, trivial
+//   shutdown              ← clone of ShutdownHandle, has Arc inside
+//   cross_wake            ← Arc<CrossWakeContext>; off-thread holders may
+//                           still exist; Arc keeps it alive past Runtime drop
+//   cross_thread_drain_limit, event_interval ← trivial
+//   _slab_guard           ← MUST drop AFTER executor (invariant 1)
+//   _runtime_presence     ← MUST drop AFTER everything (invariant 3)
+//   _not_thread_safe      ← PhantomData, no Drop
+//
+// Invariants:
+//
+// 1. `_slab_guard` after `executor`
+//    Reason: BUG-1 (#167). When `Executor::drop` walks `all_tasks`
+//    and encounters slab-allocated survivors, it dispatches their
+//    `free_fn` through TLS. The TLS install lives on `_slab_guard`.
+//    If `_slab_guard` drops first, slab tasks see the no-slab panic
+//    stub.
+//    Enforced: `const _:` offset assert below (added pre-PR-1a).
+//
+// 2. `_cross_wake_tls_guard` after `executor`
+//    Reason: PR 1a. When `Executor::drop` walks `all_tasks` and
+//    triggers `TaskRef::Drop`, the terminal-drop routing in
+//    `dispose_terminal` reads `CURRENT_RUNTIME_CTX` to decide
+//    on-thread (defer) vs off-thread (queue). If `_cross_wake_tls_guard`
+//    drops first, the on-thread fast path silently misroutes terminal
+//    frees to the cross-queue, where nothing drains them — leak,
+//    OR for slab tasks, eventual UAF when `_slab_guard` releases
+//    the slab backing storage.
+//    FAILURE MODE: silent UAF in production for slab tasks.
+//    Enforced: `const _:` offset assert below (added in PR 1a).
+//
+// 3. `_runtime_presence` after everything else
+//    Reason: defensive. Some inner Drop impl might attempt to construct
+//    another Runtime mid-teardown. With `_runtime_presence` dropping
+//    last, the "Runtime alive" flag remains set, and that nested
+//    construction panics rather than silently corrupting TLS.
+//    Enforced: convention. No const_assert because there are too many
+//    fields to assert against; relies on the doc-block + code review.
+//
+// 4. `cross_wake` outlives off-thread holders implicitly via Arc
+//    Reason: cross-thread wakers (channel slots, tokio_compat) hold an
+//    Arc<CrossWakeContext>. The Arc keeps the queue alive after Runtime
+//    drops. When the LAST off-thread waker drops its Arc, the queue is
+//    finally freed. Off-thread `dispose_terminal` calling
+//    `try_set_queued + push` on a queue whose Runtime has been dropped
+//    is safe: the queue is alive, we push to it, but no consumer
+//    drains. The terminal task pointer leaks (memory, not UAF). PR 2
+//    §2.3's `ShutdownStats` will surface this as a counter.
+//
+// Adding new fields:
+// - Place trivial fields anywhere; non-trivial fields go to the
+//   bottom of the appropriate group.
+// - If your field has a Drop with cross-thread implications, document
+//   the invariant here AND add an `offset_of` assert next to the
+//   existing ones.
+// - When in doubt, add to the bottom and document.
+
 // BUG-1 (#167) invariant: `_slab_guard` MUST drop after `executor`.
 // Field drop order is declaration order, and offset is a proxy: a
 // later-declared field has a higher offset (modulo alignment padding,

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -78,7 +78,6 @@ const FLAG_MASK: usize = 0b11_1111;
 /// One reference count unit (bit 6).
 const REF_ONE: usize = 1 << 6;
 /// Mask for refcount bits (6+).
-#[allow(dead_code)]
 const REF_MASK: usize = !FLAG_MASK;
 
 /// Lifecycle flags: must be cleared before a task can reach terminal.
@@ -391,14 +390,6 @@ where
 /// The pointer is stable for the task's lifetime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct TaskId(pub(crate) *mut u8);
-
-impl TaskId {
-    /// Returns the raw pointer to the task.
-    #[allow(dead_code)]
-    pub(crate) fn as_ptr(&self) -> *mut u8 {
-        self.0
-    }
-}
 
 // =============================================================================
 // JoinHandle


### PR DESCRIPTION
## Summary

Second of four PRs in the `nexus-async-rt` hardening plan. Mechanical consolidation on top of PR 1a's foundation: `TaskWakerSlot` + `FallbackWaker` collapse from four duplicates to one, the white-box test scenarios collapse from twelve duplicate bodies to three canonical ones, and the runtime field-ordering invariants get a single discoverable doc-block.

**Public API unchanged.** Internal-only refactor.

Companion plan: `.claude/nexus-async-rt-hardening-plan-2026-05-03.md` (§1.3 + §1.4 + §1.5).
Council review: `.claude/review.md` (PR 1b sections).

## What's in this PR

### §1.3 — Shared `TaskWakerSlot` + `FallbackWaker`

- `TaskWakerSlot` (~250 LOC) and `FallbackWaker` (~50 LOC) consolidated into `cross_wake.rs` as `pub(crate)` types.
- Each channel module (`mpsc.rs`, `spsc.rs`, `mpsc_bytes.rs`, `spsc_bytes.rs`) deletes its local `RxWakerSlot` (~150 LOC each), `FallbackWaker` (~50 LOC each), and `release_slot_ref` (~30 LOC each).
- `Inner<T>` field type updated `RxWakerSlot` → `TaskWakerSlot`.
- `EMPTY/STORED/REGISTERING` constants deleted from `mpsc.rs` + `mpsc_bytes.rs`; kept in `spsc.rs` + `spsc_bytes.rs` because their `TxWakerSlot` (out of 1b scope, see below) still uses them.

### §1.4 — Unified white-box test scenarios

- Three canonical scenario bodies in `crate::cross_wake::uaf_scenarios` (~330 LOC). Ported verbatim from `mpsc.rs` (the most thoroughly commented version).
- Each channel's `mod uaf_tests` reduced to three thin `#[test]` wrappers calling `crate::cross_wake::uaf_scenarios::*`.
- Test name parity preserved: `cargo test mpsc::uaf_tests::*` etc. still resolves to the same names.
- Test count parity: 12 channel-uaf tests pre-1b → 12 post-1b (3 wrappers × 4 channels).

### §1.5 — Runtime field-ordering invariants doc-block

- Added at the top of `runtime.rs`'s `const _: ()` assert region. Documents all four known invariants with explicit failure modes:
  1. `_slab_guard` after `executor` (BUG-1, enforced by `const _:`)
  2. `_cross_wake_tls_guard` after `executor` (PR 1a invariant — **silent UAF** for slab tasks if violated, enforced by `const _:`)
  3. `_runtime_presence` last (defensive, convention only — no const_assert because too many fields to check against)
  4. `cross_wake` Arc lifetime via off-thread holders (runtime property, not layout)
- "Adding new fields" guidance for future contributors.

## Two CALLOUT invariants preserved verbatim

The consolidated `TaskWakerSlot` carries forward two load-bearing properties from the BUG-2 / BUG-2-followup fixes:

- **CALLOUT 1 — BUG-2 follow-up race fix in `register`** (`cross_wake.rs:514-530`). `prev_ptr` checked for null ALONE; the `prev` from `state.swap` is captured but intentionally NOT used in the gate. Verbatim BUG-2 follow-up comment block ported.
- **CALLOUT 2 — Dispatch-before-release in `wake`** (`cross_wake.rs:551-575`). Order preserved: CAS → swap → `wake_task_cross_thread` → `TaskRef::from_owned + drop`. Releasing first would risk the deref hitting freed memory if our release was the terminal ref.

A `CRITICAL invariants` block at `cross_wake.rs:431-452` documents both for future readers.

## Three Carl deviations from plan — all the right calls

### 1. Test harness lives inline, not in `tests/cross_thread_harness.rs`

Plan suggested an integration test in `tests/`. Carl found the forcing issue: the scenarios poke `TaskWakerSlot` internals (`state`, `task_ptr`) and use private constants (`EMPTY`, `STORED`). Integration tests can only see `pub` items, so the harness would have required exposing those as `pub` — leaking unsafe-internal-coordination state into the public API for test ergonomics. The plan explicitly named this alternative ("Stick with integration test unless something forces otherwise.") — the API surface concern was the forcing.

Took the explicitly-allowed alternative: `#[cfg(test)] pub(crate) mod uaf_scenarios` inline in `cross_wake.rs`. Achieves all the plan's goals (test count parity, name parity, single canonical body) without the API leak.

### 2. Plan miscount caught (3 not 5 scenarios per channel)

Plan said "5 tests per channel × 4 = 20." Audit found 3 `#[test]` functions per channel — the plan conflated 2 helpers + 3 tests. Caught before any test deletion happened. Hardening plan F2 amended.

### 3. `TxWakerSlot` follow-up logged

Carl noticed during the audit that `TxWakerSlot` (sender-side waker slot, SPSC-only) is also duplicated identically across `spsc.rs` and `spsc_bytes.rs`. Did NOT touch it (correctly out of plan scope; plan named only `RxWakerSlot` and `FallbackWaker`). Logged as §1.3.1 in the hardening plan with three landing options. Council recommendation: standalone mini-PR before PR 2.

## Council follow-up: stale `#[allow(dead_code)]` cleanup

Two stale `#[allow(dead_code)]` attributes in `task.rs` removed:
- `REF_MASK` (line 81) — actively used at four sites (ref_inc, ref_dec, ref_count, complete_and_unref). Allow was misleading.
- `TaskId::as_ptr()` method — zero callers anywhere (lib.rs accesses `.0` directly). Speculative API surface, removed entirely. Same pattern as `TaskRef::release()` removed between PR 1a and 1b.

## Diff stats

```
nexus-async-rt/src/channel/mpsc.rs       | -307 LOC
nexus-async-rt/src/channel/mpsc_bytes.rs | -181 LOC
nexus-async-rt/src/channel/spsc.rs       | -205 LOC
nexus-async-rt/src/channel/spsc_bytes.rs | -190 LOC
nexus-async-rt/src/cross_wake.rs         | +557 LOC (slot + fallback + scenarios)
nexus-async-rt/src/runtime.rs            |  +74 LOC (field-ordering doc-block)
nexus-async-rt/src/task.rs               |   -9 LOC (dead-code cleanup)
```

Net: **+703 / −1661 = −958 LOC.** Within the plan's "+250 / −1500" estimated range; the +250 difference is the inline test scenarios (which don't really count as production code growth).

## BUG status notes

- **BUG-1 (#167) — slab shutdown:** unchanged. PR 1a's parallel field-order invariant for `_cross_wake_tls_guard` continues to hold; `const _:` asserts both invariants.
- **BUG-2 (#168) and BUG-2-followup — channel UAF / wake-register race:** the regression tests for both (`waker_slot_uaf_when_task_freed_mid_dispatch` and `register_during_wake_does_not_leak_ref`) now run against the consolidated `TaskWakerSlot`. CALLOUT 1 + CALLOUT 2 invariants verified empirically under tree-borrows miri — not just by code-reading.
- **BUG-3 (#169) — Cancelled waker leak:** still open. PR 3 in this hardening sequence is the architectural fix.
- **BUG-4 (#196) — busy-spin + slab UAF on unwind:** unchanged. The `executor_drop_during_unwind_*` regression tests continue to pass.

## Test plan

- [x] `cargo build -p nexus-async-rt` — clean
- [x] `cargo fmt -p nexus-async-rt --check` — clean
- [x] `cargo clippy -p nexus-async-rt --all-features --lib -- -D warnings` — clean
- [x] `cargo test -p nexus-async-rt --lib` — 207 pass (matches PR 1a baseline)
- [x] `cargo test -p nexus-async-rt --tests` — all integration suites green (`join_handle_stress`, `miri_task`, `miri_channel`, `slab_shutdown_bug`, `cancel_fuzz`, `channel*`, `net_tcp`, `net_udp`)
- [x] `MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-ignore-leaks" cargo +nightly miri test --lib -- channel uaf` — 12 uaf_tests + others pass (CALLOUT 1 + 2 verified against the consolidated slot)
- [x] `cargo +nightly miri test --test miri_channel` — 18 pass under tree-borrows
- [x] `cargo +nightly miri test --test miri_task` — 28 pass under tree-borrows

## Out of scope (per plan)

- `TxWakerSlot` consolidation (deferred — see §1.3.1 in the hardening plan; council recommends standalone mini-PR before PR 2).
- Per-clone `Box → Arc` in tokio bridge (PR 2 §2.1).
- `Executor::drop` 4-branch refactor (PR 2 §2.2).
- `ShutdownStats` + `shutdown_quiesce` (PR 2 §2.3 + §2.4).
- Cancellation rewrite — properly closes BUG-3 (PR 3).

## Follow-ups after merge

1. (optional) `TxWakerSlot` consolidation mini-PR (~80 LOC delete).
2. PR 2 — Hardening (§2.1 + §2.2 + §2.3 + §2.4).
3. PR 3 — Cancellation rewrite (spinlock + embedded WaiterNode design).
