### PR TITLE
adding in more miri coverage across workspace

### DIFF
--- a/nexus-collections/benches/perf_rbtree.rs
+++ b/nexus-collections/benches/perf_rbtree.rs
@@ -493,7 +493,10 @@ fn main() {
             let e = rdtsc_end();
             samples.push((e - s) / STEADY_SIZE as u64);
         }
-        print_row(&format!("iter scan (per-elem, @{STEADY_SIZE})"), &mut samples);
+        print_row(
+            &format!("iter scan (per-elem, @{STEADY_SIZE})"),
+            &mut samples,
+        );
         map.clear(&slab);
     }
 

--- a/nexus-notify/tests/miri_event_queue.rs
+++ b/nexus-notify/tests/miri_event_queue.rs
@@ -12,8 +12,6 @@
 //! Test counts kept small (2–4 producer threads, a few hundred ops at
 //! most) because miri is ~10–100× slower than native.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 use nexus_notify::{Events, Token, event_queue};
@@ -237,56 +235,37 @@ fn cross_thread_conflation() {
 }
 
 // =============================================================================
-// 2.9 — Independent counter check: each notify produces exactly one push
+// 2.9 — Racing notifies on the same token conflate to one polled event
 // =============================================================================
 //
-// The per-token flag is set/cleared exactly once per FIFO entry. Use a
-// shared atomic counter on the producer side to count "I won the swap
-// race" — the count must equal the polled-event count for the token.
+// Two producer threads notify the same token concurrently. The per-token
+// flag's `swap(true, Acquire)` pairing means exactly one wins the race
+// and pushes to the queue; the other observes flag=true and skips. From
+// outside the crate the swap winner isn't observable, but the
+// consequence is: each round produces exactly one polled event, no
+// matter how the threads interleave.
 
 #[test]
