### PR TITLE
addressing cleanup issues related to logbuf

### DIFF
--- a/docs/cookbook-latency-monitoring.md
+++ b/docs/cookbook-latency-monitoring.md
@@ -135,7 +135,7 @@ pub fn on_tick_instrumented(
         tick_ts_ns: tick.ts_ns,
     };
     // fixed: Producer method is `try_claim` and returns
-    // `Result<WriteClaim, TryClaimError>`. WriteClaim derefs to &mut [u8].
+    // `Result<WriteClaim, BufferFull>`. WriteClaim derefs to &mut [u8].
     if let Ok(mut claim) = metrics
         .sample_log
         .try_claim(std::mem::size_of::<LatencySample>())

--- a/nexus-async-net/Cargo.toml
+++ b/nexus-async-net/Cargo.toml
@@ -31,7 +31,7 @@ tokio-rustls = { version = "0.26", optional = true }
 socket2 = { version = "0.5", optional = true }
 futures-core = { version = "0.3", optional = true }
 futures-sink = { version = "0.3", optional = true }
-nexus-async-rt = { version = "0.5.0", path = "../nexus-async-rt", optional = true }
+nexus-async-rt = { version = "0.6.0", path = "../nexus-async-rt", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/nexus-async-rt/CHANGELOG.md
+++ b/nexus-async-rt/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to nexus-async-rt are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] — 2026-05-08
+
+The "byte-channel error contract cleanup" release. Companion to
+[nexus-logbuf 2.2.0](../nexus-logbuf/CHANGELOG.md). The `ZeroLength`
+variant in `nexus-logbuf::{TryClaimError, SendError, TrySendError}`
+was a programmer-bug-as-error; it's now a panic at the queue layer.
+The cascade reaches `nexus-async-rt::channel::{spsc_bytes,
+mpsc_bytes}::ClaimError`, which had its own redundant `ZeroLength`
+variant — removed. `Sender::try_claim` signature changes to reflect
+the new `nexus_logbuf::BufferFull` unit struct.
+
+### Breaking changes
+
+- **`ClaimError::ZeroLength` removed** from both `channel::spsc_bytes`
+  and `channel::mpsc_bytes`. The variant is unreachable now that
+  `nexus-logbuf` panics on `len == 0`. `ClaimError` retains
+  `Closed` and `TooLarge` (still `#[non_exhaustive]`).
+- **`Sender::try_claim` error type changed** in both `spsc_bytes` and
+  `mpsc_bytes`:
+  - Before: `try_claim(len) -> Result<WriteClaim<'_>, nexus_logbuf::TryClaimError>`
+  - After:  `try_claim(len) -> Result<WriteClaim<'_>, nexus_logbuf::BufferFull>`
+- **`Sender::claim(len).await` and `Sender::try_claim(len)` now panic on
+  `len == 0`.** Channel-layer `assert!(len > 0)` runs before any state
+  inspection, so the panic contract is unconditional regardless of
+  whether the receiver has been dropped.
+
+### Changed
+
+- Dependency declaration: `nexus-logbuf` `2.1.3` → `2.2.0`. Pulls in
+  the new `BufferFull` / `ChannelClosed` types and the structural
+  `assert!(len > 0)` at the queue layer.
+
+### Migration
+
+| 0.5.0 | 0.6.0 |
+|---|---|
+| `Err(ClaimError::ZeroLength)` (in match) | remove arm; assert it can't happen, or fix the bug |
+| `Result<_, nexus_logbuf::TryClaimError>` (function sig) | `Result<_, nexus_logbuf::BufferFull>` |
+| `Err(nexus_logbuf::TryClaimError::Full)` (in match) | `Err(nexus_logbuf::BufferFull)` |
+| `Err(nexus_logbuf::TryClaimError::ZeroLength)` (in match) | remove arm |
+
+If your code called `claim(0).await` / `try_claim(0)` and handled
+the `ClaimError::ZeroLength` variant, that path was already a
+programmer bug surfaced as a soft error — the fix is to ensure
+`len > 0` upstream, not to handle the panic.
+
 ## [0.5.0] — 2026-05-05
 
 The "production hardening" release. Five PRs over the hardening

--- a/nexus-async-rt/Cargo.toml
+++ b/nexus-async-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-async-rt"
-version = "0.5.0"
+version = "0.6.0"
 description = "Single-threaded async executor with pre-allocated task storage"
 edition.workspace = true
 rust-version.workspace = true
@@ -18,7 +18,7 @@ libc = "0.2"
 mio = { version = "1", features = ["os-poll", "net"] }
 nexus-rt = { version = "2.0.0", path = "../nexus-rt" }
 slab = "0.4"
-nexus-logbuf = { version = "2.1.3", path = "../nexus-logbuf" }
+nexus-logbuf = { version = "2.2.0", path = "../nexus-logbuf" }
 nexus-queue = { version = "1.2.0", path = "../nexus-queue" }
 nexus-slab = { version = "2.3.1", path = "../nexus-slab" }
 nexus-timer = { version = "1.4.0", path = "../nexus-timer" }

