### PR TITLE
perf improvements to nexus-pool

### DIFF
--- a/nexus-pool/CHANGELOG.md
+++ b/nexus-pool/CHANGELOG.md
@@ -10,6 +10,60 @@ contained.
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-05-10
+
+Performance + contract change. Pooled guards now hold a strong
+reference (Rc/Arc) instead of Weak, eliminating per-release refcount
+work on the hot path.
+
+### Changed (breaking contract)
+
+- **In-pool values live until the last `Pooled<T>` guard drops.**
+  Previously, dropping the pool with outstanding guards caused
+  in-pool values to drop immediately, and guard drops bypassed the
+  reset closure. Now: guards return values to the orphaned `Inner`
+  (reset runs normally), and `Inner` with all in-pool values dies
+  when the last guard exits. No leak, no UAF — just a delayed-drop
+  semantic that affects shutdown ordering for resources holding
+  external handles. See `docs/caveats.md` §2.
+- `Pooled<T>::inner` field type changed from `Weak<Inner<T>>` to
+  `Rc<Inner<T>>` (local) / `Arc<Inner<T>>` (sync). External code
+  cannot observe the field directly, and `Pooled<T>` size is
+  unchanged on both 32-bit and 64-bit targets (`Rc` and `Weak` are
+  the same size).
+
+### Performance
+
+Measured on Intel Core Ultra 7 165U, pinned to physical P-cores
+0,2 via `taskset`. Best-of-5 floor per percentile.
+
+- **Sync pool same-thread release p50:** 72cy → 62cy (–10cy, 13.9%).
+- **Sync pool concurrent 1-thread release p50:** 74cy → 60cy
+  (–14cy, 18.9%).
+- **Sync pool concurrent 4-thread release p50:** 476cy → 288cy
+  (–188cy, 39.5%) — biggest tail-latency win because the contended
+  `Weak::upgrade` CAS retry loop is gone.
+- **Sync pool cross-thread 1-Returner release p50:** 430cy → 366cy
+  (–64cy, 14.9%).
+- **Local pool release p50:** unchanged at p50 in rdtscp benches,
+  but `cargo asm` confirms hot-path `Pooled::drop` shrinks from
+  3 `Cell` RMWs + 4 conditional branches to 1 RMW + 1 branch
+  (function body 141 → 108 lines of generated asm). The single-
+  threaded `Cell` load/dec/store pipelines well behind the
+  surrounding `return_value` call and `Vec::push`, so the saved
+  cycles aren't measurable above the rdtscp floor at p50. The
+  codegen reduction is real and the contract now matches the sync
+  path; the cycles win simply doesn't surface in this measurement
+  methodology.
+
+### Internal
+
+- `#[inline]` added to hot accessors in `local::BoundedPool`,
+  `local::Pool`, `sync::Pool`: `try_acquire`, `acquire`, `take`,
+  `try_take`, `put`, `available` (8 sites total). Carries through
+  monomorphization to user code without `cargo-llvm-lines`
+  ballooning. (Originally landed in #244.)
+
 ## [1.0.4] — 2026-05-08
 
 ### Added

--- a/nexus-pool/Cargo.toml
+++ b/nexus-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-pool"
-version = "1.0.4"
+version = "1.1.0"
 description = "High-performance object pools for low latency systems"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-pool/README.md
+++ b/nexus-pool/README.md
@@ -12,7 +12,7 @@ High-performance object pools for latency-sensitive applications.
 - **Zero allocation on hot path**: Pre-allocate objects at startup
 - **RAII guards**: Objects automatically return to pool on drop
 - **Manual take/put**: Owned values without RAII when guard lifetime doesn't fit
-- **Graceful shutdown**: Guards safely drop values if pool is gone
+- **Graceful shutdown**: Guards retain values past pool drop; everything cleans up when the last guard exits. No leak, no UAF.
 
 ## Quick Start
 

--- a/nexus-pool/docs/caveats.md
+++ b/nexus-pool/docs/caveats.md
@@ -19,19 +19,28 @@ operations. No `.unwrap()`, no indexing, no user callbacks.
 If you drop the pool while `Pooled<T>` guards are still alive:
 
 - Existing guards continue to work normally.
-- When each guard drops, it drops its `T` directly instead of
-  returning it to the (now-gone) pool.
+- When each guard drops, it returns its `T` to the (now-orphaned)
+  internal storage via the normal push path. The reset closure runs.
+- In-pool values (already in the free list when the pool dropped, plus
+  values returned by guards after pool drop) are **retained** until
+  the last `Pooled<T>` drops, then all drop together when the
+  internal storage finally dies.
 - No panic, no leak, no use-after-free.
 
 This is safe but operationally surprising: if your shutdown path
 drops the pool first and then waits for worker threads to finish,
-the worker threads will drop values on the allocator instead of
-returning them. If you care (e.g., because drop is expensive), keep
-the pool alive until all workers have exited.
+in-pool values stay alive until every worker has dropped its guard.
+If you care about prompt destruction of pool-retained resources
+(e.g., values holding file descriptors or holding socket buffers
+open), ensure all guards are dropped before dropping the pool.
 
-Under the hood, guards hold `Weak<Inner>` (local) or `Weak<Inner>`
-(sync) — the `Drop` impl upgrades and returns, or falls back to
-direct drop.
+Under the hood, guards hold `Rc<Inner>` (local) or `Arc<Inner>`
+(sync) — a strong reference. The pool itself drops the factory at
+its own `Drop` time, but the `Inner` storage lives on as long as any
+guard does. (Prior to 1.1.0 the guards held `Weak`, which gave
+prompt drop-on-pool-drop at the cost of refcount work on every
+release. The 1.1.0 change is a deliberate semantic-for-cycles
+trade-off — see CHANGELOG.)
 
 ## 3. Sizing the pool
 
@@ -98,9 +107,11 @@ factory calls.
 ## 9. Pool objects outlive pool only as long as their guards
 
 If you keep the value alive (via a `Pooled<T>` guard) longer than
-the pool, that's fine — the value drops directly on guard drop.
-But you cannot "rescue" a value from a dropped pool and
-reattach it to a different pool. The guard is one-shot.
+the pool, that's fine — the guard returns the value to the
+orphaned internal storage on drop, and the storage (along with any
+other in-pool values) finally dies when the last guard exits.
+You cannot "rescue" a value from a dropped pool and reattach it to
+a different pool. The guard is one-shot.
 
 ## 10. Don't pool huge objects
 

--- a/nexus-pool/src/lib.rs
+++ b/nexus-pool/src/lib.rs
@@ -121,8 +121,10 @@
 //!
 //! The RAII pool types use guards ([`local::Pooled`], [`sync::Pooled`]) that
 //! automatically return objects to the pool on drop. If the pool is dropped
-//! before all guards, the guards will drop their values directly instead of
-//! returning them—no panic, no leak, no use-after-free.
+//! before all guards, the guards keep the internal storage alive via a
+//! strong reference; values flow back into the orphaned storage on guard
+//! drop, and the last guard to exit drops every retained value in one
+//! shot — no panic, no leak, no use-after-free. See `docs/caveats.md` §2.
 //!
 //! [`local::Pool`] also supports manual [`take()`](local::Pool::take) /
 //! [`put()`](local::Pool::put) for cases where RAII lifetime doesn't fit

--- a/nexus-pool/src/local.rs
+++ b/nexus-pool/src/local.rs
@@ -9,7 +9,7 @@
 use std::cell::UnsafeCell;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ops::{Deref, DerefMut};
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 
 // =============================================================================
 // Inner - shared storage for both pool types
@@ -175,7 +175,7 @@ impl<T> BoundedPool<T> {
     pub fn try_acquire(&self) -> Option<Pooled<T>> {
         self.inner.try_pop().map(|value| Pooled {
             value: ManuallyDrop::new(value),
-            inner: Rc::downgrade(&self.inner),
+            inner: Rc::clone(&self.inner),
         })
     }
 
@@ -264,7 +264,7 @@ impl<T> Pool<T> {
         let value = unsafe { self.inner.pop_or_create() };
         Pooled {
             value: ManuallyDrop::new(value),
-            inner: Rc::downgrade(&self.inner),
+            inner: Rc::clone(&self.inner),
         }
     }
 
@@ -275,7 +275,7 @@ impl<T> Pool<T> {
     pub fn try_acquire(&self) -> Option<Pooled<T>> {
         self.inner.try_pop().map(|value| Pooled {
             value: ManuallyDrop::new(value),
-            inner: Rc::downgrade(&self.inner),
+            inner: Rc::clone(&self.inner),
         })
     }
 
@@ -342,8 +342,16 @@ impl<T> Drop for Pool<T> {
     fn drop(&mut self) {
         // SAFETY: Pool::new/with_capacity always calls new_growable, which
         // initializes the factory via MaybeUninit::new. We must drop it here
-        // before Rc drops Inner, because Inner's Drop doesn't know whether
-        // factory was initialized (BoundedPool leaves it uninit).
+        // before the strong-count reaches zero, because Inner's Drop doesn't
+        // know whether factory was initialized (BoundedPool leaves it uninit).
+        //
+        // Factory-ownership invariant: the factory is reachable only through
+        // `Pool::acquire` / `Pool::take`, both of which take `&self` on
+        // `Pool`. Once `Pool` drops, no code path can touch the factory
+        // again — even if `Pooled` guards keep `Inner` alive past this
+        // point via the strong Rc, the factory has been destroyed and is
+        // unreachable. Inner has no `Drop` of its own, so the (now-empty)
+        // `MaybeUninit` slot dies harmlessly when the last guard drops.
         unsafe {
             let factory = &mut *self.inner.factory.get();
             factory.assume_init_drop();
@@ -362,7 +370,7 @@ impl<T> Drop for Pool<T> {
 #[must_use = "dropping the guard immediately returns the object to the pool"]
 pub struct Pooled<T> {
     value: ManuallyDrop<T>,
-    inner: Weak<Inner<T>>,
+    inner: Rc<Inner<T>>,
 }
 
 impl<T> Deref for Pooled<T> {
@@ -383,18 +391,20 @@ impl<T> DerefMut for Pooled<T> {
 
 impl<T> Drop for Pooled<T> {
     fn drop(&mut self) {
-        if let Some(inner) = self.inner.upgrade() {
-            // Reset and return to pool
-            inner.return_value(&mut self.value);
-            // SAFETY: value is valid (ManuallyDrop preserves it until explicit take/drop).
-            // After take, self.value is consumed and we never touch it again.
-            let value = unsafe { ManuallyDrop::take(&mut self.value) };
-            inner.push(value);
-        } else {
-            // SAFETY: Pool is gone. Value is valid (ManuallyDrop preserves it) and must
-            // be dropped to avoid a leak. After drop, we never touch self.value again.
-            unsafe { ManuallyDrop::drop(&mut self.value) };
-        }
+        // Reset and return to pool. The strong Rc guarantees Inner is
+        // alive — no upgrade check needed. If `Pool` already dropped,
+        // Inner is now an "orphan": values keep flowing into its Vec
+        // and stay there until the last `Pooled` drops, at which point
+        // the strong-count hits zero and the Vec drops in one shot.
+        self.inner.return_value(&mut self.value);
+        // SAFETY: value is valid (ManuallyDrop preserves it until
+        // explicit take/drop). After take we never touch self.value
+        // again; Inner takes ownership via push.
+        let value = unsafe { ManuallyDrop::take(&mut self.value) };
+        self.inner.push(value);
+        // self.inner Rc drops here: one strong-count--. If we were the
+        // last guard, Inner's `data: UnsafeCell<Vec<T>>` drops, which
+        // drops every value still in the pool.
     }
 }
 
@@ -469,9 +479,11 @@ mod tests {
             let pool = BoundedPool::new(1, || String::from("test"), String::clear);
             guard = pool.try_acquire().unwrap();
         }
-        // Pool dropped, guard still valid
+        // Pool dropped, guard still valid (Inner survives via the
+        // strong Rc the guard holds).
         assert_eq!(&*guard, "test");
-        // Drop guard - value is dropped, not returned (pool is gone)
+        // Drop guard — value returns to the orphaned Inner, then Inner
+        // dies (last strong ref) and drops the value. No leak, no UAF.
         drop(guard);
     }
 
@@ -528,8 +540,10 @@ mod tests {
             let pool = Pool::new(|| String::from("test"), String::clear);
             guard = pool.acquire();
         }
-        // Pool dropped, guard still valid
+        // Pool dropped, guard still valid (Inner alive via guard's Rc).
         assert_eq!(&*guard, "test");
+        // Guard drops; value returns to orphan, last strong ref dies,
+        // Inner's Vec drops the value. No leak, no UAF.
         drop(guard);
     }
 

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -118,10 +118,15 @@ impl<T> Inner<T> {
 
 impl<T> Drop for Inner<T> {
     fn drop(&mut self) {
-        // Only drop values that are currently in the free list.
-        // Values that are "out" (held by Pooled) have been moved
-        // out of the slot, and the guard's Drop impl will handle them
-        // (either returning to pool, or dropping directly if pool is gone).
+        // Inner::drop runs only when the last Arc dies — which means
+        // no `Pooled` guards are alive (each guard holds a strong
+        // Arc). So every slot that was ever acquired has been pushed
+        // back via `Pooled::drop`, and the free list now contains
+        // every slot we own. Drop them all here. The only way a slot
+        // can be missing from the free list at this point is if a
+        // reset closure panicked during a guard's drop — that path
+        // leaks the value (documented in caveats.md §1) and is the
+        // same as the 1.0.x behavior.
         let mut idx = *self.free_head.get_mut();
         while idx != NONE {
             // SAFETY: Slots in the free list contain valid values (written by new()
@@ -148,9 +153,9 @@ impl<T> Drop for Inner<T> {
 /// across threads (it is `Send` but not `Sync` or `Clone`).
 ///
 /// When the `Pool` is dropped while `Pooled` guards are still alive,
-/// the guards keep `Inner` alive via a strong `Arc`. Each guard drops
-/// returns its value to the (now-orphaned) free list; the last guard
-/// to drop releases `Inner`, which drops every in-pool slot.
+/// the guards keep `Inner` alive via a strong `Arc`. Each guard, on
+/// drop, returns its value to the (now-orphaned) free list; the last
+/// guard to drop releases `Inner`, which drops every in-pool slot.
 /// See `docs/caveats.md` §2.
 ///
 /// # Example
@@ -262,7 +267,10 @@ impl<T> Pool<T> {
 /// RAII guard that returns the object to the pool on drop.
 ///
 /// This guard can be sent to other threads. When dropped, the object
-/// is automatically returned to the pool (if the pool still exists).
+/// is automatically returned to the pool's storage. If the pool was
+/// already dropped, the value goes back into the orphaned `Inner`,
+/// which finally dies (along with every in-pool value) when the last
+/// `Pooled` exits. See `docs/caveats.md` §2.
 #[must_use = "dropping the guard immediately returns the object to the pool"]
 pub struct Pooled<T> {
     value: ManuallyDrop<T>,

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -8,8 +8,8 @@
 use std::cell::UnsafeCell;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
 
 const NONE: usize = usize::MAX;
 
@@ -147,8 +147,11 @@ impl<T> Drop for Inner<T> {
 /// Only one `Pool` exists per pool. It cannot be cloned or shared
 /// across threads (it is `Send` but not `Sync` or `Clone`).
 ///
-/// When the `Pool` is dropped, outstanding `Pooled` guards
-/// will drop their values directly instead of returning them to the pool.
+/// When the `Pool` is dropped while `Pooled` guards are still alive,
+/// the guards keep `Inner` alive via a strong `Arc`. Each guard drops
+/// returns its value to the (now-orphaned) free list; the last guard
+/// to drop releases `Inner`, which drops every in-pool slot.
+/// See `docs/caveats.md` §2.
 ///
 /// # Example
 ///
@@ -236,7 +239,7 @@ impl<T> Pool<T> {
             Pooled {
                 value: ManuallyDrop::new(value),
                 idx,
-                inner: Arc::downgrade(&self.inner),
+                inner: Arc::clone(&self.inner),
             }
         })
     }
@@ -264,16 +267,16 @@ impl<T> Pool<T> {
 pub struct Pooled<T> {
     value: ManuallyDrop<T>,
     idx: usize,
-    inner: Weak<Inner<T>>,
+    inner: Arc<Inner<T>>,
 }
 
-// SAFETY: Pooled owns its value exclusively (ManuallyDrop<T>). The Weak<Inner<T>>
+// SAFETY: Pooled owns its value exclusively (ManuallyDrop<T>). The Arc<Inner<T>>
 // is only used during drop to push the slot back via atomic CAS. T: Send ensures
-// the value can cross threads.
+// the value can cross threads. Arc<T: Send> is itself Send (same as Weak was).
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T: Send> Send for Pooled<T> {}
 // SAFETY: Pooled's &self access goes through Deref to &T, which requires T: Sync.
-// The Weak and idx fields are not mutated through &self.
+// The Arc and idx fields are not mutated through &self.
 unsafe impl<T: Send + Sync> Sync for Pooled<T> {}
 
 impl<T> Deref for Pooled<T> {
@@ -294,16 +297,20 @@ impl<T> DerefMut for Pooled<T> {
 
 impl<T> Drop for Pooled<T> {
     fn drop(&mut self) {
-        if let Some(inner) = self.inner.upgrade() {
-            // SAFETY: Value is valid (ManuallyDrop preserves it until explicit take/drop).
-            // After take, self.value is consumed; inner.push writes it back to the slot.
-            let value = unsafe { ManuallyDrop::take(&mut self.value) };
-            inner.push(self.idx, value);
-        } else {
-            // SAFETY: Pool is gone. Value is valid and must be dropped to avoid a leak.
-            // After drop, we never touch self.value again.
-            unsafe { ManuallyDrop::drop(&mut self.value) };
-        }
+        // SAFETY: self.inner is a strong Arc — Inner is alive by
+        // construction. Value is valid (ManuallyDrop preserves it
+        // until explicit take/drop). After take, self.value is
+        // consumed; inner.push writes it back to the slot.
+        let value = unsafe { ManuallyDrop::take(&mut self.value) };
+        self.inner.push(self.idx, value);
+        // self.inner Arc drops here: one strong fetch_sub. If we were
+        // the last reference, Inner::drop walks the free list and
+        // assume_init_drops every in-pool slot (including the one we
+        // just pushed). Arc's fetch_sub(Release) + last-drop
+        // fence(Acquire) is the canonical "single-writer drops after
+        // all readers" pattern — sufficient for the refcount alone;
+        // the value transfer is independently ordered by the Release
+        // CAS in `Inner::push`.
     }
 }
 
@@ -365,11 +372,14 @@ mod tests {
         {
             let acquirer = Pool::new(1, || String::from("test"), String::clear);
             item = acquirer.try_acquire().unwrap();
-            // acquirer drops here
+            // acquirer drops here — its Arc decrements but the item
+            // still holds a strong Arc, so Inner survives.
         }
-        // item still valid - we can access it
+        // item still valid — we can access it.
         assert_eq!(&*item, "test");
-        // item drops here - should not panic
+        // item drops here: returns slot to the orphan free list, Arc
+        // hits zero, Inner::drop walks the free list and drops every
+        // in-pool slot. No leak, no UAF.
     }
 
     #[test]

--- a/nexus-pool/tests/miri_tests.rs
+++ b/nexus-pool/tests/miri_tests.rs
@@ -4,6 +4,8 @@
 
 use std::cell::Cell;
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
 fn local_bounded_acquire_release() {
@@ -89,49 +91,92 @@ fn sync_acquire_release() {
 }
 
 #[test]
-fn local_drop_tracker() {
+fn local_guard_outlives_pool_retains_inpool_values_until_last_guard() {
+    // New (1.1.0) contract: in-pool values live until the last
+    // `Pooled<T>` guard drops. Dropping the pool with outstanding
+    // guards no longer drops in-pool values immediately — they sit in
+    // the orphaned Inner's Vec until the strong-count reaches zero.
+
     struct Tracked {
-        data: Vec<u8>,
         counter: Rc<Cell<u32>>,
     }
-
     impl Drop for Tracked {
         fn drop(&mut self) {
             self.counter.set(self.counter.get() + 1);
         }
     }
 
-    // Track how many times drop is called across all values.
     let drop_count = Rc::new(Cell::new(0u32));
-
     let dc = drop_count.clone();
     let pool = nexus_pool::local::BoundedPool::new(
         4,
         move || Tracked {
-            data: Vec::with_capacity(64),
             counter: dc.clone(),
         },
-        |t: &mut Tracked| t.data.clear(),
+        |_| {},
     );
 
-    // Acquire 2 items and hold them while dropping the pool.
+    // Acquire 2 items, hold them. 2 still in the pool, 2 out.
     let a = pool.try_acquire().unwrap();
     let b = pool.try_acquire().unwrap();
-    // 2 items still in the pool, 2 out.
-
     assert_eq!(drop_count.get(), 0);
 
-    // Drop the pool -- the 2 items still inside should be dropped.
+    // Drop pool. NEW SEMANTICS: in-pool values are NOT dropped yet —
+    // Inner survives via the strong Rc held by `a` and `b`.
     drop(pool);
+    assert_eq!(
+        drop_count.get(),
+        0,
+        "in-pool values retained until last guard drops"
+    );
 
-    // The 2 items that were in the pool's internal storage are now dropped.
-    assert_eq!(drop_count.get(), 2);
-
-    // Drop the outstanding guards -- since the pool is gone, values are
-    // dropped directly (not returned).
+    // Drop first guard — it returns to orphaned Inner; no drop yet.
     drop(a);
-    assert_eq!(drop_count.get(), 3);
+    assert_eq!(drop_count.get(), 0);
 
+    // Drop last guard — Inner finally dies; all 4 values drop together
+    // (2 returned-to-orphan + 2 still-in-pool).
     drop(b);
     assert_eq!(drop_count.get(), 4);
+}
+
+#[test]
+fn sync_guard_outlives_pool_miri() {
+    // Same pattern for sync::Pool — must not UAF.
+    // Pool's Arc drops -> Inner survives via Pooled's Arc.
+    // Last guard drops -> Inner::drop walks the free list,
+    // assume_init_drops every in-pool slot.
+
+    struct Tracked {
+        c: Arc<AtomicUsize>,
+    }
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            self.c.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&counter);
+    let pool = nexus_pool::sync::Pool::new(4, move || Tracked { c: Arc::clone(&c) }, |_| {});
+
+    let g1 = pool.try_acquire().unwrap();
+    let g2 = pool.try_acquire().unwrap();
+
+    drop(pool);
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        0,
+        "in-pool slots retained while guards alive"
+    );
+
+    drop(g1);
+    assert_eq!(counter.load(Ordering::Relaxed), 0);
+
+    drop(g2);
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        4,
+        "all 4 slots drop when last guard exits and Inner::drop runs"
+    );
 }


### PR DESCRIPTION
## Summary

Replaces `Weak<Inner<T>>` with `Rc<Inner<T>>` (local) / `Arc<Inner<T>>` (sync) in `Pooled<T>`. Eliminates per-release refcount work — `Weak::upgrade` (CAS retry loop on sync, `Cell` RMW on local) is gone from the hot path.

## Contract change (breaking)

In-pool values now live until the last `Pooled<T>` guard drops. Previously, dropping the pool with outstanding guards dropped in-pool values immediately and bypassed reset on guard drop. Now guards return values to the orphaned `Inner` (reset runs normally), and `Inner` (with all in-pool values) dies when the last guard exits. No leak, no UAF — only a delayed-drop semantic that affects shutdown ordering for resources holding external handles.

Shipped under the workspace's "minor bump may carry small, narrowly-scoped breaking changes" allowance. After publish, 1.0.4 will be yanked so `^1.0` consumers must consciously upgrade.

## Performance (best-of-5 floor, taskset -c 0,2)

- **Sync release p50 same-thread:** 72cy → 62cy (−13.9%)
- **Sync release p50 1-thread concurrent:** 74cy → 60cy (−18.9%)
- **Sync release p50 4-thread concurrent:** 476cy → 288cy (**−39.5%**) — biggest tail-latency win, the contended `Weak::upgrade` CAS retry loop is gone
- **Local release p50:** unchanged in rdtscp, but `cargo asm` confirms hot-path `Pooled::drop` shrinks from 3 `Cell` RMWs + 4 branches to 1 RMW + 1 branch (function body 141 → 108 lines of asm). Single-threaded `Cell` ops pipeline well behind dominators (`return_value`, `Vec::push`), so the codegen win doesn't surface above the rdtscp floor at p50.

## Bundles in

- 8 `#[inline]` additions on hot accessors from #244 polish sweep (already merged on main, unpublished).

## Test plan

- [x] `cargo test -p nexus-pool` — all green (lib + integration + doc)
- [x] `cargo test --workspace --no-fail-fast` — all green; no downstream breakage
- [x] `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-pool --test miri_tests` — 5/5 pass, including new `local_guard_outlives_pool_retains_inpool_values_until_last_guard` and `sync_guard_outlives_pool_miri`
- [x] `cargo clippy -p nexus-pool -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #175