### PR TITLE
bumping up nexus-pool version for http client pooling

### DIFF
--- a/nexus-async-net/CHANGELOG.md
+++ b/nexus-async-net/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Dependency declaration: `nexus-pool` `1.0.0` → `1.1.0`. Pulls in
+  the strong-Rc/Arc guard contract change from nexus-pool 1.1.0.
+  No behavior change for HTTP client pool usage — the new contract
+  (in-pool values retained until last guard drops) doesn't bite
+  app-lifetime client pools, and the API surface is unchanged.
+
 ## [0.7.1] — 2026-05-10
 
 Doc + internal cleanup release. No public API change.

--- a/nexus-async-net/Cargo.toml
+++ b/nexus-async-net/Cargo.toml
@@ -25,7 +25,7 @@ features = ["tokio-tls", "socket-opts", "bytes"]
 
 [dependencies]
 nexus-net = { version = "0.7.1", path = "../nexus-net" }
-nexus-pool = { version = "1.0.0", path = "../nexus-pool" }
+nexus-pool = { version = "1.1.0", path = "../nexus-pool" }
 tokio = { version = "1", features = ["io-util", "net", "rt", "time"], optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 socket2 = { version = "0.5", optional = true }


### PR DESCRIPTION
## Summary

Bumps the `nexus-pool` dep declaration from `1.0.0` → `1.1.0` so it explicitly tracks the strong-Rc/Arc guard contract change shipped in nexus-pool 1.1.0 (#247). Caret semantics already accept 1.1.0, but pinning the floor makes the dependency relationship explicit.

## Why no behavior change

`nexus-async-net` uses `nexus_pool::local::Pool` and `nexus_pool::sync::Pool` in three HTTP client pool sites (`rest/nexus/pool.rs`, `rest/tokio/pool.rs`, `rest/tokio/atomic_pool.rs`). The 1.1.0 contract change ("in-pool values retained until last guard drops") is irrelevant for HTTP client pool usage — clients live for app lifetime, not session lifetime, so the prompt-drop semantic was never exercised. API surface is unchanged.

## Versioning

No version bump on nexus-async-net itself — bundles with the next functional release per the workspace pending-publishes convention.

## Test plan

- [x] `cargo build -p nexus-async-net` (default features) — clean
- [x] `cargo build -p nexus-async-net --no-default-features --features nexus,tls` — clean