--- a/nexus-async-rt/docs/channels.md
+++ b/nexus-async-rt/docs/channels.md
@@ -158,12 +158,13 @@ fn main() {
 }
 ```
 
-### `ClaimError::ZeroLength`
+### Zero-length claims panic
 
-Claiming zero bytes is an error (it would produce an empty message that's
-indistinguishable from no message). Validate your `len > 0` precondition
-before claiming. For real wire protocols this falls out naturally — you
-always know the frame size before claiming.
+Claiming zero bytes panics in `nexus_logbuf` — `len == 0` is the wire-format
+"uncommitted" sentinel, and letting it through would silently hang the
+consumer. Validate your `len > 0` precondition before claiming. For real
+wire protocols this falls out naturally — you always know the frame size
+before claiming.
 
 ### When to Use Byte Channels
 

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -322,6 +322,9 @@ impl Drop for ReadClaim<'_> {
 // =============================================================================
 
 /// Claim failed.
+///
+/// `len == 0` is not a runtime error — it's a precondition violation and
+/// panics in [`nexus_logbuf::queue::mpsc::Producer::try_claim`].
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ClaimError {
@@ -329,8 +332,6 @@ pub enum ClaimError {
     Closed,
     /// Requested length exceeds buffer capacity (can never succeed).
     TooLarge,
-    /// Requested length is zero (claims must be non-empty).
-    ZeroLength,
 }
 
 impl std::fmt::Display for ClaimError {
@@ -338,7 +339,6 @@ impl std::fmt::Display for ClaimError {
         match self {
             Self::Closed => f.write_str("byte channel closed"),
             Self::TooLarge => f.write_str("message exceeds buffer capacity"),
-            Self::ZeroLength => f.write_str("zero-length claim"),
         }
     }
 }
@@ -423,12 +423,22 @@ impl Sender {
     ///
     /// Returns `Err(ClaimError::TooLarge)` immediately if `len` exceeds
     /// the buffer capacity (can never succeed).
+    ///
+    /// # Panics
+    ///
+    /// Polling the returned future with `len == 0` panics (see
+    /// [`nexus_logbuf::queue::mpsc::Producer::try_claim`]).
     pub fn claim(&mut self, len: usize) -> ClaimFut<'_> {
         ClaimFut { sender: self, len }
     }
 
     /// Try to claim without waiting.
-    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, nexus_logbuf::TryClaimError> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see
+    /// [`nexus_logbuf::queue::mpsc::Producer::try_claim`]).
+    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, nexus_logbuf::BufferFull> {
         let inner_claim = self.producer.try_claim(len)?;
         Ok(WriteClaim {
             inner: inner_claim,
@@ -488,6 +498,11 @@ impl<'a> Future for ClaimFut<'a> {
         // - The future won't be polled again after returning Ready
         let sender: &'a mut Sender = unsafe { &mut *(this.sender as *mut Sender) };
 
+        // Precondition check before any state inspection — `len == 0` is a
+        // contract violation regardless of channel state, and the doc
+        // contract is honest only if it panics unconditionally.
+        assert!(this.len > 0, "payload length must be non-zero");
+
         if sender.inner.rx_closed.load(Ordering::Acquire) {
             return Poll::Ready(Err(ClaimError::Closed));
         }
@@ -496,25 +511,21 @@ impl<'a> Future for ClaimFut<'a> {
             return Poll::Ready(Err(ClaimError::TooLarge));
         }
 
-        match sender.producer.try_claim(this.len) {
-            Ok(inner_claim) => Poll::Ready(Ok(WriteClaim {
+        if let Ok(inner_claim) = sender.producer.try_claim(this.len) {
+            return Poll::Ready(Ok(WriteClaim {
                 inner: inner_claim,
                 notify: &sender.inner,
-            })),
-            Err(nexus_logbuf::TryClaimError::Full) => {
-                let node = &sender.wake_node;
-                if !node.queued.load(Ordering::Acquire) {
-                    // Not in list yet -- safe to write waker, then push.
-                    // SAFETY: exclusive access -- node not in any shared structure.
-                    unsafe { *node.waker.get() = Some(cx.waker().clone()) };
-                    sender.inner.tx_waiters.push(node);
-                }
-                Poll::Pending
-            }
-            Err(nexus_logbuf::TryClaimError::ZeroLength) => {
-                Poll::Ready(Err(ClaimError::ZeroLength))
-            }
+            }));
         }
+        // BufferFull — park in the waiter list.
+        let node = &sender.wake_node;
+        if !node.queued.load(Ordering::Acquire) {
+            // Not in list yet -- safe to write waker, then push.
+            // SAFETY: exclusive access -- node not in any shared structure.
+            unsafe { *node.waker.get() = Some(cx.waker().clone()) };
+            sender.inner.tx_waiters.push(node);
+        }
+        Poll::Pending
     }
 }
 

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -172,6 +172,9 @@ impl DerefMut for WriteClaim<'_> {
 // =============================================================================
 
 /// Claim failed.
+///
+/// `len == 0` is not a runtime error — it's a precondition violation and
+/// panics in [`nexus_logbuf::queue::spsc::Producer::try_claim`].
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ClaimError {
@@ -179,8 +182,6 @@ pub enum ClaimError {
     Closed,
     /// Requested length exceeds buffer capacity (can never succeed).
     TooLarge,
-    /// Requested length is zero (claims must be non-empty).
-    ZeroLength,
 }
 
 impl std::fmt::Display for ClaimError {
@@ -188,7 +189,6 @@ impl std::fmt::Display for ClaimError {
         match self {
             Self::Closed => f.write_str("byte channel closed"),
             Self::TooLarge => f.write_str("message exceeds buffer capacity"),
-            Self::ZeroLength => f.write_str("zero-length claim"),
         }
     }
 }
@@ -269,12 +269,22 @@ impl Sender {
     ///
     /// Returns `Err(ClaimError::TooLarge)` immediately if `len` exceeds
     /// the buffer capacity (can never succeed).
+    ///
+    /// # Panics
+    ///
+    /// Polling the returned future with `len == 0` panics (see
+    /// [`nexus_logbuf::queue::spsc::Producer::try_claim`]).
     pub fn claim(&mut self, len: usize) -> ClaimFut<'_> {
         ClaimFut { sender: self, len }
     }
 
     /// Try to claim without waiting.
-    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, nexus_logbuf::TryClaimError> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see
+    /// [`nexus_logbuf::queue::spsc::Producer::try_claim`]).
+    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, nexus_logbuf::BufferFull> {
         let inner_claim = self.producer.try_claim(len)?;
         Ok(WriteClaim {
             inner: inner_claim,
@@ -296,6 +306,11 @@ impl<'a> Future for ClaimFut<'a> {
         let this = unsafe { &mut *std::pin::Pin::into_inner_unchecked(self) };
         let sender: &'a mut Sender = unsafe { &mut *(this.sender as *mut Sender) };
 
+        // Precondition check before any state inspection — `len == 0` is a
+        // contract violation regardless of channel state, and the doc
+        // contract is honest only if it panics unconditionally.
+        assert!(this.len > 0, "payload length must be non-zero");
+
         if sender.inner.rx_closed.load(Ordering::Acquire) {
             return Poll::Ready(Err(ClaimError::Closed));
         }
@@ -304,19 +319,15 @@ impl<'a> Future for ClaimFut<'a> {
             return Poll::Ready(Err(ClaimError::TooLarge));
         }
 
-        match sender.producer.try_claim(this.len) {
-            Ok(inner_claim) => Poll::Ready(Ok(WriteClaim {
+        if let Ok(inner_claim) = sender.producer.try_claim(this.len) {
+            return Poll::Ready(Ok(WriteClaim {
                 inner: inner_claim,
                 notify: &sender.inner,
-            })),
-            Err(nexus_logbuf::TryClaimError::Full) => {
-                sender.inner.tx_waker.register(cx.waker());
-                Poll::Pending
-            }
-            Err(nexus_logbuf::TryClaimError::ZeroLength) => {
-                Poll::Ready(Err(ClaimError::ZeroLength))
-            }
+            }));
         }
+        // BufferFull — park and wake on receiver progress.
+        sender.inner.tx_waker.register(cx.waker());
+        Poll::Pending
     }
 }
 

--- a/nexus-async-rt/tests/channel_fuzz.rs
+++ b/nexus-async-rt/tests/channel_fuzz.rs
@@ -206,10 +206,9 @@ fn spsc_bytes_random_sizes() {
                             claim.commit();
                             break;
                         }
-                        Err(nexus_logbuf::TryClaimError::Full) => {
+                        Err(nexus_logbuf::BufferFull) => {
                             std::hint::spin_loop();
                         }
-                        Err(_) => return,
                     }
                 }
             }
@@ -270,10 +269,9 @@ fn mpsc_bytes_concurrent_random_sizes() {
                                 sent.fetch_add(1, Ordering::Relaxed);
                                 break;
                             }
-                            Err(nexus_logbuf::TryClaimError::Full) => {
+                            Err(nexus_logbuf::BufferFull) => {
                                 std::hint::spin_loop();
                             }
-                            Err(_) => return,
                         }
                     }
                 }

--- a/nexus-logbuf/CHANGELOG.md
+++ b/nexus-logbuf/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+All notable changes to nexus-logbuf are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained (see "Migration notes" below).
+
+## [2.2.0] — 2026-05-08
+
+The "honest error contracts" release. `len == 0` is a wire-format
+sentinel (the "uncommitted" marker in record headers) — letting it
+through silently hangs the consumer. Prior versions treated `len == 0`
+as a recoverable runtime error (`ZeroLength` variant in three error
+types); this release treats it as the precondition violation it
+always was, panicking at the queue layer. Closes
+[#171](https://github.com/Abso1ut3Zer0/nexus/issues/171).
+
+Also rebuilds the channel-layer error types around their actual
+runtime states: `Sender::send` has exactly one runtime failure mode
+(receiver gone), so `SendError` collapses from a 2-variant enum to a
+unit struct `ChannelClosed`. The "`SendError` is overloaded" naming
+collision with `nexus-channel::SendError<T>(T)` and
+`nexus-async-rt::SendError<T>(T)` is resolved as a side-effect.
+
+### Breaking changes
+
+- **`pub enum TryClaimError` removed.** Replaced by `pub struct BufferFull`.
+  - Before: `try_claim(len) -> Result<WriteClaim<'_>, TryClaimError>`
+  - After:  `try_claim(len) -> Result<WriteClaim<'_>, BufferFull>`
+  - Match arms drop the wrapper:
+    ```rust
+    // before
+    match prod.try_claim(n) {
+        Ok(c) => ...,
+        Err(TryClaimError::Full) => retry,
+        Err(TryClaimError::ZeroLength) => bug(),
+    }
+    // after
+    match prod.try_claim(n) {
+        Ok(c) => ...,
+        Err(BufferFull) => retry,
+    }
+    ```
+- **`pub enum SendError` removed.** Replaced by `pub struct ChannelClosed`.
+  Affects both `channel::spsc::Sender::send` and `channel::mpsc::Sender::send`:
+  - Before: `send(len) -> Result<WriteClaim<'_>, SendError>`
+  - After:  `send(len) -> Result<WriteClaim<'_>, ChannelClosed>`
+- **`TrySendError::ZeroLength` removed.** `TrySendError` now has only
+  `Full` and `Disconnected` variants. Both `channel::spsc` and
+  `channel::mpsc`.
+- **`Producer::try_claim`, `Sender::send`, `Sender::try_send` now panic
+  on `len == 0`.** Previously returned an error variant. The check is
+  structural: `len == 0` is reserved by the wire format as the
+  "uncommitted" sentinel in record headers, so allowing it through
+  would silently hang the consumer. Always-on `assert!`, not
+  `debug_assert!` — the cost is identical to the old `if len == 0
+  return Err(...)` (one cmp+branch, predictable), only the response
+  to violation changes. Aborting a non-zero claim (drop the
+  `WriteClaim` without committing) is fully supported and writes a
+  skip marker the consumer handles correctly.
+
+### Migration notes
+
+Search-and-replace covers most callers:
+
+| 2.1.x | 2.2.0 |
+|---|---|
+| `TryClaimError::Full` (in match) | `BufferFull` |
+| `TryClaimError::ZeroLength` (in match) | remove arm; assert it can't happen, or fix the bug |
+| `SendError::Disconnected` | `ChannelClosed` |
+| `SendError::ZeroLength` | remove arm |
+| `TrySendError::ZeroLength` | remove arm |
+| `Result<_, TryClaimError>` (function sig) | `Result<_, BufferFull>` |
+| `Result<_, SendError>` (function sig) | `Result<_, ChannelClosed>` |
+
+If your code has a path that actually called `try_claim(0)` /
+`send(0)` / `try_send(0)` and handled the error, that path was
+already a programmer-bug-as-soft-error — the fix is to ensure
+`len > 0` upstream, not to handle the panic.
+
+Since this is a minor bump with breaking changes, the `2.1.5`
+release will be yanked once `2.2.0` publishes. External consumers
+on a default `^2` spec will pick up `2.2.0` on `cargo update`; pin
+to `=2.1.5` if you need to defer.
+
+## [2.1.5] and earlier
+
+Earlier 2.x versions are not documented in this CHANGELOG. See
+git history and GitHub release notes for details.

