### PR TITLE
addressing slowdowns in collections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,28 @@ Be especially careful with memory ordering across architectures:
 
 Code must be **correct on all architectures**. Performance can vary, correctness cannot.
 
+### Manual Prefetching
+
+**Default: don't.** Trust the hardware prefetcher. It handles the cases that matter (linear access, predictable strides, cache-resident working sets) without our help. Explicit `_mm_prefetch` calls are a tax on every invocation — extra µops issued, execution-port pressure, and potential conflict with the CPU's own speculation.
+
+Manual prefetching can hurt — sometimes substantially — when:
+
+- The working set already fits in cache after warmup (no DRAM latency to hide)
+- Both branches are prefetched but only one is followed (50%+ wasted bandwidth)
+- The access pattern is already predictable to the hardware prefetcher
+- Tree depth or call rate causes the per-call hint cost to compound
+
+Removing 6 prefetch sites from rbtree tree-walks restored a 25-27% regression on `get(hit)` and `entry(occupied)` at 10K populations. Removing similar sites from btree tree-walks and rbtree iterators showed neutral to slight wins.
+
+**If you genuinely need a prefetch:**
+
+1. Bench the proposed site at realistic populations (small / fits-cache / exceeds-cache).
+2. Measure prefetch ON vs OFF at each population.
+3. Only ship the prefetch if it shows ≥10% improvement at *some* population AND no regression at *any*.
+4. Land the bench evidence in the PR body or a `.claude/scratch/` doc so future audits don't re-litigate the same question.
+
+Same discipline as `#[inline]`: measure first, only add when you can prove it earns its place.
+
 ## Code Standards
 
 ### Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,18 +175,16 @@ Code must be **correct on all architectures**. Performance can vary, correctness
 Manual prefetching can hurt — sometimes substantially — when:
 
 - The working set already fits in cache after warmup (no DRAM latency to hide)
-- Both branches are prefetched but only one is followed (50%+ wasted bandwidth)
+- Both branches are prefetched but only one is followed (wasted bandwidth)
 - The access pattern is already predictable to the hardware prefetcher
 - Tree depth or call rate causes the per-call hint cost to compound
-
-Removing 6 prefetch sites from rbtree tree-walks restored a 25-27% regression on `get(hit)` and `entry(occupied)` at 10K populations. Removing similar sites from btree tree-walks and rbtree iterators showed neutral to slight wins.
 
 **If you genuinely need a prefetch:**
 
 1. Bench the proposed site at realistic populations (small / fits-cache / exceeds-cache).
 2. Measure prefetch ON vs OFF at each population.
-3. Only ship the prefetch if it shows ≥10% improvement at *some* population AND no regression at *any*.
-4. Land the bench evidence in the PR body or a `.claude/scratch/` doc so future audits don't re-litigate the same question.
+3. Only ship the prefetch if it shows a meaningful improvement at *some* population AND no regression at *any*.
+4. Land the bench evidence in the PR body so future audits don't re-litigate the same question.
 
 Same discipline as `#[inline]`: measure first, only add when you can prove it earns its place.
 

--- a/nexus-collections/README.md
+++ b/nexus-collections/README.md
@@ -216,11 +216,11 @@ p50 floors, taskset-pinned P-cores, turbo on, best-of-5.
 
 | Operation | RbTree | BTree | std BTreeMap |
 |-----------|--------|-------|-------------|
-| get (hit) | **21** | 31 | 36 |
+| get (hit) | **16** | 31 | 36 |
 | insert (steady) | 303 | **237** | 186 |
 | remove | 283 | **220** | 195 |
 | pop_first | **24** | 43 | 51 |
-| entry (occupied) | **31** | 41 | 35 |
+| entry (occupied) | **22** | 41 | 35 |
 | insert (growing) p999 | **612** | 698 | 3714 |
 
 RbTree wins on lookups and pops. BTree wins on insert and remove. std

--- a/nexus-collections/benches/perf_rbtree.rs
+++ b/nexus-collections/benches/perf_rbtree.rs
@@ -469,7 +469,7 @@ fn main() {
         map.clear(&slab);
     }
 
