### PR TITLE
add must used on nexus pool Pooled

### DIFF
--- a/nexus-pool/Cargo.toml
+++ b/nexus-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-pool"
-version = "1.0.3"
+version = "1.0.4"
 description = "High-performance object pools for low latency systems"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-pool/src/local.rs
+++ b/nexus-pool/src/local.rs
@@ -352,6 +352,7 @@ impl<T> Drop for Pool<T> {
 ///
 /// The object is always returned to the pool when the guard is dropped.
 /// There is no way to "take" the object out permanently.
+#[must_use = "dropping the guard immediately returns the object to the pool"]
 pub struct Pooled<T> {
     value: ManuallyDrop<T>,
     inner: Weak<Inner<T>>,

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -258,6 +258,7 @@ impl<T> Pool<T> {
 ///
 /// This guard can be sent to other threads. When dropped, the object
 /// is automatically returned to the pool (if the pool still exists).
+#[must_use = "dropping the guard immediately returns the object to the pool"]
 pub struct Pooled<T> {
     value: ManuallyDrop<T>,
     idx: usize,


### PR DESCRIPTION
## Summary

Adds `#[must_use]` to `Pooled<T>` in both `nexus-pool::local` and `nexus-pool::sync`. Catches the bug where a caller writes `pool.acquire()` without binding the guard, immediately returning the object to the pool.

Brings `Pooled<T>` in line with the other RAII guards in the workspace (`JoinHandle`, `TimerHandle`, `DropGuard`, `RcSlot`).

## Changes

- `nexus-pool/src/sync.rs`: `#[must_use]` on `Pooled<T>`
- `nexus-pool/src/local.rs`: `#[must_use]` on `Pooled<T>`
- `nexus-pool/Cargo.toml`: 1.0.3 → 1.0.4 (patch)

No behavior change — purely a lint hint at the call site.

Closes #170