### PR TITLE
adding additional ergonomics around Res and ResMut

### DIFF
--- a/nexus-rt/Cargo.toml
+++ b/nexus-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-rt"
-version = "2.2.0"
+version = "2.3.0"
 description = "Single-threaded, event-driven runtime primitives with pre-resolved dispatch"
 edition.workspace = true
 rust-version.workspace = true

--- a/nexus-rt/src/pipeline.rs
+++ b/nexus-rt/src/pipeline.rs
@@ -5127,7 +5127,7 @@ mod tests {
     #[test]
     fn ok_or_else_named_fn_with_param() {
         fn make_error(msg: Res<String>) -> String {
-            msg.clone()
+            (*msg).clone()
         }
         let mut wb = WorldBuilder::new();
         wb.register::<String>("not found".into());

--- a/nexus-rt/src/resource.rs
+++ b/nexus-rt/src/resource.rs
@@ -49,6 +49,13 @@ use crate::world::Sequence;
 /// Appears in handler function signatures to declare a read dependency.
 /// Derefs to the inner value transparently.
 ///
+/// # Cloning
+///
+/// `Res<T>` is `Copy + Clone` regardless of `T` — the wrapped reference
+/// is `&T`, which is always `Copy`. To clone the *inner* value, use
+/// `(*res).clone()` or `res.to_owned()`. Calling `res.clone()` returns
+/// `Res<T>`, not `T` — same shadowing pattern as Bevy's `Res<T>`.
+///
 /// For exclusive write access, use [`ResMut<T>`]. For optional read
 /// access (no panic if unregistered), use [`Option<Res<T>>`].
 ///
@@ -96,6 +103,12 @@ impl<T: Resource> Deref for Res<'_, T> {
 ///
 /// Appears in handler function signatures to declare a write dependency.
 /// Derefs to the inner value transparently.
+///
+/// # Passing by value
+///
+/// `ResMut<T>` cannot be `Copy` (exclusive borrow). To pass the wrapper
+/// to inner functions without moving, call [`reborrow()`](Self::reborrow)
+/// — analogous to the `&mut *x` pattern for `&mut T`.
 ///
 /// For shared read access, use [`Res<T>`]. For optional write access
 /// (no panic if unregistered), use [`Option<ResMut<T>>`].

--- a/nexus-rt/src/resource.rs
+++ b/nexus-rt/src/resource.rs
@@ -63,6 +63,18 @@ impl<'w, T: Resource> Res<'w, T> {
     }
 }
 
+// Manual Copy/Clone impls (not derived) so the bounds depend only on what
+// the field actually requires. The single field is `&T`, which is always
+// Copy regardless of `T`. A derive would erroneously add `T: Clone`.
+impl<T: Resource> Clone for Res<'_, T> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Resource> Copy for Res<'_, T> {}
+
 impl<T: std::fmt::Debug + Resource> std::fmt::Debug for Res<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.value.fmt(f)
@@ -96,6 +108,22 @@ pub struct ResMut<'w, T: Resource> {
 impl<'w, T: Resource> ResMut<'w, T> {
     pub(crate) fn new(value: &'w mut T) -> Self {
         Self { value }
+    }
+
+    /// Reborrow as a `ResMut<'_, T>` with a shorter lifetime.
+    ///
+    /// The original is frozen for the duration of the reborrow, then usable
+    /// again. Lets you pass `ResMut<T>` to inner functions without moving —
+    /// analogous to the `&mut *x` reborrow pattern for `&mut T`.
+    ///
+    /// `ResMut<T>` cannot be `Copy` (exclusive borrow), so this is the
+    /// counterpart to [`Res<T>`]'s `Copy` impl when the inner function
+    /// signature takes the wrapper itself rather than `&mut T`.
+    #[inline(always)]
+    pub fn reborrow(&mut self) -> ResMut<'_, T> {
+        ResMut {
+            value: &mut *self.value,
+        }
     }
 }
 