-    // iter full scan (per-element cycles, exercises iterator prefetch sites)
+    // iter full scan (per-element cycles, in-order successor traversal cost)
     {
         let mut map = RbTree::new();
         for i in 0..STEADY_SIZE {

--- a/nexus-collections/benches/perf_rbtree.rs
+++ b/nexus-collections/benches/perf_rbtree.rs
@@ -469,6 +469,34 @@ fn main() {
         map.clear(&slab);
     }
 
+    // iter full scan (per-element cycles, exercises iterator prefetch sites)
+    {
+        let mut map = RbTree::new();
+        for i in 0..STEADY_SIZE {
+            map.try_insert(&slab, i as u64, 0).unwrap();
+        }
+        let mut samples = Vec::with_capacity(SAMPLES);
+        for _ in 0..WARMUP {
+            let mut sum: u64 = 0;
+            for (k, _) in map.iter() {
+                sum = sum.wrapping_add(*k);
+            }
+            black_box(sum);
+        }
+        for _ in 0..SAMPLES {
+            let s = rdtsc_start();
+            let mut sum: u64 = 0;
+            for (k, _) in map.iter() {
+                sum = sum.wrapping_add(*k);
+            }
+            black_box(sum);
+            let e = rdtsc_end();
+            samples.push((e - s) / STEADY_SIZE as u64);
+        }
+        print_row(&format!("iter scan (per-elem, @{STEADY_SIZE})"), &mut samples);
+        map.clear(&slab);
+    }
+
     println!();
 
     // ── CHURN ─────────────────────────────────────────────────────────

--- a/nexus-collections/src/btree.rs
+++ b/nexus-collections/src/btree.rs
@@ -353,20 +353,6 @@ unsafe fn split_child_core<K, V, const B: usize>(
 }
 
 // =============================================================================
-// Prefetch
-// =============================================================================
-
-fn prefetch_read_node<K, V, const B: usize>(ptr: NodePtr<K, V, B>) {
-    #[cfg(target_arch = "x86_64")]
-    if !ptr.is_null() {
-        // SAFETY: ptr is non-null. Prefetch is a hint — does not dereference.
-        unsafe {
-            std::arch::x86_64::_mm_prefetch(ptr as *const i8, std::arch::x86_64::_MM_HINT_T0);
-        }
-    }
-}
-
-// =============================================================================
 // BTree<K, V, B, C>
 // =============================================================================
 
@@ -456,7 +442,6 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             path[path_len] = (current, idx);
             path_len += 1;
             let next = unsafe { child_at(current, idx) };
-            prefetch_read_node(next);
             current = next;
         }
     }
@@ -476,7 +461,6 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             path[path_len] = (current, 0);
             path_len += 1;
             let next = unsafe { child_at(current, 0) };
-            prefetch_read_node(next);
             current = next;
         }
 
@@ -504,7 +488,6 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             path[path_len] = (current, len);
             path_len += 1;
             let next = unsafe { child_at(current, len) };
-            prefetch_read_node(next);
             current = next;
         }
 
@@ -577,7 +560,6 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 break;
             }
             let next = unsafe { child_at(current, idx) };
-            prefetch_read_node(next);
             current = next;
         }
 
@@ -820,7 +802,6 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 return None;
             }
             let next = unsafe { child_at(current, idx) };
-            prefetch_read_node(next);
             current = next;
         }
         None

--- a/nexus-collections/src/rbtree.rs
+++ b/nexus-collections/src/rbtree.rs
@@ -262,20 +262,6 @@ unsafe fn predecessor<K, V>(ptr: NodePtr<K, V>) -> NodePtr<K, V> {
 }
 
 // =============================================================================
-// Prefetch
-// =============================================================================
-
-fn prefetch_read_node<K, V>(ptr: NodePtr<K, V>) {
-    #[cfg(target_arch = "x86_64")]
-    if !ptr.is_null() {
-        // SAFETY: ptr is non-null. Prefetch is a hint — does not dereference.
-        unsafe {
-            std::arch::x86_64::_mm_prefetch(ptr as *const i8, std::arch::x86_64::_MM_HINT_T0);
-        }
-    }
-}
-
-// =============================================================================
 // RbTree<K, V, C>
 // =============================================================================
 
