### PR TITLE
relaxing 8 byte alignment in flat strings

### DIFF
--- a/nexus-ascii/Cargo.toml
+++ b/nexus-ascii/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-ascii"
-version = "1.5.2"
+version = "1.6.0"
 description = "Fixed-capacity ASCII strings for high-performance systems"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-ascii/src/flat_string.rs
+++ b/nexus-ascii/src/flat_string.rs
@@ -45,11 +45,8 @@ pub struct FlatAsciiString<const CAP: usize>(pub(crate) [u8; CAP]);
 // =============================================================================
 
 impl<const CAP: usize> FlatAsciiString<CAP> {
-    /// Compile-time assertion that CAP is >= 8 and a multiple of 8.
-    pub(crate) const _CAP_ASSERT: () = assert!(
-        CAP >= 8 && CAP % 8 == 0,
-        "FlatAsciiString CAP must be >= 8 and a multiple of 8"
-    );
+    /// Compile-time assertion that CAP is >= 1.
+    pub(crate) const _CAP_ASSERT: () = assert!(CAP >= 1, "FlatAsciiString CAP must be >= 1");
 
     /// Creates an empty flat ASCII string (all zeros).
     ///
@@ -657,7 +654,7 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     ///
     /// # Panics
     ///
-    /// Panics at compile time if `NEW_CAP < CAP` or `NEW_CAP % 8 != 0`.
+    /// Panics at compile time if `NEW_CAP < CAP`.
     ///
     /// # Example
     ///
@@ -668,9 +665,17 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     /// let wide: FlatAsciiString<32> = s.widen();
     /// assert_eq!(wide.as_str(), "hello");
     /// ```
+    ///
+    /// Invalid `NEW_CAP=0` is rejected at compile time:
+    ///
+    /// ```compile_fail
+    /// use nexus_ascii::FlatAsciiString;
+    /// let s: FlatAsciiString<4> = FlatAsciiString::empty();
+    /// let _bad: FlatAsciiString<0> = s.widen();
+    /// ```
     #[inline]
     pub fn widen<const NEW_CAP: usize>(self) -> FlatAsciiString<NEW_CAP> {
-        const { assert!(NEW_CAP % 8 == 0, "NEW_CAP must be a multiple of 8") };
+        let () = FlatAsciiString::<NEW_CAP>::_CAP_ASSERT;
 
         // Runtime check (can't do CAP comparison in const block with two generics)
         // This will be optimized away since both are const
@@ -700,9 +705,17 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     /// let tight: FlatAsciiString<8> = s.tighten().unwrap();
     /// assert_eq!(tight.as_str(), "hello");
     /// ```
+    ///
+    /// Invalid `NEW_CAP=0` is rejected at compile time:
+    ///
+    /// ```compile_fail
+    /// use nexus_ascii::FlatAsciiString;
+    /// let s: FlatAsciiString<8> = FlatAsciiString::empty();
+    /// let _bad: Result<FlatAsciiString<0>, _> = s.tighten();
+    /// ```
     #[inline]
     pub fn tighten<const NEW_CAP: usize>(self) -> Result<FlatAsciiString<NEW_CAP>, AsciiError> {
-        const { assert!(NEW_CAP % 8 == 0, "NEW_CAP must be a multiple of 8") };
+        let () = FlatAsciiString::<NEW_CAP>::_CAP_ASSERT;
 
         let len = self.len();
         if len > NEW_CAP {
@@ -2049,5 +2062,122 @@ mod tests {
     fn from_str_invalid() {
         let result = "héllo".parse::<FlatAsciiString<32>>();
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // CAP=4 coverage (non-multiple-of-8 capacity, post-1.6.0)
+    // =========================================================================
+
+    #[test]
+    fn flat_string_cap4_empty() {
+        let s: FlatAsciiString<4> = FlatAsciiString::empty();
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.as_str(), "");
+    }
+
+    #[test]
+    fn flat_string_cap4_from_static() {
+        const TAG: FlatAsciiString<4> = FlatAsciiString::from_static("MM01");
+        assert_eq!(TAG.as_str(), "MM01");
+        assert_eq!(TAG.len(), 4);
+    }
+
+    #[test]
+    fn flat_string_cap4_partial_fill() {
+        let s: FlatAsciiString<4> = FlatAsciiString::try_from("AB").unwrap();
+        assert_eq!(s.as_str(), "AB");
+        assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn flat_string_cap4_too_long() {
+        let r: Result<FlatAsciiString<4>, _> = FlatAsciiString::try_from("TOOLONG");
+        assert!(matches!(r, Err(AsciiError::TooLong { len: 7, cap: 4 })));
+    }
+
+    #[test]
+    fn flat_string_cap4_eq_and_cmp() {
+        let a: FlatAsciiString<4> = FlatAsciiString::try_from("MM01").unwrap();
+        let b: FlatAsciiString<4> = FlatAsciiString::try_from("MM01").unwrap();
+        let c: FlatAsciiString<4> = FlatAsciiString::try_from("MM02").unwrap();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a < c);
+    }
+
+    #[test]
+    fn flat_string_cap4_hashmap() {
+        use std::collections::HashMap;
+        let mut m: HashMap<FlatAsciiString<4>, i32> = HashMap::new();
+        let k: FlatAsciiString<4> = FlatAsciiString::try_from("MM01").unwrap();
+        m.insert(k, 42);
+        assert_eq!(m.get(&k), Some(&42));
+    }
+
+    #[test]
+    fn flat_string_cap4_display() {
+        let s: FlatAsciiString<4> = FlatAsciiString::try_from("AB").unwrap();
+        assert_eq!(format!("{}", s), "AB");
+    }
+
+    #[test]
+    fn flat_string_cap4_widen_to_8() {
+        let s: FlatAsciiString<4> = FlatAsciiString::try_from("AB").unwrap();
+        let w: FlatAsciiString<8> = s.widen();
+        assert_eq!(w.as_str(), "AB");
+    }
+
+    #[test]
+    fn flat_string_cap8_tighten_to_4() {
+        let s: FlatAsciiString<8> = FlatAsciiString::try_from("AB").unwrap();
+        let t: FlatAsciiString<4> = s.tighten().unwrap();
+        assert_eq!(t.as_str(), "AB");
+    }
+
+    #[test]
+    fn flat_string_cap8_tighten_to_4_too_long() {
+        let s: FlatAsciiString<8> = FlatAsciiString::try_from("ABCDEF").unwrap();
+        let t: Result<FlatAsciiString<4>, _> = s.tighten();
+        assert!(matches!(t, Err(AsciiError::TooLong { len: 6, cap: 4 })));
+    }
+
+    #[test]
+    fn flat_string_cap4_as_raw_mut() {
+        let mut s: FlatAsciiString<4> = FlatAsciiString::empty();
+        // SAFETY: writing valid ASCII into the buffer
+        unsafe {
+            let buf = s.as_raw_mut();
+            buf[0] = b'M';
+            buf[1] = b'M';
+            buf[2] = b'0';
+            buf[3] = b'1';
+        }
+        assert_eq!(s.as_str(), "MM01");
+    }
+
+    // CAP=3 coverage — odd, sub-8 capacity. Sanity check that the
+    // length-dispatched copy_short path handles non-power-of-2 small CAPs.
+    #[test]
+    fn flat_string_cap3_partial_fill() {
+        let s: FlatAsciiString<3> = FlatAsciiString::try_from("AB").unwrap();
+        assert_eq!(s.as_str(), "AB");
+        assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn flat_string_cap3_full_fill() {
+        let s: FlatAsciiString<3> = FlatAsciiString::try_from("ABC").unwrap();
+        assert_eq!(s.as_str(), "ABC");
+        assert_eq!(s.len(), 3);
+    }
+
+    // CAP=12 coverage — non-multiple-of-8 above 8. Tests the >=8 path
+    // through copy_short / find_null_byte without the legacy CAP%8 invariant.
+    #[test]
+    fn flat_string_cap12_full_fill() {
+        let s: FlatAsciiString<12> = FlatAsciiString::try_from("ABCDEFGHIJKL").unwrap();
+        assert_eq!(s.as_str(), "ABCDEFGHIJKL");
+        assert_eq!(s.len(), 12);
     }
 }

--- a/nexus-ascii/src/flat_string.rs
+++ b/nexus-ascii/src/flat_string.rs
@@ -673,13 +673,23 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     /// let s: FlatAsciiString<4> = FlatAsciiString::empty();
     /// let _bad: FlatAsciiString<0> = s.widen();
     /// ```
+    ///
+    /// Wrong direction (`NEW_CAP < CAP`) is also rejected at compile time:
+    ///
+    /// ```compile_fail
+    /// use nexus_ascii::FlatAsciiString;
+    /// let s: FlatAsciiString<32> = FlatAsciiString::empty();
+    /// let _bad: FlatAsciiString<8> = s.widen(); // use tighten instead
+    /// ```
     #[inline]
     pub fn widen<const NEW_CAP: usize>(self) -> FlatAsciiString<NEW_CAP> {
         let () = FlatAsciiString::<NEW_CAP>::_CAP_ASSERT;
-
-        // Runtime check (can't do CAP comparison in const block with two generics)
-        // This will be optimized away since both are const
-        assert!(NEW_CAP >= CAP, "NEW_CAP must be >= CAP");
+        const {
+            assert!(
+                NEW_CAP >= CAP,
+                "widen requires NEW_CAP >= CAP; use tighten for smaller"
+            );
+        }
 
         let mut data = [0u8; NEW_CAP];
         // SAFETY: CAP <= NEW_CAP, buffers don't overlap
@@ -691,6 +701,11 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     }
 
     /// Tightens the string to a smaller capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics at compile time if `NEW_CAP > CAP` (use [`widen`](Self::widen)
+    /// for larger capacities) or `NEW_CAP == 0`.
     ///
     /// # Errors
     ///
@@ -713,9 +728,23 @@ impl<const CAP: usize> FlatAsciiString<CAP> {
     /// let s: FlatAsciiString<8> = FlatAsciiString::empty();
     /// let _bad: Result<FlatAsciiString<0>, _> = s.tighten();
     /// ```
+    ///
+    /// Wrong direction (`NEW_CAP > CAP`) is also rejected at compile time:
+    ///
+    /// ```compile_fail
+    /// use nexus_ascii::FlatAsciiString;
+    /// let s: FlatAsciiString<8> = FlatAsciiString::empty();
+    /// let _bad: Result<FlatAsciiString<32>, _> = s.tighten(); // use widen instead
+    /// ```
     #[inline]
     pub fn tighten<const NEW_CAP: usize>(self) -> Result<FlatAsciiString<NEW_CAP>, AsciiError> {
         let () = FlatAsciiString::<NEW_CAP>::_CAP_ASSERT;
+        const {
+            assert!(
+                NEW_CAP <= CAP,
+                "tighten requires NEW_CAP <= CAP; use widen for larger"
+            );
+        }
 
         let len = self.len();
         if len > NEW_CAP {
@@ -2179,5 +2208,110 @@ mod tests {
         let s: FlatAsciiString<12> = FlatAsciiString::try_from("ABCDEFGHIJKL").unwrap();
         assert_eq!(s.as_str(), "ABCDEFGHIJKL");
         assert_eq!(s.len(), 12);
+    }
+
+    // =========================================================================
+    // CAP=1 coverage — smallest legal capacity per `_CAP_ASSERT`.
+    // Pins that none of the small-CAP code paths assume CAP >= 8 (or even
+    // CAP > 1).
+    // =========================================================================
+
+    #[test]
+    fn flat_string_cap1_empty() {
+        let s: FlatAsciiString<1> = FlatAsciiString::empty();
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.as_str(), "");
+    }
+
+    #[test]
+    fn flat_string_cap1_full_fill() {
+        let s: FlatAsciiString<1> = FlatAsciiString::try_from("X").unwrap();
+        assert_eq!(s.as_str(), "X");
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn flat_string_cap1_too_long() {
+        let r: Result<FlatAsciiString<1>, _> = FlatAsciiString::try_from("XY");
+        assert!(matches!(r, Err(AsciiError::TooLong { len: 2, cap: 1 })));
+    }
+
+    #[test]
+    fn flat_string_cap1_eq_and_cmp() {
+        let a: FlatAsciiString<1> = FlatAsciiString::try_from("A").unwrap();
+        let b: FlatAsciiString<1> = FlatAsciiString::try_from("A").unwrap();
+        let c: FlatAsciiString<1> = FlatAsciiString::try_from("B").unwrap();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a < c);
+    }
+
+    #[test]
+    fn flat_string_cap1_from_static() {
+        const FLAG: FlatAsciiString<1> = FlatAsciiString::from_static("Y");
+        assert_eq!(FLAG.as_str(), "Y");
+        assert_eq!(FLAG.len(), 1);
+    }
+
+    // =========================================================================
+    // Cross-cap widen/tighten — non-multiple-of-8 source AND destination.
+    // Pins that the const-block direction checks accept legal odd-cap
+    // pairings and that the runtime copy path handles them correctly.
+    // =========================================================================
+
+    #[test]
+    fn flat_string_widen_cap4_to_cap12() {
+        let s: FlatAsciiString<4> = FlatAsciiString::try_from("AB").unwrap();
+        let w: FlatAsciiString<12> = s.widen();
+        assert_eq!(w.as_str(), "AB");
+        assert_eq!(w.len(), 2);
+    }
+
+    #[test]
+    fn flat_string_widen_cap4_full_to_cap12() {
+        let s: FlatAsciiString<4> = FlatAsciiString::try_from("ABCD").unwrap();
+        let w: FlatAsciiString<12> = s.widen();
+        assert_eq!(w.as_str(), "ABCD");
+        assert_eq!(w.len(), 4);
+    }
+
+    #[test]
+    fn flat_string_widen_cap3_to_cap7() {
+        let s: FlatAsciiString<3> = FlatAsciiString::try_from("AB").unwrap();
+        let w: FlatAsciiString<7> = s.widen();
+        assert_eq!(w.as_str(), "AB");
+        assert_eq!(w.len(), 2);
+    }
+
+    #[test]
+    fn flat_string_tighten_cap12_to_cap4() {
+        let s: FlatAsciiString<12> = FlatAsciiString::try_from("AB").unwrap();
+        let t: FlatAsciiString<4> = s.tighten().unwrap();
+        assert_eq!(t.as_str(), "AB");
+        assert_eq!(t.len(), 2);
+    }
+
+    #[test]
+    fn flat_string_tighten_cap12_full_to_cap4() {
+        let s: FlatAsciiString<12> = FlatAsciiString::try_from("ABCD").unwrap();
+        let t: FlatAsciiString<4> = s.tighten().unwrap();
+        assert_eq!(t.as_str(), "ABCD");
+        assert_eq!(t.len(), 4);
+    }
+
+    #[test]
+    fn flat_string_tighten_cap12_too_long_to_cap4() {
+        let s: FlatAsciiString<12> = FlatAsciiString::try_from("ABCDEFG").unwrap();
+        let t: Result<FlatAsciiString<4>, _> = s.tighten();
+        assert!(matches!(t, Err(AsciiError::TooLong { len: 7, cap: 4 })));
+    }
+
+    #[test]
+    fn flat_string_tighten_cap7_to_cap3() {
+        let s: FlatAsciiString<7> = FlatAsciiString::try_from("AB").unwrap();
+        let t: FlatAsciiString<3> = s.tighten().unwrap();
+        assert_eq!(t.as_str(), "AB");
+        assert_eq!(t.len(), 2);
     }
 }

--- a/nexus-ascii/src/flat_text.rs
+++ b/nexus-ascii/src/flat_text.rs
@@ -1113,4 +1113,30 @@ mod tests {
         let result = "hello\x01".parse::<FlatAsciiText<32>>();
         assert!(result.is_err());
     }
+
+    // =========================================================================
+    // CAP=4 coverage (non-multiple-of-8 capacity, post-1.6.0)
+    // =========================================================================
+
+    #[test]
+    fn flat_text_cap4_empty() {
+        let t: FlatAsciiText<4> = FlatAsciiText::empty();
+        assert!(t.is_empty());
+        assert_eq!(t.len(), 0);
+        assert_eq!(t.as_str(), "");
+    }
+
+    #[test]
+    fn flat_text_cap4_from_static() {
+        const TAG: FlatAsciiText<4> = FlatAsciiText::from_static("MM01");
+        assert_eq!(TAG.as_str(), "MM01");
+        assert_eq!(TAG.len(), 4);
+    }
+
+    #[test]
+    fn flat_text_cap4_try_from_partial() {
+        let t: FlatAsciiText<4> = FlatAsciiText::try_from("AB").unwrap();
+        assert_eq!(t.as_str(), "AB");
+        assert_eq!(t.len(), 2);
+    }
 }

--- a/nexus-ascii/src/lib.rs
+++ b/nexus-ascii/src/lib.rs
@@ -87,6 +87,8 @@ pub type AsciiText64 = AsciiText<64>;
 /// 128-byte capacity printable ASCII text.
 pub type AsciiText128 = AsciiText<128>;
 
+/// 4-byte capacity flat ASCII string.
+pub type FlatAsciiString4 = FlatAsciiString<4>;
 /// 8-byte capacity flat ASCII string.
 pub type FlatAsciiString8 = FlatAsciiString<8>;
 /// 16-byte capacity flat ASCII string.
@@ -100,6 +102,8 @@ pub type FlatAsciiString128 = FlatAsciiString<128>;
 /// 256-byte capacity flat ASCII string.
 pub type FlatAsciiString256 = FlatAsciiString<256>;
 
+/// 4-byte capacity flat printable ASCII text.
+pub type FlatAsciiText4 = FlatAsciiText<4>;
 /// 8-byte capacity flat printable ASCII text.
 pub type FlatAsciiText8 = FlatAsciiText<8>;
 /// 16-byte capacity flat printable ASCII text.


### PR DESCRIPTION
## Summary

Relaxes the `FlatAsciiString<CAP>` capacity constraint from `CAP >= 8 && CAP % 8 == 0` down to `CAP >= 1`. Unblocks `FlatAsciiString<4>` for use cases like 4-char order tagging.

`FlatAsciiText<CAP>` inherits the relaxed constraint via the shared `_CAP_ASSERT`.

`AsciiString<CAP>` (precomputed-hash variant) keeps `CAP % 8 == 0` — its `Ord::cmp` does unconditional `[u8; 8]` chunk reads. Out of scope for this PR.

## Changes

- `flat_string.rs`: `_CAP_ASSERT` relaxed to `CAP >= 1`. `widen`/`tighten` const-asserts replaced with `let () = FlatAsciiString::<NEW_CAP>::_CAP_ASSERT;` (forces compile-time validation of `NEW_CAP`).
- `lib.rs`: `FlatAsciiString4` + `FlatAsciiText4` aliases.
- `Cargo.toml`: 1.5.2 → 1.6.0 (additive minor).

## Tests

- 10 CAP=4 tests on `FlatAsciiString` (empty, from_static, try_from, eq/cmp, hashmap, widen→8, 8→tighten round-trip, as_raw_mut)
- 2 CAP=3 + 1 CAP=12 sanity tests covering the safety claims (sub-8 odd, non-multiple-of-8 above 8)
- 3 CAP=4 tests on `FlatAsciiText`
- 2 `compile_fail` doctests proving `NEW_CAP=0` is rejected at compile time

Closes #208