--- a/nexus-logbuf/Cargo.toml
+++ b/nexus-logbuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-logbuf"
-version = "2.1.5"
+version = "2.2.0"
 description = "Lock-free SPSC and MPSC byte ring buffers for logging and archival"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-logbuf/docs/caveats.md
+++ b/nexus-logbuf/docs/caveats.md
@@ -36,13 +36,18 @@ always a smell, and here it's a bug.
 For WebSocket feeds, 1-4 MiB is typical. For in-process
 telemetry, 256 KiB is usually plenty.
 
-## 3. Zero-length payloads are rejected
+## 3. Zero-length payloads panic
 
-`try_claim(0)` returns `Err(TryClaimError::ZeroLength)`. This is
-because `len == 0` is the "not yet committed" sentinel in the
-record header; allowing zero-length records would break the
-commit protocol. If you need a "marker" record, write at least
-one byte.
+`try_claim(0)` panics. `len == 0` is the "not yet committed"
+sentinel in the record header; allowing zero-length records
+would silently hang the consumer waiting for the producer to
+commit. The check is structural, not ergonomic — passing zero
+is a contract violation, not a runtime error you handle.
+
+If you need a "marker" record, write at least one byte. Aborting
+a non-zero claim (drop the `WriteClaim` without committing) is
+fully supported and writes a skip marker the consumer handles
+correctly.
 
 ## 4. Skip markers waste space near buffer wrap
 
