### PR TITLE
TLS plaintext-backpressure + steady-state hardening (supersedes #205)

### DIFF
--- a/nexus-async-net/Cargo.toml
+++ b/nexus-async-net/Cargo.toml
@@ -69,5 +69,9 @@ required-features = ["tokio-rt"]
 name = "httpbin"
 required-features = ["tokio-rt"]
 
+[[test]]
+name = "maybe_tls_nexus_backpressure"
+required-features = ["nexus", "tls"]
+
 [lints]
 workspace = true

--- a/nexus-async-net/src/maybe_tls/nexus.rs
+++ b/nexus-async-net/src/maybe_tls/nexus.rs
@@ -29,6 +29,8 @@ pub enum MaybeTls {
 pub struct TlsInner {
     pub(crate) stream: TcpStream,
     pub(crate) codec: nexus_net::tls::TlsCodec,
+    /// Ciphertext read from the transport but not yet accepted by rustls.
+    pending_read: Vec<u8>,
     /// Ciphertext waiting to be flushed to the transport.
     pending_write: Vec<u8>,
 }
@@ -39,6 +41,7 @@ impl TlsInner {
         Self {
             stream,
             codec,
+            pending_read: Vec::with_capacity(8192),
             pending_write: Vec::with_capacity(16_384),
         }
     }
@@ -69,33 +72,35 @@ impl AsyncRead for MaybeTls {
             MaybeTls::Plain(s) => Pin::new(s).poll_read(cx, buf),
             #[cfg(feature = "tls")]
             MaybeTls::Tls(inner) => {
-                // Try already-buffered plaintext first.
-                let n = inner.codec.read_plaintext(buf).map_err(tls_to_io)?;
-                if n > 0 {
-                    return Poll::Ready(Ok(n));
+                if buf.is_empty() {
+                    return Poll::Ready(Ok(0));
                 }
 
-                // Need more ciphertext from the transport.
                 let mut tmp = [0u8; 8192];
-                match Pin::new(&mut inner.stream).poll_read(cx, &mut tmp) {
-                    Poll::Ready(Ok(0)) => Poll::Ready(Ok(0)), // EOF
-                    Poll::Ready(Ok(n)) => {
-                        inner
-                            .codec
-                            .read_and_process_tls(&tmp[..n])
-                            .map_err(tls_to_io)?;
-                        let pn = inner.codec.read_plaintext(buf).map_err(tls_to_io)?;
-                        if pn > 0 {
-                            Poll::Ready(Ok(pn))
-                        } else {
-                            // Non-application TLS record consumed (handshake, alert, etc.).
-                            // Wake self to retry.
-                            cx.waker().wake_by_ref();
-                            Poll::Pending
-                        }
+
+                loop {
+                    // Try already-buffered plaintext first.
+                    let n = inner.codec.read_plaintext(buf).map_err(tls_to_io)?;
+                    if n > 0 {
+                        return Poll::Ready(Ok(n));
                     }
-                    Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-                    Poll::Pending => Poll::Pending,
+
+                    if !inner.pending_read.is_empty() {
+                        process_pending_tls(&mut inner.codec, &mut inner.pending_read)
+                            .map_err(tls_to_io)?;
+                        continue;
+                    }
+
+                    // Need more ciphertext from the transport.
+                    match Pin::new(&mut inner.stream).poll_read(cx, &mut tmp) {
+                        Poll::Ready(Ok(0)) => return Poll::Ready(Ok(0)), // EOF
+                        Poll::Ready(Ok(n)) => {
+                            feed_tls_input(&mut inner.codec, &mut inner.pending_read, &tmp[..n])
+                                .map_err(tls_to_io)?;
+                        }
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                        Poll::Pending => return Poll::Pending,
+                    }
                 }
             }
         }
@@ -178,6 +183,48 @@ impl AsyncWrite for MaybeTls {
 // Helpers
 // =============================================================================
 
+#[cfg(feature = "tls")]
+fn feed_tls_input(
+    codec: &mut nexus_net::tls::TlsCodec,
+    pending_read: &mut Vec<u8>,
+    input: &[u8],
+) -> Result<(), nexus_net::tls::TlsError> {
+    debug_assert!(pending_read.is_empty());
+
+    let consumed = codec.read_tls(input)?;
+    if consumed == 0 {
+        return Err(nexus_net::tls::TlsError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS codec stopped before consuming buffered input",
+        )));
+    }
+
+    codec.process_new_packets()?;
+    if consumed < input.len() {
+        pending_read.extend_from_slice(&input[consumed..]);
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "tls")]
+fn process_pending_tls(
+    codec: &mut nexus_net::tls::TlsCodec,
+    pending_read: &mut Vec<u8>,
+) -> Result<(), nexus_net::tls::TlsError> {
+    let consumed = codec.read_tls(pending_read)?;
+    if consumed == 0 {
+        return Err(nexus_net::tls::TlsError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS codec stopped before consuming buffered input",
+        )));
+    }
+
+    codec.process_new_packets()?;
+    pending_read.drain(..consumed);
+    Ok(())
+}
+
 /// Drain the `pending_write` buffer to the transport, writing as much as the
 /// socket will accept without blocking.
 #[cfg(feature = "tls")]
@@ -206,5 +253,138 @@ fn tls_to_io(e: nexus_net::tls::TlsError) -> io::Error {
     match e {
         nexus_net::tls::TlsError::Io(io_err) => io_err,
         other => io::Error::other(other),
+    }
+}
+
+#[cfg(all(test, feature = "tls"))]
+mod tests {
+    use std::io::{Cursor, Write};
+    use std::sync::Arc;
+
+    use nexus_net::tls::{TlsCodec, TlsConfig};
+
+    use super::{feed_tls_input, process_pending_tls};
+
+    fn generate_self_signed() -> (Vec<rustls::pki_types::CertificateDer<'static>>, Vec<u8>) {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("cert generation");
+        (
+            vec![rustls::pki_types::CertificateDer::from(
+                cert.cert.der().to_vec(),
+            )],
+            cert.key_pair.serialize_der(),
+        )
+    }
+
+    fn connected_pair() -> (TlsCodec, rustls::ServerConnection) {
+        let (cert_chain, key_der) = generate_self_signed();
+        let key = rustls::pki_types::PrivateKeyDer::try_from(key_der).unwrap();
+        let server_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(cert_chain, key)
+                .unwrap(),
+        );
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+
+        let client_config = TlsConfig::builder().danger_no_verify().build().unwrap();
+        let mut client = TlsCodec::new(&client_config, "localhost").unwrap();
+
+        let mut c2s = Vec::new();
+        let mut s2c = Vec::new();
+
+        for _ in 0..64 {
+            while client.wants_write() {
+                client.write_tls_to(&mut c2s).unwrap();
+            }
+
+            if !c2s.is_empty() {
+                server.read_tls(&mut Cursor::new(&c2s)).unwrap();
+                server.process_new_packets().unwrap();
+                c2s.clear();
+            }
+
+            while server.wants_write() {
+                server.write_tls(&mut s2c).unwrap();
+            }
+
+            if !s2c.is_empty() {
+                client.read_and_process_tls(&s2c).unwrap();
+                s2c.clear();
+            }
+
+            if !client.is_handshaking() && !server.is_handshaking() {
+                return (client, server);
+            }
+        }
+
+        panic!("TLS handshake did not complete");
+    }
+
+    fn encrypt_server_payload(server: &mut rustls::ServerConnection, payload: &[u8]) -> Vec<u8> {
+        server.writer().write_all(payload).unwrap();
+
+        let mut ciphertext = Vec::new();
+        while server.wants_write() {
+            server.write_tls(&mut ciphertext).unwrap();
+        }
+        ciphertext
+    }
+
+    #[test]
+    fn full_slice_tls_processing_can_hit_plaintext_backpressure() {
+        let (mut client, mut server) = connected_pair();
+        let payload = vec![b'x'; 64 * 1024];
+        let ciphertext = encrypt_server_payload(&mut server, &payload);
+
+        let error = client
+            .read_and_process_tls(&ciphertext)
+            .expect_err("full-slice processing should overfill rustls plaintext");
+
+        assert!(
+            error.to_string().contains("received plaintext buffer full"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pending_read_flow_drains_plaintext_before_more_ciphertext() {
+        let (mut client, mut server) = connected_pair();
+        let payload = vec![b'x'; 64 * 1024];
+        let ciphertext = encrypt_server_payload(&mut server, &payload);
+
+        let mut pending_read = Vec::new();
+        let mut plaintext = Vec::with_capacity(payload.len());
+        let mut offset = 0;
+        let mut dst = [0u8; 1024];
+
+        for _ in 0..100_000 {
+            let n = client.read_plaintext(&mut dst).unwrap();
+            if n > 0 {
+                plaintext.extend_from_slice(&dst[..n]);
+                if plaintext.len() == payload.len() {
+                    break;
+                }
+                continue;
+            }
+
+            if !pending_read.is_empty() {
+                process_pending_tls(&mut client, &mut pending_read).unwrap();
+                continue;
+            }
+
+            if offset < ciphertext.len() {
+                let end = (offset + 8192).min(ciphertext.len());
+                feed_tls_input(&mut client, &mut pending_read, &ciphertext[offset..end]).unwrap();
+                offset = end;
+                continue;
+            }
+
+            break;
+        }
+
+        assert_eq!(plaintext, payload);
+        assert_eq!(offset, ciphertext.len());
+        assert!(pending_read.is_empty());
     }
 }

--- a/nexus-async-net/src/maybe_tls/nexus.rs
+++ b/nexus-async-net/src/maybe_tls/nexus.rs
@@ -9,10 +9,68 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use nexus_async_rt::{AsyncRead, AsyncWrite, TcpStream};
+#[cfg(feature = "tls")]
+use nexus_net::buf::{ReadBuf, WriteBuf};
+
+/// Per-poll TLS read chunk size used by the TLS adapter's `poll_read`.
+/// Module-level const so it can be used in struct field types;
+/// re-exposed publicly as [`TlsInner::TMP_SIZE`].
+#[cfg(feature = "tls")]
+const TMP_SIZE: usize = 8192;
+
+// Latent bug guard: read_and_process_tls is used during handshake to
+// consume the full slice. If the burst carrying ServerFinished also
+// piggybacks app-data records (TLS 1.3 allows this), the helper
+// continues consuming past the handshake transition and queues the
+// app-data plaintext in rustls's internal buffer — capped at ~16 KiB.
+// With TMP_SIZE = 8 KiB we cannot overflow it on a single read. **If
+// you bump TMP_SIZE past 16 KiB, fix the handshake-piggyback path
+// first** — see the 0.7.0 follow-up issue. The proper fix is
+// hoisting handshake into TlsInner so `pending_read` is reachable
+// for direct stash without an intermediate allocation.
+#[cfg(feature = "tls")]
+const _: () = assert!(
+    TMP_SIZE <= 16 * 1024,
+    "TMP_SIZE > 16 KiB requires handshake-piggyback fix (0.7.0)"
+);
 
 /// Async stream that may or may not be TLS-wrapped.
 ///
 /// Created by connection builders based on the URL scheme.
+///
+/// # Shutdown (TLS variant)
+///
+/// `poll_shutdown` queues a TLS `close_notify` alert, flushes the
+/// resulting ciphertext to the transport, then closes the underlying
+/// transport. Callers do not need to flush manually — `poll_shutdown`
+/// drives any pending plaintext through to the wire as part of its
+/// shutdown sequence.
+///
+/// If the caller drops the stream without calling `poll_shutdown`,
+/// any pending plaintext (in rustls's outbound queue) and ciphertext
+/// (in `pending_write`) is discarded, and the peer sees TCP FIN
+/// without close_notify — which rustls treats as a truncation alert.
+/// Callers needing graceful termination must call `shutdown().await`
+/// (or drive `poll_shutdown` to `Ready`) before drop.
+///
+/// # Memory (TLS variant)
+///
+/// Each TLS-wrapped connection allocates approximately 81 KiB of
+/// heap-resident buffers:
+///
+/// | Buffer | Size | Purpose |
+/// |---|---|---|
+/// | `pending_read` | 8 KiB | Spillover for partially-consumed inbound TLS records |
+/// | `pending_write` | 64 KiB | Outbound ciphertext FIFO (drains to socket) |
+/// | `tmp` | 8 KiB | Per-connection scratch buffer for transport reads |
+/// | rustls state | ~1 KiB | Crypto state + small fixed buffers |
+///
+/// Trading workloads with small frequent messages can reduce
+/// `pending_write` via the connection builder's
+/// `tls_buffer_capacities(read_cap, write_cap)` setter — 8–16 KiB
+/// is sufficient for most order-entry and market-data clients. For
+/// 1000 connections with default sizing, expect ~81 MiB of buffer
+/// footprint.
 pub enum MaybeTls {
     /// Plain TCP (ws://, http://).
     Plain(TcpStream),
@@ -21,7 +79,8 @@ pub enum MaybeTls {
     Tls(Box<TlsInner>),
 }
 
-/// TLS state: a TCP stream plus the sans-IO codec and a write staging buffer.
+/// TLS state: a TCP stream plus the sans-IO codec and cursor-based
+/// staging buffers for ciphertext in both directions.
 ///
 /// Opaque to users — fields are `pub(crate)`. Exposed only because
 /// [`MaybeTls::Tls`] holds a `Box<TlsInner>`.
@@ -29,22 +88,89 @@ pub enum MaybeTls {
 pub struct TlsInner {
     pub(crate) stream: TcpStream,
     pub(crate) codec: nexus_net::tls::TlsCodec,
-    /// Ciphertext read from the transport but not yet accepted by rustls.
-    pending_read: Vec<u8>,
-    /// Ciphertext waiting to be flushed to the transport.
-    pending_write: Vec<u8>,
+    /// Ciphertext read from the transport but not yet accepted by
+    /// rustls. Cursor-based — `advance(n)` is O(1) and auto-resets
+    /// when fully drained.
+    pending_read: ReadBuf,
+    /// Ciphertext waiting to be flushed to the transport. Same
+    /// cursor semantics as `pending_read`.
+    pending_write: WriteBuf,
+    /// Per-poll scratch buffer for `poll_read`. Boxed so the 8 KiB
+    /// stays off the per-poll stack frame — eliminates a per-poll
+    /// memset + stack-probe pair.
+    tmp: Box<[u8; TMP_SIZE]>,
 }
 
 #[cfg(feature = "tls")]
 impl TlsInner {
+    /// Per-poll TLS read chunk size used by `poll_read`.
+    /// `pending_read` capacity must be at least this large so the
+    /// spillover-copy after a partial codec read fits.
+    pub(crate) const TMP_SIZE: usize = TMP_SIZE;
+
+    /// Default capacity for the outbound ciphertext buffer.
+    ///
+    /// 64 KiB matches rustls's `DEFAULT_BUFFER_LIMIT` — the outbound
+    /// plaintext queue cap. A 64 KiB plaintext encrypt produces
+    /// ~64 KiB + ~120 bytes of ciphertext (TLS record headers + auth
+    /// tags), so a single max-size encrypt triggers exactly one
+    /// drain/refill iteration in `poll_write`. Bumping this to
+    /// 80 KiB would absorb the overhead in one shot but breaks the
+    /// symmetric default; the drain/refill is cheap (non-blocking
+    /// write) and the symmetry is the more discoverable choice.
+    ///
+    /// Larger writes are chunked across multiple `poll_write` calls
+    /// via `TlsCodec::try_encrypt` regardless of this cap.
+    pub(crate) const DEFAULT_PENDING_WRITE_CAPACITY: usize = 65_536;
+
+    /// Construct with default buffer capacities. Convenience wrapper
+    /// around [`with_capacities`](Self::with_capacities) — kept for
+    /// callers that don't need overrides (currently only tests; the
+    /// builder plumbing always goes through `with_capacities`).
+    #[allow(dead_code)]
     pub(crate) fn new(stream: TcpStream, codec: nexus_net::tls::TlsCodec) -> Self {
+        Self::with_capacities(
+            stream,
+            codec,
+            Self::TMP_SIZE,
+            Self::DEFAULT_PENDING_WRITE_CAPACITY,
+        )
+    }
+
+    /// Construct with explicit buffer capacities.
+    ///
+    /// `pending_read_cap` **must be at least [`TMP_SIZE`](Self::TMP_SIZE)** —
+    /// the per-poll read chunk size in `poll_read`. The spillover-copy
+    /// after a partial codec read assumes spare capacity for the full
+    /// remainder of one tmp read.
+    ///
+    /// # Panics
+    /// Panics if `pending_read_cap < TMP_SIZE`.
+    pub(crate) fn with_capacities(
+        stream: TcpStream,
+        codec: nexus_net::tls::TlsCodec,
+        pending_read_cap: usize,
+        pending_write_cap: usize,
+    ) -> Self {
+        assert!(
+            pending_read_cap >= Self::TMP_SIZE,
+            "pending_read_cap ({pending_read_cap}) must be >= TMP_SIZE ({})",
+            Self::TMP_SIZE,
+        );
         Self {
             stream,
             codec,
-            pending_read: Vec::with_capacity(8192),
-            pending_write: Vec::with_capacity(16_384),
+            pending_read: ReadBuf::with_capacity(pending_read_cap),
+            pending_write: WriteBuf::new(pending_write_cap, 0),
+            // Heap-allocated, lives for the connection's lifetime. Earlier
+            // versions stack-allocated this per `poll_read`; the per-poll
+            // memset + stack probe was a measurable cost on the steady-state
+            // hot path. For long-lived TLS connections the alloc amortises
+            // over millions of polls.
+            tmp: Box::new([0u8; TMP_SIZE]),
         }
     }
+
 }
 
 impl MaybeTls {
@@ -76,30 +202,52 @@ impl AsyncRead for MaybeTls {
                     return Poll::Ready(Ok(0));
                 }
 
-                let mut tmp = [0u8; 8192];
-
                 loop {
-                    // Try already-buffered plaintext first.
+                    // 1. Drain any plaintext rustls has decrypted.
                     let n = inner.codec.read_plaintext(buf).map_err(tls_to_io)?;
                     if n > 0 {
                         return Poll::Ready(Ok(n));
                     }
 
+                    // 2. Step buffered ciphertext one packet at a time
+                    //    so rustls can release plaintext between calls.
                     if !inner.pending_read.is_empty() {
-                        process_pending_tls(&mut inner.codec, &mut inner.pending_read)
+                        let consumed = inner
+                            .codec
+                            .read_tls_step(inner.pending_read.data())
                             .map_err(tls_to_io)?;
+                        // State invariant: every error leg above this
+                        // line MUST return before reaching here. If you
+                        // add new error returns, place them BEFORE this
+                        // side-effect — pending_read can be left
+                        // inconsistent if advance() is half-applied.
+                        inner.pending_read.advance(consumed);
                         continue;
                     }
 
-                    // Need more ciphertext from the transport.
-                    match Pin::new(&mut inner.stream).poll_read(cx, &mut tmp) {
+                    // 3. No buffered ciphertext — pull more from the transport
+                    //    into the heap-resident scratch buffer (avoids a
+                    //    per-poll 8 KiB stack memset).
+                    let n = match Pin::new(&mut inner.stream).poll_read(cx, &mut inner.tmp[..]) {
                         Poll::Ready(Ok(0)) => return Poll::Ready(Ok(0)), // EOF
-                        Poll::Ready(Ok(n)) => {
-                            feed_tls_input(&mut inner.codec, &mut inner.pending_read, &tmp[..n])
-                                .map_err(tls_to_io)?;
-                        }
+                        Poll::Ready(Ok(n)) => n,
                         Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                         Poll::Pending => return Poll::Pending,
+                    };
+                    let consumed = inner
+                        .codec
+                        .read_tls_step(&inner.tmp[..n])
+                        .map_err(tls_to_io)?;
+                    if consumed < n {
+                        let rem_len = n - consumed;
+                        let spare = inner.pending_read.spare();
+                        spare[..rem_len].copy_from_slice(&inner.tmp[consumed..n]);
+                        // State invariant: every error leg above this
+                        // line MUST return before reaching here. If you
+                        // add new error returns, place them BEFORE this
+                        // side-effect — pending_read can be left
+                        // inconsistent if filled() is half-applied.
+                        inner.pending_read.filled(rem_len);
                     }
                 }
             }
@@ -121,26 +269,40 @@ impl AsyncWrite for MaybeTls {
             MaybeTls::Plain(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "tls")]
             MaybeTls::Tls(inner) => {
-                // Drain any pending ciphertext before encrypting more.
+                // 1. Drain pending ciphertext to free pending_write space.
                 drain_pending(inner, cx)?;
                 if !inner.pending_write.is_empty() {
-                    // Couldn't drain — backpressure.
                     return Poll::Pending;
                 }
 
-                // Encrypt plaintext through the codec.
-                inner.codec.encrypt(buf).map_err(tls_to_io)?;
+                // 2. Pull queued ciphertext from rustls into pending_write
+                //    and on to the socket. Frees rustls's plaintext queue
+                //    so try_encrypt has room for new bytes.
+                drain_codec_to_pending(inner, cx)?;
+                drain_pending(inner, cx)?;
+                if !inner.pending_write.is_empty() {
+                    return Poll::Pending;
+                }
 
-                // Collect resulting ciphertext into pending_write.
-                inner
-                    .codec
-                    .write_tls_to(&mut inner.pending_write)
-                    .map_err(io::Error::other)?;
+                // 3. Encrypt as much of buf as rustls's queue can accept.
+                //    Chunked: returns Ok(0) if the queue is full and the
+                //    caller must come back later.
+                let consumed = inner.codec.try_encrypt(buf).map_err(tls_to_io)?;
+                if consumed == 0 {
+                    // Defensive: rustls should not return 0 here after
+                    // we've drained both its outbound queue and the
+                    // socket. If it does (rustls bug or edge case),
+                    // wake_by_ref ensures the runtime re-polls us
+                    // instead of stalling indefinitely.
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
 
-                // Best-effort drain of what we just encrypted.
+                // 4. Best-effort flush of what we just produced.
+                drain_codec_to_pending(inner, cx)?;
                 drain_pending(inner, cx)?;
 
-                Poll::Ready(Ok(buf.len()))
+                Poll::Ready(Ok(consumed))
             }
         }
     }
@@ -151,12 +313,7 @@ impl AsyncWrite for MaybeTls {
             #[cfg(feature = "tls")]
             MaybeTls::Tls(inner) => {
                 // Drain any codec ciphertext not yet staged.
-                if inner.codec.wants_write() {
-                    inner
-                        .codec
-                        .write_tls_to(&mut inner.pending_write)
-                        .map_err(io::Error::other)?;
-                }
+                drain_codec_to_pending(inner, cx)?;
 
                 // Drain pending_write to the transport.
                 drain_pending(inner, cx)?;
@@ -174,7 +331,25 @@ impl AsyncWrite for MaybeTls {
         match self.get_mut() {
             MaybeTls::Plain(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(feature = "tls")]
-            MaybeTls::Tls(inner) => Pin::new(&mut inner.stream).poll_shutdown(cx),
+            MaybeTls::Tls(inner) => {
+                // 1. Queue close_notify (idempotent — rustls no-ops on
+                //    dupes, so re-entering after Pending is safe).
+                inner.codec.send_close_notify();
+
+                // 2. Drain rustls's queue (now including close_notify
+                //    ciphertext) into pending_write.
+                drain_codec_to_pending(inner, cx)?;
+
+                // 3. Flush pending_write to the transport. If we can't
+                //    fully drain yet, wait for the next poll.
+                drain_pending(inner, cx)?;
+                if !inner.pending_write.is_empty() {
+                    return Poll::Pending;
+                }
+
+                // 4. Now safe to shutdown the transport.
+                Pin::new(&mut inner.stream).poll_shutdown(cx)
+            }
         }
     }
 }
@@ -183,54 +358,13 @@ impl AsyncWrite for MaybeTls {
 // Helpers
 // =============================================================================
 
-#[cfg(feature = "tls")]
-fn feed_tls_input(
-    codec: &mut nexus_net::tls::TlsCodec,
-    pending_read: &mut Vec<u8>,
-    input: &[u8],
-) -> Result<(), nexus_net::tls::TlsError> {
-    debug_assert!(pending_read.is_empty());
-
-    let consumed = codec.read_tls(input)?;
-    if consumed == 0 {
-        return Err(nexus_net::tls::TlsError::Io(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "TLS codec stopped before consuming buffered input",
-        )));
-    }
-
-    codec.process_new_packets()?;
-    if consumed < input.len() {
-        pending_read.extend_from_slice(&input[consumed..]);
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "tls")]
-fn process_pending_tls(
-    codec: &mut nexus_net::tls::TlsCodec,
-    pending_read: &mut Vec<u8>,
-) -> Result<(), nexus_net::tls::TlsError> {
-    let consumed = codec.read_tls(pending_read)?;
-    if consumed == 0 {
-        return Err(nexus_net::tls::TlsError::Io(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "TLS codec stopped before consuming buffered input",
-        )));
-    }
-
-    codec.process_new_packets()?;
-    pending_read.drain(..consumed);
-    Ok(())
-}
-
 /// Drain the `pending_write` buffer to the transport, writing as much as the
-/// socket will accept without blocking.
+/// socket will accept without blocking. Cursor advances are O(1) and
+/// auto-reset to the buffer's start when fully drained.
 #[cfg(feature = "tls")]
 fn drain_pending(inner: &mut TlsInner, cx: &mut Context<'_>) -> io::Result<()> {
     while !inner.pending_write.is_empty() {
-        match Pin::new(&mut inner.stream).poll_write(cx, &inner.pending_write) {
+        match Pin::new(&mut inner.stream).poll_write(cx, inner.pending_write.data()) {
             Poll::Ready(Ok(0)) => {
                 return Err(io::Error::new(
                     io::ErrorKind::WriteZero,
@@ -238,11 +372,55 @@ fn drain_pending(inner: &mut TlsInner, cx: &mut Context<'_>) -> io::Result<()> {
                 ));
             }
             Poll::Ready(Ok(n)) => {
-                inner.pending_write.drain(..n);
+                inner.pending_write.advance(n);
             }
             Poll::Ready(Err(e)) => return Err(e),
             Poll::Pending => return Ok(()), // will retry on next poll
         }
+    }
+    Ok(())
+}
+
+/// Move all ciphertext rustls wants to write into `pending_write`,
+/// draining `pending_write` to the socket between iterations so a
+/// single big encrypt can't outrun `pending_write`'s fixed capacity.
+///
+/// Returns `Ok(())` once rustls is drained or the socket can no longer
+/// accept bytes (in which case the leftover ciphertext stays inside
+/// rustls and is picked up on the next call).
+///
+/// Distinguishes two distinct exit conditions:
+/// - `pending_write.spare().is_empty()` after a drain attempt —
+///   legitimate backpressure, returns `Ok(())`.
+/// - `write_tls_to` returns 0 into a non-empty spare slice — a rustls
+///   contract violation. Surfaced as `WriteZero` rather than masked
+///   as a stalled connection.
+#[cfg(feature = "tls")]
+fn drain_codec_to_pending(inner: &mut TlsInner, cx: &mut Context<'_>) -> io::Result<()> {
+    while inner.codec.wants_write() {
+        if inner.pending_write.spare().is_empty() {
+            // Backpressure: try to drain to free space.
+            drain_pending(inner, cx)?;
+            if inner.pending_write.spare().is_empty() {
+                // Socket can't take more right now. Remaining
+                // ciphertext stays queued inside rustls and is picked
+                // up by the next poll_write/poll_flush.
+                return Ok(());
+            }
+        }
+        let n = inner.codec.write_tls_to(&mut inner.pending_write.spare())?;
+        if n == 0 {
+            // wants_write said yes, spare was non-empty, yet rustls
+            // produced 0 bytes. Surface explicitly — silent break here
+            // would mask a stalled connection as success.
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "rustls reported wants_write but produced 0 bytes \
+                 into a non-empty buffer",
+            ));
+        }
+        inner.pending_write.filled(n);
+        drain_pending(inner, cx)?;
     }
     Ok(())
 }
@@ -261,9 +439,8 @@ mod tests {
     use std::io::{Cursor, Write};
     use std::sync::Arc;
 
+    use nexus_net::buf::ReadBuf;
     use nexus_net::tls::{TlsCodec, TlsConfig};
-
-    use super::{feed_tls_input, process_pending_tls};
 
     fn generate_self_signed() -> (Vec<rustls::pki_types::CertificateDer<'static>>, Vec<u8>) {
         let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
@@ -331,34 +508,32 @@ mod tests {
         ciphertext
     }
 
-    #[test]
-    fn full_slice_tls_processing_can_hit_plaintext_backpressure() {
-        let (mut client, mut server) = connected_pair();
-        let payload = vec![b'x'; 64 * 1024];
-        let ciphertext = encrypt_server_payload(&mut server, &payload);
-
-        let error = client
-            .read_and_process_tls(&ciphertext)
-            .expect_err("full-slice processing should overfill rustls plaintext");
-
-        assert!(
-            error.to_string().contains("received plaintext buffer full"),
-            "unexpected error: {error}"
-        );
-    }
-
+    /// Mirror of the adapter's `poll_read` loop, exercised against a
+    /// real connected codec pair: drain plaintext → step pending
+    /// ciphertext → pull more ciphertext.
+    ///
+    /// Uses 32 KiB chunks — deliberately oversized vs the 8 KiB tmp
+    /// the adapter currently uses. At the adapter's current tmp size
+    /// this test passes regardless of which helper drives the loop
+    /// (8 KiB stays under rustls's plaintext queue cap). The
+    /// codec-level pin for the bug lives at
+    /// `nexus_net::tls::codec::tests::adapter_pattern_with_read_and_process_tls_overflows_on_oversize_chunks`
+    /// — that proves `read_tls_step` is the correct primitive. This
+    /// adapter test guards against future tmp-size tuning
+    /// re-introducing the bug here at the integration layer.
     #[test]
     fn pending_read_flow_drains_plaintext_before_more_ciphertext() {
         let (mut client, mut server) = connected_pair();
         let payload = vec![b'x'; 64 * 1024];
         let ciphertext = encrypt_server_payload(&mut server, &payload);
 
-        let mut pending_read = Vec::new();
+        let chunk_size = 32 * 1024;
+        let mut pending_read = ReadBuf::with_capacity(chunk_size);
         let mut plaintext = Vec::with_capacity(payload.len());
         let mut offset = 0;
         let mut dst = [0u8; 1024];
 
-        for _ in 0..100_000 {
+        for _ in 0..1_000_000 {
             let n = client.read_plaintext(&mut dst).unwrap();
             if n > 0 {
                 plaintext.extend_from_slice(&dst[..n]);
@@ -369,13 +544,21 @@ mod tests {
             }
 
             if !pending_read.is_empty() {
-                process_pending_tls(&mut client, &mut pending_read).unwrap();
+                let consumed = client.read_tls_step(pending_read.data()).unwrap();
+                pending_read.advance(consumed);
                 continue;
             }
 
             if offset < ciphertext.len() {
-                let end = (offset + 8192).min(ciphertext.len());
-                feed_tls_input(&mut client, &mut pending_read, &ciphertext[offset..end]).unwrap();
+                let end = (offset + chunk_size).min(ciphertext.len());
+                let chunk = &ciphertext[offset..end];
+                let consumed = client.read_tls_step(chunk).unwrap();
+                if consumed < chunk.len() {
+                    let rem = &chunk[consumed..];
+                    let spare = pending_read.spare();
+                    spare[..rem.len()].copy_from_slice(rem);
+                    pending_read.filled(rem.len());
+                }
                 offset = end;
                 continue;
             }

--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -39,6 +39,7 @@ async fn flush_async<S: AsyncWrite + Unpin>(s: &mut S) -> io::Result<()> {
 // TLS handshake (sans-IO codec driven over async transport)
 // =============================================================================
 
+/// Drive the TLS handshake to completion.
 #[cfg(feature = "tls")]
 #[allow(clippy::future_not_send)]
 async fn handshake_tls(
@@ -95,6 +96,10 @@ async fn handshake_tls(
 pub struct HttpConnectionBuilder {
     #[cfg(feature = "tls")]
     tls_config: Option<TlsConfig>,
+    #[cfg(feature = "tls")]
+    tls_pending_read_capacity: Option<usize>,
+    #[cfg(feature = "tls")]
+    tls_pending_write_capacity: Option<usize>,
     nodelay: bool,
     connect_timeout: Option<std::time::Duration>,
     #[cfg(feature = "socket-opts")]
@@ -112,6 +117,10 @@ impl HttpConnectionBuilder {
         Self {
             #[cfg(feature = "tls")]
             tls_config: None,
+            #[cfg(feature = "tls")]
+            tls_pending_read_capacity: None,
+            #[cfg(feature = "tls")]
+            tls_pending_write_capacity: None,
             nodelay: false,
             connect_timeout: None,
             #[cfg(feature = "socket-opts")]
@@ -128,6 +137,33 @@ impl HttpConnectionBuilder {
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
         self.tls_config = Some(config.clone());
+        self
+    }
+
+    /// Override the TLS adapter's per-connection ciphertext buffer
+    /// capacities. Only applies when the connection is `https://`.
+    ///
+    /// `pending_read_cap` holds ciphertext read from the transport
+    /// but not yet accepted by rustls. Must be at least
+    /// [`crate::maybe_tls::TlsInner::TMP_SIZE`] (8 KiB).
+    /// Default: 8 KiB.
+    ///
+    /// `pending_write_cap` holds ciphertext rustls has produced but
+    /// not yet flushed. Smaller capacities mean more drain/refill
+    /// cycles for big writes; larger capacities cost per-connection
+    /// memory. Default: 64 KiB.
+    ///
+    /// # Panics
+    /// Panics during connect if `pending_read_cap < TlsInner::TMP_SIZE`.
+    #[cfg(feature = "tls")]
+    #[must_use]
+    pub fn tls_buffer_capacities(
+        mut self,
+        pending_read_cap: usize,
+        pending_write_cap: usize,
+    ) -> Self {
+        self.tls_pending_read_capacity = Some(pending_read_cap);
+        self.tls_pending_write_capacity = Some(pending_write_cap);
         self
     }
 
@@ -216,7 +252,14 @@ impl HttpConnectionBuilder {
 
                 handshake_tls(&mut tcp, &mut codec).await?;
 
-                let tls_inner = crate::maybe_tls::TlsInner::new(tcp, codec);
+                let tls_inner = crate::maybe_tls::TlsInner::with_capacities(
+                    tcp,
+                    codec,
+                    self.tls_pending_read_capacity
+                        .unwrap_or(crate::maybe_tls::TlsInner::TMP_SIZE),
+                    self.tls_pending_write_capacity
+                        .unwrap_or(crate::maybe_tls::TlsInner::DEFAULT_PENDING_WRITE_CAPACITY),
+                );
                 MaybeTls::Tls(Box::new(tls_inner))
             }
             #[cfg(not(feature = "tls"))]

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -38,6 +38,7 @@ async fn write_all_async<S: AsyncWrite + Unpin>(s: &mut S, mut buf: &[u8]) -> io
 // TLS handshake (sans-IO codec driven over async transport)
 // =============================================================================
 
+/// Drive the TLS handshake to completion.
 #[cfg(feature = "tls")]
 #[allow(clippy::future_not_send)]
 async fn handshake_tls(
@@ -454,6 +455,10 @@ pub struct WsStreamBuilder {
     max_read_size: Option<usize>,
     #[cfg(feature = "tls")]
     tls_config: Option<TlsConfig>,
+    #[cfg(feature = "tls")]
+    tls_pending_read_capacity: Option<usize>,
+    #[cfg(feature = "tls")]
+    tls_pending_write_capacity: Option<usize>,
     nodelay: bool,
     connect_timeout: Option<std::time::Duration>,
     #[cfg(feature = "socket-opts")]
@@ -477,6 +482,10 @@ impl WsStreamBuilder {
             max_read_size: None,
             #[cfg(feature = "tls")]
             tls_config: None,
+            #[cfg(feature = "tls")]
+            tls_pending_read_capacity: None,
+            #[cfg(feature = "tls")]
+            tls_pending_write_capacity: None,
             nodelay: false,
             connect_timeout: None,
             #[cfg(feature = "socket-opts")]
@@ -553,6 +562,34 @@ impl WsStreamBuilder {
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
         self.tls_config = Some(config.clone());
+        self
+    }
+
+    /// Override the TLS adapter's per-connection ciphertext buffer
+    /// capacities. Only applies when the connection is `wss://`.
+    ///
+    /// `pending_read_cap` holds ciphertext read from the transport
+    /// but not yet accepted by rustls. Must be at least
+    /// [`crate::maybe_tls::TlsInner::TMP_SIZE`] (8 KiB).
+    /// Default: 8 KiB.
+    ///
+    /// `pending_write_cap` holds ciphertext rustls has produced but
+    /// not yet flushed. Smaller capacities mean more drain/refill
+    /// cycles for big writes; larger capacities cost per-connection
+    /// memory. Default: 64 KiB.
+    ///
+    /// # Panics
+    /// Panics during [`connect`](Self::connect) if
+    /// `pending_read_cap < TlsInner::TMP_SIZE`.
+    #[cfg(feature = "tls")]
+    #[must_use]
+    pub fn tls_buffer_capacities(
+        mut self,
+        pending_read_cap: usize,
+        pending_write_cap: usize,
+    ) -> Self {
+        self.tls_pending_read_capacity = Some(pending_read_cap);
+        self.tls_pending_write_capacity = Some(pending_write_cap);
         self
     }
 
@@ -649,7 +686,14 @@ impl WsStreamBuilder {
 
                 handshake_tls(&mut tcp, &mut codec).await?;
 
-                let tls_inner = crate::maybe_tls::TlsInner::new(tcp, codec);
+                let tls_inner = crate::maybe_tls::TlsInner::with_capacities(
+                    tcp,
+                    codec,
+                    self.tls_pending_read_capacity
+                        .unwrap_or(crate::maybe_tls::TlsInner::TMP_SIZE),
+                    self.tls_pending_write_capacity
+                        .unwrap_or(crate::maybe_tls::TlsInner::DEFAULT_PENDING_WRITE_CAPACITY),
+                );
                 MaybeTls::Tls(Box::new(tls_inner))
             }
             #[cfg(not(feature = "tls"))]

--- a/nexus-async-net/tests/maybe_tls_nexus_backpressure.rs
+++ b/nexus-async-net/tests/maybe_tls_nexus_backpressure.rs
@@ -1,0 +1,292 @@
+//! Hermetic TLS backpressure tests for the **nexus-async-rt
+//! backend**. Mirrors `nexus-net/tests/tls_stream_async_backpressure.rs`
+//! but drives `MaybeTls`'s `poll_read` / `poll_write` / `poll_shutdown`
+//! through `nexus_async_rt::Runtime` instead of tokio.
+//!
+//! Three scenarios:
+//!
+//! - `maybe_tls_handles_oversize_app_data_burst` — server pushes
+//!   256 KiB to client, client receives it all via `recv()`.
+//!   Exercises `MaybeTls::poll_read` over a large steady-state burst.
+//! - `maybe_tls_handles_large_write_via_chunking` — client sends
+//!   256 KiB to server. Exercises `try_encrypt`'s chunking path
+//!   in `MaybeTls::poll_write` (256 KiB > rustls's 64 KiB plaintext
+//!   queue → multiple poll_write cycles).
+//! - `maybe_tls_oversize_write_with_tiny_pending_write` — client
+//!   sends 32 KiB with `pending_write_cap = TMP_SIZE` (8 KiB),
+//!   exercising the legitimate-backpressure exit path of
+//!   `drain_codec_to_pending`.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p nexus-async-net --no-default-features \
+//!     --features nexus,tls --test maybe_tls_nexus_backpressure
+//! ```
+
+#![cfg(all(feature = "nexus", feature = "tls"))]
+
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use nexus_async_net::ws::WsStreamBuilder;
+use nexus_async_rt::Runtime;
+use nexus_net::tls::TlsConfig;
+use nexus_net::ws::{Client as SyncWsClient, CloseCode, Message};
+use nexus_rt::WorldBuilder;
+
+const PAYLOAD_LEN: usize = 256 * 1024;
+
+// =============================================================================
+// Server config (simple self-signed cert; chain-depth tests are covered
+// by the existing wss_loopback test).
+// =============================================================================
+
+fn make_server_config() -> Arc<rustls::ServerConfig> {
+    let cert_kp = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("cert generation");
+    let chain = vec![rustls::pki_types::CertificateDer::from(
+        cert_kp.cert.der().to_vec(),
+    )];
+    let key = rustls::pki_types::PrivateKeyDer::try_from(cert_kp.key_pair.serialize_der())
+        .expect("server key");
+    Arc::new(
+        rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(chain, key)
+            .expect("server config"),
+    )
+}
+
+// =============================================================================
+// Sync server companions — one per test scenario.
+// =============================================================================
+
+/// Server that accepts a WS connection, sends one big binary
+/// message, then drains incoming until close.
+#[allow(clippy::needless_pass_by_value)]
+fn run_burst_send_server(
+    listener: TcpListener,
+    server_config: Arc<rustls::ServerConfig>,
+    payload: Vec<u8>,
+) {
+    let (tcp, _addr) = listener.accept().expect("server accept");
+    tcp.set_nodelay(true).ok();
+    tcp.set_read_timeout(Some(Duration::from_secs(15))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(15))).ok();
+
+    let server_conn = rustls::ServerConnection::new(server_config).expect("server conn");
+    let tls_stream = rustls::StreamOwned::new(server_conn, tcp);
+
+    // Need a write_buffer big enough for the whole frame.
+    let mut ws = SyncWsClient::builder()
+        .write_buffer_capacity(payload.len() + 1024)
+        .accept(tls_stream)
+        .expect("server WS accept");
+    ws.send_binary(&payload).expect("server send burst");
+
+    // Drain until close.
+    while let Some(msg) = ws.recv().expect("server recv") {
+        if let Message::Close(_) = msg {
+            break;
+        }
+    }
+}
+
+/// Server that accepts a WS connection, reads one big binary message,
+/// asserts the expected length, then closes.
+#[allow(clippy::needless_pass_by_value)]
+fn run_burst_recv_server(
+    listener: TcpListener,
+    server_config: Arc<rustls::ServerConfig>,
+    expected_len: usize,
+    expected_byte: u8,
+) {
+    let (tcp, _addr) = listener.accept().expect("server accept");
+    tcp.set_nodelay(true).ok();
+    tcp.set_read_timeout(Some(Duration::from_secs(15))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(15))).ok();
+
+    let server_conn = rustls::ServerConnection::new(server_config).expect("server conn");
+    let tls_stream = rustls::StreamOwned::new(server_conn, tcp);
+
+    // Reader buffer must hold the whole inbound frame.
+    let mut ws = SyncWsClient::builder()
+        .buffer_capacity(2 * expected_len.max(65_536))
+        .max_frame_size(expected_len as u64 + 1024)
+        .max_message_size(expected_len + 1024)
+        .accept(tls_stream)
+        .expect("server WS accept");
+    let msg = ws
+        .recv()
+        .expect("server recv")
+        .expect("server saw EOF before payload");
+    match msg {
+        Message::Binary(b) => {
+            assert_eq!(b.len(), expected_len, "server payload length");
+            assert!(
+                b.iter().all(|&x| x == expected_byte),
+                "server payload bytes intact"
+            );
+        }
+        other => panic!("expected Binary, got {other:?}"),
+    }
+
+    // Acknowledge close from client.
+    while let Some(msg) = ws.recv().expect("server recv after payload") {
+        if let Message::Close(_) = msg {
+            break;
+        }
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[test]
+fn maybe_tls_handles_oversize_app_data_burst() {
+    let server_config = make_server_config();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let payload = vec![b'x'; PAYLOAD_LEN];
+    let server_handle =
+        thread::spawn(move || run_burst_send_server(listener, server_config, payload));
+
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::new(&mut world);
+
+    rt.block_on(async move {
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+
+        let mut ws = WsStreamBuilder::new()
+            .tls(&tls_config)
+            // Frame reader buffer must hold the whole 256 KiB message.
+            .buffer_capacity(2 * PAYLOAD_LEN)
+            .max_frame_size(PAYLOAD_LEN as u64 + 1024)
+            .max_message_size(PAYLOAD_LEN + 1024)
+            .connect_timeout(Duration::from_secs(15))
+            .connect(&format!("wss://127.0.0.1:{port}/"))
+            .await
+            .expect("client wss connect");
+
+        let msg = ws
+            .recv()
+            .await
+            .expect("client recv")
+            .expect("server closed early");
+        match msg {
+            Message::Binary(b) => {
+                assert_eq!(b.len(), PAYLOAD_LEN, "client payload length");
+                assert!(b.iter().all(|&x| x == b'x'), "client payload intact");
+            }
+            other => panic!("expected Binary, got {other:?}"),
+        }
+
+        ws.close(CloseCode::Normal, "done")
+            .await
+            .expect("client close");
+    });
+
+    server_handle.join().expect("server join");
+}
+
+#[test]
+fn maybe_tls_handles_large_write_via_chunking() {
+    let server_config = make_server_config();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let server_handle = thread::spawn(move || {
+        run_burst_recv_server(listener, server_config, PAYLOAD_LEN, b'z')
+    });
+
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::new(&mut world);
+
+    rt.block_on(async move {
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+
+        // write_buffer_capacity must hold one whole frame; 256 KiB
+        // payload + WS header.
+        let mut ws = WsStreamBuilder::new()
+            .tls(&tls_config)
+            .write_buffer_capacity(PAYLOAD_LEN + 1024)
+            .connect_timeout(Duration::from_secs(15))
+            .connect(&format!("wss://127.0.0.1:{port}/"))
+            .await
+            .expect("client wss connect");
+
+        let payload = vec![b'z'; PAYLOAD_LEN];
+        ws.send_binary(&payload).await.expect("client send big");
+
+        ws.close(CloseCode::Normal, "done")
+            .await
+            .expect("client close");
+    });
+
+    server_handle.join().expect("server join");
+}
+
+#[test]
+fn maybe_tls_oversize_write_with_tiny_pending_write() {
+    let server_config = make_server_config();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    // 32 KiB stays under rustls's 64 KiB outbound plaintext queue cap
+    // (so encrypt itself doesn't error). With pending_write_cap = 8 KiB
+    // (= TMP_SIZE), the drain loop in poll_write must iterate ~4 times
+    // to flush all the ciphertext.
+    let payload_len = 32 * 1024;
+    let server_handle = thread::spawn(move || {
+        run_burst_recv_server(listener, server_config, payload_len, b'y')
+    });
+
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+    let mut rt = Runtime::new(&mut world);
+
+    rt.block_on(async move {
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+
+        // pending_write_cap = TMP_SIZE (8 KiB) forces the
+        // drain-and-refill loop to iterate multiple times. Hardcoded
+        // here because `TlsInner::TMP_SIZE` is `pub(crate)` — the
+        // const is internally enforced by an assert in
+        // `with_capacities`, so this literal can't drift from the
+        // real value without the construct panicking.
+        let tiny_cap = 8192;
+        let mut ws = WsStreamBuilder::new()
+            .tls(&tls_config)
+            .write_buffer_capacity(payload_len + 1024)
+            .tls_buffer_capacities(tiny_cap, tiny_cap)
+            .connect_timeout(Duration::from_secs(15))
+            .connect(&format!("wss://127.0.0.1:{port}/"))
+            .await
+            .expect("client wss connect");
+
+        let payload = vec![b'y'; payload_len];
+        ws.send_binary(&payload).await.expect("client send");
+
+        ws.close(CloseCode::Normal, "done")
+            .await
+            .expect("client close");
+    });
+
+    server_handle.join().expect("server join");
+}
+

--- a/nexus-net/src/buf/write_buf.rs
+++ b/nexus-net/src/buf/write_buf.rs
@@ -16,6 +16,22 @@
 ///
 /// After [`clear()`](WriteBuf::clear): `head = headroom`, `tail = headroom`.
 ///
+/// # Modes
+///
+/// **One-shot message** (sk_buff style):
+/// [`prepend()`](WriteBuf::prepend) / [`append()`](WriteBuf::append) to
+/// build a single frame, [`data()`](WriteBuf::data) to send,
+/// [`clear()`](WriteBuf::clear) between frames. This is what most
+/// protocol-frame builders want.
+///
+/// **Cursor FIFO**: [`spare()`](WriteBuf::spare) /
+/// [`filled()`](WriteBuf::filled) to stage bytes (e.g. from a sans-IO
+/// codec writing into the tail region), [`data()`](WriteBuf::data) to
+/// send, [`advance(n)`](WriteBuf::advance) after partial writes.
+/// Auto-reset on full drain means the buffer is reusable across cycles
+/// without an explicit `clear()`. This is what TLS adapters use for
+/// ciphertext staging.
+///
 /// # Examples
 ///
 /// ```
@@ -126,15 +142,53 @@ impl WriteBuf {
         &mut self.buf[self.head..self.tail]
     }
 
+    /// Writable tail region for direct in-place writes.
+    ///
+    /// Pair with [`filled()`](Self::filled) to commit bytes after a
+    /// successful write. Used by sans-IO codecs that produce bytes
+    /// directly (e.g. `TlsCodec::write_tls_to(&mut buf.spare())`).
+    ///
+    /// Returns `buf[tail .. buf.len()]`. May be empty if tail has
+    /// reached the buffer boundary.
+    #[inline]
+    pub fn spare(&mut self) -> &mut [u8] {
+        &mut self.buf[self.tail..]
+    }
+
+    /// Commit `n` bytes written into [`spare()`](Self::spare).
+    ///
+    /// # Panics
+    /// Panics if `n` would push tail past the buffer boundary.
+    #[inline]
+    pub fn filled(&mut self, n: usize) {
+        let new_tail = self.tail + n;
+        if new_tail > self.buf.len() {
+            Self::panic_filled(n, self.tail, self.buf.len());
+        }
+        self.tail = new_tail;
+    }
+
     /// Consume `n` bytes from front after a partial write.
+    ///
+    /// If the buffer becomes empty after advance, resets head and tail
+    /// to `reset_offset` (free — no memmove, just cursor reset). This
+    /// makes WriteBuf usable as a cursor FIFO: encrypt → drain partial →
+    /// encrypt more → drain more, with auto-reclaim when fully drained.
+    /// Calling [`clear()`](Self::clear) after a fully-drained
+    /// `advance()` is now redundant.
     ///
     /// # Panics
     /// Panics if `n > self.len()`.
+    #[inline]
     pub fn advance(&mut self, n: usize) {
         if n > self.len() {
             Self::panic_advance(n, self.len());
         }
         self.head += n;
+        if self.head == self.tail {
+            self.head = self.reset_offset;
+            self.tail = self.reset_offset;
+        }
     }
 
     // =========================================================================
@@ -205,6 +259,12 @@ impl WriteBuf {
     #[inline(never)]
     fn panic_shrink(n: usize, len: usize) -> ! {
         panic!("shrink_tail({n}) exceeds data length ({len})")
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn panic_filled(n: usize, tail: usize, end: usize) -> ! {
+        panic!("filled({n}) would exceed buffer (tail={tail}, end={end})")
     }
 }
 
@@ -377,15 +437,66 @@ mod tests {
     }
 
     #[test]
-    fn advance_full_then_reuse() {
+    fn advance_auto_resets_on_empty() {
         let mut buf = WriteBuf::new(64, 10);
         buf.append(b"Hello");
         buf.advance(5);
         assert!(buf.is_empty());
-        // After full advance, head moved but headroom is consumed
-        assert_eq!(buf.headroom(), 15); // original 10 + consumed 5
-        // clear() restores headroom
-        buf.clear();
+        // Auto-reset: headroom returns to its initial value, no clear() needed.
         assert_eq!(buf.headroom(), 10);
+        assert_eq!(buf.tailroom(), 54);
+    }
+
+    #[test]
+    fn advance_partial_does_not_reset() {
+        let mut buf = WriteBuf::new(64, 10);
+        buf.append(b"Hello");
+        buf.advance(2);
+        // Still has data — no reset.
+        assert_eq!(buf.data(), b"llo");
+        assert_eq!(buf.headroom(), 12);
+    }
+
+    #[test]
+    fn cursor_fifo_cycle() {
+        // Demonstrates the cursor-FIFO use case: write into spare,
+        // commit with filled, partially drain via advance, repeat.
+        // Ciphertext-style cycling without per-step memmove.
+        let mut buf = WriteBuf::new(32, 0);
+
+        buf.spare()[..10].copy_from_slice(b"0123456789");
+        buf.filled(10);
+        assert_eq!(buf.data(), b"0123456789");
+
+        buf.advance(4);
+        assert_eq!(buf.data(), b"456789");
+
+        // Spare reflects the post-tail region — head is mid-buffer.
+        assert_eq!(buf.spare().len(), 22);
+        buf.spare()[..3].copy_from_slice(b"ABC");
+        buf.filled(3);
+        assert_eq!(buf.data(), b"456789ABC");
+
+        buf.advance(9);
+        assert!(buf.is_empty());
+        // Auto-reset gave us full tailroom back.
+        assert_eq!(buf.tailroom(), 32);
+    }
+
+    #[test]
+    fn spare_is_post_tail_region() {
+        let mut buf = WriteBuf::new(32, 8);
+        // tail starts at headroom offset → spare is buf[8..32]
+        assert_eq!(buf.spare().len(), 24);
+        buf.append(b"hi");
+        // tail advanced by 2 → spare shrinks by 2
+        assert_eq!(buf.spare().len(), 22);
+    }
+
+    #[test]
+    #[should_panic(expected = "filled")]
+    fn filled_exceeds_buffer() {
+        let mut buf = WriteBuf::new(16, 0);
+        buf.filled(32);
     }
 }

--- a/nexus-net/src/tls/codec.rs
+++ b/nexus-net/src/tls/codec.rs
@@ -57,11 +57,9 @@ impl TlsCodec {
     /// Returns the number of bytes consumed. **May be less than
     /// `src.len()`** — rustls's deframer can require a
     /// [`process_new_packets`](Self::process_new_packets) call before
-    /// accepting more bytes. Most callers want
-    /// [`read_and_process_tls`](Self::read_and_process_tls), which
-    /// loops until the entire slice is consumed and is the correct
-    /// primitive when bytes have already been read into a buffer
-    /// (async paths, sans-IO pipelines).
+    /// accepting more bytes. If a streaming adapter may receive arbitrary
+    /// application data, it must also give the caller a chance to drain
+    /// plaintext between `process_new_packets` calls.
     pub fn read_tls(&mut self, src: &[u8]) -> Result<usize, TlsError> {
         let mut cursor = io::Cursor::new(src);
         Ok(self.inner.read_tls(&mut cursor)?)
@@ -70,11 +68,13 @@ impl TlsCodec {
     /// Feed buffered TLS bytes through rustls, looping until the entire
     /// slice is consumed.
     ///
-    /// Use this anywhere code reads bytes into a buffer first (async
-    /// paths, IO drivers that don't expose a `Read` trait, sans-IO
-    /// pipelines) and then needs to push them into the codec. Sync paths
-    /// reading directly from a [`Read`](std::io::Read) trait should use
-    /// [`read_tls_from`](Self::read_tls_from) instead — rustls handles
+    /// Use this for bounded buffered input where the caller can tolerate
+    /// plaintext staying inside rustls until the helper returns, such as TLS
+    /// handshakes or tests. Streaming adapters for arbitrary application
+    /// data should feed at most one accepted prefix at a time, return
+    /// plaintext to the caller, and only then feed more ciphertext. Sync
+    /// paths reading directly from a [`Read`](std::io::Read) trait should
+    /// use [`read_tls_from`](Self::read_tls_from) instead — rustls handles
     /// the consume-loop internally there.
     ///
     /// # Why a loop is required

--- a/nexus-net/src/tls/codec.rs
+++ b/nexus-net/src/tls/codec.rs
@@ -57,25 +57,108 @@ impl TlsCodec {
     /// Returns the number of bytes consumed. **May be less than
     /// `src.len()`** — rustls's deframer can require a
     /// [`process_new_packets`](Self::process_new_packets) call before
-    /// accepting more bytes. If a streaming adapter may receive arbitrary
-    /// application data, it must also give the caller a chance to drain
-    /// plaintext between `process_new_packets` calls.
+    /// accepting more bytes.
+    ///
+    /// For an overview of when to use each input primitive, see the
+    /// [module-level docs](crate::tls). Most callers want
+    /// [`read_tls_step`](Self::read_tls_step) (streaming app-data) or
+    /// [`read_and_process_tls`](Self::read_and_process_tls) (bounded
+    /// handshake input). Reach for `read_tls` directly only when
+    /// implementing a new adapter shape that none of those fit.
+    #[deprecated(
+        since = "0.6.2",
+        note = "use `read_tls_step` (streaming) or `read_and_process_tls` \
+                (bounded handshake) — these encode rustls's partial-consumption \
+                failure mode that bare `read_tls` does not"
+    )]
     pub fn read_tls(&mut self, src: &[u8]) -> Result<usize, TlsError> {
         let mut cursor = io::Cursor::new(src);
         Ok(self.inner.read_tls(&mut cursor)?)
     }
 
+    /// Advance the codec by a single TLS packet step: one
+    /// [`read_tls`](Self::read_tls) + [`process_new_packets`](Self::process_new_packets)
+    /// pair.
+    ///
+    /// Returns the number of ciphertext bytes consumed from `src`. The
+    /// caller must drain any plaintext (via
+    /// [`read_plaintext`](Self::read_plaintext) or
+    /// [`process_into`](Self::process_into)) before calling again —
+    /// feeding more ciphertext while plaintext is queued can overflow
+    /// rustls's internal plaintext buffer.
+    ///
+    /// Use this for streaming application data where the caller
+    /// interleaves ciphertext input with plaintext output (the standard
+    /// async TLS adapter shape: poll socket → step codec → drain
+    /// plaintext → repeat). For bounded input where the caller can
+    /// tolerate plaintext staying inside rustls until the full slice is
+    /// consumed (TLS handshakes, in-memory tests), use
+    /// [`read_and_process_tls`](Self::read_and_process_tls) instead.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(0)` if `src` is empty. Otherwise `Ok(n)` where `n > 0` is the
+    /// number of bytes consumed (always `<= src.len()`; rustls's
+    /// deframer caps each call at its internal `READ_SIZE`).
+    ///
+    /// # Errors
+    ///
+    /// Two distinct error sources:
+    ///
+    /// - **Propagated from rustls** via `?`: any error from
+    ///   [`read_tls`](Self::read_tls) (including
+    ///   `received plaintext buffer full` when the caller hasn't
+    ///   drained plaintext between steps) or
+    ///   [`process_new_packets`](Self::process_new_packets) (alerts,
+    ///   decryption failures, protocol violations).
+    /// - **`TlsError::Io(InvalidData)` from this method**: rustls's
+    ///   deframer accepted 0 bytes from a non-empty input slice
+    ///   without erroring — meaning it cannot complete a record from
+    ///   the bytes provided alone (partial record, or the caller
+    ///   misused the API by passing zero-byte progress repeatedly).
+    #[inline]
+    pub fn read_tls_step(&mut self, src: &[u8]) -> Result<usize, TlsError> {
+        if src.is_empty() {
+            return Ok(0);
+        }
+        // Internal use of the deprecated primitive. The deprecation
+        // warns external callers; we know the failure mode and are
+        // wrapping it correctly here.
+        #[allow(deprecated)]
+        let consumed = self.read_tls(src)?;
+        if consumed == 0 {
+            return Err(TlsError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "TLS codec made no progress on non-empty input \
+                 (deframer cannot complete a record from the provided bytes)",
+            )));
+        }
+        self.process_new_packets()?;
+        Ok(consumed)
+    }
+
     /// Feed buffered TLS bytes through rustls, looping until the entire
     /// slice is consumed.
     ///
-    /// Use this for bounded buffered input where the caller can tolerate
-    /// plaintext staying inside rustls until the helper returns, such as TLS
-    /// handshakes or tests. Streaming adapters for arbitrary application
-    /// data should feed at most one accepted prefix at a time, return
-    /// plaintext to the caller, and only then feed more ciphertext. Sync
-    /// paths reading directly from a [`Read`](std::io::Read) trait should
-    /// use [`read_tls_from`](Self::read_tls_from) instead — rustls handles
-    /// the consume-loop internally there.
+    /// **Use only for bounded input** where the caller can tolerate
+    /// plaintext staying queued inside rustls until the helper returns
+    /// — TLS handshakes (the original motivation, see issue #200) and
+    /// in-memory tests. Do **not** use for streaming application data:
+    /// rustls's internal plaintext buffer has a cap, and feeding a
+    /// large ciphertext slice without giving the caller a chance to
+    /// drain plaintext between steps will overflow it
+    /// (`received plaintext buffer full`). For streaming adapters, use
+    /// [`read_tls_step`](Self::read_tls_step) instead — feed at most
+    /// one accepted prefix, return plaintext to the caller, then feed
+    /// more.
+    ///
+    /// Sync paths reading directly from a [`Read`](std::io::Read)
+    /// source should use [`read_tls_from`](Self::read_tls_from)
+    /// instead. Each call reads up to rustls's internal `READ_SIZE`
+    /// (4 KiB) from the source and buffers it; the caller pairs it
+    /// with [`process_new_packets`](Self::process_new_packets) and
+    /// re-drives in their own loop, pulling more bytes from the
+    /// transport as available.
     ///
     /// # Why a loop is required
     ///
@@ -104,6 +187,9 @@ impl TlsCodec {
     pub fn read_and_process_tls(&mut self, src: &[u8]) -> Result<usize, TlsError> {
         let mut consumed = 0;
         while consumed < src.len() {
+            // Internal use of the deprecated primitive — the loop here
+            // is what makes it safe to call.
+            #[allow(deprecated)]
             let n = self.read_tls(&src[consumed..])?;
             if n == 0 {
                 return Err(TlsError::Io(io::Error::new(
@@ -171,6 +257,7 @@ impl TlsCodec {
     ///
     /// For users who want to feed bytes into FrameReader manually
     /// or use a different parser.
+    #[inline]
     pub fn read_plaintext(&mut self, dst: &mut [u8]) -> Result<usize, TlsError> {
         match self.inner.reader().read(dst) {
             Ok(n) => Ok(n),
@@ -183,13 +270,93 @@ impl TlsCodec {
     // Outbound (FrameWriter → TLS → socket)
     // =========================================================================
 
-    /// Encrypt plaintext for sending.
+    /// Encrypt plaintext for sending (all-or-nothing).
     ///
     /// The encrypted bytes are buffered internally. Call
     /// [`write_tls_to`](Self::write_tls_to) to flush them to a socket.
+    ///
+    /// **Errors with `WriteZero` if `plaintext.len()` exceeds rustls's
+    /// outbound plaintext queue limit** (default 64 KiB; see
+    /// [`set_buffer_limit`](Self::set_buffer_limit)). For streaming
+    /// adapters where the caller may pass arbitrarily-large buffers
+    /// (the standard `AsyncWrite::poll_write` shape), use the chunked
+    /// [`try_encrypt`](Self::try_encrypt) instead and let the caller
+    /// chunk via `write_all`.
+    #[deprecated(
+        since = "0.6.2",
+        note = "use `try_encrypt` — it returns the accepted byte count instead \
+                of erroring when rustls's plaintext queue is full, and is the \
+                correct primitive for `AsyncWrite::poll_write`"
+    )]
+    #[inline]
     pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         self.inner.writer().write_all(plaintext)?;
         Ok(())
+    }
+
+    /// Encrypt up to `plaintext.len()` bytes, returning the number of
+    /// bytes actually accepted by rustls's outbound plaintext queue.
+    ///
+    /// This is the chunked variant of [`encrypt`](Self::encrypt). Use
+    /// it when the caller may pass more bytes than rustls's queue
+    /// limit (default `DEFAULT_BUFFER_LIMIT = 64 KiB`; tune with
+    /// [`set_buffer_limit`](Self::set_buffer_limit)). Returning the
+    /// accepted count lets the caller chunk subsequent writes — the
+    /// standard `AsyncWrite::poll_write` contract. Paired with
+    /// [`encrypt`](Self::encrypt) for all-or-nothing semantics on
+    /// known-small plaintexts.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(0)` if rustls's queue is full and cannot accept any bytes
+    /// (caller should drain ciphertext to the socket and retry).
+    /// Otherwise `Ok(n)` where `n > 0` is the number of plaintext
+    /// bytes queued for encryption. `n` may be less than
+    /// `plaintext.len()`.
+    ///
+    /// # Errors
+    ///
+    /// Any error from rustls's writer other than `WriteZero` (which
+    /// is translated to `Ok(0)` so the caller treats it as
+    /// backpressure rather than a hard failure).
+    #[inline]
+    pub fn try_encrypt(&mut self, plaintext: &[u8]) -> Result<usize, TlsError> {
+        match self.inner.writer().write(plaintext) {
+            Ok(n) => Ok(n),
+            Err(e) if e.kind() == io::ErrorKind::WriteZero => Ok(0),
+            Err(e) => Err(TlsError::Io(e)),
+        }
+    }
+
+    /// Set rustls's outbound plaintext queue limit. `None` for
+    /// unlimited (rustls accepts as much plaintext as memory allows;
+    /// pair with a caller-side bound).
+    ///
+    /// Default is rustls's `DEFAULT_BUFFER_LIMIT = 64 KiB`. Trading
+    /// workloads with small messages typically don't need to change
+    /// this. Bulk-transfer workloads (large snapshots, file uploads
+    /// over TLS) may benefit from raising it to reduce drain/refill
+    /// cycles in [`try_encrypt`](Self::try_encrypt).
+    pub fn set_buffer_limit(&mut self, limit: Option<usize>) {
+        self.inner.set_buffer_limit(limit);
+    }
+
+    /// Queue a TLS `close_notify` alert.
+    ///
+    /// Subsequent calls to [`wants_write`](Self::wants_write) will
+    /// return true until the alert ciphertext has been written via
+    /// [`write_tls_to`](Self::write_tls_to).
+    ///
+    /// Idempotent: rustls tracks whether close_notify has been sent
+    /// and no-ops on duplicate calls.
+    ///
+    /// Use in `AsyncWrite::poll_shutdown` (or equivalent) before
+    /// closing the underlying transport. Without close_notify, the
+    /// peer sees TCP FIN as a potential truncation and may error its
+    /// read loop mid-stream.
+    #[inline]
+    pub fn send_close_notify(&mut self) {
+        self.inner.send_close_notify();
     }
 
     /// Flush encrypted bytes to a socket.
@@ -205,16 +372,19 @@ impl TlsCodec {
     // =========================================================================
 
     /// Whether the TLS handshake is still in progress.
+    #[inline]
     pub fn is_handshaking(&self) -> bool {
         self.inner.is_handshaking()
     }
 
     /// Whether the codec has buffered TLS data to read.
+    #[inline]
     pub fn wants_read(&self) -> bool {
         self.inner.wants_read()
     }
 
     /// Whether the codec has encrypted data to write.
+    #[inline]
     pub fn wants_write(&self) -> bool {
         self.inner.wants_write()
     }
@@ -232,6 +402,8 @@ impl std::fmt::Debug for TlsCodec {
 mod tests {
     use std::io::Cursor;
     use std::sync::Arc;
+
+    use crate::buf::ReadBuf;
 
     use super::*;
 
@@ -509,6 +681,309 @@ mod tests {
         );
     }
 
+    /// Drive an in-memory TLS 1.3 handshake to completion.
+    /// Returns the connected client codec + server connection ready for
+    /// app-data exchange. Used by `read_tls_step` tests that need a
+    /// post-handshake codec.
+    fn connected_pair() -> (TlsCodec, rustls::ServerConnection) {
+        let (cert_chain, key_der) = generate_self_signed();
+        let key = rustls::pki_types::PrivateKeyDer::try_from(key_der).unwrap();
+        let server_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(cert_chain, key)
+                .unwrap(),
+        );
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+
+        let client_config = TlsConfig::builder().danger_no_verify().build().unwrap();
+        let mut client = TlsCodec::new(&client_config, "localhost").unwrap();
+
+        let mut c2s = Vec::new();
+        let mut s2c = Vec::new();
+
+        for _ in 0..64 {
+            while client.wants_write() {
+                client.write_tls_to(&mut c2s).unwrap();
+            }
+            if !c2s.is_empty() {
+                server.read_tls(&mut Cursor::new(&c2s)).unwrap();
+                server.process_new_packets().unwrap();
+                c2s.clear();
+            }
+            while server.wants_write() {
+                server.write_tls(&mut s2c).unwrap();
+            }
+            if !s2c.is_empty() {
+                client.read_and_process_tls(&s2c).unwrap();
+                s2c.clear();
+            }
+            if !client.is_handshaking() && !server.is_handshaking() {
+                return (client, server);
+            }
+        }
+        panic!("TLS handshake did not complete");
+    }
+
+    /// Encrypt `payload` from the server side and capture the resulting
+    /// ciphertext.
+    fn encrypt_server_payload(server: &mut rustls::ServerConnection, payload: &[u8]) -> Vec<u8> {
+        use std::io::Write as _;
+        server.writer().write_all(payload).unwrap();
+        let mut ciphertext = Vec::new();
+        while server.wants_write() {
+            server.write_tls(&mut ciphertext).unwrap();
+        }
+        ciphertext
+    }
+
+    /// Empty input should be a cheap no-op, not an error.
+    #[test]
+    fn read_tls_step_empty_input_returns_zero() {
+        let client_config = TlsConfig::builder().danger_no_verify().build().unwrap();
+        let mut client = TlsCodec::new(&client_config, "localhost").unwrap();
+
+        let n = client
+            .read_tls_step(&[])
+            .expect("empty input must not error");
+        assert_eq!(n, 0);
+    }
+
+    /// Happy path: feed a small ciphertext prefix, get a non-zero
+    /// consumed count back, drain the resulting plaintext.
+    #[test]
+    fn read_tls_step_normal_step() {
+        let (mut client, mut server) = connected_pair();
+        let payload = b"hello, world";
+        let ciphertext = encrypt_server_payload(&mut server, payload);
+        assert!(!ciphertext.is_empty());
+
+        let consumed = client
+            .read_tls_step(&ciphertext)
+            .expect("step must succeed on fresh ciphertext");
+        assert!(consumed > 0, "must consume at least one byte");
+        assert!(consumed <= ciphertext.len());
+
+        let mut dst = vec![0u8; payload.len()];
+        let n = client.read_plaintext(&mut dst).unwrap();
+        assert_eq!(n, payload.len());
+        assert_eq!(&dst[..n], payload);
+    }
+
+    /// `read_tls_step` itself never overflows the plaintext buffer
+    /// because it consumes one accepted prefix per call. The error
+    /// surfaces on `read_and_process_tls` (the bounded helper) when
+    /// fed a large slice without an interleaved drain. This test is
+    /// the moved-from-nexus-async-net pin documenting the constraint
+    /// that motivates `read_tls_step`'s existence.
+    ///
+    /// Named for what the body actually exercises (the failing
+    /// helper), not for the helper it advocates against.
+    #[test]
+    fn read_and_process_tls_rejects_when_plaintext_buffer_full() {
+        let (mut client, mut server) = connected_pair();
+        let payload = vec![b'x'; 64 * 1024];
+        let ciphertext = encrypt_server_payload(&mut server, &payload);
+
+        let error = client
+            .read_and_process_tls(&ciphertext)
+            .expect_err("full-slice processing should overfill rustls plaintext");
+
+        assert!(
+            error.to_string().contains("received plaintext buffer full"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// `try_encrypt` returns the partial accepted count when rustls's
+    /// outbound plaintext queue can't hold the full input. Lower the
+    /// queue limit explicitly so the test doesn't depend on rustls's
+    /// internal default.
+    #[test]
+    fn try_encrypt_returns_partial_when_queue_fills() {
+        let (mut client, _server) = connected_pair();
+        client.set_buffer_limit(Some(4096));
+
+        // First 4 KiB fits.
+        let n1 = client.try_encrypt(&[b'a'; 4096]).unwrap();
+        assert_eq!(n1, 4096);
+
+        // Next chunk: queue is full. try_encrypt accepts 0.
+        let n2 = client.try_encrypt(&[b'b'; 4096]).unwrap();
+        assert_eq!(n2, 0, "queue full → try_encrypt must report 0 accepted");
+    }
+
+    /// `set_buffer_limit(None)` lifts the cap entirely — `try_encrypt`
+    /// accepts everything in one shot.
+    #[test]
+    fn set_buffer_limit_none_unlimits_queue() {
+        let (mut client, _server) = connected_pair();
+        client.set_buffer_limit(None);
+
+        let n = client.try_encrypt(&[b'x'; 256 * 1024]).unwrap();
+        assert_eq!(
+            n,
+            256 * 1024,
+            "unlimited queue must accept the entire payload"
+        );
+    }
+
+    /// The original `encrypt` is all-or-nothing: it errors with
+    /// `WriteZero` if the input doesn't fit. This test pins that
+    /// shape so the migration to `try_encrypt` in adapters stays
+    /// motivated.
+    #[test]
+    #[allow(deprecated)] // exercising the deprecated primitive on purpose
+    fn encrypt_errors_when_payload_exceeds_queue_limit() {
+        let (mut client, _server) = connected_pair();
+        client.set_buffer_limit(Some(4096));
+
+        let err = client
+            .encrypt(&[b'x'; 8192])
+            .expect_err("encrypt must error when input > queue limit");
+        let TlsError::Io(io_err) = err else {
+            panic!("expected TlsError::Io, got {err:?}");
+        };
+        assert_eq!(io_err.kind(), io::ErrorKind::WriteZero);
+    }
+
+    // -------------------------------------------------------------------------
+    // Side-by-side adapter-pattern demonstrators
+    //
+    // These two tests are the strong pin for why `read_tls_step` exists.
+    // They mimic the EXACT shape of an async adapter loop: pull a chunk of
+    // ciphertext, drain plaintext between chunks, repeat.
+    //
+    // The negative test fixes the chunk size at 32 KiB — the size a future
+    // adapter optimisation might use to amortise syscall cost (the
+    // current 8 KiB tmp accidentally hides the bug). At that size,
+    // `read_and_process_tls` overflows rustls's 16 KiB plaintext queue
+    // mid-chunk: the helper's internal loop iterates until the slice is
+    // consumed, so it processes ~5 records back-to-back before yielding,
+    // and the inter-chunk plaintext drain doesn't help.
+    //
+    // The positive test runs the same shape with the same chunk size
+    // through `read_tls_step` + a `pending_read` spillover. It recovers
+    // the full payload because each `read_tls_step` advances by exactly
+    // one accepted prefix, which lets the caller drain plaintext between
+    // packet steps — never letting rustls's queue fill.
+    //
+    // Together they pin: the bug is real, the fix solves it, and the
+    // chunk-size headroom that would otherwise be a latent foot-gun for
+    // future adapter authors is closed.
+    // -------------------------------------------------------------------------
+
+    /// **Negative side**: feeding 32 KiB ciphertext chunks through
+    /// `read_and_process_tls` overflows rustls's plaintext queue
+    /// mid-chunk, even with proper inter-chunk plaintext draining.
+    #[test]
+    fn adapter_pattern_with_read_and_process_tls_overflows_on_oversize_chunks() {
+        let (mut client, mut server) = connected_pair();
+        let payload = vec![b'x'; 64 * 1024];
+        let ciphertext = encrypt_server_payload(&mut server, &payload);
+
+        // 32 KiB > 16 KiB plaintext queue cap. The helper's internal
+        // loop processes ~5 records back-to-back per chunk; queue
+        // overflows on the ~5th record.
+        let chunk_size = 32 * 1024;
+        let mut cursor = 0;
+        let mut dst = [0u8; 4096];
+
+        let result = loop {
+            // Drain plaintext between chunks (proper adapter etiquette).
+            let n = client
+                .read_plaintext(&mut dst)
+                .expect("read_plaintext must not error here");
+            if n > 0 {
+                continue;
+            }
+
+            if cursor >= ciphertext.len() {
+                break Ok(());
+            }
+
+            let end = (cursor + chunk_size).min(ciphertext.len());
+            match client.read_and_process_tls(&ciphertext[cursor..end]) {
+                Ok(consumed) => cursor += consumed,
+                Err(e) => break Err(e),
+            }
+        };
+
+        let err = result.expect_err(
+            "32 KiB ciphertext chunks via read_and_process_tls must overflow \
+             rustls's plaintext queue mid-chunk",
+        );
+        assert!(
+            err.to_string().contains("received plaintext buffer full"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// **Positive side**: the same 64 KiB payload, same 32 KiB chunk
+    /// size, but consumed via `read_tls_step` + a `pending_read`
+    /// spillover. The step-and-drain pattern recovers the entire
+    /// payload without overflowing.
+    #[test]
+    fn adapter_pattern_with_read_tls_step_handles_oversize_chunks() {
+        let (mut client, mut server) = connected_pair();
+        let payload = vec![b'x'; 64 * 1024];
+        let ciphertext = encrypt_server_payload(&mut server, &payload);
+
+        let chunk_size = 32 * 1024;
+        let mut pending = ReadBuf::with_capacity(chunk_size);
+        let mut plaintext = Vec::with_capacity(payload.len());
+        let mut cursor = 0;
+        let mut dst = [0u8; 4096];
+
+        // Cap iterations so a regression doesn't loop forever.
+        for _ in 0..1_000_000 {
+            // 1. Drain rustls's plaintext queue.
+            let n = client.read_plaintext(&mut dst).unwrap();
+            if n > 0 {
+                plaintext.extend_from_slice(&dst[..n]);
+                if plaintext.len() == payload.len() {
+                    break;
+                }
+                continue;
+            }
+
+            // 2. Step buffered ciphertext one packet at a time.
+            if !pending.is_empty() {
+                let consumed = client
+                    .read_tls_step(pending.data())
+                    .expect("step must succeed against buffered ciphertext");
+                pending.advance(consumed);
+                continue;
+            }
+
+            // 3. Pull the next 32 KiB chunk.
+            if cursor < ciphertext.len() {
+                let end = (cursor + chunk_size).min(ciphertext.len());
+                let chunk = &ciphertext[cursor..end];
+                let consumed = client
+                    .read_tls_step(chunk)
+                    .expect("step must succeed on fresh chunk");
+                if consumed < chunk.len() {
+                    let rem = &chunk[consumed..];
+                    let spare = pending.spare();
+                    spare[..rem.len()].copy_from_slice(rem);
+                    pending.filled(rem.len());
+                }
+                cursor = end;
+                continue;
+            }
+
+            break;
+        }
+
+        assert_eq!(
+            plaintext, payload,
+            "step + drain must recover the entire payload"
+        );
+        assert_eq!(cursor, ciphertext.len(), "must consume entire ciphertext");
+        assert!(pending.is_empty(), "no leftover ciphertext");
+    }
+
     /// Demonstrates the contract difference between `read_tls` and
     /// `read_and_process_tls` (issue #200).
     ///
@@ -535,6 +1010,7 @@ mod tests {
     /// correct — partial consumption is the documented contract of
     /// `Connection::read_tls`, not an implementation accident.
     #[test]
+    #[allow(deprecated)] // exercising the deprecated primitive on purpose
     fn bare_read_tls_partially_consumes_large_slice() {
         let client_config = TlsConfig::builder().danger_no_verify().build().unwrap();
         let mut client = TlsCodec::new(&client_config, "localhost").unwrap();

--- a/nexus-net/src/tls/mod.rs
+++ b/nexus-net/src/tls/mod.rs
@@ -22,6 +22,17 @@
 //!     process(msg);
 //! }
 //! ```
+//!
+//! # Choosing an input primitive
+//!
+//! [`TlsCodec`] provides three inbound primitives. Pick based on how
+//! the caller produces ciphertext:
+//!
+//! | Primitive | Use when |
+//! |---|---|
+//! | [`TlsCodec::read_tls_step`] | **Streaming app-data adapters** (the common case for async TLS). Caller alternates ciphertext input with plaintext output to avoid overflowing rustls's internal plaintext queue. |
+//! | [`TlsCodec::read_and_process_tls`] | **Bounded handshake input.** Caller tolerates plaintext queuing internally until the helper returns. Do **not** use for streaming app-data — large inputs overflow rustls's plaintext queue mid-call. |
+//! | [`TlsCodec::read_tls`] | **Advanced use only.** Direct rustls wrapper; caller drives [`TlsCodec::process_new_packets`] and tracks partial consumption manually. Use only when neither of the helpers above fits the adapter shape. |
 
 mod codec;
 mod config;

--- a/nexus-net/src/tls/stream.rs
+++ b/nexus-net/src/tls/stream.rs
@@ -12,33 +12,185 @@
 
 use std::io::{self, Read, Write};
 
+#[cfg(feature = "tokio")]
+use crate::buf::{ReadBuf, WriteBuf};
+
 use super::codec::TlsCodec;
+
+/// Per-poll TLS read chunk size used by the tokio adapter's
+/// `poll_read`. Module-level const so it can be used in struct field
+/// types; re-exposed publicly as [`TlsStream::TMP_SIZE`].
+#[cfg(feature = "tokio")]
+const TMP_SIZE: usize = 8192;
+
+// Latent bug guard: read_and_process_tls is used during handshake to
+// consume the full slice. If the burst carrying ServerFinished also
+// piggybacks app-data records (TLS 1.3 allows this), the helper
+// continues consuming past the handshake transition and queues the
+// app-data plaintext in rustls's internal buffer — capped at ~16 KiB.
+// With TMP_SIZE = 8 KiB we cannot overflow it on a single read. **If
+// you bump TMP_SIZE past 16 KiB, fix the handshake-piggyback path
+// first** — see the 0.7.0 follow-up issue. The proper fix is
+// hoisting handshake into TlsInner so `pending_read` is reachable
+// for direct stash without an intermediate allocation.
+#[cfg(feature = "tokio")]
+const _: () = assert!(
+    TMP_SIZE <= 16 * 1024,
+    "TMP_SIZE > 16 KiB requires handshake-piggyback fix (0.7.0)"
+);
 
 /// A stream that transparently encrypts and decrypts via [`TlsCodec`].
 ///
 /// Implements `Read` and `Write` by routing through the TLS codec.
 /// The inner stream `S` carries raw ciphertext; callers see plaintext.
+///
+/// # Shutdown
+///
+/// `poll_shutdown` queues a TLS `close_notify` alert, flushes the
+/// resulting ciphertext to the transport, then closes the underlying
+/// transport. Callers do not need to flush manually — `poll_shutdown`
+/// drives any pending plaintext through to the wire as part of its
+/// shutdown sequence.
+///
+/// If the caller drops the stream without calling `poll_shutdown`,
+/// any pending plaintext (in rustls's outbound queue) and ciphertext
+/// (in `pending_write`) is discarded, and the peer sees TCP FIN
+/// without close_notify — which rustls treats as a truncation alert.
+/// Callers needing graceful termination must call `shutdown().await`
+/// (or drive `poll_shutdown` to `Ready`) before drop.
+///
+/// # Memory
+///
+/// Each TLS-wrapped connection on the tokio adapter allocates
+/// approximately 81 KiB of heap-resident buffers:
+///
+/// | Buffer | Size | Purpose |
+/// |---|---|---|
+/// | `pending_read` | 8 KiB | Spillover for partially-consumed inbound TLS records |
+/// | `pending_write` | 64 KiB | Outbound ciphertext FIFO (drains to socket) |
+/// | `tmp` | 8 KiB | Per-connection scratch buffer for transport reads |
+/// | rustls state | ~1 KiB | Crypto state + small fixed buffers |
+///
+/// Trading workloads with small frequent messages can reduce
+/// `pending_write` via [`with_capacities`](Self::with_capacities) —
+/// 8–16 KiB is sufficient for most order-entry and market-data
+/// clients. For 1000 connections with default sizing, expect
+/// ~81 MiB of buffer footprint.
 pub struct TlsStream<S> {
     stream: S,
     codec: TlsCodec,
-    /// Pending ciphertext from a partial write. When `poll_write` on the
-    /// underlying stream accepts fewer bytes than we produced, the
-    /// remainder is stored here and drained on the next poll.
-    #[cfg_attr(not(feature = "tokio"), allow(dead_code))]
-    pending_write: Vec<u8>,
+    /// Ciphertext read from the transport but not yet accepted by rustls.
+    /// Used by the tokio adapter to interleave plaintext draining with
+    /// ciphertext stepping (avoids `received plaintext buffer full` on
+    /// large steady-state app data bursts).
+    #[cfg(feature = "tokio")]
+    pending_read: ReadBuf,
+    /// Ciphertext waiting to be flushed to the transport. Cursor-based
+    /// FIFO — no per-write memmove (auto-resets on full drain).
+    #[cfg(feature = "tokio")]
+    pending_write: WriteBuf,
+    /// Per-poll scratch buffer for the tokio adapter's `poll_read`.
+    /// Boxed so the 8 KiB stays off the per-poll stack frame —
+    /// eliminates a per-poll memset + stack-probe pair on the hot
+    /// read path.
+    #[cfg(feature = "tokio")]
+    tmp: Box<[u8; TMP_SIZE]>,
 }
 
 impl<S> TlsStream<S> {
-    /// Wrap a transport stream with a TLS codec.
+    /// Per-poll TLS read chunk size used by the tokio adapter's
+    /// `poll_read`. `pending_read` capacity must be at least this
+    /// large so the spillover-copy after a partial codec read fits.
+    /// Only present under `feature = "tokio"` — non-tokio builds
+    /// don't have the buffers this sizes.
+    #[cfg(feature = "tokio")]
+    pub const TMP_SIZE: usize = TMP_SIZE;
+
+    /// Default capacity for the outbound ciphertext buffer used by
+    /// the tokio adapter.
+    ///
+    /// 64 KiB matches rustls's `DEFAULT_BUFFER_LIMIT` — the outbound
+    /// plaintext queue cap. A 64 KiB plaintext encrypt produces about
+    /// 64 KiB plus ~120 bytes of ciphertext (TLS record headers and
+    /// auth tags), so a single max-size encrypt triggers exactly one
+    /// drain/refill iteration in `poll_write`. Bumping this to 80 KiB
+    /// would absorb the overhead in one shot but breaks the symmetric
+    /// default; the drain/refill is cheap (non-blocking write) and the
+    /// symmetry is the more discoverable choice.
+    ///
+    /// Larger writes are chunked across multiple `poll_write` calls
+    /// via [`TlsCodec::try_encrypt`] regardless of this cap.
+    #[cfg(feature = "tokio")]
+    pub const DEFAULT_PENDING_WRITE_CAPACITY: usize = 65_536;
+
+    /// Wrap a transport stream with a TLS codec, using default
+    /// buffer capacities for the tokio adapter (`TMP_SIZE` for
+    /// `pending_read`, `DEFAULT_PENDING_WRITE_CAPACITY` for
+    /// `pending_write`).
     ///
     /// The codec should already be constructed with the correct hostname.
-    /// Call [`handshake`](Self::handshake) to complete the TLS handshake
-    /// before reading or writing plaintext.
+    /// Call [`handshake`](Self::handshake) (sync) or
+    /// [`handshake_async`](Self::handshake_async) (tokio) before
+    /// reading or writing plaintext.
+    ///
+    /// For custom buffer sizing on tokio, use
+    /// [`with_capacities`](Self::with_capacities).
     pub fn new(stream: S, codec: TlsCodec) -> Self {
         Self {
             stream,
             codec,
-            pending_write: Vec::new(),
+            #[cfg(feature = "tokio")]
+            pending_read: ReadBuf::with_capacity(Self::TMP_SIZE),
+            #[cfg(feature = "tokio")]
+            pending_write: WriteBuf::new(Self::DEFAULT_PENDING_WRITE_CAPACITY, 0),
+            // Heap-allocated, lives for the connection's lifetime. Earlier
+            // versions stack-allocated this per `poll_read`; the per-poll
+            // memset + stack probe was a measurable cost on the steady-state
+            // hot path. For long-lived TLS connections the alloc amortises
+            // over millions of polls.
+            #[cfg(feature = "tokio")]
+            tmp: Box::new([0u8; TMP_SIZE]),
+        }
+    }
+
+    /// Wrap a transport stream with explicit buffer capacities for
+    /// the tokio adapter.
+    ///
+    /// `pending_read_cap` holds ciphertext read from the transport
+    /// but not yet accepted by rustls. **Must be at least
+    /// [`TMP_SIZE`](Self::TMP_SIZE)** — the per-poll read chunk size.
+    /// 8 KiB suffices for any well-formed TLS stream; oversize is
+    /// harmless waste.
+    ///
+    /// `pending_write_cap` holds ciphertext rustls has produced but
+    /// not yet flushed to the transport. The drain loop in
+    /// `poll_write` handles arbitrary plaintext sizes regardless of
+    /// this capacity, but smaller capacities mean more drain/refill
+    /// cycles for big writes. 64 KiB amortises a single 64 KiB
+    /// plaintext encrypt; trading workloads with small messages can
+    /// use 8–16 KiB to reduce per-connection footprint.
+    ///
+    /// # Panics
+    /// Panics if `pending_read_cap < TMP_SIZE`.
+    #[cfg(feature = "tokio")]
+    pub fn with_capacities(
+        stream: S,
+        codec: TlsCodec,
+        pending_read_cap: usize,
+        pending_write_cap: usize,
+    ) -> Self {
+        assert!(
+            pending_read_cap >= Self::TMP_SIZE,
+            "pending_read_cap ({pending_read_cap}) must be >= TMP_SIZE ({})",
+            Self::TMP_SIZE,
+        );
+        Self {
+            stream,
+            codec,
+            pending_read: ReadBuf::with_capacity(pending_read_cap),
+            pending_write: WriteBuf::new(pending_write_cap, 0),
+            // Heap-allocated; see comment in `new()`.
+            tmp: Box::new([0u8; TMP_SIZE]),
         }
     }
 
@@ -66,6 +218,18 @@ impl<S> TlsStream<S> {
     pub fn into_parts(self) -> (S, TlsCodec) {
         (self.stream, self.codec)
     }
+
+    /// Set rustls's outbound plaintext queue limit. Convenience
+    /// pass-through to [`TlsCodec::set_buffer_limit`].
+    ///
+    /// Default is rustls's `DEFAULT_BUFFER_LIMIT = 64 KiB`. Bulk-
+    /// transfer workloads (large snapshots, file uploads over TLS)
+    /// may benefit from raising it to reduce drain/refill cycles in
+    /// `poll_write`. `None` for unlimited (caller is responsible for
+    /// not encrypting more than memory allows).
+    pub fn set_buffer_limit(&mut self, limit: Option<usize>) {
+        self.codec.set_buffer_limit(limit);
+    }
 }
 
 impl<S: Read + Write> TlsStream<S> {
@@ -78,6 +242,11 @@ impl<S: Read + Write> TlsStream<S> {
                 self.codec.write_tls_to(&mut self.stream)?;
             }
             if self.codec.wants_read() {
+                // Sync path: hand rustls a `Read` directly so it drives
+                // the per-call read internally. The async equivalent
+                // (`handshake_async`) buffers bytes from the async
+                // transport into a tmp slice first, then feeds them
+                // via `read_and_process_tls`.
                 self.codec.read_tls_from(&mut self.stream)?;
                 self.codec.process_new_packets()?;
             }
@@ -121,6 +290,11 @@ impl<S: Read + Write> Read for TlsStream<S> {
 
 impl<S: Read + Write> Write for TlsStream<S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Sync `Write` is all-or-nothing by trait contract, so the
+        // deprecated `encrypt` is the right primitive here — async
+        // adapters use `try_encrypt` to surface partial acceptance to
+        // the runtime, which sync Write doesn't model.
+        #[allow(deprecated)]
         self.codec.encrypt(buf).map_err(tls_to_io)?;
         while self.codec.wants_write() {
             self.codec.write_tls_to(&mut self.stream)?;
@@ -186,40 +360,61 @@ impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> tokio::io::AsyncRe
     ) -> std::task::Poll<io::Result<()>> {
         let this = self.get_mut();
 
-        // Try reading already-buffered plaintext first.
-        let slice = buf.initialize_unfilled();
-        let n = this.codec.read_plaintext(slice).map_err(tls_to_io)?;
-        if n > 0 {
-            buf.advance(n);
-            return std::task::Poll::Ready(Ok(()));
-        }
-
-        // Need more ciphertext from the transport.
-        let mut tmp = [0u8; 8192];
-        let mut tmp_buf = tokio::io::ReadBuf::new(&mut tmp);
-        match std::pin::Pin::new(&mut this.stream).poll_read(cx, &mut tmp_buf) {
-            std::task::Poll::Ready(Ok(())) => {
-                let filled = tmp_buf.filled().len();
-                if filled == 0 {
-                    return std::task::Poll::Ready(Ok(())); // EOF
-                }
-                this.codec
-                    .read_and_process_tls(&tmp[..filled])
-                    .map_err(tls_to_io)?;
-                let slice = buf.initialize_unfilled();
-                let pn = this.codec.read_plaintext(slice).map_err(tls_to_io)?;
-                if pn > 0 {
-                    buf.advance(pn);
-                    std::task::Poll::Ready(Ok(()))
-                } else {
-                    // TLS consumed a non-application record. Need to poll
-                    // again — wake ourselves so the executor retries.
-                    cx.waker().wake_by_ref();
-                    std::task::Poll::Pending
-                }
+        loop {
+            // 1. Drain any plaintext already decrypted by rustls.
+            let slice = buf.initialize_unfilled();
+            let n = this.codec.read_plaintext(slice).map_err(tls_to_io)?;
+            if n > 0 {
+                buf.advance(n);
+                return std::task::Poll::Ready(Ok(()));
             }
-            std::task::Poll::Ready(Err(e)) => std::task::Poll::Ready(Err(e)),
-            std::task::Poll::Pending => std::task::Poll::Pending,
+
+            // 2. If we have ciphertext from a previous step that didn't
+            //    fully consume, advance one packet step on it.
+            if !this.pending_read.is_empty() {
+                let consumed = this
+                    .codec
+                    .read_tls_step(this.pending_read.data())
+                    .map_err(tls_to_io)?;
+                // State invariant: every error leg above this line MUST
+                // return before reaching here. If you add new error
+                // returns, place them BEFORE this side-effect — pending_read
+                // can be left inconsistent if advance() is half-applied.
+                this.pending_read.advance(consumed);
+                continue;
+            }
+
+            // 3. No buffered ciphertext — pull more from the transport.
+            //    Use the heap-resident scratch buffer so the 8 KiB
+            //    doesn't sit on every poll_read stack frame.
+            let filled = {
+                let mut tmp_buf = tokio::io::ReadBuf::new(&mut this.tmp[..]);
+                match std::pin::Pin::new(&mut this.stream).poll_read(cx, &mut tmp_buf) {
+                    std::task::Poll::Ready(Ok(())) => tmp_buf.filled().len(),
+                    std::task::Poll::Ready(Err(e)) => {
+                        return std::task::Poll::Ready(Err(e));
+                    }
+                    std::task::Poll::Pending => return std::task::Poll::Pending,
+                }
+            };
+            if filled == 0 {
+                return std::task::Poll::Ready(Ok(())); // EOF
+            }
+            let consumed = this
+                .codec
+                .read_tls_step(&this.tmp[..filled])
+                .map_err(tls_to_io)?;
+            if consumed < filled {
+                let rem_len = filled - consumed;
+                let spare = this.pending_read.spare();
+                spare[..rem_len].copy_from_slice(&this.tmp[consumed..filled]);
+                // State invariant: every error leg above this line MUST
+                // return before reaching here. If you add new error
+                // returns, place them BEFORE this side-effect — pending_read
+                // can be left inconsistent if filled() is half-applied.
+                this.pending_read.filled(rem_len);
+            }
+            // Loop back: drain plaintext or step pending_read.
         }
     }
 }
@@ -235,32 +430,50 @@ impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWr
     ) -> std::task::Poll<io::Result<usize>> {
         let this = self.get_mut();
 
-        // Drain any pending ciphertext from a previous partial write.
-        if let Err(e) = tokio_drain_pending(this, cx) {
+        // 1. Drain pending ciphertext to free pending_write space.
+        if let Err(e) = drain_pending(this, cx) {
             return std::task::Poll::Ready(Err(e));
         }
         if !this.pending_write.is_empty() {
-            // Still have pending data — can't accept more plaintext yet.
+            // Socket can't take more — backpressure surfaces here.
             return std::task::Poll::Pending;
         }
 
-        this.codec.encrypt(buf).map_err(tls_to_io)?;
-
-        // Drain ciphertext from rustls into pending_write, then flush
-        // as much as we can to the underlying stream.
-        let mut tmp = [0u8; 8192];
-        while this.codec.wants_write() {
-            let n = this.codec.write_tls_to(&mut tmp.as_mut_slice())?;
-            this.pending_write.extend_from_slice(&tmp[..n]);
+        // 2. Pull queued ciphertext from rustls into pending_write and
+        //    on to the socket. Frees rustls's plaintext queue so
+        //    try_encrypt has room for new bytes.
+        if let Err(e) = drain_codec_to_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
+        }
+        if let Err(e) = drain_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
+        }
+        if !this.pending_write.is_empty() {
+            return std::task::Poll::Pending;
         }
 
-        if let Err(e) = tokio_drain_pending(this, cx) {
+        // 3. Encrypt as much of buf as rustls's queue can accept.
+        //    Chunked: returns Ok(0) if the queue is full and the caller
+        //    must come back later (after socket drains more).
+        let consumed = this.codec.try_encrypt(buf).map_err(tls_to_io)?;
+        if consumed == 0 {
+            // Defensive: rustls should not return 0 here after we've
+            // drained both its outbound queue and the socket. If it
+            // does (rustls bug or edge case), wake_by_ref ensures the
+            // runtime re-polls us instead of stalling indefinitely.
+            cx.waker().wake_by_ref();
+            return std::task::Poll::Pending;
+        }
+
+        // 4. Best-effort flush of what we just produced.
+        if let Err(e) = drain_codec_to_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
+        }
+        if let Err(e) = drain_pending(this, cx) {
             return std::task::Poll::Ready(Err(e));
         }
 
-        // Report all plaintext as written — ciphertext is either flushed
-        // or buffered in pending_write for the next poll.
-        std::task::Poll::Ready(Ok(buf.len()))
+        std::task::Poll::Ready(Ok(consumed))
     }
 
     fn poll_flush(
@@ -269,15 +482,13 @@ impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWr
     ) -> std::task::Poll<io::Result<()>> {
         let this = self.get_mut();
 
-        // Drain any remaining rustls ciphertext.
-        let mut tmp = [0u8; 8192];
-        while this.codec.wants_write() {
-            let n = this.codec.write_tls_to(&mut tmp.as_mut_slice())?;
-            this.pending_write.extend_from_slice(&tmp[..n]);
+        // Drain any remaining rustls ciphertext into pending_write.
+        if let Err(e) = drain_codec_to_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
         }
 
         // Flush pending ciphertext to the stream.
-        if let Err(e) = tokio_drain_pending(this, cx) {
+        if let Err(e) = drain_pending(this, cx) {
             return std::task::Poll::Ready(Err(e));
         }
         if !this.pending_write.is_empty() {
@@ -291,28 +502,96 @@ impl<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWr
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<io::Result<()>> {
-        std::pin::Pin::new(&mut self.get_mut().stream).poll_shutdown(cx)
+        let this = self.get_mut();
+
+        // 1. Queue close_notify (idempotent — rustls no-ops on dupes,
+        //    so this loop re-entering after Pending is safe).
+        this.codec.send_close_notify();
+
+        // 2. Drain rustls's queue (now including close_notify
+        //    ciphertext) into pending_write.
+        if let Err(e) = drain_codec_to_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
+        }
+
+        // 3. Flush pending_write to the transport. If we can't fully
+        //    drain yet, wait for the next poll.
+        if let Err(e) = drain_pending(this, cx) {
+            return std::task::Poll::Ready(Err(e));
+        }
+        if !this.pending_write.is_empty() {
+            return std::task::Poll::Pending;
+        }
+
+        // 4. Now safe to shutdown the transport.
+        std::pin::Pin::new(&mut this.stream).poll_shutdown(cx)
     }
 }
 
 /// Drain pending ciphertext to the underlying tokio stream. Handles partial
-/// writes by advancing the buffer.
+/// writes by advancing the buffer cursor (auto-resets on full drain).
 #[cfg(feature = "tokio")]
-fn tokio_drain_pending<S: tokio::io::AsyncWrite + Unpin>(
+fn drain_pending<S: tokio::io::AsyncWrite + Unpin>(
     this: &mut TlsStream<S>,
     cx: &mut std::task::Context<'_>,
 ) -> io::Result<()> {
     while !this.pending_write.is_empty() {
-        match std::pin::Pin::new(&mut this.stream).poll_write(cx, &this.pending_write) {
+        match std::pin::Pin::new(&mut this.stream).poll_write(cx, this.pending_write.data()) {
             std::task::Poll::Ready(Ok(0)) => {
                 return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
             }
             std::task::Poll::Ready(Ok(n)) => {
-                this.pending_write.drain(..n);
+                this.pending_write.advance(n);
             }
             std::task::Poll::Ready(Err(e)) => return Err(e),
             std::task::Poll::Pending => return Ok(()), // Will be retried next poll.
         }
+    }
+    Ok(())
+}
+
+/// Move all ciphertext rustls wants to write into `pending_write`,
+/// draining `pending_write` to the socket between iterations so a
+/// single big encrypt can't outrun `pending_write`'s fixed capacity.
+///
+/// Returns `Ok(())` once rustls is drained or the socket can no longer
+/// accept bytes (in which case the leftover ciphertext stays inside
+/// rustls and is picked up on the next call).
+///
+/// Distinguishes two distinct exit conditions:
+/// - `pending_write.spare().is_empty()` after a drain attempt —
+///   legitimate backpressure, returns `Ok(())`.
+/// - `write_tls_to` returns 0 into a non-empty spare slice — a rustls
+///   contract violation. Surfaced as `WriteZero` rather than masked
+///   as a stalled connection.
+#[cfg(feature = "tokio")]
+fn drain_codec_to_pending<S: tokio::io::AsyncWrite + Unpin>(
+    this: &mut TlsStream<S>,
+    cx: &mut std::task::Context<'_>,
+) -> io::Result<()> {
+    while this.codec.wants_write() {
+        if this.pending_write.spare().is_empty() {
+            // Backpressure: try to drain to free space.
+            drain_pending(this, cx)?;
+            if this.pending_write.spare().is_empty() {
+                // Socket can't take more right now. Remaining ciphertext
+                // stays queued in rustls until the next poll re-enters.
+                return Ok(());
+            }
+        }
+        let n = this.codec.write_tls_to(&mut this.pending_write.spare())?;
+        if n == 0 {
+            // wants_write said yes, spare was non-empty, yet rustls
+            // produced 0 bytes. Surface explicitly — silent break here
+            // would mask a stalled connection as success.
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "rustls reported wants_write but produced 0 bytes \
+                 into a non-empty buffer",
+            ));
+        }
+        this.pending_write.filled(n);
+        drain_pending(this, cx)?;
     }
     Ok(())
 }
@@ -325,5 +604,47 @@ fn tls_to_io(e: super::TlsError) -> io::Error {
     match e {
         super::TlsError::Io(io) => io,
         other => io::Error::other(other),
+    }
+}
+
+#[cfg(all(test, feature = "tokio"))]
+mod tests {
+    use super::*;
+    use crate::tls::TlsConfig;
+
+    fn make_codec() -> TlsCodec {
+        let cfg = TlsConfig::builder().danger_no_verify().build().unwrap();
+        TlsCodec::new(&cfg, "localhost").unwrap()
+    }
+
+    #[test]
+    fn with_capacities_at_minimum_succeeds() {
+        // pending_read_cap == TMP_SIZE is the minimum allowed; must
+        // construct without panicking.
+        let _ = TlsStream::with_capacities(
+            (),
+            make_codec(),
+            TlsStream::<()>::TMP_SIZE,
+            TlsStream::<()>::DEFAULT_PENDING_WRITE_CAPACITY,
+        );
+    }
+
+    #[test]
+    fn new_uses_default_capacities() {
+        // Smoke test: default constructor must build successfully.
+        let _ = TlsStream::new((), make_codec());
+    }
+
+    #[test]
+    #[should_panic(expected = "TMP_SIZE")]
+    fn with_capacities_panics_on_undersized_pending_read() {
+        // Anything below TMP_SIZE breaks the spillover-copy invariant
+        // in poll_read.
+        let _ = TlsStream::with_capacities(
+            (),
+            make_codec(),
+            TlsStream::<()>::TMP_SIZE - 1,
+            TlsStream::<()>::DEFAULT_PENDING_WRITE_CAPACITY,
+        );
     }
 }

--- a/nexus-net/src/ws/connecting.rs
+++ b/nexus-net/src/ws/connecting.rs
@@ -209,9 +209,13 @@ impl<S: Read + Write> Connecting<S> {
                     if let Some(tls) = &mut self.tls {
                         // TLS path: encrypt ALL remaining plaintext at once,
                         // then flush ciphertext. encrypt() consumes everything;
-                        // write_tls_to may partially flush.
+                        // write_tls_to may partially flush. The HTTP upgrade
+                        // request is small (always under rustls's plaintext
+                        // queue cap), so the all-or-nothing `encrypt` shape
+                        // is correct here — async streaming uses try_encrypt.
                         if self.req_offset < self.req_buf.len() {
                             let data = &self.req_buf[self.req_offset..];
+                            #[allow(deprecated)]
                             tls.encrypt(data)?;
                             self.req_offset = self.req_buf.len(); // all plaintext consumed
                         }

--- a/nexus-net/tests/tls_stream_async_backpressure.rs
+++ b/nexus-net/tests/tls_stream_async_backpressure.rs
@@ -1,0 +1,370 @@
+//! End-to-end positive guard for `TlsStream::poll_read` over tokio's
+//! AsyncRead — drives a 256 KiB app-data burst through a loopback TLS
+//! connection and asserts every byte arrives.
+//!
+//! At the current 8 KiB `tmp` chunk size in `poll_read`, this test
+//! passes both pre-fix and post-fix (8 KiB ciphertext stays under
+//! rustls's plaintext queue cap). The codec-level pin for the bug
+//! lives at
+//! `nexus-net::tls::codec::tests::adapter_pattern_with_read_and_process_tls_overflows_on_oversize_chunks`
+//! — that is the strong demonstrator that proves `read_tls_step` is
+//! the correct primitive, not `read_and_process_tls`. This integration
+//! test guards against future tmp-size tuning re-introducing the bug
+//! at the integration layer.
+
+#![cfg(all(feature = "tls", feature = "tokio"))]
+
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use nexus_net::tls::{TlsCodec, TlsConfig, TlsStream};
+
+const PAYLOAD_LEN: usize = 256 * 1024;
+
+fn make_server_config() -> Arc<rustls::ServerConfig> {
+    let cert_kp =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("cert generation");
+    let chain = vec![rustls::pki_types::CertificateDer::from(
+        cert_kp.cert.der().to_vec(),
+    )];
+    let key = rustls::pki_types::PrivateKeyDer::try_from(cert_kp.key_pair.serialize_der())
+        .expect("server key");
+    Arc::new(
+        rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(chain, key)
+            .expect("server config"),
+    )
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn run_burst_server(listener: TcpListener, server_config: Arc<rustls::ServerConfig>) {
+    let (tcp, _addr) = listener.accept().expect("accept");
+    tcp.set_nodelay(true).ok();
+    tcp.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(10))).ok();
+
+    let server = rustls::ServerConnection::new(server_config).expect("server conn");
+    // StreamOwned interleaves rustls plaintext writes with TCP I/O —
+    // exactly what's needed so a 256 KiB write_all flushes records as
+    // they're produced rather than overflowing rustls's outbound queue.
+    let mut tls = rustls::StreamOwned::new(server, tcp);
+
+    let payload = vec![b'x'; PAYLOAD_LEN];
+    tls.write_all(&payload).expect("server send burst");
+    tls.flush().expect("server flush burst");
+
+    // Drain anything the client says back so the server-side socket
+    // stays alive until the client finishes reading.
+    let mut sink = [0u8; 1024];
+    loop {
+        match tls.read(&mut sink) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+}
+
+#[test]
+fn tls_stream_handles_oversize_app_data_burst() {
+    let server_config = make_server_config();
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    let server_handle = thread::spawn(move || run_burst_server(listener, server_config));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("client connect");
+        tcp.set_nodelay(true).ok();
+
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+        let codec = TlsCodec::new(&tls_config, "localhost").expect("client codec");
+        let mut stream = TlsStream::new(tcp, codec);
+
+        // Drive the async handshake to completion before reading
+        // application data.
+        stream
+            .handshake_async()
+            .await
+            .expect("client handshake_async");
+
+        let mut received = Vec::with_capacity(PAYLOAD_LEN);
+        let mut buf = vec![0u8; 16 * 1024];
+        while received.len() < PAYLOAD_LEN {
+            let n = tokio::time::timeout(Duration::from_secs(10), stream.read(&mut buf))
+                .await
+                .expect("read timeout (likely the pre-fix backpressure bug)")
+                .expect("client read");
+            assert!(
+                n > 0,
+                "unexpected EOF mid-burst at {} bytes",
+                received.len()
+            );
+            received.extend_from_slice(&buf[..n]);
+        }
+
+        assert_eq!(received.len(), PAYLOAD_LEN, "must receive entire burst");
+        assert!(received.iter().all(|&b| b == b'x'), "payload bytes intact");
+    });
+
+    server_handle.join().expect("server join");
+}
+
+/// AsyncWriteExt::write_all with a payload larger than rustls's
+/// default outbound plaintext queue (64 KiB), followed by the natural
+/// `flush → shutdown` shape. Pre-fix (R3): errors with `WriteZero`
+/// from rustls's writer mid-call (all-or-nothing `encrypt`).
+/// Post-R3: `try_encrypt` chunks the write across multiple poll_write
+/// cycles. Post-R4: `poll_shutdown` queues a TLS `close_notify` so the
+/// server reads to a clean EOF rather than seeing a truncation alert.
+#[test]
+fn tls_stream_handles_large_write_via_chunking() {
+    let server_config = make_server_config();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let payload = vec![b'z'; PAYLOAD_LEN];
+    let server_handle =
+        thread::spawn(move || run_burst_sink_to_eof_server(listener, server_config, PAYLOAD_LEN));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("client connect");
+        tcp.set_nodelay(true).ok();
+
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+        let codec = TlsCodec::new(&tls_config, "localhost").expect("client codec");
+
+        // Default capacities. The chunking happens in poll_write
+        // because the 256 KiB payload is 4× rustls's default
+        // plaintext queue (64 KiB).
+        let mut stream = TlsStream::new(tcp, codec);
+
+        stream
+            .handshake_async()
+            .await
+            .expect("client handshake_async");
+
+        tokio::time::timeout(Duration::from_secs(10), stream.write_all(&payload))
+            .await
+            .expect("write timeout — chunking loop may be stalled")
+            .expect("client write_all");
+        stream.flush().await.expect("client flush");
+
+        // poll_shutdown queues close_notify, drains, then closes the
+        // transport — server's rustls reader sees a clean EOF (Ok(0)),
+        // not the truncation alert it would get from a bare TCP FIN.
+        stream.shutdown().await.expect("client shutdown");
+
+        // Drain any inbound bytes the server pushed asynchronously
+        // (e.g. TLS 1.3 NewSessionTicket records). Without this, the
+        // OS sees unread data in the receive buffer when TcpStream
+        // drops and sends RST instead of FIN — surfaces on the server
+        // as ConnectionReset mid-read.
+        let mut sink = [0u8; 1024];
+        loop {
+            match tokio::time::timeout(Duration::from_secs(1), stream.read(&mut sink)).await {
+                Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+                Ok(Ok(_)) => {}
+            }
+        }
+    });
+
+    server_handle.join().expect("server join");
+}
+
+/// Drop a `TlsStream` between a `poll_read` returning `Pending` and
+/// the runtime re-entering. Guards against future `Drop`-impl
+/// regressions: no UB, no panic, no leak. The duplex pipe never
+/// writes from the other end so `poll_read` returns `Pending`
+/// immediately; the `tokio::time::timeout` then cancels the inner
+/// read future, dropping the borrow on the stream — and then the
+/// explicit `drop(stream)` runs the destructor.
+#[test]
+fn tls_stream_drop_mid_poll_does_not_panic() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async {
+        // 1 KiB duplex; the other end is held alive but never written to.
+        let (other_end, near_end) = tokio::io::duplex(1024);
+        let _keepalive = other_end;
+
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+        let codec = TlsCodec::new(&tls_config, "localhost").expect("codec");
+        let mut stream = TlsStream::new(near_end, codec);
+
+        // poll_read returns Pending (no inbound bytes). Cancel the
+        // inner future via timeout to simulate "dropped mid-poll".
+        let mut buf = [0u8; 16];
+        let res = tokio::time::timeout(Duration::from_millis(50), stream.read(&mut buf)).await;
+        assert!(res.is_err(), "expected timeout (no data should arrive)");
+
+        // Explicit drop with buffers possibly populated by the
+        // handshake-attempt write side.
+        drop(stream);
+    });
+}
+/// (rustls returns Ok(0) once close_notify arrives), then asserts the
+/// full payload arrived.
+#[allow(clippy::needless_pass_by_value)]
+fn run_burst_sink_to_eof_server(
+    listener: TcpListener,
+    server_config: Arc<rustls::ServerConfig>,
+    expected_len: usize,
+) {
+    let (tcp, _addr) = listener.accept().expect("accept");
+    tcp.set_nodelay(true).ok();
+    tcp.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(10))).ok();
+
+    let server = rustls::ServerConnection::new(server_config).expect("server conn");
+    let mut tls = rustls::StreamOwned::new(server, tcp);
+
+    let mut received = Vec::with_capacity(expected_len);
+    let mut buf = vec![0u8; 8192];
+    loop {
+        let n = tls.read(&mut buf).expect("server read");
+        if n == 0 {
+            break; // clean close_notify
+        }
+        received.extend_from_slice(&buf[..n]);
+    }
+    assert_eq!(received.len(), expected_len, "server-side payload length");
+    assert!(
+        received.iter().all(|&b| b == b'z'),
+        "server-side payload bytes intact"
+    );
+}
+
+/// Exercises the write-side backpressure branch of
+/// `drain_codec_to_pending`: with `pending_write_cap == TMP_SIZE`
+/// (8 KiB) the loop must drain-and-refill multiple times to flush a
+/// 32 KiB encrypt through. The write succeeds end-to-end without
+/// surfacing the `WriteZero` "rustls produced 0 bytes" branch — that
+/// branch only fires on a rustls contract violation, never on
+/// legitimate "spare is full, drain to socket" backpressure.
+///
+/// Why 32 KiB and not larger: rustls bounds its outbound plaintext
+/// queue at `DEFAULT_BUFFER_LIMIT = 64 KiB`. A single `encrypt(buf)`
+/// larger than that errors with WriteZero from rustls's writer (not
+/// from our adapter). 32 KiB stays well under the limit while still
+/// requiring ~4 drain/refill iterations through an 8 KiB
+/// pending_write.
+const WRITE_BACKPRESSURE_PAYLOAD_LEN: usize = 32 * 1024;
+
+#[allow(clippy::needless_pass_by_value)]
+fn run_burst_sink_server(
+    listener: TcpListener,
+    server_config: Arc<rustls::ServerConfig>,
+    expected_len: usize,
+) {
+    let (tcp, _addr) = listener.accept().expect("accept");
+    tcp.set_nodelay(true).ok();
+    tcp.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(10))).ok();
+
+    let server = rustls::ServerConnection::new(server_config).expect("server conn");
+    let mut tls = rustls::StreamOwned::new(server, tcp);
+
+    let mut received = Vec::with_capacity(expected_len);
+    let mut buf = vec![0u8; 8192];
+    while received.len() < expected_len {
+        match tls.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => received.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+    assert_eq!(received.len(), expected_len, "server-side payload length");
+    assert!(
+        received.iter().all(|&b| b == b'y'),
+        "server-side payload bytes intact"
+    );
+}
+
+#[test]
+fn tls_stream_handles_oversize_write_with_tiny_pending_write() {
+    let server_config = make_server_config();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let payload = vec![b'y'; WRITE_BACKPRESSURE_PAYLOAD_LEN];
+    let server_handle = thread::spawn(move || {
+        run_burst_sink_server(listener, server_config, WRITE_BACKPRESSURE_PAYLOAD_LEN)
+    });
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let tcp = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("client connect");
+        tcp.set_nodelay(true).ok();
+
+        let tls_config = TlsConfig::builder()
+            .danger_no_verify()
+            .build()
+            .expect("client tls config");
+        let codec = TlsCodec::new(&tls_config, "localhost").expect("client codec");
+
+        // pending_write_cap = TMP_SIZE forces the drain-and-refill
+        // loop to iterate multiple times for a 32 KiB encrypt,
+        // exercising the legitimate backpressure exit path of
+        // `drain_codec_to_pending`.
+        let mut stream = TlsStream::with_capacities(
+            tcp,
+            codec,
+            TlsStream::<tokio::net::TcpStream>::TMP_SIZE,
+            TlsStream::<tokio::net::TcpStream>::TMP_SIZE,
+        );
+
+        stream
+            .handshake_async()
+            .await
+            .expect("client handshake_async");
+
+        tokio::time::timeout(Duration::from_secs(10), stream.write_all(&payload))
+            .await
+            .expect("write timeout — backpressure loop may be stalled")
+            .expect("client write_all");
+        stream.flush().await.expect("client flush");
+        stream.shutdown().await.expect("client shutdown");
+    });
+
+    server_handle.join().expect("server join");
+}


### PR DESCRIPTION
## Summary

Supersedes #205 (birch's diagnosis + initial fix mechanism — preserved as the first commit on this branch with original authorship). Layered on top: hoisted the helper into nexus-net as `read_tls_step`, applied the same fix to nexus-net's tokio `TlsStream` (which had the identical bug), migrated `pending_read`/`pending_write` from `Vec<u8>` (O(n) drain) to `ReadBuf`/`WriteBuf` (O(1) cursor advance with auto-reset), closed the AsyncWrite chunking bug for plaintexts > rustls's 64 KiB queue limit, and added TLS \`close_notify\` on shutdown.

Three review passes:
- **Round 1** — 3 blockers + 4 strong recs + 4 nits, all addressed
- **Hot-path audit** — \`#[inline]\` on TlsCodec hot methods, hoisted per-poll \`tmp\` into the struct (eliminates 8 KiB stack memset per \`poll_read\`)
- **Deep audit** — 2 blockers + 4 strong recs + 3 nits + 1 architectural observation, addressed except where filed as 0.7.0 follow-up

Net diff vs birch: +1384/-187 + 662 LOC of new integration tests across two files. Every line traces back to a concern raised in audit or to a real production failure mode.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p nexus-net --features tls,tokio -- -D warnings\` clean
- [x] \`cargo test -p nexus-net --features tls --lib\` — 220 passed
- [x] \`cargo test -p nexus-net --features tls,tokio --test tls_stream_async_backpressure\` — 4 passed
- [x] \`cargo test -p nexus-async-net --no-default-features --features nexus,tls --tests\` — 3+3+4+1 across 4 suites
- [x] \`cargo test -p nexus-async-net --lib\` (tokio backend default) — 41 passed
- [x] Pre-flight regression: revert poll_shutdown to bare TCP shutdown, integration test fails with \`peer closed connection without sending TLS close_notify\`

## Follow-up issues (0.7.0)

A separate architectural-refactor PR will follow. The pattern of bugs across five rounds is the signal: the original codec API doesn't encode rustls's failure modes well enough, and \`TlsInner\` constructed-after-handshake forces an awkward state handoff that prevents the cleanest piggyback fix.

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)