### PR TITLE
improve workspace hygiene with docs and CHANGELOGs

### DIFF
--- a/nexus-ascii/CHANGELOG.md
+++ b/nexus-ascii/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to nexus-ascii are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.6.1] — 2026-05-08
+
+### Fixed
+
+- Minor follow-ups in `format.rs`, `parse.rs`, and `text.rs` after the
+  flat-cap relaxation work in 1.6.0.
+
+## [1.6.0] — 2026-05-08
+
+The "non-multiple-of-8 flat capacities" release. `FlatAsciiString<CAP>`
+and `FlatAsciiText<CAP>` now accept any `CAP >= 1`, lifting the prior
+`CAP >= 8 && CAP % 8 == 0` constraint that ruled out short capacities
+like `4` for fixed-width order tags.
+
+### Added
+
+- **`FlatAsciiString4`** and **`FlatAsciiText4`** type aliases for the
+  newly-supported 4-byte capacity.
+
+### Changed
+
+- **Compile-time check relaxed** on `FlatAsciiString<CAP>` /
+  `FlatAsciiText<CAP>` from `CAP >= 8 && CAP % 8 == 0` to `CAP >= 1`.
+  Reads now fall back from u64 chunked loads to byte-by-byte loads
+  when the capacity is non-multiple-of-8.
+- `widen` and `tighten` now compile-time reject `NEW_CAP == 0`.
+
+## [1.5.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -537,6 +537,7 @@ impl<'w> RuntimeBuilder<'w> {
 
     /// Maximum tasks polled per cycle before yielding to check IO.
     /// Default: 64.
+    #[must_use]
     pub fn tasks_per_cycle(mut self, limit: usize) -> Self {
         self.tasks_per_cycle = limit;
         self
@@ -549,6 +550,7 @@ impl<'w> RuntimeBuilder<'w> {
     /// `epoll_wait(0)` to check for socket events, even if tasks are
     /// ready. Lower values improve IO responsiveness at the cost of
     /// more syscalls; higher values favor task throughput.
+    #[must_use]
     pub fn event_interval(mut self, n: u32) -> Self {
         assert!(n > 0, "event_interval must be > 0");
         self.event_interval = n;
@@ -562,30 +564,35 @@ impl<'w> RuntimeBuilder<'w> {
     /// local ready queue per iteration. Prevents a firehose of
     /// cross-thread wakes from starving local tasks and IO. Remaining
     /// wakes are drained on the next iteration.
+    #[must_use]
     pub fn cross_thread_drain_limit(mut self, limit: usize) -> Self {
         self.cross_thread_drain_limit = limit;
         self
     }
 
     /// Pre-allocated capacity for internal queues. Default: 64.
+    #[must_use]
     pub fn queue_capacity(mut self, cap: usize) -> Self {
         self.queue_capacity = cap;
         self
     }
 
     /// Maximum IO events processed per epoll cycle. Default: 1024.
+    #[must_use]
     pub fn event_capacity(mut self, cap: usize) -> Self {
         self.event_capacity = cap;
         self
     }
 
     /// Initial number of IO source slots. Default: 64.
+    #[must_use]
     pub fn token_capacity(mut self, cap: usize) -> Self {
         self.token_capacity = cap;
         self
     }
 
     /// Install SIGTERM/SIGINT signal handlers. Default: false.
+    #[must_use]
     pub fn signal_handlers(mut self, enable: bool) -> Self {
         self.signal_handlers = enable;
         self

--- a/nexus-bits-derive/CHANGELOG.md
+++ b/nexus-bits-derive/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-bits-derive are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [0.4.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-bits-derive/src/lib.rs
+++ b/nexus-bits-derive/src/lib.rs
@@ -1514,7 +1514,11 @@ fn to_snake_case(s: &str) -> String {
             if i > 0 {
                 result.push('_');
             }
-            result.push(c.to_lowercase().next().unwrap());
+            result.push(
+                c.to_lowercase()
+                    .next()
+                    .expect("Unicode guarantees char::to_lowercase yields at least one char"),
+            );
         } else {
             result.push(c);
         }

--- a/nexus-bits/CHANGELOG.md
+++ b/nexus-bits/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-bits are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [0.4.4] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-channel/CHANGELOG.md
+++ b/nexus-channel/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-channel are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.2.3] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-collections/CHANGELOG.md
+++ b/nexus-collections/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-collections are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.1.4] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-decimal/src/bytes.rs
+++ b/nexus-decimal/src/bytes.rs
@@ -70,14 +70,18 @@ impl<const D: u8> Decimal<i32, D> {
     /// Reads little-endian bytes from `buf`. Panics if `buf.len() < 4`.
     #[inline]
     pub fn read_le_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 4] = buf[..4].try_into().unwrap();
+        let bytes: [u8; 4] = buf[..4]
+            .try_into()
+            .expect("buf[..4] always yields a 4-byte slice");
         Self::from_le_bytes(bytes)
     }
 
     /// Reads big-endian bytes from `buf`. Panics if `buf.len() < 4`.
     #[inline]
     pub fn read_be_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 4] = buf[..4].try_into().unwrap();
+        let bytes: [u8; 4] = buf[..4]
+            .try_into()
+            .expect("buf[..4] always yields a 4-byte slice");
         Self::from_be_bytes(bytes)
     }
 }
@@ -147,14 +151,18 @@ impl<const D: u8> Decimal<i64, D> {
     /// Reads little-endian bytes from `buf`. Panics if `buf.len() < 8`.
     #[inline]
     pub fn read_le_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 8] = buf[..8].try_into().unwrap();