-fn won_swap_count_matches_polled_count() {
+fn racing_notifies_conflate_to_one_polled_event() {
     const ITERS: usize = 8;
     let (notifier, poller) = event_queue(1);
     let mut events = Events::with_capacity(1);
     let t = Token::new(0);
 
-    let won = Arc::new(AtomicUsize::new(0));
-    let mut total_polled = 0;
-
     for _ in 0..ITERS {
-        // 2 spawned producers spam the same token. Whichever wins the
-        // swap (sees flag=false) actually pushes; the other conflates.
         let n_a = notifier.clone();
         let n_b = notifier.clone();
-        let won_a = won.clone();
-        let won_b = won.clone();
 
-        let h_a = thread::spawn(move || {
-            // We can't observe the swap winner from outside the API,
-            // so this just drives concurrent notifies to interleave.
-            n_a.notify(t).unwrap();
-            // Bump the counter unconditionally — see invariant below.
-            won_a.fetch_add(1, Ordering::Relaxed);
-        });
-        let h_b = thread::spawn(move || {
-            n_b.notify(t).unwrap();
-            won_b.fetch_add(1, Ordering::Relaxed);
-        });
+        let h_a = thread::spawn(move || n_a.notify(t).unwrap());
+        let h_b = thread::spawn(move || n_b.notify(t).unwrap());
 
         h_a.join().unwrap();
         h_b.join().unwrap();
 
-        // Each round, the polled count for token 0 is exactly 1 (both
-        // producers raced; the second saw flag=true and conflated).
+        // Both threads called notify(); the dedup contract collapses
+        // them to a single queue entry.
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
         assert_eq!(events.iter().next().unwrap().index(), 0);
-        total_polled += events.len();
     }
-
-    // Sanity: producer-thread fetch_add count is 2 per iteration
-    // regardless of who won the swap.
-    assert_eq!(won.load(Ordering::Relaxed), ITERS * 2);
-    assert_eq!(total_polled, ITERS);
 }

--- a/nexus-notify/tests/miri_event_queue.rs
+++ b/nexus-notify/tests/miri_event_queue.rs
@@ -1,0 +1,292 @@
+//! Miri tests for nexus-notify's event_queue (intrusive MPSC + per-token
+//! atomic dedup).
+//!
+//! Run: `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-notify --test miri_event_queue`
+//!
+//! Focuses on the swap/push/pop/poll cycle and cross-thread atomic
+//! ordering. The per-token `swap(true, Acquire)` paired with the
+//! poller's `store(false, Release)` is the load-bearing synchronization
+//! and is exactly the kind of code where miri can surface a missed
+//! ordering or a torn pointer publish.
+//!
+//! Test counts kept small (2–4 producer threads, a few hundred ops at
+//! most) because miri is ~10–100× slower than native.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use nexus_notify::{Events, Token, event_queue};
+
+// =============================================================================
+// 2.1 — Single notifier → single poll cycle
+// =============================================================================
+
+#[test]
+fn single_notify_single_poll() {
+    let (notifier, poller) = event_queue(8);
+    let mut events = Events::with_capacity(8);
+
+    notifier.notify(Token::new(3)).unwrap();
+    poller.poll(&mut events);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().index(), 3);
+}
+
+// =============================================================================
+// 2.2 — Dedup invariant: notify twice without polling, see one event
+// =============================================================================
+
+#[test]
+fn notify_twice_yields_one_event() {
+    let (notifier, poller) = event_queue(8);
+    let mut events = Events::with_capacity(8);
+    let t = Token::new(2);
+
+    notifier.notify(t).unwrap();
+    notifier.notify(t).unwrap();
+    poller.poll(&mut events);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().index(), 2);
+}
+
+// =============================================================================
+// 2.3 — Multiple tokens, mixed-order notifies → FIFO by notify order
+// =============================================================================
+
+#[test]
+fn fifo_by_notify_order() {
+    let (notifier, poller) = event_queue(8);
+    let mut events = Events::with_capacity(8);
+
+    notifier.notify(Token::new(2)).unwrap();
+    notifier.notify(Token::new(0)).unwrap();
+    notifier.notify(Token::new(5)).unwrap();
+    poller.poll(&mut events);
+
+    let order: Vec<usize> = events.iter().map(Token::index).collect();
+    assert_eq!(order, vec![2, 0, 5]);
+}
+
+// =============================================================================
+// 2.4 — Notify after drain: flag must reset cleanly
+// =============================================================================
+
+#[test]
+fn notify_after_drain_works() {
+    let (notifier, poller) = event_queue(4);
+    let mut events = Events::with_capacity(4);
+    let t = Token::new(1);
+
+    notifier.notify(t).unwrap();
+    poller.poll(&mut events);
+    assert_eq!(events.len(), 1);
+
+    // Second cycle — flag was cleared on poll, must accept new notify.
+    notifier.notify(t).unwrap();
+    poller.poll(&mut events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().index(), 1);
+}
+
+// =============================================================================
+// 2.5 — Capacity boundary: fill queue to capacity, drain, refill
+// =============================================================================
+//
+// The per-token dedup flag prevents the queue from ever holding more
+// than `capacity` entries at once. Verify we can saturate at capacity
+// and drain cleanly.
+
+#[test]
+fn fill_to_capacity_then_drain() {
+    const CAP: usize = 4;
+    let (notifier, poller) = event_queue(CAP);
+    let mut events = Events::with_capacity(CAP);
+
+    for i in 0..CAP {
+        notifier.notify(Token::new(i)).unwrap();
+    }
+    poller.poll(&mut events);
+    assert_eq!(events.len(), CAP);
+
+    let order: Vec<usize> = events.iter().map(Token::index).collect();
+    assert_eq!(order, (0..CAP).collect::<Vec<_>>());
+
+    // Refill — flags were cleared, must work again.
+    for i in (0..CAP).rev() {
+        notifier.notify(Token::new(i)).unwrap();
+    }
+    poller.poll(&mut events);
+    assert_eq!(events.len(), CAP);
+    let order: Vec<usize> = events.iter().map(Token::index).collect();
+    assert_eq!(order, (0..CAP).rev().collect::<Vec<_>>());
+}
+
+// =============================================================================
+// 2.6 — Cross-thread Notifier clone: producer thread, consumer thread
+// =============================================================================
+//
+// The producer threads each own a cloned `Notifier`; the poller stays on
+// the main thread. Miri's data-race detector validates the
+// `swap(true, Acquire)` / `store(false, Release)` pairing. We use small N
+// to keep miri's runtime sane.
+
+#[test]
+fn cross_thread_notifier_clone() {
+    const N: usize = 4;
+    let (notifier, poller) = event_queue(N);
+    let mut events = Events::with_capacity(N);
+
+    let n2 = notifier.clone();
+    let producer = thread::spawn(move || {
+        // Each notify is a swap on the per-token flag + a queue push if
+        // newly ready.
+        for i in 0..N {
+            n2.notify(Token::new(i)).unwrap();
+        }
+    });
+
+    producer.join().unwrap();
+    drop(notifier); // drop the original after producer finishes; queue is closed
+
+    poller.poll(&mut events);
+    assert_eq!(events.len(), N);
+
+    // Notifies arrived in 0..N order; FIFO contract preserved.
+    let order: Vec<usize> = events.iter().map(Token::index).collect();
+    assert_eq!(order, (0..N).collect::<Vec<_>>());
+}
+
+// =============================================================================
+// 2.7 — Multiple producer threads, single consumer
+// =============================================================================
+//
+// Real MPSC stress under miri: 2 producer threads each notify a
+// disjoint half of the token space. The poller drains both. Miri's
+// scheduler interleaves the threads and validates atomic ordering on
+// every interleaving it explores.
+
+#[test]
+fn two_producers_one_consumer() {
+    const HALF: usize = 4;
+    const TOTAL: usize = HALF * 2;
+    let (notifier, poller) = event_queue(TOTAL);
+    let mut events = Events::with_capacity(TOTAL);
+
+    let n1 = notifier.clone();
+    let n2 = notifier.clone();
+
+    let p1 = thread::spawn(move || {
+        for i in 0..HALF {
+            n1.notify(Token::new(i)).unwrap();
+        }
+    });
+    let p2 = thread::spawn(move || {
+        for i in HALF..TOTAL {
+            n2.notify(Token::new(i)).unwrap();
+        }
+    });
+
+    p1.join().unwrap();
+    p2.join().unwrap();
+    drop(notifier);
+
+    poller.poll(&mut events);
+    assert_eq!(events.len(), TOTAL);
+
+    // Order between the two producers is interleaved by the scheduler;
+    // validate the *set* matches.
+    let mut seen: Vec<usize> = events.iter().map(Token::index).collect();
+    seen.sort_unstable();
+    assert_eq!(seen, (0..TOTAL).collect::<Vec<_>>());
+}
+
+// =============================================================================
+// 2.8 — Conflation under cross-thread spam
+// =============================================================================
+//
+// One producer hammers a single token from a spawned thread while the
+// main thread does NOT poll until the producer is done. Result: exactly
+// one event for that token. Validates that the Acquire on swap is
+// strong enough that concurrent notifies still conflate to one entry
+// even when interleaved with — well — nothing else (single producer);
+// what we're really checking is that the flag-set + queue-push pair is
+// atomic enough at the protocol level. Miri's race detector covers the
+// memory model side.
+
+#[test]
+fn cross_thread_conflation() {
+    let (notifier, poller) = event_queue(2);
+    let mut events = Events::with_capacity(2);
+    let t = Token::new(1);
+
+    let n2 = notifier.clone();
+    let producer = thread::spawn(move || {
+        for _ in 0..16 {
+            n2.notify(t).unwrap();
+        }
+    });
+    producer.join().unwrap();
+    drop(notifier);
+
+    poller.poll(&mut events);
+    assert_eq!(events.len(), 1, "16 notifies must conflate to 1 event");
+    assert_eq!(events.iter().next().unwrap().index(), 1);
+}
+
+// =============================================================================
+// 2.9 — Independent counter check: each notify produces exactly one push
+// =============================================================================
+//
+// The per-token flag is set/cleared exactly once per FIFO entry. Use a
+// shared atomic counter on the producer side to count "I won the swap
+// race" — the count must equal the polled-event count for the token.
+
+#[test]
+fn won_swap_count_matches_polled_count() {
+    const ITERS: usize = 8;
+    let (notifier, poller) = event_queue(1);
+    let mut events = Events::with_capacity(1);
+    let t = Token::new(0);
+
+    let won = Arc::new(AtomicUsize::new(0));
+    let mut total_polled = 0;
+
+    for _ in 0..ITERS {
+        // 2 spawned producers spam the same token. Whichever wins the
+        // swap (sees flag=false) actually pushes; the other conflates.
+        let n_a = notifier.clone();
+        let n_b = notifier.clone();
+        let won_a = won.clone();
+        let won_b = won.clone();
+
+        let h_a = thread::spawn(move || {
+            // We can't observe the swap winner from outside the API,
+            // so this just drives concurrent notifies to interleave.
+            n_a.notify(t).unwrap();
+            // Bump the counter unconditionally — see invariant below.
+            won_a.fetch_add(1, Ordering::Relaxed);
+        });
+        let h_b = thread::spawn(move || {
+            n_b.notify(t).unwrap();
+            won_b.fetch_add(1, Ordering::Relaxed);
+        });
+
+        h_a.join().unwrap();
+        h_b.join().unwrap();
+
+        // Each round, the polled count for token 0 is exactly 1 (both
+        // producers raced; the second saw flag=true and conflated).
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events.iter().next().unwrap().index(), 0);
+        total_polled += events.len();
+    }
+
+    // Sanity: producer-thread fetch_add count is 2 per iteration
+    // regardless of who won the swap.
+    assert_eq!(won.load(Ordering::Relaxed), ITERS * 2);
+    assert_eq!(total_polled, ITERS);
+}

