### PR TITLE
nexus-net + nexus-async-net: HTTP buffer constant, error doc, naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,47 @@ Every public item needs documentation that explains:
 
 Unsafe code requires a `// SAFETY:` comment explaining why it's sound. "It's faster" is not sufficient — explain the invariants being upheld.
 
+### Builder and Setter Naming
+
+Workspace convention for naming methods that configure or mutate
+state. Matches Rust ecosystem patterns (`Vec`, `String`, `BufReader`,
+`tokio`, `hyper`).
+
+**Builder methods** take `mut self` and return `Self`:
+
+- `*_capacity` — application-level allocated buffer (matches
+  `Vec::with_capacity`, `String::with_capacity`,
+  `BufReader::with_capacity`).
+- `*_size` (in OS-option setters) — kernel-side buffer size for
+  socket options (matches `tokio::TcpSocket::set_recv_buffer_size`,
+  `socket2::Socket::set_*_buffer_size`).
+- `max_*_size` — application-level upper limit (matches
+  `hyper::Builder::max_buf_size`, `hyper::Body::limit_max_size`).
+- No `set_` prefix on builder methods. Builders compose; setters
+  mutate.
+
+**Runtime setters** on already-constructed types take `&mut self`,
+return `()`, and use the `set_*` prefix (matches `Vec::set_len`).
+This is the standard distinction between "configure during
+construction" and "mutate after construction."
+
+Example:
+
+```rust
+// Builder — no `set_` prefix
+let stream = WsStream::builder()
+    .buffer_capacity(8192)        // app buffer
+    .recv_buffer_size(64 * 1024)  // SO_RCVBUF
+    .max_message_size(1 << 20)    // app limit
+    .build()?;
+
+// Runtime mutator — `set_` prefix
+stream.set_max_read_size(16 * 1024);  // adjust after construction
+```
+
+When in doubt, look at how `std`, `tokio`, or `hyper` names a similar
+concept.
+
 ## Submitting Changes
 
 1. **Open an issue first** for non-trivial changes. Let's discuss the approach before you write code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,14 +237,17 @@ construction" and "mutate after construction."
 Example:
 
 ```rust
-// Builder — no `set_` prefix
-let stream = WsStream::builder()
+use nexus_async_net::ws::WsStreamBuilder;
+
+// Builder — no `set_` prefix; chains `mut self -> Self`.
+let mut stream = WsStreamBuilder::new()
     .buffer_capacity(8192)        // app buffer
     .recv_buffer_size(64 * 1024)  // SO_RCVBUF
     .max_message_size(1 << 20)    // app limit
-    .build()?;
+    .connect("wss://exchange.com/ws")
+    .await?;
 
-// Runtime mutator — `set_` prefix
+// Runtime mutator — `set_` prefix; takes `&mut self`.
 stream.set_max_read_size(16 * 1024);  // adjust after construction
 ```
 

--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -5,7 +5,7 @@ use std::net::ToSocketAddrs;
 use std::pin::Pin;
 
 use nexus_async_rt::TcpStream;
-use nexus_net::http::{HttpError, ResponseReader};
+use nexus_net::http::{HTTP_HANDSHAKE_BUFFER, HttpError, ResponseReader};
 use nexus_net::rest::{Request, RestError, RestResponse};
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
@@ -417,7 +417,7 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
                     "response head exceeds reader capacity",
                 )));
             }