+        let bytes: [u8; 8] = buf[..8]
+            .try_into()
+            .expect("buf[..8] always yields an 8-byte slice");
         Self::from_le_bytes(bytes)
     }
 
     /// Reads big-endian bytes from `buf`. Panics if `buf.len() < 8`.
     #[inline]
     pub fn read_be_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 8] = buf[..8].try_into().unwrap();
+        let bytes: [u8; 8] = buf[..8]
+            .try_into()
+            .expect("buf[..8] always yields an 8-byte slice");
         Self::from_be_bytes(bytes)
     }
 }
@@ -224,14 +232,18 @@ impl<const D: u8> Decimal<i128, D> {
     /// Reads little-endian bytes from `buf`. Panics if `buf.len() < 16`.
     #[inline]
     pub fn read_le_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 16] = buf[..16].try_into().unwrap();
+        let bytes: [u8; 16] = buf[..16]
+            .try_into()
+            .expect("buf[..16] always yields a 16-byte slice");
         Self::from_le_bytes(bytes)
     }
 
     /// Reads big-endian bytes from `buf`. Panics if `buf.len() < 16`.
     #[inline]
     pub fn read_be_bytes(buf: &[u8]) -> Self {
-        let bytes: [u8; 16] = buf[..16].try_into().unwrap();
+        let bytes: [u8; 16] = buf[..16]
+            .try_into()
+            .expect("buf[..16] always yields a 16-byte slice");
         Self::from_be_bytes(bytes)
     }
 }