--- a/nexus-smartptr/tests/miri_tests.rs
+++ b/nexus-smartptr/tests/miri_tests.rs
@@ -1,0 +1,258 @@
+//! Miri tests for nexus-smartptr.
+//!
+//! Run: `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-smartptr --test miri_tests`
+//!
+//! Exercises the unsafe pointer machinery (fat-pointer decomposition,
+//! inline storage of `?Sized` values, heap fallback in `Flex`, drop
+//! ordering) through the public API only. Each test is small and
+//! focused so miri's stacked-borrows + provenance model has a clean
+//! shot at the unsafe paths.
+
+use std::cell::Cell;
+use std::fmt::{self, Display};
+use std::rc::Rc;
+
+use nexus_smartptr::{B16, B32, Flat, Flex, flat, flex};
+
+// =============================================================================
+// Trait used across tests
+// =============================================================================
+
+trait Greet {
+    fn greet(&self) -> String;
+}
+
+struct Hello;
+impl Greet for Hello {
+    fn greet(&self) -> String {
+        "hello".into()
+    }
+}
+
+struct Bye(u32);
+impl Greet for Bye {
+    fn greet(&self) -> String {
+        format!("bye-{}", self.0)
+    }
+}
+
+// =============================================================================
+// Pass 1.1 — Flat with two different concretes (no data/vtable mixing)
+// =============================================================================
+
+#[test]
+fn flat_two_concrete_impls_dont_mix_vtables() {
+    let a: Flat<dyn Greet, B32> = flat!(Hello);
+    let b: Flat<dyn Greet, B32> = flat!(Bye(7));
+
+    assert_eq!(a.greet(), "hello");
+    assert_eq!(b.greet(), "bye-7");
+
+    // Drop ordering — drop a then b; if vtables had been crossed, miri
+    // would surface either a UB read or a wrong destructor invocation.
+    drop(a);
+    drop(b);
+}
+
+// =============================================================================
+// Pass 1.2 — Flex with two different concretes (inline path)
+// =============================================================================
+
+#[test]
+fn flex_two_concrete_impls_dont_mix_vtables() {
+    let a: Flex<dyn Greet, B32> = flex!(Hello);
+    let b: Flex<dyn Greet, B32> = flex!(Bye(11));
+
+    assert!(a.is_inline());
+    assert!(b.is_inline());
+    assert_eq!(a.greet(), "hello");
+    assert_eq!(b.greet(), "bye-11");
+}
+
+// =============================================================================
+// Pass 1.3 — Metadata round-trip via the public API
+// =============================================================================
+//
+// `meta::{extract_metadata, make_ptr}` are pub(crate). Exercising the
+// round-trip from outside the crate has to go through Flat/Flex
+// construction + deref, which is the same code path. This test
+// constructs via `flat!`, derefs many times to force re-reads of the
+// stored metadata word, and checks the value each time.
+
+#[test]
+fn flat_metadata_word_survives_repeated_deref() {
+    let f: Flat<dyn Display, B32> = flat!(123_u64);
+
+    // Repeated deref re-reads the metadata each call (see `as_ptr`).
+    // Miri will flag any provenance loss / type confusion.
+    for _ in 0..16 {
+        assert_eq!(format!("{}", &*f), "123");
+    }
+}
+
+// =============================================================================
+// Pass 1.4 — Drop ordering
+// =============================================================================
+
+struct DropTracker {
+    counter: Rc<Cell<u32>>,
+}
+
+impl Drop for DropTracker {
+    fn drop(&mut self) {
+        self.counter.set(self.counter.get() + 1);
+    }
+}
+
+#[test]
+fn flat_runs_inner_drop() {
+    let counter = Rc::new(Cell::new(0u32));
+    {
+        let _f: Flat<DropTracker, B32> = Flat::new(DropTracker {
+            counter: counter.clone(),
+        });
+        assert_eq!(counter.get(), 0);
+    }
+    assert_eq!(counter.get(), 1, "inner Drop ran exactly once");
+}
+
+#[test]
+fn flex_inline_runs_inner_drop() {
+    let counter = Rc::new(Cell::new(0u32));
+    {
+        let f: Flex<DropTracker, B32> = Flex::new(DropTracker {
+            counter: counter.clone(),
+        });
+        assert!(f.is_inline());
+    }
+    assert_eq!(counter.get(), 1, "inner Drop ran exactly once (inline)");
+}
+
+#[test]
+fn flex_heap_runs_inner_drop() {
+    // 24 bytes of payload won't fit Flex<_, B16>'s ?Sized capacity
+    // (B16 - 16 = 0). Force the heap path.
+    struct BigDrop {
+        _payload: [u64; 4],
+        counter: Rc<Cell<u32>>,
+    }
+    impl Drop for BigDrop {
+        fn drop(&mut self) {
+            self.counter.set(self.counter.get() + 1);
+        }
+    }
+    impl Greet for BigDrop {
+        fn greet(&self) -> String {
+            "big".into()
+        }
+    }
+
+    let counter = Rc::new(Cell::new(0u32));
+    {
+        let f: Flex<dyn Greet, B16> = flex!(BigDrop {
+            _payload: [1, 2, 3, 4],
+            counter: counter.clone(),
+        });
+        assert!(!f.is_inline(), "BigDrop should route to heap");
+        assert_eq!(f.greet(), "big");
+    }
+    assert_eq!(counter.get(), 1, "heap allocation freed and Drop ran");
+}
+
+// =============================================================================
+// Pass 1.5 — Panic-during-drop
+// =============================================================================
+//
+// Exercises the unwind path through the smart-pointer's own Drop. Miri
+// is sensitive to double-free / use-after-free even on unwind. The
+// outer `catch_unwind` swallows the panic so the test doesn't abort.
+
+#[test]
+fn flat_panic_in_inner_drop_is_safe() {
+    struct Panicker {
+        ran: Rc<Cell<bool>>,
+    }
+    impl Drop for Panicker {
+        fn drop(&mut self) {
+            self.ran.set(true);
+            // SAFETY of unwind isn't on the inner type — it's whether
+            // Flat<T,B>::drop calls our Drop only once and doesn't touch
+            // freed memory after.
+            panic!("intentional panic during inner Drop");
+        }
+    }
+
+    let ran = Rc::new(Cell::new(false));
+    let ran_clone = ran.clone();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _f: Flat<Panicker, B32> = Flat::new(Panicker { ran: ran_clone });
+        // _f drops here, panicking.
+    }));
+    assert!(result.is_err(), "panic must propagate out of catch_unwind");
+    assert!(ran.get(), "inner Drop must have run");
+}
+
+// =============================================================================
+// Pass 1.6 — B16 ?Sized boundary (8-byte concrete fits exactly)
+// =============================================================================
+//
+// Flat<dyn Display, B16> reserves 8 bytes for metadata, leaving 8 bytes
+// for the concrete value. `u64` is exactly 8 bytes — the "exactly fits"
+// edge case from #173.
+
+#[test]
+fn flat_b16_fits_8_byte_concrete() {
+    let f: Flat<dyn Display, B16> = flat!(0xCAFE_BABEu64);
+    assert_eq!(format!("{}", &*f), "3405691582");
+}
+
+#[test]
+fn flat_b16_fits_8_byte_newtype() {
+    // 8-byte newtype with a non-trivial Display impl — exercises the
+    // exactly-fits boundary with both the construction and the
+    // destruction side present.
+    struct EightByteVal(u64);
+    impl Display for EightByteVal {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "v{}", self.0)
+        }
+    }
+    assert_eq!(std::mem::size_of::<EightByteVal>(), 8);
+
+    let f: Flat<dyn Display, B16> = flat!(EightByteVal(99));
+    assert_eq!(format!("{}", &*f), "v99");
+}
+
+// =============================================================================
+// Pass 1.7 — Heap fallback round-trip (Flex)
+// =============================================================================
+
+#[test]
+fn flex_heap_path_deref_and_drop() {
+    // Force the heap path: payload bigger than B16 ?Sized capacity (0 bytes).
+    let payload: Vec<u8> = (0..64).collect();
+    let f: Flex<dyn Greet, B16> = {
+        struct Wrap(Vec<u8>);
+        impl Greet for Wrap {
+            fn greet(&self) -> String {
+                format!("wrap-{}", self.0.len())
+            }
+        }
+        flex!(Wrap(payload))
+    };
+    assert!(!f.is_inline(), "must be heap-allocated");
+    assert_eq!(f.greet(), "wrap-64");
+    drop(f);
+}
+
+// =============================================================================
+// Pass 1.8 — Slice trait object via Flat (length metadata, not vtable)
+// =============================================================================
+
+#[test]
+fn flat_slice_carries_length_metadata() {
+    let f: Flat<[u32], B32> = flat!([10u32, 20, 30, 40]);
+    assert_eq!(f.len(), 4);
+    assert_eq!(&*f, &[10, 20, 30, 40][..]);
+}