@@ -98,10 +103,10 @@ first.
 
 In the raw `queue::spsc` / `queue::mpsc` API, there is no
 built-in disconnect tracking. If you need producer-side
-`SendError::Disconnected`, use the [`channel`](./channels.md)
-wrapper. The raw API assumes both sides live for the duration
-of the program, which is the common case for archival and
-journaling loops.
+disconnect detection (`ChannelClosed`), use the
+[`channel`](./channels.md) wrapper. The raw API assumes both
+sides live for the duration of the program, which is the common
+case for archival and journaling loops.
 
 ## 9. The consumer zeros. That's O(n) in record size.
 

--- a/nexus-logbuf/docs/channels.md
+++ b/nexus-logbuf/docs/channels.md
@@ -109,13 +109,17 @@ let the receiver observe disconnect.
 
 ## Error types
 
-- `SendError::Disconnected` — receiver is gone.
-- `SendError::ZeroLength` — you passed `len == 0`.
+- `ChannelClosed` (returned by `send`) — receiver is gone.
 - `TrySendError::Full` — transient, try again.
 - `TrySendError::Disconnected` — permanent.
-- `TrySendError::ZeroLength` — permanent user error.
 - `RecvError::Timeout` — nothing arrived in time.
 - `RecvError::Disconnected` — all senders are gone.
+
+`send(0)` and `try_send(0)` panic. `len == 0` is the wire-format
+"uncommitted" sentinel — a zero-length claim would silently hang
+the consumer. This is a contract violation, not a runtime error.
+Aborting a non-zero claim (drop the `WriteClaim` without
+committing) is fully supported.
 
 ## When to use channel vs raw queue
 

--- a/nexus-logbuf/docs/spsc.md
+++ b/nexus-logbuf/docs/spsc.md
@@ -52,7 +52,7 @@ Each record on the wire is:
 ## Producer — `try_claim`
 
 ```rust
-pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, TryClaimError>;
+pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, BufferFull>;
 ```
 
 Reserves space for a record of `len` bytes (plus header and
@@ -61,9 +61,13 @@ alignment padding).
 Returns:
 - `Ok(WriteClaim)` — you now own a `&mut [u8]` of exactly `len`
   bytes. Write your payload, then call `claim.commit()`.
-- `Err(TryClaimError::Full)` — not enough contiguous space.
-- `Err(TryClaimError::ZeroLength)` — `len == 0` is not allowed
-  because zero is the "not committed" sentinel.
+- `Err(BufferFull)` — not enough contiguous space.
+
+**Panics if `len == 0`.** Zero is reserved as the "not committed"
+sentinel in the record header. Letting it through would silently
+hang the consumer. Aborting a non-zero claim (drop the
+`WriteClaim` without committing) is fully supported and writes
+a skip marker the consumer handles correctly.
 
 If the remaining space to the end of the buffer is too small,
 the producer writes a **skip marker** of that size and advances