@@ -390,8 +376,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
             parent = current;
             // SAFETY: current is non-null and a valid tree node.
             let node = unsafe { &*node_deref(current) };
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             match C::cmp(&key, &node.key) {
                 Ordering::Equal => {
                     // SAFETY: current is a valid node; &mut self ensures exclusivity.
@@ -436,8 +420,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
             parent = current;
             // SAFETY: current is non-null and a valid tree node.
             let node = unsafe { &*node_deref(current) };
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             match C::cmp(&key, &node.key) {
                 Ordering::Equal => {
                     // SAFETY: current is a valid node; &mut self ensures exclusivity.
@@ -485,8 +467,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         while !current.is_null() {
             parent = current;
             let node = unsafe { &*node_deref(current) };
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             match C::cmp(&key, &node.key) {
                 Ordering::Equal => {
                     drop(key);
@@ -625,9 +605,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         while !current.is_null() {
             // SAFETY: current is non-null and a valid tree node (root or child).
             let node = unsafe { &*node_deref(current) };
-            // Prefetch both children before the comparison stalls on result
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             match C::cmp(key, &node.key) {
                 Ordering::Equal => return Some(current),
                 Ordering::Less => current = node.left.get(),
@@ -642,8 +619,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let mut current = self.root;
         while !current.is_null() {
             let node = unsafe { &*node_deref(current) };
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             if C::cmp(key, &node.key) == Ordering::Greater {
                 current = node.right.get();
             } else {
@@ -659,8 +634,6 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let mut current = self.root;
         while !current.is_null() {
             let node = unsafe { &*node_deref(current) };
-            prefetch_read_node(node.left.get());
-            prefetch_read_node(node.right.get());
             if C::cmp(key, &node.key) == Ordering::Less {
                 result = current;
                 current = node.left.get();
@@ -1427,7 +1400,6 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
         let node = unsafe { &*node_deref(ptr) };
         self.front = unsafe { successor(ptr) };
         self.len -= 1;
-        prefetch_read_node(self.front);
         Some((&node.key, &node.value))
     }
 
@@ -1507,7 +1479,6 @@ impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
         let node = unsafe { &mut *node_deref_mut(ptr) };
         self.front = next;
         self.len -= 1;
-        prefetch_read_node(self.front);
         Some((&node.key, &mut node.value))
     }
 
@@ -1550,7 +1521,6 @@ impl<'a, K: 'a, V: 'a> Iterator for Range<'a, K, V> {
         // SAFETY: ptr is non-null and a valid tree node within the range.
         let node = unsafe { &*node_deref(ptr) };
         self.front = unsafe { successor(ptr) };
-        prefetch_read_node(self.front);
         Some((&node.key, &node.value))
     }
 }
@@ -1573,7 +1543,6 @@ impl<'a, K: 'a, V: 'a> Iterator for RangeMut<'a, K, V> {
         let next = unsafe { successor(ptr) };
         let node = unsafe { &mut *node_deref_mut(ptr) };
         self.front = next;
-        prefetch_read_node(self.front);
         Some((&node.key, &mut node.value))
     }
 }
@@ -1623,7 +1592,6 @@ impl<K, V, C: Compare<K>, S: SlabOps<RbNode<K, V>>> Cursor<'_, K, V, C, S> {
         if !self.started {
             self.started = true;
             self.current = self.tree.leftmost;
-            prefetch_read_node(self.current);
             return !self.current.is_null();
         }
         if self.current.is_null() {
@@ -1631,7 +1599,6 @@ impl<K, V, C: Compare<K>, S: SlabOps<RbNode<K, V>>> Cursor<'_, K, V, C, S> {
         }
         // SAFETY: current is non-null and a valid tree node.
         self.current = unsafe { successor(self.current) };
-        prefetch_read_node(self.current);
         !self.current.is_null()
     }
 


### PR DESCRIPTION
## Summary

Bisect + triage of F3 (RbTree get/entry slowdown). Found the prefetch helpers added in `77451fd` were a measurable pessimization at any cached population, not the optimization they were intended as. Swept the related sites in btree and rbtree iterators; removed for consistency. `prefetch_read_node` is now gone from `nexus-collections`.

## Changes

- **rbtree.rs:** removed 6 prefetch pairs in tree-walk methods (`find`, `lower_bound`, `upper_bound`, `entry`, `insert`, `insert_or_replace`) — the regression source
- **rbtree.rs:** removed 6 prefetch sites in iterator paths — neutral (±1cy), removed for consistency
- **btree.rs:** removed 5 single-child prefetch sites in tree walks — mostly neutral (±5%), +19% on `pop_first` was small enough to live with for consistency
- **rbtree.rs / btree.rs:** `prefetch_read_node` helpers deleted
- **perf_rbtree.rs:** added an in-order successor traversal bench scenario for ongoing iterator coverage
- **README.md:** RbTree get/entry numbers reverted to pre-regression baseline (16/22cy)
- **CONTRIBUTING.md:** new "Manual Prefetching" section under Architecture Support — codifies "default: don't" policy + 4-step checklist for when prefetch IS being added

## Verification

Best-of-5 floors on Intel Core Ultra 7 165U, taskset -c 0,2 P-cores, turbo on:

| Operation | Pre-fix floor | Post-fix floor | Δ |
|---|---|---|---|
| `RbTree::get(hit) @100` | 16 cy | 11 cy | **-31%** |
| `RbTree::get(hit) @10000` | 21 cy | 15 cy | **-29%** |
| `RbTree::entry(occupied) @10000` | 30 cy | 20 cy | **-33%** |

`cargo build --workspace` ✓ · `cargo test --workspace --no-fail-fast` ✓ · lib clippy clean.

## Diff

5 files, +52 / -54 (deletion-positive).

Closes #239
Closes #182