--- a/nexus-smartptr/tests/miri_tests.rs
+++ b/nexus-smartptr/tests/miri_tests.rs
@@ -130,8 +130,12 @@ fn flex_inline_runs_inner_drop() {
 
 #[test]
 fn flex_heap_runs_inner_drop() {
-    // 24 bytes of payload won't fit Flex<_, B16>'s ?Sized capacity
-    // (B16 - 16 = 0). Force the heap path.
+    // For `Flex<dyn Greet, B16>` the inline `?Sized` capacity is 0
+    // (16 bytes total, fully consumed by storage bookkeeping for the
+    // trait-object case). Any non-ZST payload routes to heap; the
+    // 32-byte payload below makes that explicit but is not the
+    // discriminator — a single `u8` would do the same. The test
+    // exercises the heap allocation + drop path.
     struct BigDrop {
         _payload: [u64; 4],
         counter: Rc<Cell<u32>>,


### PR DESCRIPTION
## Summary

Bundle C from the audit roadmap — adds the conventional `tests/miri_tests.rs` files to the two crates that were missing them. Both crates carry unsafe machinery (smartptr's manual fat-pointer decomposition, notify's intrusive MPSC + atomic dedup) that previously had inline `#[cfg(test)]` coverage but no dedicated miri target file.

## Changes

- **`nexus-smartptr/tests/miri_tests.rs`** (258 LOC, 11 tests) — covers `flat!`/`flex!` macro construction with `?Sized` types, vtable-stays-with-data, repeated deref provenance, drop ordering, panic-during-drop, B16 exactly-fits boundary, slice metadata round-trip, heap fallback path.
- **`nexus-notify/tests/miri_event_queue.rs`** (292 LOC, 9 tests) — covers single notify+poll, dedup invariant, FIFO order, post-drain re-notify, capacity boundary, cross-thread `Notifier` clone, MPSC two-producer race, cross-thread conflation, swap-race exactly-1-poll invariant.
- **`nexus-collections/benches/perf_rbtree.rs`** (+3/-1) — drive-by `cargo fmt` of the iter-scan bench block from #240 that wasn't wrapped on merge.

## Verification

- `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-smartptr --test miri_tests` — 11/11 pass, **zero UB findings**
- `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-notify --test miri_event_queue` — 9/9 pass, **zero UB findings**
- `cargo build --workspace` ✓
- `cargo test -p nexus-smartptr -p nexus-notify` ✓
- `cargo fmt --check` ✓
- Lib-test clippy clean for both new test files

## Diff

3 files, +553 / -1 (net additive, no source modifications).

Closes #173
Closes #217