--- a/nexus-logbuf/src/channel/mpsc.rs
+++ b/nexus-logbuf/src/channel/mpsc.rs
@@ -120,25 +120,21 @@ impl Clone for Sender {
     }
 }
 
-/// Error returned from [`Sender::send`].
+/// Error returned from [`Sender::send`] when the receiver has been dropped.
+///
+/// `send` has only one runtime failure mode — the receiver is gone. Passing
+/// `len == 0` is a precondition violation and panics (see
+/// [`queue::Producer::try_claim`] for details).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SendError {
-    /// The receiver has been dropped.
-    Disconnected,
-    /// The payload length was zero.
-    ZeroLength,
-}
+pub struct ChannelClosed;
 
-impl std::fmt::Display for SendError {
+impl std::fmt::Display for ChannelClosed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Disconnected => write!(f, "channel disconnected"),
-            Self::ZeroLength => write!(f, "payload length must be non-zero"),
-        }
+        f.write_str("channel disconnected")
     }
 }
 
-impl std::error::Error for SendError {}
+impl std::error::Error for ChannelClosed {}
 
 /// Error returned from [`Sender::try_send`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,8 +143,6 @@ pub enum TrySendError {
     Full,
     /// The receiver has been dropped.
     Disconnected,
-    /// The payload length was zero.
-    ZeroLength,
 }
 
 impl std::fmt::Display for TrySendError {
@@ -156,7 +150,6 @@ impl std::fmt::Display for TrySendError {
         match self {
             Self::Full => write!(f, "channel full"),
             Self::Disconnected => write!(f, "channel disconnected"),
-            Self::ZeroLength => write!(f, "payload length must be non-zero"),
         }
     }
 }
@@ -175,16 +168,19 @@ impl Sender {
     ///
     /// # Errors
     ///
-    /// - [`SendError::Disconnected`] if receiver was dropped
-    /// - [`SendError::ZeroLength`] if `len` is zero
+    /// Returns [`ChannelClosed`] if the receiver was dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see [`queue::Producer::try_claim`]).
     #[inline]
-    pub fn send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, SendError> {
-        // Check preconditions first
-        if len == 0 {
-            return Err(SendError::ZeroLength);
-        }
+    pub fn send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, ChannelClosed> {
+        // Precondition check before any state inspection — `len == 0` is a
+        // contract violation regardless of channel state, and the doc
+        // contract is honest only if it panics unconditionally.
+        assert!(len > 0, "payload length must be non-zero");
         if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
-            return Err(SendError::Disconnected);
+            return Err(ChannelClosed);
         }
 
         let backoff = Backoff::new();
@@ -196,24 +192,20 @@ impl Sender {
             // This is a known borrow checker limitation that Polonius handles.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
-                match (*inner_ptr).try_claim(len) {
-                    Ok(claim) => {
-                        return Ok(std::mem::transmute::<
-                            queue::WriteClaim<'_>,
-                            queue::WriteClaim<'_>,
-                        >(claim));
-                    }
-                    Err(crate::TryClaimError::Full) => {
-                        backoff.snooze();
-                        if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
-                            return Err(SendError::Disconnected);
-                        }
-                        // Reset backoff after it completes to keep spinning
-                        if backoff.is_completed() {
-                            backoff.reset();
-                        }
-                    }
-                    Err(crate::TryClaimError::ZeroLength) => return Err(SendError::ZeroLength),
+                if let Ok(claim) = (*inner_ptr).try_claim(len) {
+                    return Ok(std::mem::transmute::<
+                        queue::WriteClaim<'_>,
+                        queue::WriteClaim<'_>,
+                    >(claim));
+                }
+                // BufferFull — wait for receiver to drain.
+                backoff.snooze();
+                if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
+                    return Err(ChannelClosed);
+                }
+                // Reset backoff after it completes to keep spinning
+                if backoff.is_completed() {
+                    backoff.reset();
                 }
             }
         }
@@ -225,17 +217,21 @@ impl Sender {
     ///
     /// - [`TrySendError::Full`] if buffer is full
     /// - [`TrySendError::Disconnected`] if receiver was dropped
-    /// - [`TrySendError::ZeroLength`] if `len` is zero
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see [`queue::Producer::try_claim`]).
     #[inline]
     pub fn try_send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, TrySendError> {
+        // Precondition check before any state inspection — see `send` for why.
+        assert!(len > 0, "payload length must be non-zero");
         if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
             return Err(TrySendError::Disconnected);
         }
 
         match self.inner.try_claim(len) {
             Ok(claim) => Ok(claim),
-            Err(crate::TryClaimError::Full) => Err(TrySendError::Full),
-            Err(crate::TryClaimError::ZeroLength) => Err(TrySendError::ZeroLength),
+            Err(crate::BufferFull) => Err(TrySendError::Full),
         }
     }
 
@@ -538,8 +534,8 @@ mod tests {
         drop(rx);
 
         match tx.send(8) {
-            Err(SendError::Disconnected) => {}
-            _ => panic!("expected Disconnected"),
+            Err(ChannelClosed) => {}
+            _ => panic!("expected ChannelClosed"),
         }
     }
 
@@ -557,10 +553,17 @@ mod tests {
     }
 
     #[test]