-            match fill_async(&mut self.stream, reader, 4096).await {
+            match fill_async(&mut self.stream, reader, HTTP_HANDSHAKE_BUFFER).await {
                 Ok(0) => {
                     self.poisoned = true;
                     return Err(RestError::ConnectionClosed(
@@ -483,7 +483,7 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
                     available: 0,
                 }));
             }
-            match fill_async(&mut self.stream, reader, 4096).await {
+            match fill_async(&mut self.stream, reader, HTTP_HANDSHAKE_BUFFER).await {
                 Ok(0) => {
                     self.poisoned = true;
                     return Err(RestError::ConnectionClosed(
@@ -507,9 +507,9 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
 
         let max_body = reader.max_body_size_limit();
         let mut decoder = ChunkedDecoder::new();
-        let mut body = Vec::with_capacity(4096);
-        let mut wire_buf = [0u8; 4096];
-        let mut decode_buf = [0u8; 4096];
+        let mut body = Vec::with_capacity(HTTP_HANDSHAKE_BUFFER);
+        let mut wire_buf = [0u8; HTTP_HANDSHAKE_BUFFER];
+        let mut decode_buf = [0u8; HTTP_HANDSHAKE_BUFFER];
 
         // Decode any chunk data that arrived with the headers.
         let remainder = reader.remainder();
@@ -680,7 +680,7 @@ mod tests {
 
         let mock = NexusAsyncReadAdapter::new(MockAsyncStream::new(&ok_response(r#"{"ok":true}"#)));
         let mut writer = RequestWriter::new("api.example.com").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         block_on(async {
@@ -702,7 +702,7 @@ mod tests {
         let mock =
             NexusAsyncReadAdapter::new(MockAsyncStream::new(&ok_response(r#"{"filled":true}"#)));
         let mut writer = RequestWriter::new("api.example.com").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         block_on(async {
@@ -724,7 +724,7 @@ mod tests {
         let resp_bytes = b"HTTP/1.1 200 OK\r\nX-Request-Id: abc\r\nContent-Length: 2\r\n\r\n{}";
         let mock = NexusAsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         block_on(async {
@@ -742,7 +742,7 @@ mod tests {
         let resp_bytes = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial";
         let mock = NexusAsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         block_on(async {
@@ -764,7 +764,7 @@ mod tests {
             b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
         let mock = NexusAsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         block_on(async {

--- a/nexus-async-net/src/rest/nexus/pool.rs
+++ b/nexus-async-net/src/rest/nexus/pool.rs
@@ -7,6 +7,8 @@ use std::future::poll_fn;
 use std::pin::Pin;
 
 use nexus_async_rt::AsyncWrite;
+#[cfg(test)]
+use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 use nexus_net::http::ResponseReader;
 use nexus_net::rest::{RequestWriter, RestError};
 #[cfg(feature = "tls")]
@@ -553,7 +555,7 @@ mod tests {
     fn make_disconnected_slot() -> ClientSlot {
         ClientSlot {
             writer: RequestWriter::new("host").unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: None,
         }
     }

--- a/nexus-async-net/src/rest/tokio/atomic_pool.rs
+++ b/nexus-async-net/src/rest/tokio/atomic_pool.rs
@@ -8,6 +8,8 @@
 use std::future::poll_fn;
 use std::pin::Pin;
 
+#[cfg(test)]
+use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 use nexus_net::http::ResponseReader;
 use nexus_net::rest::{RequestWriter, RestError};
 #[cfg(feature = "tls")]
@@ -467,7 +469,7 @@ mod tests {
             n,
             || AtomicClientSlot {
                 writer: RequestWriter::new("host").unwrap(),
-                reader: ResponseReader::new(4096),
+                reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
                 conn: None,
             },
             |slot| {
@@ -499,7 +501,7 @@ mod tests {
     fn atomic_slot_needs_reconnect() {
         let slot = AtomicClientSlot {
             writer: RequestWriter::new("host").unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: None,
         };
         assert!(slot.needs_reconnect());
@@ -515,7 +517,7 @@ mod tests {
 
         tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 4096];
+            let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
             let _ = tcp.read(&mut buf).await.unwrap();
             let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
             tcp.write_all(resp).await.unwrap();
@@ -595,7 +597,7 @@ mod tests {
         tokio::spawn(async move {
             for _ in 0..4 {
                 let (mut tcp, _) = listener.accept().await.unwrap();
-                let mut buf = [0u8; 4096];
+                let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
                 let _ = tcp.read(&mut buf).await.unwrap();
                 let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
                 tcp.write_all(resp).await.unwrap();

--- a/nexus-async-net/src/rest/tokio/connection.rs
+++ b/nexus-async-net/src/rest/tokio/connection.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::pin::Pin;
 
-use nexus_net::http::{HttpError, ResponseReader};
+use nexus_net::http::{HTTP_HANDSHAKE_BUFFER, HttpError, ResponseReader};
 use nexus_net::rest::{Request, RestError, RestResponse};
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
@@ -398,7 +398,7 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
                     "response head exceeds reader capacity",
                 )));
             }
-            match fill_async(&mut self.stream, reader, 4096).await {
+            match fill_async(&mut self.stream, reader, HTTP_HANDSHAKE_BUFFER).await {
                 Ok(0) => {
                     self.poisoned = true;
                     return Err(RestError::ConnectionClosed(
@@ -466,7 +466,7 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
                     available: 0,
                 }));
             }
-            match fill_async(&mut self.stream, reader, 4096).await {
+            match fill_async(&mut self.stream, reader, HTTP_HANDSHAKE_BUFFER).await {
                 Ok(0) => {
                     self.poisoned = true;
                     return Err(RestError::ConnectionClosed(
@@ -490,9 +490,9 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
 
         let max_body = reader.max_body_size_limit();
         let mut decoder = ChunkedDecoder::new();
-        let mut body = Vec::with_capacity(4096);
-        let mut wire_buf = [0u8; 4096];
-        let mut decode_buf = [0u8; 4096];
+        let mut body = Vec::with_capacity(HTTP_HANDSHAKE_BUFFER);
+        let mut wire_buf = [0u8; HTTP_HANDSHAKE_BUFFER];
+        let mut decode_buf = [0u8; HTTP_HANDSHAKE_BUFFER];
 
         // Decode any chunk data that arrived with the headers.
         let remainder = reader.remainder();
@@ -638,7 +638,7 @@ mod tests {
 
         let mock = AsyncReadAdapter::new(MockAsyncStream::new(&ok_response(r#"{"ok":true}"#)));
         let mut writer = RequestWriter::new("api.example.com").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         let req = writer.get("/status").finish().unwrap();
@@ -657,7 +657,7 @@ mod tests {
 
         let mock = AsyncReadAdapter::new(MockAsyncStream::new(&ok_response(r#"{"filled":true}"#)));
         let mut writer = RequestWriter::new("api.example.com").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         let body = br#"{"symbol":"BTC","side":"buy"}"#;
@@ -677,7 +677,7 @@ mod tests {
         let resp_bytes = b"HTTP/1.1 200 OK\r\nX-Request-Id: abc\r\nContent-Length: 2\r\n\r\n{}";
         let mock = AsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         let req = writer.get("/test").finish().unwrap();
@@ -693,7 +693,7 @@ mod tests {
         let resp_bytes = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial";
         let mock = AsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         let req = writer.get("/test").finish().unwrap();
@@ -713,7 +713,7 @@ mod tests {
             b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
         let mock = AsyncReadAdapter::new(MockAsyncStream::new(resp_bytes));
         let mut writer = RequestWriter::new("host").unwrap();
-        let mut reader = ResponseReader::new(4096);
+        let mut reader = ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         let mut conn = HttpConnection::new(mock);
 
         let req = writer.get("/test").finish().unwrap();

--- a/nexus-async-net/src/rest/tokio/pool.rs
+++ b/nexus-async-net/src/rest/tokio/pool.rs
@@ -8,6 +8,8 @@
 use std::future::poll_fn;
 use std::pin::Pin;
 
+#[cfg(test)]
+use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 use nexus_net::http::ResponseReader;
 use nexus_net::rest::{RequestWriter, RestError};
 #[cfg(feature = "tls")]
@@ -541,7 +543,7 @@ mod tests {
     fn make_disconnected_slot() -> ClientSlot {
         ClientSlot {
             writer: RequestWriter::new("host").unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: None,
         }
     }
@@ -663,7 +665,7 @@ mod tests {
         tokio::spawn(async move {
             for _ in 0..4 {
                 let (mut tcp, _) = listener.accept().await.unwrap();
-                let mut buf = [0u8; 4096];
+                let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
                 let _ = tcp.read(&mut buf).await.unwrap();
                 let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
                 tcp.write_all(resp).await.unwrap();
@@ -687,7 +689,7 @@ mod tests {
             let conn = HttpConnection::new(stream);
             pool.put(ClientSlot {
                 writer: RequestWriter::new(&addr.to_string()).unwrap(),
-                reader: ResponseReader::new(4096),
+                reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
                 conn: Some(conn),
             });
 
@@ -717,7 +719,7 @@ mod tests {
         // Server: read request, send canned response.
         tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 4096];
+            let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
             let _ = tcp.read(&mut buf).await.unwrap();
             let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\n\r\n{\"orderId\":123}";
             tcp.write_all(resp).await.unwrap();
@@ -730,7 +732,7 @@ mod tests {
 
         let mut slot = ClientSlot {
             writer: RequestWriter::new(&addr.to_string()).unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: Some(conn),
         };
 
@@ -761,7 +763,7 @@ mod tests {
         // Server: handle two sequential requests on the same connection.
         tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 4096];
+            let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
 
             // Request 1
             let _ = tcp.read(&mut buf).await.unwrap();
@@ -789,7 +791,7 @@ mod tests {
         });
         pool.put(ClientSlot {
             writer: RequestWriter::new(&addr.to_string()).unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: Some(conn),
         });
 
@@ -844,7 +846,7 @@ mod tests {
         // Server: accept, respond to first request, then close the connection.
         tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.unwrap();
-            let mut buf = [0u8; 4096];
+            let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
 
             // First request — respond normally.
             let _ = tcp.read(&mut buf).await.unwrap();
@@ -869,7 +871,7 @@ mod tests {
         });
         pool.put(ClientSlot {
             writer: RequestWriter::new(&addr.to_string()).unwrap(),
-            reader: ResponseReader::new(4096),
+            reader: ResponseReader::new(HTTP_HANDSHAKE_BUFFER),
             conn: Some(conn),
         });
 
@@ -943,7 +945,7 @@ mod tests {
                         let listener = TcpListener::from_std(listener_fd).unwrap();
                         // Accept first connection — respond then close.
                         let (mut tcp, _) = listener.accept().await.unwrap();
-                        let mut buf = [0u8; 4096];
+                        let mut buf = [0u8; HTTP_HANDSHAKE_BUFFER];
                         let _ = tcp.read(&mut buf).await.unwrap();
                         tcp.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nfirst")
                             .await

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 use nexus_async_rt::TcpStream;
 use nexus_net::buf::WriteBuf;
+use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_net::ws::{
@@ -241,7 +242,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
         // Feed bytes directly into resp_reader's spare region via
         // WireStream — one fewer copy than reading into a tmp slice
         // and pushing through resp_reader.read().
-        let mut resp_reader = nexus_net::http::ResponseReader::new(4096);
+        let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         loop {
             // Pre-check the WireStream::poll_fill_into precondition
             // (sink.spare() non-empty). If full without a parsed
@@ -249,7 +250,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
             if resp_reader.spare().is_empty() {
                 return Err(HandshakeError::MalformedHttp.into());
             }
-            let n = fill_async(&mut stream, &mut resp_reader, 4096).await?;
+            let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
             if n == 0 {
                 return Err(HandshakeError::MalformedHttp.into());
             }
@@ -313,7 +314,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
         write_cap: usize,
         max_read_size: usize,
     ) -> Result<Self, WsError> {
-        let mut req_reader = nexus_net::http::RequestReader::new(4096);
+        let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
 
         let ws_key;
         loop {
@@ -325,7 +326,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
             }
             // Direct-feed via WireStream — bytes land in
             // req_reader.spare() without a tmp slice intermediate.
-            let n = fill_async(&mut stream, &mut req_reader, 4096).await?;
+            let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
             if n == 0 {
                 return Err(HandshakeError::MalformedHttp.into());
             }

--- a/nexus-async-net/src/ws/tokio/stream.rs
+++ b/nexus-async-net/src/ws/tokio/stream.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::pin::Pin;
 
 use nexus_net::buf::WriteBuf;
+use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_net::ws::{
@@ -234,7 +235,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
 
         write_all_async(&mut stream, &req_buf[..n]).await?;
 
-        let mut resp_reader = nexus_net::http::ResponseReader::new(4096);
+        let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
         loop {
             // Pre-check the WireStream::poll_fill_into precondition
             // (sink.spare() non-empty). If full without a parsed
@@ -242,7 +243,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
             if resp_reader.spare().is_empty() {
                 return Err(HandshakeError::MalformedHttp.into());
             }
-            let n = fill_async(&mut stream, &mut resp_reader, 4096).await?;
+            let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
             if n == 0 {
                 return Err(HandshakeError::MalformedHttp.into());
             }
@@ -306,7 +307,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
         write_cap: usize,
         max_read_size: usize,
     ) -> Result<Self, WsError> {
-        let mut req_reader = nexus_net::http::RequestReader::new(4096);
+        let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
 
         let ws_key;
         loop {
@@ -316,7 +317,7 @@ impl<S: WireStream + Unpin> WsStream<S> {
             if req_reader.spare().is_empty() {
                 return Err(HandshakeError::MalformedHttp.into());
             }
-            let n = fill_async(&mut stream, &mut req_reader, 4096).await?;
+            let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
             if n == 0 {
                 return Err(HandshakeError::MalformedHttp.into());
             }

--- a/nexus-net/src/http/mod.rs
+++ b/nexus-net/src/http/mod.rs
@@ -15,6 +15,21 @@ mod error;
 mod request;
 mod response;
 
+/// Default capacity for HTTP request/response handshake buffers.
+///
+/// Sized to comfortably fit a typical HTTP/1.1 head section
+/// (request line + headers up to ~3-4 KiB) on a single allocation.
+/// Used as the initial capacity of [`RequestReader`] / [`ResponseReader`]
+/// and as the per-recv read cap during the WebSocket upgrade handshake
+/// and REST request/response headers.
+///
+/// Tuning beyond this default is a follow-up — currently this is a
+/// hardcoded internal default. Callers that need larger handshake
+/// budgets (very long cookies, many headers, OCSP-stapled
+/// certificates over HTTP) would currently work around by sending
+/// fewer headers; a builder knob is a separate concern.
+pub const HTTP_HANDSHAKE_BUFFER: usize = 4096;
+
 pub use chunked::ChunkedDecoder;
 pub use error::HttpError;
 // RequestReader parses inbound HTTP requests (used for WS upgrade handshake).

--- a/nexus-net/src/http/mod.rs
+++ b/nexus-net/src/http/mod.rs
@@ -15,19 +15,19 @@ mod error;
 mod request;
 mod response;
 
-/// Default capacity for HTTP request/response handshake buffers.
+/// Default capacity for HTTP read/decode/scratch buffers.
 ///
-/// Sized to comfortably fit a typical HTTP/1.1 head section
-/// (request line + headers up to ~3-4 KiB) on a single allocation.
-/// Used as the initial capacity of [`RequestReader`] / [`ResponseReader`]
-/// and as the per-recv read cap during the WebSocket upgrade handshake
-/// and REST request/response headers.
+/// Sized to comfortably fit a typical HTTP/1.1 head section (request
+/// line + headers up to ~3-4 KiB) in a single allocation, which is the
+/// dominant use site. Also used by `nexus-async-net` as the per-recv
+/// read cap during WebSocket upgrade and REST request/response cycles,
+/// and as the initial capacity of intermediate body / wire / decode
+/// scratch buffers.
 ///
-/// Tuning beyond this default is a follow-up — currently this is a
-/// hardcoded internal default. Callers that need larger handshake
-/// budgets (very long cookies, many headers, OCSP-stapled
-/// certificates over HTTP) would currently work around by sending
-/// fewer headers; a builder knob is a separate concern.
+/// Currently a hardcoded internal default. Callers with unusually large
+/// HTTP heads (very long cookies, many or large header values) would
+/// today need to work around by sending fewer headers; a builder knob
+/// is a separate concern.
 pub const HTTP_HANDSHAKE_BUFFER: usize = 4096;
 
 pub use chunked::ChunkedDecoder;

--- a/nexus-net/src/rest/error.rs
+++ b/nexus-net/src/rest/error.rs
@@ -1,3 +1,18 @@
+//! REST client error types.
+//!
+//! ## TLS error handling
+//!
+//! `From<TlsError> for RestError` partially preserves the TLS layer:
+//! non-IO `TlsError` variants (decrypt failure, peer alert, malformed
+//! record) surface as [`RestError::Tls`]; `TlsError::Io` flattens to
+//! [`RestError::Io`] because it represents a genuine `io::Error` that
+//! happened during TLS operations and the underlying async transport
+//! ([`WireStream`](crate::WireStream)) returns `io::Result` either
+//! way. The original `TlsError::Io` is preserved as the source of the
+//! resulting `io::Error` and reachable via `io_err.source()` /
+//! `io_err.get_ref()`. See [`RestError::Tls`] for the full
+//! sync-vs-async asymmetry note.
+
 use std::fmt;
 
 use crate::http::HttpError;

--- a/nexus-net/src/ws/stream.rs
+++ b/nexus-net/src/ws/stream.rs
@@ -126,7 +126,21 @@ pub enum Error {
     Encode(super::frame_writer::EncodeError),
     /// HTTP handshake failed.
     Handshake(HandshakeError),
-    /// TLS error.
+    /// TLS error during connection setup (handshake, certificate
+    /// validation, hostname resolution).
+    ///
+    /// **Steady-state TLS protocol errors** (decrypt failure, peer
+    /// alert, malformed record received during a frame) on the async
+    /// `nexus-async-net` paths surface as [`Error::Io`](Self::Io)
+    /// instead — the underlying [`TlsError`](crate::tls::TlsError) is
+    /// wrapped via `io::Error::other` and reachable via
+    /// `io_err.source()` or `io_err.get_ref()`. This asymmetry stems
+    /// from the [`WireStream`](crate::WireStream) trait returning
+    /// `io::Result` for poll methods. Sync WS surfaces `Tls` directly
+    /// because its `TlsStream` exposes `TlsError` natively. Pattern-
+    /// match on both `Io` and `Tls` if you need to distinguish TLS-
+    /// protocol failures from generic transport failures across both
+    /// surfaces.
     #[cfg(feature = "tls")]
     Tls(TlsError),
     /// Invalid WebSocket URL.

--- a/nexus-net/src/ws/stream.rs
+++ b/nexus-net/src/ws/stream.rs
@@ -127,7 +127,7 @@ pub enum Error {
     /// HTTP handshake failed.
     Handshake(HandshakeError),
     /// TLS error during connection setup (handshake, certificate
-    /// validation, hostname resolution).
+    /// validation, SNI hostname verification).
     ///
     /// **Steady-state TLS protocol errors** (decrypt failure, peer
     /// alert, malformed record received during a frame) on the async


### PR DESCRIPTION
## Summary

Bundle D from the audit roadmap. Three small cleanups touching nexus-net and nexus-async-net — one named constant, one doc improvement, and a workspace convention written down.

## Changes

- **#225** — `nexus-net::http` exports `pub const HTTP_HANDSHAKE_BUFFER: usize = 4096`. Replaces 18 production literals + 25 test literals across `nexus-async-net/src/{ws,rest}/{tokio,nexus}/`. Tests now track production tuning (cfg-gated import on parent module so lib build stays warning-free; tests inherit via `use super::*;`).
- **#227** — Module-level doc paragraph on `nexus-net/src/rest/error.rs` explaining the sync-vs-async TLS error asymmetry, plus mirroring expansion on `nexus-net::ws::Error::Tls`. The `Tls(TlsError)` variant + correct partial-preservation `From<TlsError>` impl already existed; the audit was based on a stale read. The fix is discoverability so future audits don't re-flag the same question.
- **#228** — New "Builder and Setter Naming" section in `CONTRIBUTING.md`. Documents the workspace convention (which the code already follows): `*_capacity` for app-allocated buffers (matches `Vec::with_capacity`), `*_size` for OS socket options (matches `tokio::TcpSocket::set_recv_buffer_size`), `max_*_size` for app-level limits (matches `hyper::Builder::max_buf_size`), no `set_` prefix on builder methods, `set_*` prefix on runtime mutators (matches `Vec::set_len`).

## Versioning

No version bumps. All changes are internal cleanup, docs, or already-resolved findings. No public API surface change.

## Verification

- `cargo build --workspace` ✓
- `cargo build --workspace --tests` ✓
- `cargo build -p nexus-async-net --no-default-features --features nexus,tls` ✓ (nexus backend feature config)
- `cargo fmt --check` ✓
- `cargo clippy -p nexus-net -p nexus-async-net -- -D warnings` ✓
- `cargo test --workspace --no-fail-fast` ✓ all green
- `cargo doc -p nexus-net --no-deps` ✓ no new warnings

## Diff

11 files, +139 / -46 (deletion-positive after Carl's removals exceed the new const + doc additions).

## Note on #227

The variant + correct From impl already exist (since the original REST commit `7d4e53c`, March 2026):

```rust
impl From<crate::tls::TlsError> for RestError {
    fn from(e: crate::tls::TlsError) -> Self {
        match e {
            crate::tls::TlsError::Io(io) => Self::Io(io),  // intentional flattening
            other => Self::Tls(other),                      // preserves TLS context
        }
    }
}
```

`TlsError::Io` flattening to `RestError::Io` is intentional and documented — the underlying async `WireStream` returns `io::Result` so structured TLS info would be lost on that path anyway, but the original `TlsError` is preserved as the resulting `io::Error::source()`. This PR adds a module-level doc paragraph so the design intent is discoverable without reading the long variant doc; #227 will be closed as resolved-by-existing-code with a pointer to the new docs.

Closes #225
Closes #227
Closes #228