--- a/nexus-decimal/src/convert.rs
+++ b/nexus-decimal/src/convert.rs
@@ -60,7 +60,9 @@ fn parse_digits_u64(bytes: &[u8]) -> Result<u64, ParseError> {
 
     // SWAR fast path: 8 digits at a time
     while pos + 8 <= bytes.len() {
-        let chunk: &[u8; 8] = bytes[pos..pos + 8].try_into().unwrap();
+        let chunk: &[u8; 8] = bytes[pos..pos + 8]
+            .try_into()
+            .expect("loop invariant: pos + 8 <= bytes.len()");
         let val = parse_8_digits(chunk).ok_or(ParseError::InvalidFormat)?;
         result = result
             .checked_mul(100_000_000)
@@ -91,7 +93,9 @@ fn parse_digits_wide(bytes: &[u8]) -> Result<i128, ParseError> {
     let mut pos = 0;
 
     while pos + 8 <= bytes.len() {
-        let chunk: &[u8; 8] = bytes[pos..pos + 8].try_into().unwrap();
+        let chunk: &[u8; 8] = bytes[pos..pos + 8]
+            .try_into()
+            .expect("loop invariant: pos + 8 <= bytes.len()");
         let val = parse_8_digits(chunk).ok_or(ParseError::InvalidFormat)?;
         result = result
             .checked_mul(100_000_000)

--- a/nexus-decimal/src/error.rs
+++ b/nexus-decimal/src/error.rs
@@ -4,6 +4,19 @@
 //! `checked_*` methods return `Option` (std convention).
 //! `try_*` and fallible constructors return `Result` with the
 //! narrowest error type for that operation.
+//!
+//! ## Error shape convention
+//!
+//! Error shapes in this crate match the number of distinct runtime states:
+//!
+//! - **Single-state errors are unit structs** (e.g., [`OverflowError`]).
+//!   Match arms are `Err(OverflowError)`, no variant pattern needed.
+//! - **Multi-state errors are enums** (e.g., [`DivError`], [`ParseError`]).
+//!   Each variant represents an actually-distinct runtime outcome.
+//!
+//! When adding a new error type, pick the shape that matches its actual
+//! runtime states. Don't make a unit struct into an enum "in case we add
+//! variants later" — bump the type when that case actually arrives.
 
 use core::fmt;
 

--- a/nexus-id/CHANGELOG.md
+++ b/nexus-id/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to nexus-id are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.1.4] and earlier
+
+`nexus-id` ships a broad family of ID generators (`Snowflake64`,
+`Snowflake32`, `UuidV4`, `UuidV7`, `UlidGenerator`) and the
+corresponding ID types (`Uuid`, `UuidCompact`, `Ulid`, `HexId64`,
+`Base62Id`, `Base36Id`, `TypeId`, `MixedId64`, `SnowflakeId64`/`32`).
+SIMD-accelerated hex encode/decode (SSSE3 / SSE2) on x86_64, with a
+scalar fallback that is also used as the parity-test reference.
+
+Earlier per-version history is not documented here. See git history
+and GitHub release notes for details.

--- a/nexus-id/src/simd/scalar.rs
+++ b/nexus-id/src/simd/scalar.rs
@@ -5,7 +5,9 @@
 
 /// Lookup table for byte-to-hex conversion.
 /// Each entry is the 2-char lowercase hex representation of that byte.
-#[allow(dead_code)] // Used when SSSE3 is not available
+// Production fallback when SSSE3 is unavailable, and reference implementation
+// for parity tests in `super::ssse3` on x86_64+ssse3 builds.
+#[allow(dead_code)]
 const HEX_TABLE: [[u8; 2]; 256] = {
     let mut table = [[0u8; 2]; 256];
     let hex_chars = b"0123456789abcdef";
@@ -19,7 +21,9 @@ const HEX_TABLE: [[u8; 2]; 256] = {
 };
 
 /// Encode a u64 as 16 lowercase hex bytes.
-#[allow(dead_code)] // Used when SSSE3 is not available
+// Production fallback when SSSE3 is unavailable, and reference implementation
+// for parity tests in `super::ssse3` on x86_64+ssse3 builds.
+#[allow(dead_code)]
 #[inline]
 pub fn hex_encode_u64(value: u64) -> [u8; 16] {
     let bytes = value.to_be_bytes();
@@ -37,7 +41,9 @@ pub fn hex_encode_u64(value: u64) -> [u8; 16] {
 }
 
 /// Encode two u64s as 32 lowercase hex bytes.
-#[allow(dead_code)] // Used when SSSE3 is not available
+// Production fallback when SSSE3 is unavailable, and reference implementation
+// for parity tests in `super::ssse3` on x86_64+ssse3 builds.
+#[allow(dead_code)]
 #[inline]
 pub fn hex_encode_u128(hi: u64, lo: u64) -> [u8; 32] {
     let hi_bytes = hi.to_be_bytes();
@@ -65,7 +71,9 @@ pub fn hex_encode_u128(hi: u64, lo: u64) -> [u8; 32] {
 
 /// Decode a hex nibble value from an ASCII byte.
 /// Returns 0-15 for valid hex, 0xFF for invalid.
-#[allow(dead_code)] // Used on non-x86_64 targets
+// Production path on non-x86_64, and reference implementation for parity
+// tests in `super::sse2` on x86_64 builds.
+#[allow(dead_code)]
 #[inline(always)]
 const fn hex_nibble(b: u8) -> u8 {
     match b {
@@ -78,7 +86,9 @@ const fn hex_nibble(b: u8) -> u8 {
 
 /// Decode 16 hex chars to u64.
 /// Returns Err(position) on first invalid character.
-#[allow(dead_code)] // Used on non-x86_64 targets
+// Production path on non-x86_64, and reference implementation for parity
+// tests in `super::sse2` on x86_64 builds.
+#[allow(dead_code)]
 #[inline]
 pub fn hex_decode_16(bytes: &[u8; 16]) -> Result<u64, usize> {
     let mut value: u64 = 0;
@@ -96,7 +106,9 @@ pub fn hex_decode_16(bytes: &[u8; 16]) -> Result<u64, usize> {
 
 /// Decode 32 hex chars to (hi, lo) u64 pair.
 /// Returns Err(position) on first invalid character.
-#[allow(dead_code)] // Used on non-x86_64 targets
+// Production path on non-x86_64, and reference implementation for parity
+// tests in `super::sse2` on x86_64 builds.
+#[allow(dead_code)]
 #[inline]
 pub fn hex_decode_32(bytes: &[u8; 32]) -> Result<(u64, u64), usize> {
     let mut hi: u64 = 0;

--- a/nexus-logbuf/src/channel/mpsc.rs
+++ b/nexus-logbuf/src/channel/mpsc.rs
@@ -186,10 +186,29 @@ impl Sender {
         let backoff = Backoff::new();
 
         loop {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the loop terminates. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // Polonius / NLL successor workaround.
+            //
+            // The naive form
+            //   `if let Ok(claim) = self.inner.try_claim(len) { return Ok(claim); }`
+            // fails to compile because the borrow checker holds the
+            // `&mut self.inner` borrow for the entire `if let` body — and
+            // therefore for the whole loop iteration — even on the
+            // early-return path. Without the early-return-as-narrowing
+            // analysis Polonius provides, the compiler can't see that the
+            // borrow is dead at the `return` statement, so the next loop
+            // iteration's `try_claim` is rejected as a conflicting reborrow.
+            //
+            // The transmute<'a, 'a> here is a runtime no-op — same type,
+            // same lifetime — that bypasses the borrow checker for a
+            // pattern that is actually sound. When Polonius lands in
+            // stable rustc, this can be rewritten to the natural form and
+            // the unsafe block deleted.
+            //
+            // SAFETY: The transmute is between two identical types with
+            // identical lifetimes. The early return guarantees the
+            // original `&mut self.inner` borrow is dead before the
+            // returned claim is used, and the loop only re-borrows after
+            // the previous iteration's borrow has fully expired.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
                 if let Ok(claim) = (*inner_ptr).try_claim(len) {
@@ -330,10 +349,9 @@ impl Receiver {
     pub fn recv(&mut self, timeout: Option<Duration>) -> Result<queue::ReadClaim<'_>, RecvError> {
         // Fast path for zero timeout - single try, no spinning
         if timeout == Some(Duration::ZERO) {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the function returns. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // SAFETY: see Polonius pattern at the top of `Sender::send` in
+            // this file. Same shape: early return frees the borrow before
+            // any reuse.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -353,10 +371,9 @@ impl Receiver {
         let backoff = Backoff::new();
 
         loop {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the loop terminates. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // SAFETY: see Polonius pattern at the top of `Sender::send` in
+            // this file. Same shape: early return frees the borrow before
+            // the next loop iteration reuses it.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -385,8 +402,9 @@ impl Receiver {
             // For Some(timeout), only park once then return Timeout
             // For None, loop back and try again
             if timeout.is_some() {
-                // Final try after park
-                // SAFETY: Same as above - borrow checker limitation workaround.
+                // Final try after park.
+                // SAFETY: see Polonius pattern at the top of
+                // `Sender::send` in this file.
                 unsafe {
                     let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                     if let Some(claim) = (*inner_ptr).try_claim() {

--- a/nexus-logbuf/src/channel/spsc.rs
+++ b/nexus-logbuf/src/channel/spsc.rs
@@ -167,10 +167,29 @@ impl Sender {
         let backoff = Backoff::new();
 
         loop {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the loop terminates. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // Polonius / NLL successor workaround.
+            //
+            // The naive form
+            //   `if let Ok(claim) = self.inner.try_claim(len) { return Ok(claim); }`
+            // fails to compile because the borrow checker holds the
+            // `&mut self.inner` borrow for the entire `if let` body — and
+            // therefore for the whole loop iteration — even on the
+            // early-return path. Without the early-return-as-narrowing
+            // analysis Polonius provides, the compiler can't see that the
+            // borrow is dead at the `return` statement, so the next loop
+            // iteration's `try_claim` is rejected as a conflicting reborrow.
+            //
+            // The transmute<'a, 'a> here is a runtime no-op — same type,
+            // same lifetime — that bypasses the borrow checker for a
+            // pattern that is actually sound. When Polonius lands in
+            // stable rustc, this can be rewritten to the natural form and
+            // the unsafe block deleted.
+            //
+            // SAFETY: The transmute is between two identical types with
+            // identical lifetimes. The early return guarantees the
+            // original `&mut self.inner` borrow is dead before the
+            // returned claim is used, and the loop only re-borrows after
+            // the previous iteration's borrow has fully expired.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
                 if let Ok(claim) = (*inner_ptr).try_claim(len) {
@@ -311,10 +330,9 @@ impl Receiver {
     pub fn recv(&mut self, timeout: Option<Duration>) -> Result<queue::ReadClaim<'_>, RecvError> {
         // Fast path for zero timeout - single try, no spinning
         if timeout == Some(Duration::ZERO) {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the function returns. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // SAFETY: see Polonius pattern at the top of `Sender::send` in
+            // this file. Same shape: early return frees the borrow before
+            // any reuse.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -334,10 +352,9 @@ impl Receiver {
         let backoff = Backoff::new();
 
         loop {
-            // SAFETY: We only return the claim when we get one, at which point
-            // the loop terminates. The borrow checker can't prove this, but there
-            // is never a second mutable borrow while the first is alive.
-            // This is a known borrow checker limitation that Polonius handles.
+            // SAFETY: see Polonius pattern at the top of `Sender::send` in
+            // this file. Same shape: early return frees the borrow before
+            // the next loop iteration reuses it.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -366,8 +383,9 @@ impl Receiver {
             // For Some(timeout), only park once then return Timeout
             // For None, loop back and try again
             if timeout.is_some() {
-                // Final try after park
-                // SAFETY: Same as above - borrow checker limitation workaround.
+                // Final try after park.
+                // SAFETY: see Polonius pattern at the top of
+                // `Sender::send` in this file.
                 unsafe {
                     let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                     if let Some(claim) = (*inner_ptr).try_claim() {

--- a/nexus-logbuf/src/lib.rs
+++ b/nexus-logbuf/src/lib.rs
@@ -45,6 +45,21 @@
 //!     // record dropped here -> zeros region, advances head
 //! }
 //! ```
+//!
+//! # Error shape convention
+//!
+//! Error shapes in this crate match the number of distinct runtime states:
+//!
+//! - **Single-state errors are unit structs** (e.g., [`BufferFull`],
+//!   [`channel::spsc::ChannelClosed`]). Match arms are
+//!   `Err(BufferFull)`, no variant pattern needed.
+//! - **Multi-state errors are enums** (e.g.,
+//!   [`channel::spsc::TrySendError`], [`channel::spsc::RecvError`]).
+//!   Each variant represents an actually-distinct runtime outcome.
+//!
+//! When adding a new error type, pick the shape that matches its actual
+//! runtime states. Don't make a unit struct into an enum "in case we add
+//! variants later" — bump the type when that case actually arrives.
 
 #![warn(missing_docs)]
 

--- a/nexus-notify/CHANGELOG.md
+++ b/nexus-notify/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-notify are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.0.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-notify/src/event_queue.rs
+++ b/nexus-notify/src/event_queue.rs
@@ -26,6 +26,14 @@ use nexus_queue::mpsc;
 /// let from_usize = Token::from(7usize);
 /// assert_eq!(from_usize.index(), 7);
 /// ```
+///
+/// # Type-tag intent
+///
+/// `Token` is a `usize` newtype with no invariants beyond what the
+/// underlying integer provides. The newtype exists purely to prevent
+/// accidentally passing some other identifier (slab key, array index,
+/// raw `usize`) where a `Token` is expected. Don't reduce it to a type
+/// alias and don't add invariants the rest of the crate doesn't enforce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Token(usize);
 

--- a/nexus-pool/CHANGELOG.md
+++ b/nexus-pool/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to nexus-pool are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.0.4] — 2026-05-08
+
+### Added
+
+- **`#[must_use]` on `Pooled<T>`** in both `local::Pool` and
+  `sync::Pool`. Dropping the guard immediately returns the object to
+  the pool, so silently discarding the result of `pool.acquire()` was
+  almost always a bug — the lint now catches it.
+
+## [1.0.3] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-queue/CHANGELOG.md
+++ b/nexus-queue/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-queue are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.3.1] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-rate/CHANGELOG.md
+++ b/nexus-rate/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-rate are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [2.1.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-rt-derive/CHANGELOG.md
+++ b/nexus-rt-derive/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-rt-derive are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.2.0] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to nexus-rt are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [2.3.0] — 2026-05-08
+
+Ergonomics around `Res<T>` and `ResMut<T>`. Lets handler bodies pass
+the wrappers themselves (not just `&T` / `&mut T`) into inner functions
+without moving.
+
+### Added
+
+- **`Res<T>: Copy + Clone`**, regardless of `T`. Manual impls (not
+  derived) so the bounds depend only on the inner `&T` field, which is
+  always `Copy`. A derive would have erroneously required `T: Clone`.
+  This means user code can now pass `Res<T>` to inner functions
+  multiple times without `.clone()` ceremony.
+- **`ResMut::reborrow(&mut self) -> ResMut<'_, T>`**. The exclusive-
+  borrow counterpart to `Res<T>: Copy`. Pass `ResMut<T>` to inner
+  functions without moving — the original is frozen for the duration
+  of the reborrow, then usable again. Analogous to `&mut *x` reborrow
+  for `&mut T`.
+
+### Notes on breakage
+
+- This release is a **minor bump** even though existing user code that
+  shadowed an outer `Res<T>` with a different value via something like
+  `let res = res.clone();` will now silently `Copy` instead. Behavior
+  is the same in practice, but the inferred `Clone` bound on user
+  generics may shift. Watch for diagnostic regressions, not runtime
+  ones.
+
+## [2.2.0] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-rt/src/callback.rs
+++ b/nexus-rt/src/callback.rs
@@ -45,6 +45,12 @@
 //! See the [crate-level docs](crate#returning-impl-handler-from-functions-rust-2024)
 //! for the full explanation.
 
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
+
 use crate::Handler;
 use crate::handler::Param;
 use crate::world::{Registry, World};
@@ -230,7 +236,6 @@ macro_rules! impl_into_callback {
         {
             #[allow(non_snake_case)]
             fn run(&mut self, world: &mut World, event: E) {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+ Ev>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+ Ev),
                     ctx: &mut Ctx,

--- a/nexus-rt/src/ctx_dag.rs
+++ b/nexus-rt/src/ctx_dag.rs
@@ -1,6 +1,11 @@
 // Builder return types are necessarily complex — each combinator returns
 // CtxDagChain<C, In, Out, NodeType<Chain, ...>>. Same pattern as iterator adapters.
 #![allow(clippy::type_complexity)]
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
 
 //! Context-aware DAG dispatch.
 //!
@@ -308,7 +313,6 @@ macro_rules! impl_ctx_merge2_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut C, world: &mut World, inputs: (&A, &B)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+ IA, IB, Output>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+ &IA, &IB) -> Output,
                     ctx: &mut Ctx,
@@ -397,7 +401,6 @@ macro_rules! impl_ctx_merge3_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut Ctx, world: &mut World, inputs: (&A, &B, &C)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Cx, $($P,)+ IA, IB, IC, Output>(
                     mut f: impl FnMut(&mut Cx, $($P,)+ &IA, &IB, &IC) -> Output,
                     ctx: &mut Cx,
@@ -488,7 +491,6 @@ macro_rules! impl_ctx_merge4_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut Ctx, world: &mut World, inputs: (&A, &B, &C, &D)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Cx, $($P,)+ IA, IB, IC, ID, Output>(
                     mut f: impl FnMut(&mut Cx, $($P,)+ &IA, &IB, &IC, &ID) -> Output,
                     ctx: &mut Cx,

--- a/nexus-rt/src/ctx_pipeline.rs
+++ b/nexus-rt/src/ctx_pipeline.rs
@@ -1,6 +1,11 @@
 // Builder return types are necessarily complex — each combinator returns
 // CtxPipelineChain<C, In, Out, NodeType<Chain, ...>>. Same pattern as iterator adapters.
 #![allow(clippy::type_complexity)]
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
 
 //! Context-aware pipeline dispatch.
 //!
@@ -168,7 +173,6 @@ macro_rules! impl_into_ctx_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut C, world: &mut World, input: In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+ Input, Output>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+ Input) -> Output,
                     ctx: &mut Ctx,
@@ -336,7 +340,6 @@ macro_rules! impl_into_ctx_ref_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut C, world: &mut World, input: &In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+ Input: ?Sized, Output>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+ &Input) -> Output,
                     ctx: &mut Ctx,
@@ -393,6 +396,7 @@ all_tuples!(impl_into_ctx_ref_step);
 #[doc(hidden)]
 pub struct CtxOpaqueRefStep<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -495,7 +499,6 @@ macro_rules! impl_into_ctx_producer {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, ctx: &mut C, world: &mut World) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+ Output>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+) -> Output,
                     ctx: &mut Ctx,
@@ -551,6 +554,7 @@ all_tuples!(impl_into_ctx_producer);
 #[doc(hidden)]
 pub struct CtxOpaqueProducer<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }

--- a/nexus-rt/src/dag.rs
+++ b/nexus-rt/src/dag.rs
@@ -1,5 +1,10 @@
 // Builder return types use complex generics for compile-time edge validation.
 #![allow(clippy::type_complexity)]
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
 
 //! DAG pipeline — monomorphized data-flow graphs with fan-out and merge.
 //!
@@ -213,6 +218,7 @@ pub trait IntoMergeStep<Inputs, Out, Params> {
 pub struct MergeStep<F, Params: crate::handler::Param> {
     f: F,
     state: Params::State,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -258,7 +264,6 @@ macro_rules! impl_merge2_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, inputs: (&A, &B)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, Output>(
                     mut f: impl FnMut($($P,)+ &IA, &IB) -> Output,
                     $($P: $P,)+
@@ -342,7 +347,6 @@ macro_rules! impl_merge3_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, inputs: (&A, &B, &C)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, Output>(
                     mut f: impl FnMut($($P,)+ &IA, &IB, &IC) -> Output,
                     $($P: $P,)+
@@ -424,7 +428,6 @@ macro_rules! impl_merge4_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, i: (&A, &B, &C, &D)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, ID, Output>(
                     mut f: impl FnMut($($P,)+ &IA, &IB, &IC, &ID) -> Output,
                     $($P: $P,)+ a: &IA, b: &IB, c: &IC, d: &ID,
@@ -494,7 +497,6 @@ macro_rules! impl_merge5_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, i: (&A, &B, &C, &D, &E)) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, ID, IE, Output>(
                     mut f: impl FnMut($($P,)+ &IA, &IB, &IC, &ID, &IE) -> Output,
                     $($P: $P,)+ a: &IA, b: &IB, c: &IC, d: &ID, e: &IE,

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -1,5 +1,11 @@
 //! Handler parameter resolution and dispatch primitives.
 
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
+
 use std::ops::{Deref, DerefMut};
 
 use crate::Resource;
@@ -582,7 +588,6 @@ macro_rules! impl_into_handler {
             #[allow(non_snake_case)]
             fn run(&mut self, world: &mut World, event: E) {
                 // Helper binds the HRTB lifetime at a concrete call site.
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Ev>(
                     mut f: impl FnMut($($P,)+ Ev),
                     $($P: $P,)+

--- a/nexus-rt/src/pipeline.rs
+++ b/nexus-rt/src/pipeline.rs
@@ -1,6 +1,11 @@
 // Builder return types are necessarily complex — each combinator returns
 // PipelineChain<In, Out, NodeType<Chain, ...>>. Same pattern as iterator adapters.
 #![allow(clippy::type_complexity)]
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
 
 //! Pre-resolved pipeline dispatch using [`Param`] steps.
 //!
@@ -121,6 +126,7 @@ use crate::world::{Registry, World};
 pub struct Step<F, Params: Param> {
     f: F,
     state: Params::State,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -215,7 +221,6 @@ macro_rules! impl_into_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, input: In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Input, Output>(
                     mut f: impl FnMut($($P,)+ Input) -> Output,
                     $($P: $P,)+
@@ -276,6 +281,7 @@ all_tuples!(impl_into_step);
 #[doc(hidden)]
 pub struct OpaqueStep<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -375,7 +381,6 @@ macro_rules! impl_into_ref_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, input: &In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Input: ?Sized, Output>(
                     mut f: impl FnMut($($P,)+ &Input) -> Output,
                     $($P: $P,)+
@@ -431,6 +436,7 @@ all_tuples!(impl_into_ref_step);
 #[doc(hidden)]
 pub struct OpaqueRefStep<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -546,7 +552,6 @@ macro_rules! impl_into_producer {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Output>(
                     mut f: impl FnMut($($P,)+) -> Output,
                     $($P: $P,)+
@@ -601,6 +606,7 @@ all_tuples!(impl_into_producer);
 #[doc(hidden)]
 pub struct OpaqueProducer<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -715,7 +721,6 @@ macro_rules! impl_into_scan_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, acc: &mut Acc, input: In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Accumulator, Input, Output>(
                     mut f: impl FnMut($($P,)+ &mut Accumulator, Input) -> Output,
                     $($P: $P,)+
@@ -772,6 +777,7 @@ all_tuples!(impl_into_scan_step);
 #[doc(hidden)]
 pub struct OpaqueScanStep<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -893,7 +899,6 @@ macro_rules! impl_into_ref_scan_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call(&mut self, world: &mut World, acc: &mut Acc, input: &In) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ Accumulator, Input: ?Sized, Output>(
                     mut f: impl FnMut($($P,)+ &mut Accumulator, &Input) -> Output,
                     $($P: $P,)+
@@ -950,6 +955,7 @@ all_tuples!(impl_into_ref_scan_step);
 #[doc(hidden)]
 pub struct OpaqueRefScanStep<F> {
     f: F,
+    // Retained for future diagnostic/tracing use (step name in error messages).
     #[allow(dead_code)]
     name: &'static str,
 }
@@ -1052,7 +1058,6 @@ macro_rules! impl_splat2_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call_splat(&mut self, world: &mut World, a: A, b: B) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, Output>(
                     mut f: impl FnMut($($P,)+ IA, IB) -> Output,
                     $($P: $P,)+
@@ -1148,7 +1153,6 @@ macro_rules! impl_splat3_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call_splat(&mut self, world: &mut World, a: A, b: B, c: C) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, Output>(
                     mut f: impl FnMut($($P,)+ IA, IB, IC) -> Output,
                     $($P: $P,)+
@@ -1247,7 +1251,6 @@ macro_rules! impl_splat4_step {
             #[inline(always)]
             #[allow(non_snake_case)]
             fn call_splat(&mut self, world: &mut World, a: A, b: B, c: C, d: D) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, ID, Output>(
                     mut f: impl FnMut($($P,)+ IA, IB, IC, ID) -> Output,
                     $($P: $P,)+ a: IA, b: IB, c: IC, d: ID,
@@ -1334,7 +1337,6 @@ macro_rules! impl_splat5_step {
             #[inline(always)]
             #[allow(non_snake_case, clippy::many_single_char_names)]
             fn call_splat(&mut self, world: &mut World, a: A, b: B, c: C, d: D, e: E) -> Out {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P,)+ IA, IB, IC, ID, IE, Output>(
                     mut f: impl FnMut($($P,)+ IA, IB, IC, ID, IE) -> Output,
                     $($P: $P,)+ a: IA, b: IB, c: IC, d: ID, e: IE,

--- a/nexus-rt/src/reactor.rs
+++ b/nexus-rt/src/reactor.rs
@@ -119,6 +119,12 @@
 //! }
 //! ```
 
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
+
 use std::any::{Any, TypeId};
 use std::hash::Hash;
 
@@ -138,6 +144,14 @@ use crate::world::{Registry, Resource, ResourceId, World};
 ///
 /// Registered via [`ReactorNotify::register_source`]. Event handlers
 /// mark data sources via [`ReactorNotify::mark`] to wake subscribed reactors.
+///
+/// # Type-tag intent
+///
+/// `DataSource` is a `usize` newtype with no invariants beyond what the
+/// underlying integer provides. The newtype exists purely to prevent
+/// accidentally passing some other identifier where a `DataSource` is
+/// expected. Don't reduce it to a type alias and don't add invariants
+/// the rest of the crate doesn't enforce.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DataSource(pub usize);
 
@@ -643,7 +657,6 @@ macro_rules! impl_into_reactor {
         {
             #[allow(non_snake_case)]
             fn run(&mut self, world: &mut World) {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<Ctx, $($P,)+>(
                     mut f: impl FnMut(&mut Ctx, $($P,)+),
                     ctx: &mut Ctx,

--- a/nexus-rt/src/scheduler.rs
+++ b/nexus-rt/src/scheduler.rs
@@ -86,6 +86,14 @@ use crate::world::{Registry, World, WorldBuilder};
 ///
 /// Used with [`after`](SchedulerInstaller::after) and
 /// [`before`](SchedulerInstaller::before) to declare ordering.
+///
+/// # Type-tag intent
+///
+/// `SystemId` is a `usize` newtype with no invariants beyond what the
+/// underlying integer provides. The newtype exists purely to prevent
+/// accidentally passing some other identifier where a `SystemId` is
+/// expected. Don't reduce it to a type alias and don't add invariants
+/// the rest of the crate doesn't enforce.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct SystemId(usize);
 

--- a/nexus-rt/src/system.rs
+++ b/nexus-rt/src/system.rs
@@ -27,6 +27,12 @@
 //!   for [`World::run_startup`] and systems that unconditionally
 //!   propagate.
 
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
+
 use crate::handler::Param;
 use crate::world::{Registry, World};
 
@@ -261,7 +267,6 @@ macro_rules! impl_into_system {
         {
             #[allow(non_snake_case)]
             fn run(&mut self, world: &mut World) -> bool {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P),+>(
                     mut f: impl FnMut($($P),+) -> bool,
                     $($P: $P,)+
@@ -331,7 +336,6 @@ macro_rules! impl_into_system_void {
         {
             #[allow(non_snake_case)]
             fn run(&mut self, world: &mut World) -> bool {
-                #[allow(clippy::too_many_arguments)]
                 fn call_inner<$($P),+>(
                     mut f: impl FnMut($($P),+),
                     $($P: $P,)+

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -59,6 +59,12 @@
 //! [crate-level docs](crate#returning-impl-handler-from-functions-rust-2024)
 //! for details.
 
+// Handler arity is architecturally required by the Param trait — handlers
+// take N typed parameters and the macro-generated dispatch impls expand
+// per-arity into call_inner functions with N + Input arguments. Module-level
+// allow rather than one inline attribute per arity expansion.
+#![allow(clippy::too_many_arguments)]
+
 use std::marker::PhantomData;
 
 use crate::Handler;
@@ -213,7 +219,6 @@ macro_rules! impl_template_dispatch {
                 ) where
                     for<'a> &'a mut F: FnMut($($P,)+ E) + FnMut($($P::Item<'a>,)+ E),
                 {
-                    #[allow(clippy::too_many_arguments)]
                     fn call_inner<$($P,)+ Ev>(
                         mut f: impl FnMut($($P,)+ Ev),
                         $($P: $P,)+
@@ -266,7 +271,6 @@ macro_rules! impl_template_dispatch {
                         FnMut(&mut C, $($P,)+ E) +
                         FnMut(&mut C, $($P::Item<'a>,)+ E),
                 {
-                    #[allow(clippy::too_many_arguments)]
                     fn call_inner<Ctx, $($P,)+ Ev>(
                         mut f: impl FnMut(&mut Ctx, $($P,)+ Ev),
                         ctx: &mut Ctx,

--- a/nexus-slab/CHANGELOG.md
+++ b/nexus-slab/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-slab are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [2.3.4] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-slab/src/bounded.rs
+++ b/nexus-slab/src/bounded.rs
@@ -288,6 +288,7 @@ impl<T> Slab<T> {
     /// The caller's safety obligation (free from the correct slab) was
     /// accepted at construction time.
     #[inline]
+    // Consumes the slot handle by design — the slot cannot be used after free.
     #[allow(clippy::needless_pass_by_value)]
     pub fn free(&self, slot: Slot<T>) {
         let slot_ptr = slot.into_raw();
@@ -306,6 +307,7 @@ impl<T> Slab<T> {
     ///
     /// Consumes the handle — the slot cannot be used after this call.
     #[inline]
+    // Consumes the slot handle by design — the slot cannot be used after free.
     #[allow(clippy::needless_pass_by_value)]
     pub fn take(&self, slot: Slot<T>) -> T {
         let slot_ptr = slot.into_raw();

--- a/nexus-slab/src/bounded.rs
+++ b/nexus-slab/src/bounded.rs
@@ -307,7 +307,7 @@ impl<T> Slab<T> {
     ///
     /// Consumes the handle — the slot cannot be used after this call.
     #[inline]
-    // Consumes the slot handle by design — the slot cannot be used after free.
+    // Consumes the slot handle by design — the slot cannot be used after this call.
     #[allow(clippy::needless_pass_by_value)]
     pub fn take(&self, slot: Slot<T>) -> T {
         let slot_ptr = slot.into_raw();

--- a/nexus-slab/src/rc/bounded.rs
+++ b/nexus-slab/src/rc/bounded.rs
@@ -55,6 +55,8 @@ impl<T> Slab<T> {
     ///
     /// Consumes the handle — cannot be used after.
     #[inline]
+    // Consumes the handle by design — refcount-decrementing free, the
+    // handle cannot be used after this call.
     #[allow(clippy::needless_pass_by_value)]
     pub fn free(&self, handle: RcSlot<T>) {
         let count = handle.dec_ref();

--- a/nexus-slab/src/rc/unbounded.rs
+++ b/nexus-slab/src/rc/unbounded.rs
@@ -32,6 +32,8 @@ impl<T> Slab<T> {
 
     /// Frees a handle. Decrements refcount; deallocates on last free.
     #[inline]
+    // Consumes the handle by design — refcount-decrementing free, the
+    // handle cannot be used after this call.
     #[allow(clippy::needless_pass_by_value)]
     pub fn free(&self, handle: RcSlot<T>) {
         let count = handle.dec_ref();

--- a/nexus-slab/src/unbounded.rs
+++ b/nexus-slab/src/unbounded.rs
@@ -351,6 +351,7 @@ impl<T> Slab<T> {
     ///
     /// O(n) where n = chunk count, due to chunk lookup. Typically 1-5 chunks.
     #[inline]
+    // Consumes the slot handle by design — the slot cannot be used after free.
     #[allow(clippy::needless_pass_by_value)]
     pub fn free(&self, slot: Slot<T>) {
         let slot_ptr = slot.into_raw();
@@ -373,6 +374,7 @@ impl<T> Slab<T> {
     ///
     /// O(n) where n = chunk count, due to chunk lookup. Typically 1-5 chunks.
     #[inline]
+    // Consumes the slot handle by design — the slot cannot be used after free.
     #[allow(clippy::needless_pass_by_value)]
     pub fn take(&self, slot: Slot<T>) -> T {
         let slot_ptr = slot.into_raw();

--- a/nexus-slab/src/unbounded.rs
+++ b/nexus-slab/src/unbounded.rs
@@ -374,7 +374,7 @@ impl<T> Slab<T> {
     ///
     /// O(n) where n = chunk count, due to chunk lookup. Typically 1-5 chunks.
     #[inline]
-    // Consumes the slot handle by design — the slot cannot be used after free.
+    // Consumes the slot handle by design — the slot cannot be used after this call.
     #[allow(clippy::needless_pass_by_value)]
     pub fn take(&self, slot: Slot<T>) -> T {
         let slot_ptr = slot.into_raw();

--- a/nexus-slot/CHANGELOG.md
+++ b/nexus-slot/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-slot are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.1.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-smartptr/CHANGELOG.md
+++ b/nexus-smartptr/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-smartptr are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [0.1.1] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats-control/CHANGELOG.md
+++ b/nexus-stats-control/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-stats-control are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.0.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats-core/CHANGELOG.md
+++ b/nexus-stats-core/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-stats-core are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.2.1] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats-detection/CHANGELOG.md
+++ b/nexus-stats-detection/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-stats-detection are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.0.1] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats-regression/CHANGELOG.md
+++ b/nexus-stats-regression/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-stats-regression are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.2.0] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats-smoothing/CHANGELOG.md
+++ b/nexus-stats-smoothing/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-stats-smoothing are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.2.1] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.

--- a/nexus-stats/CHANGELOG.md
+++ b/nexus-stats/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to nexus-stats are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [4.x] — workspace re-export pattern
+
+`nexus-stats` is the umbrella crate that re-exports from the
+focused subcrates: `nexus-stats-core`, `nexus-stats-control`,
+`nexus-stats-detection`, `nexus-stats-regression`, and
+`nexus-stats-smoothing`. The umbrella version tracks the workspace
+release cadence; subcrate versions track per-area changes.
+
+For per-algorithm or per-type changes, see the relevant subcrate's
+CHANGELOG (or its git history).
+
+## [4.2.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history,
+GitHub release notes, and the per-subcrate CHANGELOGs for details.

--- a/nexus-timer/CHANGELOG.md
+++ b/nexus-timer/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to nexus-timer are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [1.4.2] and earlier
+
+Earlier history is not documented in this CHANGELOG. See git history
+and GitHub release notes for details.


### PR DESCRIPTION
## Summary

Bundle B from the doc-hygiene roadmap — four issues, one PR. All mechanical text writing, no API changes.

## What landed

- **#229** — Error shape convention paragraph in `nexus-decimal/src/error.rs` and `nexus-logbuf/src/lib.rs`. Documents the unit-struct vs enum convention so future error types match the established pattern.
- **#231** — Real Polonius transmute pattern docs in `nexus-logbuf/src/channel/{spsc,mpsc}.rs`. First instance gets a full explanation block, the other 6 sites cross-reference it.
- **#232** — CHANGELOG.md added to 22 crates that lacked one. Tier B backfill for nexus-rt 2.3.0, nexus-pool 1.0.4, nexus-ascii 1.6.0/1.6.1; high-level summary entries for nexus-stats and nexus-id.
- **#233** — Doc/lint hygiene omnibus (7 sub-sections H.1-H.7): module-level allows for handler arity (26 inline → 9 module-level), SWAR `.expect()`, slab justifications, scalar SIMD comment improvements, char `.expect()`, builder `#[must_use]` gaps, type-tag newtype docs.

## Versioning

No version bumps. All changes are docs + lint config. No public API surface change.

## Verification

- `cargo build --workspace` ✓
- `cargo fmt --check` ✓
- `cargo doc --workspace --no-deps` — only the 4 pre-existing unresolved-link warnings
- `cargo clippy -p <crate> -- -D warnings` — clean for every touched crate
- `cargo test --workspace --no-fail-fast` — all green

## Diff

24 modified source files (+237 / -69) plus 22 new CHANGELOG.md files.

Closes #229
Closes #231
Closes #232
Closes #233