-    fn zero_len_error() {
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn send_zero_panics() {
         let (mut tx, _rx) = channel(1024);
-        assert!(matches!(tx.send(0), Err(SendError::ZeroLength)));
-        assert!(matches!(tx.try_send(0), Err(TrySendError::ZeroLength)));
+        let _ = tx.send(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn try_send_zero_panics() {
+        let (mut tx, _rx) = channel(1024);
+        let _ = tx.try_send(0);
     }
 
     /// High-volume stress test with multiple senders.

--- a/nexus-logbuf/src/channel/spsc.rs
+++ b/nexus-logbuf/src/channel/spsc.rs
@@ -101,25 +101,21 @@ pub struct Sender {
     shared: Arc<ChannelShared>,
 }
 
-/// Error returned from [`Sender::send`].
+/// Error returned from [`Sender::send`] when the receiver has been dropped.
+///
+/// `send` has only one runtime failure mode — the receiver is gone. Passing
+/// `len == 0` is a precondition violation and panics (see
+/// [`queue::Producer::try_claim`] for details).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SendError {
-    /// The receiver has been dropped.
-    Disconnected,
-    /// The payload length was zero.
-    ZeroLength,
-}
+pub struct ChannelClosed;
 
-impl std::fmt::Display for SendError {
+impl std::fmt::Display for ChannelClosed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Disconnected => write!(f, "channel disconnected"),
-            Self::ZeroLength => write!(f, "payload length must be non-zero"),
-        }
+        f.write_str("channel disconnected")
     }
 }
 
-impl std::error::Error for SendError {}
+impl std::error::Error for ChannelClosed {}
 
 /// Error returned from [`Sender::try_send`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,8 +124,6 @@ pub enum TrySendError {
     Full,
     /// The receiver has been dropped.
     Disconnected,
-    /// The payload length was zero.
-    ZeroLength,
 }
 
 impl std::fmt::Display for TrySendError {
@@ -137,7 +131,6 @@ impl std::fmt::Display for TrySendError {
         match self {
             Self::Full => write!(f, "channel full"),
             Self::Disconnected => write!(f, "channel disconnected"),
-            Self::ZeroLength => write!(f, "payload length must be non-zero"),
         }
     }
 }
@@ -156,16 +149,19 @@ impl Sender {
     ///
     /// # Errors
     ///
-    /// - [`SendError::Disconnected`] if receiver was dropped
-    /// - [`SendError::ZeroLength`] if `len` is zero
+    /// Returns [`ChannelClosed`] if the receiver was dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see [`queue::Producer::try_claim`]).
     #[inline]
-    pub fn send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, SendError> {
-        // Check preconditions first
-        if len == 0 {
-            return Err(SendError::ZeroLength);
-        }
+    pub fn send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, ChannelClosed> {
+        // Precondition check before any state inspection — `len == 0` is a
+        // contract violation regardless of channel state, and the doc
+        // contract is honest only if it panics unconditionally.
+        assert!(len > 0, "payload length must be non-zero");
         if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
-            return Err(SendError::Disconnected);
+            return Err(ChannelClosed);
         }
 
         let backoff = Backoff::new();
@@ -177,24 +173,20 @@ impl Sender {
             // This is a known borrow checker limitation that Polonius handles.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
-                match (*inner_ptr).try_claim(len) {
-                    Ok(claim) => {
-                        return Ok(std::mem::transmute::<
-                            queue::WriteClaim<'_>,
-                            queue::WriteClaim<'_>,
-                        >(claim));
-                    }
-                    Err(crate::TryClaimError::Full) => {
-                        backoff.snooze();
-                        if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
-                            return Err(SendError::Disconnected);
-                        }
-                        // Reset backoff after it completes to keep spinning
-                        if backoff.is_completed() {
-                            backoff.reset();
-                        }
-                    }
-                    Err(crate::TryClaimError::ZeroLength) => return Err(SendError::ZeroLength),
+                if let Ok(claim) = (*inner_ptr).try_claim(len) {
+                    return Ok(std::mem::transmute::<
+                        queue::WriteClaim<'_>,
+                        queue::WriteClaim<'_>,
+                    >(claim));
+                }
+                // BufferFull — wait for receiver to drain.
+                backoff.snooze();
+                if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
+                    return Err(ChannelClosed);
+                }
+                // Reset backoff after it completes to keep spinning
+                if backoff.is_completed() {
+                    backoff.reset();
                 }
             }
         }