@@ -226,6 +254,64 @@ mod tests {
         let mut res = ResMut::new(&mut val);
         *res = Val(123);
         assert_eq!(val.0, 123);
+    }
+
+    #[test]
+    fn res_is_copy() {
+        // Compile-time proof that Res<T> is Copy (and Clone) without
+        // requiring T: Copy or T: Clone — Val implements neither.
+        fn assert_copy<U: Copy>(_: U) {}
+        let val = Val(42);
+        let res = Res::new(&val);
+        assert_copy(res);
+        let a = res;
+        let b = res; // Copy — not a move
+        assert_eq!(a.0, 42);
+        assert_eq!(b.0, 42);
+    }
+
+    #[test]
+    fn res_pass_to_inner_function() {
+        // The motivating use case: passing Res<T> to inner functions
+        // without moving.
+        fn inner(r: Res<'_, Val>) -> u64 {
+            r.0
+        }
+        let val = Val(7);
+        let res = Res::new(&val);
+        assert_eq!(inner(res), 7);
+        assert_eq!(inner(res), 7); // would not compile without Copy
+    }
+
+    #[test]
+    fn res_mut_reborrow() {
+        // ResMut::reborrow() lets us pass ResMut<T> (the wrapper) to
+        // inner functions without moving.
+        fn inner(mut r: ResMut<'_, Val>) {
+            r.0 += 1;
+        }
+        let mut val = Val(0);
+        let mut res = ResMut::new(&mut val);
+        inner(res.reborrow());
+        inner(res.reborrow());
+        inner(res.reborrow());
+        // res is usable again here; original lifetime restored.
+        assert_eq!(res.0, 3);
+    }
+
+    #[test]
+    fn res_mut_reborrow_then_use_original() {
+        // After the reborrow goes out of scope, the original is usable
+        // for both shared and mutable access.
+        let mut val = Val(10);
+        let mut res = ResMut::new(&mut val);
+        {
+            let mut rb = res.reborrow();
+            rb.0 = 20;
+        }
+        // Original ResMut usable again.
+        res.0 = 30;
+        assert_eq!(val.0, 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two ergonomic improvements to handler parameter wrappers:

- `Res<T>: Copy + Clone` regardless of `T`'s bounds. Lets handler bodies pass `Res<T>` to inner functions without moving. Manual impls (not derive) so the bounds depend only on `&T`, which is always `Copy`.
- `ResMut::reborrow(&mut self) -> ResMut<'_, T>` — the `&mut *x` reborrow pattern for the wrapper. Lets handler bodies pass `ResMut<T>` to inner functions without moving.

Closes #193.

## Breaking change (minor-bump per workspace convention)

Adding `Clone` to `Res<T>` shadows method resolution. Pre-2.3.0, `res.clone()` (where `res: Res<String>`) deref'd to `&String` and returned `String`. Post-2.3.0, `res.clone()` returns `Res<String>`.

**Migration:** replace `res.clone()` with `(*res).clone()` (or `res.to_owned()` depending on `T`). One-line fix per call site.

The shadowing matches Bevy's `Res<T>` idiom — `(*res).clone()` is the canonical way to clone the inner value in both crates.

Internal call sites: one updated (`pipeline.rs:5129`). Greppable check across nexus-rt/nexus-async-rt/nexus-async-net found no other affected sites.

## Versioning

`2.2.0 → 2.3.0` (minor) following the workspace pattern for "small breaking changes" (compare nexus-logbuf 2.1.5 → 2.2.0). Strict semver would say 3.0.0; the workspace-wide call is to keep minor for narrow surface changes and yank the prior version on publish.

## Verification

- `cargo build --workspace --tests` ✓
- `cargo test -p nexus-rt` — 622 tests / 0 failed (incl. 4 new in `resource::tests`)
- `cargo clippy -p nexus-rt -- -D warnings` (lib) ✓
- `cargo fmt --check` ✓

## Reviewers

- John (planning agent): no blockers, S.1 (rustdoc on `.clone()` shadowing + `reborrow()` pattern) addressed in this PR.
- Copilot: same root concern, addressed by the doc additions + this PR body.

## Post-merge

Yank `nexus-rt 2.2.0` once 2.3.0 publishes:
\`\`\`
cargo yank --version 2.2.0 nexus-rt
\`\`\`