### PR TITLE
polish sweep thru workspace

### DIFF
--- a/nexus-channel/src/lib.rs
+++ b/nexus-channel/src/lib.rs
@@ -185,6 +185,7 @@ impl<T> Sender<T> {
     /// or the receiver disconnects.
     ///
     /// Returns `Err(SendError(value))` if the receiver has been dropped.
+    #[inline]
     pub fn send(&self, value: T) -> Result<(), SendError<T>> {
         if self.producer.is_disconnected() {
             return Err(SendError(value));
@@ -260,6 +261,7 @@ impl<T> Sender<T> {
     /// - `Ok(())` if the message was sent
     /// - `Err(TrySendError::Full(value))` if the channel is full
     /// - `Err(TrySendError::Disconnected(value))` if the receiver was dropped
+    #[inline]
     pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
         if self.producer.is_disconnected() {
             return Err(TrySendError::Disconnected(value));
@@ -338,6 +340,7 @@ impl<T> Receiver<T> {
     ///
     /// Returns `Err(RecvError)` if the sender has been dropped and no messages
     /// remain in the channel.
+    #[inline]
     pub fn recv(&self) -> Result<T, RecvError> {
         // Fast path
         if let Some(v) = self.consumer.pop() {
@@ -464,6 +467,7 @@ impl<T> Receiver<T> {
     /// - `Ok(value)` if a message was available
     /// - `Err(TryRecvError::Empty)` if the channel is empty
     /// - `Err(TryRecvError::Disconnected)` if the sender was dropped and channel is empty
+    #[inline]
     #[allow(clippy::option_if_let_else)]
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         match self.consumer.pop() {

--- a/nexus-id/src/types.rs
+++ b/nexus-id/src/types.rs
@@ -509,6 +509,7 @@ impl<const CAP: usize> HexId64<CAP> {
     }
 
     /// Decode back to u64.
+    #[inline]
     pub fn decode(&self) -> u64 {
         let bytes: &[u8; 16] = self.0.as_bytes().try_into().expect("16-byte hex string");
         // SAFETY: Data was validated at construction; decode cannot fail.
@@ -617,6 +618,7 @@ impl<const CAP: usize> Base62Id<CAP> {
     }
 
     /// Decode back to u64.
+    #[inline]
     pub fn decode(&self) -> u64 {
         let bytes = self.0.as_bytes();
         let mut value: u64 = 0;
@@ -731,6 +733,7 @@ impl<const CAP: usize> Base36Id<CAP> {
     }
 
     /// Decode back to u64.
+    #[inline]
     pub fn decode(&self) -> u64 {
         let bytes = self.0.as_bytes();
         let mut value: u64 = 0;

--- a/nexus-notify/src/local.rs
+++ b/nexus-notify/src/local.rs
@@ -126,7 +126,11 @@ impl LocalNotify {
     #[inline]
     pub fn mark(&mut self, token: Token) {
         let idx = token.index();
-        assert!(
+        // Match the sync variant (event_queue.rs:107) which uses
+        // debug_assert! for the same precondition. Release builds skip
+        // the bounds check; the underlying `bits[word]` index would panic
+        // on out-of-bounds anyway.
+        debug_assert!(
             idx < self.num_tokens,
             "token index {} out of range ({})",
             idx,
@@ -185,16 +189,19 @@ impl LocalNotify {
     }
 
     /// Returns `true` if any token is marked.
+    #[inline]
     pub fn has_notified(&self) -> bool {
         !self.dispatch_list.is_empty()
     }
 
     /// Number of tokens currently marked.
+    #[inline]
     pub fn notified_count(&self) -> usize {
         self.dispatch_list.len()
     }
 
     /// Number of registered tokens.
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.num_tokens
     }

--- a/nexus-pool/src/local.rs
+++ b/nexus-pool/src/local.rs
@@ -171,6 +171,7 @@ impl<T> BoundedPool<T> {
     /// Attempts to acquire an object from the pool.
     ///
     /// Returns `None` if all objects are currently in use.
+    #[inline]
     pub fn try_acquire(&self) -> Option<Pooled<T>> {
         self.inner.try_pop().map(|value| Pooled {
             value: ManuallyDrop::new(value),
@@ -179,6 +180,7 @@ impl<T> BoundedPool<T> {
     }
 
     /// Returns the number of available objects.
+    #[inline]
     pub fn available(&self) -> usize {
         self.inner.available()
     }
@@ -269,6 +271,7 @@ impl<T> Pool<T> {
     /// Attempts to acquire an object from the pool without creating.
     ///
     /// Returns `None` if the pool is empty. This is the fast path.
+    #[inline]
     pub fn try_acquire(&self) -> Option<Pooled<T>> {
         self.inner.try_pop().map(|value| Pooled {
             value: ManuallyDrop::new(value),
@@ -295,6 +298,7 @@ impl<T> Pool<T> {
     /// buf.extend_from_slice(b"hello");
     /// pool.put(buf); // manual return, reset is called
     /// ```
+    #[inline]
     pub fn take(&self) -> T {
         // SAFETY: Pool::new/with_capacity always calls new_growable, which
         // initializes the factory via MaybeUninit::new. pop_or_create's
@@ -306,6 +310,7 @@ impl<T> Pool<T> {
     ///
     /// Returns `None` if the pool is empty. The caller is responsible for
     /// returning the object via [`put()`](Pool::put).
+    #[inline]
     pub fn try_take(&self) -> Option<T> {
         self.inner.try_pop()
     }
@@ -320,12 +325,14 @@ impl<T> Pool<T> {
     /// If the reset closure panics, the value is leaked and the pool slot
     /// is not returned. The panic propagates normally. Reset closures must
     /// not panic — use simple operations like `Vec::clear()` or field resets.
+    #[inline]
     pub fn put(&self, mut value: T) {
         self.inner.return_value(&mut value);
         self.inner.push(value);
     }
 
     /// Returns the number of available objects.
+    #[inline]
     pub fn available(&self) -> usize {
         self.inner.available()
     }

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -227,6 +227,7 @@ impl<T> Pool<T> {
     /// Attempts to acquire an object from the pool.
     ///
     /// Returns `None` if all objects are currently in use.
+    #[inline]
     pub fn try_acquire(&self) -> Option<Pooled<T>> {
         self.inner.pop().map(|idx| {
             // SAFETY: We just popped this slot via CAS (exclusive ownership).
@@ -245,6 +246,7 @@ impl<T> Pool<T> {
     /// O(1) — backed by an atomic counter. This is a snapshot and may
     /// be immediately outdated if other threads are returning objects
     /// concurrently.
+    #[inline]
     pub fn available(&self) -> usize {
         self.inner.free_count.load(Ordering::Relaxed)
     }

--- a/nexus-slot/src/spmc.rs
+++ b/nexus-slot/src/spmc.rs
@@ -242,9 +242,15 @@ impl<T: Pod> SharedReader<T> {
     }
 
     /// Returns `true` if the writer has been dropped.
+    ///
+    /// Best-effort signal — the `Relaxed` load is sufficient because no
+    /// data depends on the disconnect flag's ordering relative to other
+    /// loads. A reader observing `false` racy with a writer drop simply
+    /// gets a stale "not yet disconnected" answer, which the next call
+    /// will correct.
     #[inline]
     pub fn is_disconnected(&self) -> bool {
-        !self.inner.writer_alive.load(Ordering::Acquire)
+        !self.inner.writer_alive.load(Ordering::Relaxed)
     }
 }
 

--- a/nexus-slot/src/spmc.rs
+++ b/nexus-slot/src/spmc.rs
@@ -243,14 +243,16 @@ impl<T: Pod> SharedReader<T> {
 
     /// Returns `true` if the writer has been dropped.
     ///
-    /// Best-effort signal — the `Relaxed` load is sufficient because no
-    /// data depends on the disconnect flag's ordering relative to other
-    /// loads. A reader observing `false` racy with a writer drop simply
-    /// gets a stale "not yet disconnected" answer, which the next call
-    /// will correct.
+    /// Acquire-loads `writer_alive`. Pairs with the writer's Release
+    /// store in `Drop` so a reader observing `writer_alive == false`
+    /// is also guaranteed to observe the writer's final published data
+    /// (the last `seq.store(..., Release)` before drop). Without the
+    /// Acquire, the canonical drain-then-disconnect pattern
+    /// `while !disconnected || has_update() { ... }` could exit early
+    /// and miss the writer's last value.
     #[inline]
     pub fn is_disconnected(&self) -> bool {
-        !self.inner.writer_alive.load(Ordering::Relaxed)
+        !self.inner.writer_alive.load(Ordering::Acquire)
     }
 }
 

--- a/nexus-stats-core/src/monitoring/jitter.rs
+++ b/nexus-stats-core/src/monitoring/jitter.rs
@@ -63,11 +63,7 @@ macro_rules! impl_jitter_float {
                     return Ok(Option::None);
                 }
 
-                let abs_delta = if sample > self.last_sample {
-                    sample - self.last_sample
-                } else {
-                    self.last_sample - sample
-                };
+                let abs_delta = (sample - self.last_sample).abs();
                 self.last_deviation = abs_delta;
                 self.last_sample = sample;
 

--- a/nexus-stats-core/src/smoothing/asym_ema.rs
+++ b/nexus-stats-core/src/smoothing/asym_ema.rs
@@ -15,6 +15,12 @@ macro_rules! impl_asym_ema_float {
         pub struct $name {
             alpha_up: $ty,
             alpha_down: $ty,
+            // Precomputed `1.0 - alpha_*` for the `update` hot path; saves a
+            // subtraction per sample at the cost of two `$ty` fields per
+            // instance. Set in `build()` and held constant for the
+            // instance's lifetime.
+            one_minus_alpha_up: $ty,
+            one_minus_alpha_down: $ty,
             value: $ty,
             count: u64,
             min_samples: u64,
@@ -56,12 +62,12 @@ macro_rules! impl_asym_ema_float {
                 if self.count == 1 {
                     self.value = sample;
                 } else {
-                    let alpha = if sample > self.value {
-                        self.alpha_up
+                    let (alpha, one_minus) = if sample > self.value {
+                        (self.alpha_up, self.one_minus_alpha_up)
                     } else {
-                        self.alpha_down
+                        (self.alpha_down, self.one_minus_alpha_down)
                     };
-                    self.value = alpha.fma(sample, (1.0 as $ty - alpha) * self.value);
+                    self.value = alpha.fma(sample, one_minus * self.value);
                 }
 
                 if self.count >= self.min_samples {
@@ -169,6 +175,8 @@ macro_rules! impl_asym_ema_float {
                 Ok($name {
                     alpha_up,
                     alpha_down,
+                    one_minus_alpha_up: 1.0 as $ty - alpha_up,
+                    one_minus_alpha_down: 1.0 as $ty - alpha_down,
                     value: 0.0 as $ty,
                     count: 0,
                     min_samples: self.min_samples,


### PR DESCRIPTION
## Summary

Tier 3 polish sweep — mechanical bundle of `#[inline]`, precomputed constants, and a few small cleanups across 7 crates per the audit issue. Most changes are codegen hints with no behavior change; one (in nexus-notify) brings the local variant in line with the sync variant's release-mode behavior.

## Changes by section

| Section | Crates touched | What |
|---|---|---|
| **P3.1** `#[inline]` sweep | nexus-channel, nexus-pool, nexus-notify, nexus-id | 17 hot-path methods — `send`/`try_send`/`recv`/`try_recv`, all pool acquire/take/put/available, notify counters, ID encode/decode |
| **P3.2** Precompute `1 - α` | nexus-stats-core (AsymEmaF64) | New private `one_minus_alpha_up`/`one_minus_alpha_down` fields set once in `build()`; saves a subtraction per `update()` call. Numerical result bit-identical via FMA. |
| **P3.3** Branchful abs → `.abs()` | nexus-stats-core (Jitter) | 5-line `if`/`else` collapsed to `(sample - last_sample).abs()` |
| **P3.6** Consistency | nexus-notify, nexus-slot | `assert!` → `debug_assert!` in `LocalNotify::mark` to match `event_queue.rs:107`; nexus-slot doc comment improvement (see "Want eyes on") |

## Want eyes on

**`nexus-slot::SharedReader::is_disconnected` — audit suggestion was unsound.** The original audit issue (#181 P3.6) suggested changing the load from `Acquire` to `Relaxed` for a ~2cy save. Copilot caught — and verifying against the writer's `Drop` (`spmc.rs:141` uses `Ordering::Release`) — that the Acquire is load-bearing for the drain-then-disconnect happens-before contract. A reader observing `writer_alive == false` via Relaxed could exit before observing the writer's last data store, missing the final value. **Kept Acquire, expanded the doc comment to explain why** so this doesn't get re-suggested in a future audit. Third instance in recent history (after Casey's Phase 4 and John's Pillar 1 audit) where an agent's atomic-ordering suggestion turned out wrong — worth noting as a class.

## Deferred from #181

**P3.3's HuberEma "partial" case** in `nexus-stats-smoothing` was deferred. The audit marked it partial because it's a `signum() * delta` pattern, not a clean branchful `.abs()` — a proper fix would be `delta.copysign(diff)` and requires verifying `delta >= 0.0` is invariant in the builder. Out of scope for this sweep; can be a follow-up if anyone wants the cycle.

## Versioning

No version bumps. All changes are codegen hints / private fields / doc clarifications — no public API change, no observable behavior change for valid inputs. Tracked in `.claude/pending-publishes.md` so the accumulated improvements roll into each crate's next functional release.

## Verification

- `cargo build --workspace` ✓
- `cargo test --workspace --no-fail-fast` ✓ all green
- `cargo fmt --check` ✓
- `cargo clippy -p nexus-channel -p nexus-pool -p nexus-notify -p nexus-id -p nexus-stats-core -p nexus-stats-smoothing -p nexus-slot -- -D warnings` ✓ clean for all touched crates

## Diff

8 files, +44 / -11 (with the post-Copilot Acquire revert: +46 / -13).

Closes #181