@@ -206,17 +198,21 @@ impl Sender {
     ///
     /// - [`TrySendError::Full`] if buffer is full
     /// - [`TrySendError::Disconnected`] if receiver was dropped
-    /// - [`TrySendError::ZeroLength`] if `len` is zero
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0` (see [`queue::Producer::try_claim`]).
     #[inline]
     pub fn try_send(&mut self, len: usize) -> Result<queue::WriteClaim<'_>, TrySendError> {
+        // Precondition check before any state inspection — see `send` for why.
+        assert!(len > 0, "payload length must be non-zero");
         if self.shared.receiver_disconnected.load(Ordering::Relaxed) {
             return Err(TrySendError::Disconnected);
         }
 
         match self.inner.try_claim(len) {
             Ok(claim) => Ok(claim),
-            Err(crate::TryClaimError::Full) => Err(TrySendError::Full),
-            Err(crate::TryClaimError::ZeroLength) => Err(TrySendError::ZeroLength),
+            Err(crate::BufferFull) => Err(TrySendError::Full),
         }
     }
 
@@ -520,8 +516,8 @@ mod tests {
         drop(rx);
 
         match tx.send(8) {
-            Err(SendError::Disconnected) => {}
-            _ => panic!("expected Disconnected"),
+            Err(ChannelClosed) => {}
+            _ => panic!("expected ChannelClosed"),
         }
     }
 
@@ -575,9 +571,16 @@ mod tests {
     }
 
     #[test]
-    fn zero_len_error() {
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn send_zero_panics() {
         let (mut tx, _rx) = channel(1024);
-        assert!(matches!(tx.send(0), Err(SendError::ZeroLength)));
-        assert!(matches!(tx.try_send(0), Err(TrySendError::ZeroLength)));
+        let _ = tx.send(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn try_send_zero_panics() {
+        let (mut tx, _rx) = channel(1024);
+        let _ = tx.try_send(0);
     }
 }

--- a/nexus-logbuf/src/lib.rs
+++ b/nexus-logbuf/src/lib.rs
@@ -53,25 +53,22 @@ pub mod queue;
 pub use queue::mpsc;
 pub use queue::spsc;
 
-/// Error returned from queue `try_claim` operations.
+/// Error returned from queue `try_claim` operations when the buffer has no
+/// space for the requested record.
+///
+/// This is the only failure mode that `try_claim` can surface as an error:
+/// passing `len == 0` is a precondition violation and panics (`len == 0` is
+/// reserved by the wire format as the "uncommitted" sentinel).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TryClaimError {
-    /// The buffer is full.
-    Full,
-    /// The payload length was zero.
-    ZeroLength,
-}
+pub struct BufferFull;
 
-impl std::fmt::Display for TryClaimError {
+impl std::fmt::Display for BufferFull {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Full => write!(f, "buffer full"),
-            Self::ZeroLength => write!(f, "payload length must be non-zero"),
-        }
+        f.write_str("buffer full")
     }
 }
 
-impl std::error::Error for TryClaimError {}
+impl std::error::Error for BufferFull {}
 
 /// Align a value up to the next multiple of 8.
 #[inline]

--- a/nexus-logbuf/src/queue/mpsc.rs
+++ b/nexus-logbuf/src/queue/mpsc.rs
@@ -39,7 +39,7 @@ use std::sync::atomic::{AtomicUsize, Ordering, fence};
 
 use crossbeam_utils::CachePadded;
 
-use crate::{LEN_MASK, SKIP_BIT, TryClaimError, align8};
+use crate::{BufferFull, LEN_MASK, SKIP_BIT, align8};
 
 /// Header size in bytes — one system word (`usize`).
 ///
@@ -143,8 +143,15 @@ impl Producer {
     ///
     /// # Errors
     ///
-    /// - [`TryClaimError::ZeroLength`] if `len` is zero
-    /// - [`TryClaimError::Full`] if the buffer is full
+    /// Returns [`BufferFull`] if the buffer has no space for the record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0`. The wire format reserves `len == 0` as the
+    /// "uncommitted" sentinel — letting it through would silently hang the
+    /// consumer. Aborting a non-zero claim is fully supported (drop the
+    /// [`WriteClaim`] without committing); only claiming zero bytes upfront
+    /// is forbidden.
     ///
     /// # Safety Contract
     ///
@@ -152,14 +159,12 @@ impl Producer {
     /// (unreachable in practice). On 32-bit, records >2GB could set
     /// `SKIP_BIT` and corrupt the stream — enforced with `assert!`.
     #[inline]
-    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, TryClaimError> {
+    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, BufferFull> {
+        assert!(len > 0, "payload length must be non-zero");
         #[cfg(target_pointer_width = "32")]
         assert!(len <= LEN_MASK, "payload too large for 32-bit logbuf");
         #[cfg(not(target_pointer_width = "32"))]
         debug_assert!(len <= LEN_MASK, "payload too large");
-        if len == 0 {
-            return Err(TryClaimError::ZeroLength);
-        }
 
         let record_size = align8(HEADER_SIZE + len);
 
@@ -180,7 +185,7 @@ impl Producer {
 
                 let used = tail.wrapping_sub(self.cached_head.get());
                 if used > self.shared.capacity || self.shared.capacity - used < record_size {
-                    return Err(TryClaimError::Full);
+                    return Err(BufferFull);
                 }
             }
 
@@ -203,7 +208,7 @@ impl Producer {
 
                     let used = tail.wrapping_sub(self.cached_head.get());
                     if used > self.shared.capacity || self.shared.capacity - used < total_needed {
-                        return Err(TryClaimError::Full);
+                        return Err(BufferFull);
                     }
                 }
 
@@ -787,9 +792,10 @@ mod tests {
     }
 
     #[test]
-    fn zero_len_returns_error() {
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn zero_len_panics() {
         let (mut prod, _) = new(1024);
-        assert!(matches!(prod.try_claim(0), Err(TryClaimError::ZeroLength)));
+        let _ = prod.try_claim(0);
     }
 
     #[test]

--- a/nexus-logbuf/src/queue/spsc.rs
+++ b/nexus-logbuf/src/queue/spsc.rs
@@ -49,7 +49,7 @@ use std::sync::atomic::{AtomicUsize, Ordering, fence};
 
 use crossbeam_utils::CachePadded;
 
-use crate::{LEN_MASK, SKIP_BIT, TryClaimError, align8};
+use crate::{BufferFull, LEN_MASK, SKIP_BIT, align8};
 
 /// Header size in bytes — one system word (`usize`).
 ///
@@ -150,25 +150,29 @@ impl Producer {
     ///
     /// # Errors
     ///
-    /// - [`TryClaimError::ZeroLength`] if `len` is zero
-    /// - [`TryClaimError::Full`] if the buffer is full
+    /// Returns [`BufferFull`] if the buffer has no space for the record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len == 0`. The wire format reserves `len == 0` as the
+    /// "uncommitted" sentinel — letting it through would silently hang the
+    /// consumer. Aborting a non-zero claim is fully supported (drop the
+    /// [`WriteClaim`] without committing); only claiming zero bytes upfront
+    /// is forbidden.
     ///
     /// # Safety Contract
     ///
     /// `len` must not exceed `LEN_MASK`. On 64-bit this is ~9.2 exabytes
     /// (unreachable in practice). On 32-bit, records >2GB could set
     /// `SKIP_BIT` and corrupt the stream — enforced with `assert!`.
-    /// This is checked with
-    /// `debug_assert!` only.
+    /// On 64-bit this is checked with `debug_assert!` only.
     #[inline]
-    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, TryClaimError> {
+    pub fn try_claim(&mut self, len: usize) -> Result<WriteClaim<'_>, BufferFull> {
+        assert!(len > 0, "payload length must be non-zero");
         #[cfg(target_pointer_width = "32")]
         assert!(len <= LEN_MASK, "payload too large for 32-bit logbuf");
         #[cfg(not(target_pointer_width = "32"))]
         debug_assert!(len <= LEN_MASK, "payload too large");
-        if len == 0 {
-            return Err(TryClaimError::ZeroLength);
-        }
 
         let record_size = align8(HEADER_SIZE + len);
 
@@ -184,7 +188,7 @@ impl Producer {
 
             let available = self.shared.capacity - (tail.wrapping_sub(self.cached_head.get()));
             if available < record_size {
-                return Err(TryClaimError::Full);
+                return Err(BufferFull);
             }
         }
 
@@ -205,7 +209,7 @@ impl Producer {
 
                 let available = self.shared.capacity - (tail.wrapping_sub(self.cached_head.get()));
                 if available < total_needed {
-                    return Err(TryClaimError::Full);
+                    return Err(BufferFull);
                 }
             }
 
@@ -738,9 +742,10 @@ mod tests {
     }
 
     #[test]
-    fn zero_len_returns_error() {
+    #[should_panic(expected = "payload length must be non-zero")]
+    fn zero_len_panics() {
         let (mut prod, _) = new(1024);
-        assert!(matches!(prod.try_claim(0), Err(TryClaimError::ZeroLength)));
+        let _ = prod.try_claim(0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the `nexus-logbuf::SendError` naming collision flagged in #171, plus two scope expansions discovered during planning (both pre-approved):

1. **`ZeroLength` is a programmer-bug-as-error.** `len == 0` is reserved by the wire format as the "uncommitted" sentinel in record headers — letting it through silently hangs the consumer. Removed the variant from `SendError`/`TrySendError`/`TryClaimError` and replaced with `assert!(len > 0)` at the queue layer (always-on, not `debug_assert!` — the cost is identical to the prior `if len == 0 return Err(...)`, only the response changes).
2. **nexus-async-rt cascade.** `ClaimError::ZeroLength` in `spsc_bytes`/`mpsc_bytes` became unreachable; removed. `try_claim` signature changes to use the new `nexus_logbuf::BufferFull` unit struct.

## API changes

| Before | After | Layer |
|---|---|---|
| `pub enum TryClaimError { Full, ZeroLength }` | `pub struct BufferFull;` | nexus-logbuf queue |
| `pub enum SendError { Disconnected, ZeroLength }` | `pub struct ChannelClosed;` | nexus-logbuf channel |
| `pub enum TrySendError { Full, Disconnected, ZeroLength }` | `pub enum TrySendError { Full, Disconnected }` | nexus-logbuf channel |
| `pub enum ClaimError { Closed, TooLarge, ZeroLength }` | `pub enum ClaimError { Closed, TooLarge }` (still `#[non_exhaustive]`) | nexus-async-rt byte channels |
| `if len == 0 { return Err(...) }` | `assert!(len > 0, "payload length must be non-zero")` | queue + channel + async-rt entry points |

`Sender::send`, `Sender::try_send`, `ClaimFut::poll` all assert *before* the disconnect check, so the panic contract is unconditional regardless of receiver state.

## Versioning

- `nexus-logbuf` 2.1.5 → 2.2.0 (minor, with breaking — small scope, mitigated by yanking 2.1.5 once 2.2.0 publishes)
- `nexus-async-rt` 0.5.0 → 0.6.0 (pre-1.0, breaking via minor)
- `nexus-async-net` Cargo.toml dep bumped to `nexus-async-rt = "0.6.0"`; own version unchanged (no public API change)

## Migration

Search-and-replace covers most callers. Full table in `nexus-logbuf/CHANGELOG.md` and `nexus-async-rt/CHANGELOG.md` (both new for this release / new entry).

If your code actually called `try_claim(0)` / `send(0)` / `try_send(0)` and handled the error, that path was already a programmer-bug-as-soft-error — fix is to ensure `len > 0` upstream, not to handle the panic.

## Verification

- `cargo build --workspace` ✓
- `cargo test -p nexus-logbuf` 56/56 (incl. 4 new `#[should_panic]` tests across queue + channel × spsc + mpsc)
- `cargo test -p nexus-async-rt --lib` 210/210
- `cargo clippy -p nexus-logbuf --all-targets -- -D warnings` ✓
- `cargo clippy -p nexus-async-rt -- -D warnings` ✓ (lib; pre-existing test-file `E0133` errors confirmed pre-existing on main)
- `cargo fmt --check` ✓

## Review

Reviewed by John (planning agent). Verdict: no blockers. One strong rec (missing `# Panics` doc on `Sender::claim`) and two nits (assert reorder for honest panic contract, missing CHANGELOGs) — all addressed in the final commits before push.

## Post-merge

Yank `nexus-logbuf 2.1.5` from crates.io once 2.2.0 publishes:
\`\`\`
cargo yank --version 2.1.5 nexus-logbuf
\`\`\`

Closes #171