### PR TITLE
updating async rt patterns for accessing runtime internals

### DIFF
--- a/nexus-async-net/CHANGELOG.md
+++ b/nexus-async-net/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   No behavior change for HTTP client pool usage — the new contract
   (in-pool values retained until last guard drops) doesn't bite
   app-lifetime client pools, and the API surface is unchanged.
+- **Adopted `nexus-async-rt` 0.7.0's `Type::current()` pattern.** Call
+  sites updated from `nexus_async_rt::io()` to
+  `nexus_async_rt::IoHandle::current()` in REST and WebSocket nexus
+  connection paths plus the `tls_handshake_piggyback` and
+  `ws_nexus_integration` test suites. No behavior change — same TLS
+  read, same `IoHandle` value.
+- Dependency declaration: `nexus-async-rt` `0.6.0` → `0.7.0` to pick
+  up the `Type::current()` API.
 
 ## [0.7.1] — 2026-05-10
 

--- a/nexus-async-net/CHANGELOG.md
+++ b/nexus-async-net/CHANGELOG.md
@@ -14,14 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   No behavior change for HTTP client pool usage — the new contract
   (in-pool values retained until last guard drops) doesn't bite
   app-lifetime client pools, and the API surface is unchanged.
-- **Adopted `nexus-async-rt` 0.7.0's `Type::current()` pattern.** Call
-  sites updated from `nexus_async_rt::io()` to
-  `nexus_async_rt::IoHandle::current()` in REST and WebSocket nexus
-  connection paths plus the `tls_handshake_piggyback` and
-  `ws_nexus_integration` test suites. No behavior change — same TLS
-  read, same `IoHandle` value.
+- **Adopted `nexus-async-rt` 0.7.0's API simplification.** The
+  upstream constructor signatures dropped their explicit `IoHandle`
+  parameter (now fetched internally via `IoHandle::current()`), so
+  call sites in REST and WebSocket nexus connection paths plus the
+  `tls_handshake_piggyback` and `ws_nexus_integration` test suites
+  simplify from `TcpStream::connect(addr, IoHandle::current())` to
+  `TcpStream::connect(addr)`. No behavior change — same TLS read,
+  same registration, just hidden inside the constructor.
 - Dependency declaration: `nexus-async-rt` `0.6.0` → `0.7.0` to pick
-  up the `Type::current()` API.
+  up the `Type::current()` API and constructor cleanup.
 
 ## [0.7.1] — 2026-05-10
 

--- a/nexus-async-net/Cargo.toml
+++ b/nexus-async-net/Cargo.toml
@@ -31,7 +31,7 @@ tokio-rustls = { version = "0.26", optional = true }
 socket2 = { version = "0.5", optional = true }
 futures-core = { version = "0.3", optional = true }
 futures-sink = { version = "0.3", optional = true }
-nexus-async-rt = { version = "0.6.0", path = "../nexus-async-rt", optional = true }
+nexus-async-rt = { version = "0.7.0", path = "../nexus-async-rt", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -181,7 +181,7 @@ impl HttpConnectionBuilder {
             .ok_or_else(|| RestError::InvalidUrl(format!("DNS resolution failed: {addr_str}")))?;
 
         let connect_fn = async {
-            let tcp = TcpStream::connect(addr, nexus_async_rt::io())?;
+            let tcp = TcpStream::connect(addr, nexus_async_rt::IoHandle::current())?;
             Ok::<TcpStream, RestError>(tcp)
         };
 

--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -181,7 +181,7 @@ impl HttpConnectionBuilder {
             .ok_or_else(|| RestError::InvalidUrl(format!("DNS resolution failed: {addr_str}")))?;
 
         let connect_fn = async {
-            let tcp = TcpStream::connect(addr, nexus_async_rt::IoHandle::current())?;
+            let tcp = TcpStream::connect(addr)?;
             Ok::<TcpStream, RestError>(tcp)
         };
 

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -601,7 +601,7 @@ impl WsStreamBuilder {
             })?;
 
         let connect_fn = async {
-            let tcp = TcpStream::connect(addr, nexus_async_rt::io())?;
+            let tcp = TcpStream::connect(addr, nexus_async_rt::IoHandle::current())?;
             Ok::<TcpStream, WsError>(tcp)
         };
 

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -601,7 +601,7 @@ impl WsStreamBuilder {
             })?;
 
         let connect_fn = async {
-            let tcp = TcpStream::connect(addr, nexus_async_rt::IoHandle::current())?;
+            let tcp = TcpStream::connect(addr)?;
             Ok::<TcpStream, WsError>(tcp)
         };
 

--- a/nexus-async-net/tests/tls_handshake_piggyback.rs
+++ b/nexus-async-net/tests/tls_handshake_piggyback.rs
@@ -181,8 +181,7 @@ fn drive_handshake_handles_piggyback_with_bounded_allocations() {
             .expect("client tls config");
 
         let addr = format!("127.0.0.1:{port}").parse().unwrap();
-        let tcp = AsyncTcpStream::connect(addr, nexus_async_rt::IoHandle::current())
-            .expect("client tcp connect");
+        let tcp = AsyncTcpStream::connect(addr).expect("client tcp connect");
 
         let codec = TlsCodec::new(&tls_config, "localhost").expect("client codec");
         let capacities = TlsBufferCapacities::default();

--- a/nexus-async-net/tests/tls_handshake_piggyback.rs
+++ b/nexus-async-net/tests/tls_handshake_piggyback.rs
@@ -181,7 +181,8 @@ fn drive_handshake_handles_piggyback_with_bounded_allocations() {
             .expect("client tls config");
 
         let addr = format!("127.0.0.1:{port}").parse().unwrap();
-        let tcp = AsyncTcpStream::connect(addr, nexus_async_rt::io()).expect("client tcp connect");
+        let tcp = AsyncTcpStream::connect(addr, nexus_async_rt::IoHandle::current())
+            .expect("client tcp connect");
 
         let codec = TlsCodec::new(&tls_config, "localhost").expect("client codec");
         let capacities = TlsBufferCapacities::default();

--- a/nexus-async-net/tests/ws_nexus_integration.rs
+++ b/nexus-async-net/tests/ws_nexus_integration.rs
@@ -27,7 +27,7 @@ fn text_echo_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         // Server
@@ -44,7 +44,7 @@ fn text_echo_loopback() {
         });
 
         // Client
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::io()).unwrap();
+        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -74,7 +74,7 @@ fn binary_roundtrip_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -92,7 +92,7 @@ fn binary_roundtrip_loopback() {
             ws.send_binary(&[0xCD; 128]).await.unwrap();
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::io()).unwrap();
+        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -125,7 +125,7 @@ fn ping_pong_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -145,7 +145,7 @@ fn ping_pong_loopback() {
             ws.send_pong(&ping_data).await.unwrap();
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::io()).unwrap();
+        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -175,7 +175,7 @@ fn close_handshake_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -192,7 +192,7 @@ fn close_handshake_loopback() {
             }
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::io()).unwrap();
+        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)

--- a/nexus-async-net/tests/ws_nexus_integration.rs
+++ b/nexus-async-net/tests/ws_nexus_integration.rs
@@ -27,7 +27,7 @@ fn text_echo_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let mut listener = TcpListener::bind(addr).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         // Server
@@ -44,7 +44,7 @@ fn text_echo_loopback() {
         });
 
         // Client
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -74,7 +74,7 @@ fn binary_roundtrip_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let mut listener = TcpListener::bind(addr).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -92,7 +92,7 @@ fn binary_roundtrip_loopback() {
             ws.send_binary(&[0xCD; 128]).await.unwrap();
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -125,7 +125,7 @@ fn ping_pong_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let mut listener = TcpListener::bind(addr).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -145,7 +145,7 @@ fn ping_pong_loopback() {
             ws.send_pong(&ping_data).await.unwrap();
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
@@ -175,7 +175,7 @@ fn close_handshake_loopback() {
 
     rt.block_on(async {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let mut listener = TcpListener::bind(addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let mut listener = TcpListener::bind(addr).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
         let server = spawn_boxed(async move {
@@ -192,7 +192,7 @@ fn close_handshake_loopback() {
             }
         });
 
-        let tcp = TcpStream::connect(local_addr, nexus_async_rt::IoHandle::current()).unwrap();
+        let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
         let mut ws = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)

--- a/nexus-async-rt/CHANGELOG.md
+++ b/nexus-async-rt/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (breaking)
+
+- **Bare-noun context-fetcher free functions converted to
+  `Type::current()` pattern.** The four functions that returned a handle
+  or future (not a future factory) now live as inherent `current()`
+  methods on the relevant type. Mirrors `tokio::runtime::Handle::current()`
+  convention; makes call sites self-documenting and discourages threading
+  handles through APIs.
+
+  Migration:
+
+  | 0.6.x | 0.7.0 |
+  |---|---|
+  | `nexus_async_rt::io()` | `IoHandle::current()` |
+  | `nexus_async_rt::with_world(\|w\| ...)` | `WorldCtx::current().with_world(\|w\| ...)` |
+  | `nexus_async_rt::with_world_ref(\|w\| ...)` | `WorldCtx::current().with_world_ref(\|w\| ...)` |
+  | `nexus_async_rt::shutdown_signal()` | `ShutdownSignal::current()` |
+
+  Future factories (`sleep`, `sleep_until`, `interval`, `interval_at`,
+  `after`, `after_delay`, `timeout`, `timeout_at`, `yield_now`) and the
+  pure value getter (`event_time`) stay as free functions — idiomatic for
+  the Rust async ecosystem. The future *is* the API; there's no enclosing
+  handle to fetch.
+
+### Added
+
+- `IoHandle::current()`, `WorldCtx::current()`, `ShutdownSignal::current()`
+  — TLS-based fetchers for the active runtime context. All three panic
+  outside [`Runtime::block_on`]; all three are `#[must_use]`.
+
 ## [0.6.0] — 2026-05-08
 
 The "byte-channel error contract cleanup" release. Companion to

--- a/nexus-async-rt/CHANGELOG.md
+++ b/nexus-async-rt/CHANGELOG.md
@@ -31,6 +31,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the Rust async ecosystem. The future *is* the API; there's no enclosing
   handle to fetch.
 
+- **Constructor signatures hide `IoHandle`.** Eight public constructors
+  on `TcpListener`, `TcpStream`, `TcpSocket`, and `UdpSocket` no longer
+  take an explicit `io: IoHandle` parameter — they fetch
+  `IoHandle::current()` internally. Mirrors `tokio::net::TcpListener::bind`
+  / `tokio::net::TcpStream::connect` ergonomics and demotes the runtime
+  internal from end-user APIs (it's now a library-author primitive that
+  end users rarely need to reference).
+
+  Migration:
+
+  | 0.6.x | 0.7.0 |
+  |---|---|
+  | `TcpListener::bind(addr, io)` | `TcpListener::bind(addr)` |
+  | `TcpListener::from_std(listener, io)` | `TcpListener::from_std(listener)` |
+  | `TcpStream::connect(addr, io)` | `TcpStream::connect(addr)` |
+  | `TcpStream::from_std(stream, io)` | `TcpStream::from_std(stream)` |
+  | `UdpSocket::bind(addr, io)` | `UdpSocket::bind(addr)` |
+  | `UdpSocket::from_std(socket, io)` | `UdpSocket::from_std(socket)` |
+  | `TcpSocket::connect(self, addr, io)` | `TcpSocket::connect(self, addr)` |
+  | `TcpSocket::listen(self, backlog, io)` | `TcpSocket::listen(self, backlog)` |
+
+  All constructors now panic if called outside `Runtime::block_on`
+  (because the internal `IoHandle::current()` does). This is the same
+  semantic tokio enforces — bind/connect inside the runtime context.
+
 ### Added
 
 - `IoHandle::current()`, `WorldCtx::current()`, `ShutdownSignal::current()`

--- a/nexus-async-rt/Cargo.toml
+++ b/nexus-async-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-async-rt"
-version = "0.6.0"
+version = "0.7.0"
 description = "Single-threaded async executor with pre-allocated task storage"
 edition.workspace = true
 rust-version.workspace = true

--- a/nexus-async-rt/README.md
+++ b/nexus-async-rt/README.md
@@ -106,19 +106,21 @@ loop {
 ### I/O (mio-based)
 
 ```rust
-use nexus_async_rt::{TcpStream, TcpListener, IoHandle};
+use nexus_async_rt::{TcpStream, TcpListener};
 
 // Client
-let stream = TcpStream::connect(addr, IoHandle::current())?;
+let stream = TcpStream::connect(addr)?;
 
 // Server
-let listener = TcpListener::bind(addr, IoHandle::current())?;
+let listener = TcpListener::bind(addr)?;
 let (stream, peer) = listener.accept().await?;
 ```
 
-`IoHandle::current()` returns the IO handle for the active runtime —
-mirrors `tokio::runtime::Handle::current()`. Panics if called outside
-[`Runtime::block_on`].
+The constructors fetch the runtime's `IoHandle` internally via
+`IoHandle::current()` — mirrors `tokio::net::TcpListener::bind` /
+`tokio::net::TcpStream::connect`. They panic if called outside
+[`Runtime::block_on`]. Library authors who need the handle directly
+can call `IoHandle::current()` themselves.
 
 ### Channels
 

--- a/nexus-async-rt/README.md
+++ b/nexus-async-rt/README.md
@@ -106,15 +106,19 @@ loop {
 ### I/O (mio-based)
 
 ```rust
-use nexus_async_rt::{TcpStream, TcpListener, io};
+use nexus_async_rt::{TcpStream, TcpListener, IoHandle};
 
 // Client
-let stream = TcpStream::connect(addr, io())?;
+let stream = TcpStream::connect(addr, IoHandle::current())?;
 
 // Server
-let listener = TcpListener::bind(addr, io())?;
+let listener = TcpListener::bind(addr, IoHandle::current())?;
 let (stream, peer) = listener.accept().await?;
 ```
+
+`IoHandle::current()` returns the IO handle for the active runtime —
+mirrors `tokio::runtime::Handle::current()`. Panics if called outside
+[`Runtime::block_on`].
 
 ### Channels
 
@@ -138,18 +142,23 @@ let (tx, rx) = channel::spsc::channel(64);
 Access nexus-rt `World` resources from async tasks:
 
 ```rust
-with_world(|world| {
+WorldCtx::current().with_world(|world| {
     let config = world.resource::<Config>();
     // ...
 });
 ```
+
+`WorldCtx::current()` returns the `World` handle for the active runtime
+(panics outside `block_on`). Use `WorldCtx::new(&mut world)` instead
+when constructing the handle outside the runtime context (e.g.,
+capturing into a task before `block_on`).
 
 ### Graceful shutdown
 
 ```rust
 rt.block_on(async {
     // ... spawn tasks ...
-    shutdown_signal().await; // waits for Ctrl+C
+    ShutdownSignal::current().await; // waits for Ctrl+C
 });
 ```
 

--- a/nexus-async-rt/docs/API_GUIDE.md
+++ b/nexus-async-rt/docs/API_GUIDE.md
@@ -173,18 +173,25 @@ stream.write_all(&buf[..n]).await?;
 Access nexus-rt ECS resources from async tasks:
 
 ```rust
-use nexus_async_rt::with_world;
+use nexus_async_rt::WorldCtx;
 
 // Synchronous, inline during task poll — no await point.
-with_world(|world| {
+WorldCtx::current().with_world(|world| {
     let config = world.resource::<Config>();
     println!("setting: {}", config.value);
 });
 ```
 
+`WorldCtx::current()` returns the active runtime's `World` handle —
+mirrors `tokio::runtime::Handle::current()`. Use `WorldCtx::new(&mut world)`
+when constructing the handle outside `block_on` (e.g., capturing into
+a task before the runtime starts).
+
 ### Pre-resolved handlers (hot path)
 
-For event dispatch where HashMap lookup cost matters:
+For event dispatch where HashMap lookup cost matters. Cache the
+[`WorldCtx`] once per task — `Copy` is free, but the TLS read in
+`current()` is wasted work if you're calling it in a tight loop:
 
 ```rust
 // At setup (cold path) — resolve resource IDs once:
@@ -193,7 +200,8 @@ let mut on_quote = (|mut books: ResMut<Books>, q: Quote| {
 }).into_handler(world.registry());
 
 // Per-event (hot path) — single deref per resource:
-with_world(|world| on_quote.run(world, quote));
+let ctx = WorldCtx::current();
+ctx.with_world(|world| on_quote.run(world, quote));
 ```
 
 ## Channels
@@ -249,7 +257,7 @@ let mut rt = Runtime::builder(&mut world)
 
 rt.block_on(async {
     // Completes when SIGTERM or SIGINT received
-    nexus_async_rt::shutdown_signal().await;
+    nexus_async_rt::ShutdownSignal::current().await;
     cleanup().await;
 });
 ```
@@ -293,7 +301,7 @@ rt.block_on(async {
                 let token = token.child();
                 spawn_boxed(handle_connection(stream, token));
             }
-            _ = shutdown_signal() => {
+            _ = ShutdownSignal::current() => {
                 token.cancel();
                 break;
             }
@@ -312,8 +320,8 @@ rt.block_on(async {
     loop {
         let msg = ws.recv().await?;
         match msg.msg_type() {
-            MsgType::Quote => with_world(|w| on_quote.run(w, parse_quote(&msg))),
-            MsgType::Trade => with_world(|w| on_trade.run(w, parse_trade(&msg))),
+            MsgType::Quote => WorldCtx::current().with_world(|w| on_quote.run(w, parse_quote(&msg))),
+            MsgType::Trade => WorldCtx::current().with_world(|w| on_trade.run(w, parse_trade(&msg))),
         }
     }
 });

--- a/nexus-async-rt/docs/ARCHITECTURE.md
+++ b/nexus-async-rt/docs/ARCHITECTURE.md
@@ -252,8 +252,9 @@ Zero allocation per wake.
 `ShutdownHandle` owns an `AtomicBool` flag and a waker slot. Signal handlers
 (SIGTERM, SIGINT) set the flag and wake the stored waker.
 
-Tasks await shutdown via `shutdown_signal().await`. The runtime checks the
-flag at the top of each loop iteration and re-polls the root future.
+Tasks await shutdown via `ShutdownSignal::current().await`. The runtime
+checks the flag at the top of each loop iteration and re-polls the root
+future.
 
 Single-waiter design. For multi-waiter shutdown, use `CancellationToken`
 (which supports hierarchical cancellation via parent/child relationships).

--- a/nexus-async-rt/docs/INDEX.md
+++ b/nexus-async-rt/docs/INDEX.md
@@ -21,8 +21,8 @@ wakers, mio-driven IO, and a tokio bridge for ecosystem code on cold paths.
 - [Cancellation](cancellation.md) — `CancellationToken`, hierarchical
   cancellation, `ShutdownSignal`
 - [Channels](channels.md) — `local`, `spsc`, `mpsc`, byte-oriented variants
-- [Integration with nexus-rt](integration-with-nexus-rt.md) — `with_world`,
-  `WorldCtx`, pre-resolved handler dispatch from async tasks
+- [Integration with nexus-rt](integration-with-nexus-rt.md) — `WorldCtx`,
+  `WorldCtx::current()`, pre-resolved handler dispatch from async tasks
 - [Tokio Compatibility](tokio-compat.md) — `with_tokio`, `spawn_on_tokio`,
   bridging ecosystem crates
 - [Patterns](patterns.md) — Cookbook: event loops, per-connection tasks,

--- a/nexus-async-rt/docs/cancellation.md
+++ b/nexus-async-rt/docs/cancellation.md
@@ -180,7 +180,9 @@ Top-level shutdown driven by SIGTERM/SIGINT. Installed automatically when
 `RuntimeBuilder::signal_handlers(true)` (the default).
 
 ```rust
-pub fn shutdown_signal() -> ShutdownSignal; // from module root
+impl ShutdownSignal {
+    pub fn current() -> ShutdownSignal;
+}
 ```
 
 `ShutdownSignal` is single-waiter — exactly one task can `.await` it. For
@@ -188,7 +190,7 @@ broadcast shutdown, convert the signal into a `CancellationToken::cancel()`
 call and distribute the token.
 
 ```rust
-use nexus_async_rt::{CancellationToken, Runtime, shutdown_signal, spawn_boxed};
+use nexus_async_rt::{CancellationToken, Runtime, ShutdownSignal, spawn_boxed};
 use nexus_rt::WorldBuilder;
 
 fn main() {
@@ -210,7 +212,7 @@ fn main() {
         }
 
         // Single-waiter: wait for SIGTERM, then fan out.
-        shutdown_signal().await;
+        ShutdownSignal::current().await;
         root.cancel();
 
         // Give children a grace period — in real code, join them on a
@@ -245,8 +247,8 @@ to `ShutdownSignal` for server shutdown.
 
 ```rust
 use nexus_async_rt::{
-    CancellationToken, Runtime, TcpListener, TcpStream,
-    shutdown_signal, spawn_boxed,
+    CancellationToken, Runtime, ShutdownSignal, TcpListener, TcpStream,
+    spawn_boxed,
 };
 use nexus_rt::WorldBuilder;
 
@@ -285,7 +287,7 @@ fn main() -> std::io::Result<()> {
             Ok::<_, std::io::Error>(())
         });
 
-        shutdown_signal().await;
+        ShutdownSignal::current().await;
         root.cancel();
         // optionally wait for accept + sessions to drain
         Ok(())

--- a/nexus-async-rt/docs/integration-with-nexus-rt.md
+++ b/nexus-async-rt/docs/integration-with-nexus-rt.md
@@ -12,33 +12,53 @@ nexus-rt handlers, all on one thread.
 ## The Big Picture
 
 ```text
-+----------------------------------------+
-|  Runtime::block_on()                   |  <- nexus-async-rt
-|                                        |
-|    async tasks   (sockets, timers)     |
-|        |                               |
-|        | with_world(|w| handler.run()) |
-|        v                               |
-|    World / Resources  (nexus-rt)       |
-+----------------------------------------+
++--------------------------------------------------------+
+|  Runtime::block_on()                                   |  <- nexus-async-rt
+|                                                        |
+|    async tasks   (sockets, timers)                     |
+|        |                                               |
+|        | WorldCtx::current().with_world(|w| handler.run()) |
+|        v                                               |
+|    World / Resources  (nexus-rt)                       |
++--------------------------------------------------------+
 ```
 
-The `World` is owned by the `Runtime`. Async tasks access it via
-`with_world` — a synchronous, scoped borrow — whenever they need to update
-state or dispatch a handler.
+The `World` is owned by the `Runtime`. Async tasks access it through
+[`WorldCtx`] — a `Copy` handle wrapping the World pointer — whenever
+they need to update state or dispatch a handler.
 
-## `with_world` and `with_world_ref`
+## `WorldCtx` and `WorldCtx::current()`
 
 ```rust
-pub fn with_world<R>(f: impl FnOnce(&mut nexus_rt::World) -> R) -> R;
-pub fn with_world_ref<R>(f: impl FnOnce(&nexus_rt::World) -> R) -> R;
+pub struct WorldCtx { /* Copy */ }
+
+impl WorldCtx {
+    /// Construct from a mutable World reference (use before `block_on`).
+    pub fn new(world: &mut World) -> Self;
+
+    /// Fetch the runtime's current WorldCtx from TLS (use inside tasks).
+    pub fn current() -> Self;
+
+    pub fn with_world<R>(&self, f: impl FnOnce(&mut World) -> R) -> R;
+    pub fn with_world_ref<R>(&self, f: impl FnOnce(&World) -> R) -> R;
+}
 ```
 
-Both borrow the World from thread-local storage (the Runtime puts it there
-during `block_on`). Outside a `block_on` they panic.
+The `Runtime` installs the World pointer in TLS during `block_on`.
+`WorldCtx::current()` reads that pointer; outside `block_on` it panics.
+`with_world` / `with_world_ref` are inherent methods that run a closure
+synchronously inline against the borrowed World — no await point.
+
+Two ways to obtain a `WorldCtx`:
+
+| When | Method | Why |
+|---|---|---|
+| Inside a task, occasional access | `WorldCtx::current()` | One TLS read per call site; fine for cold paths. |
+| Inside a task, hot loop | `let ctx = WorldCtx::current();` once, then reuse | `WorldCtx` is `Copy` — capture saves repeated TLS reads. |
+| Before `block_on`, capturing into closures | `WorldCtx::new(&mut world)` | No runtime context to read from yet. |
 
 ```rust
-use nexus_async_rt::{Runtime, spawn_boxed, with_world, with_world_ref};
+use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed};
 use nexus_rt::{Resource, WorldBuilder};
 
 #[derive(Resource, Default)]
@@ -53,12 +73,12 @@ fn main() {
     rt.block_on(async {
         spawn_boxed(async {
             // Mutable access — scoped to the closure.
-            with_world(|w| {
+            WorldCtx::current().with_world(|w| {
                 w.resource_mut::<Counter>().0 += 1;
             });
 
             // Read-only access.
-            let n = with_world_ref(|w| w.resource::<Counter>().0);
+            let n = WorldCtx::current().with_world_ref(|w| w.resource::<Counter>().0);
             assert_eq!(n, 1);
         })
         .await;
@@ -81,7 +101,7 @@ The fastest dispatch pattern: resolve Handler parameters **once** at setup,
 then dispatch repeatedly from async tasks without re-resolution.
 
 ```rust
-use nexus_async_rt::{Runtime, spawn_boxed, with_world};
+use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed};
 use nexus_rt::{IntoHandler, Handler, Res, ResMut, Resource, WorldBuilder};
 
 #[derive(Resource, Default)]
@@ -110,10 +130,12 @@ fn main() {
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async move {
         spawn_boxed(async move {
+            // Cache the WorldCtx outside the loop — saves one TLS read per tick.
+            let ctx = WorldCtx::current();
             let tick = recv_tick().await;
 
             // Dispatch is one World borrow + the handler's pre-resolved fetch.
-            with_world(|w| handler.run(w, tick));
+            ctx.with_world(|w| handler.run(w, tick));
         })
         .await;
     });
@@ -127,22 +149,11 @@ the socket and the parsing state, and every parsed message goes through a
 pre-resolved handler. Dispatch cost is one `with_world` borrow plus the
 handler's parameter fetch (~1 cycle per `Res`/`ResMut`).
 
-## `WorldCtx` — A Copy Handle for Capturing
+## Capturing `WorldCtx` Across Many Tasks
 
-`WorldCtx` is a zero-cost `Copy` handle that implements `with_world` /
-`with_world_ref` without needing the thread-local. It captures cleanly into
-multiple tasks and makes the "I need World access here" contract explicit
-in signatures.
-
-```rust
-pub struct WorldCtx { /* Copy */ }
-
-impl WorldCtx {
-    pub fn new(world: &mut World) -> Self;
-    pub fn with_world<R>(&self, f: impl FnOnce(&mut World) -> R) -> R;
-    pub fn with_world_ref<R>(&self, f: impl FnOnce(&World) -> R) -> R;
-}
-```
+`WorldCtx` is `Copy`, so a single handle captures cleanly into as many
+closures as you like with no reference-counting cost. This is useful when
+you want to spawn a fan-out of tasks that all share World access.
 
 ```rust
 use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed};
@@ -158,13 +169,12 @@ fn main() {
 
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async {
-        let ctx = WorldCtx::new(nexus_async_rt::with_world(|w| w as *mut _ as usize) as _);
-        // (in practice WorldCtx::new is called from the runtime setup)
-        let _ = ctx;
+        // One TLS read; reuse across all spawned tasks below.
+        let ctx = WorldCtx::current();
 
         for _ in 0..4 {
             spawn_boxed(async move {
-                nexus_async_rt::with_world(|w| {
+                ctx.with_world(|w| {
                     w.resource_mut::<Stats>().msgs += 1;
                 });
             });
@@ -173,16 +183,17 @@ fn main() {
 }
 ```
 
-In practice you construct `WorldCtx` before entering `block_on` and pass it
-into your task-spawning code. It's `Copy`, so it captures into as many
-closures as you like with no reference-counting cost.
+`WorldCtx::new(&mut world)` is the alternative for the rarer case where
+you need to construct the handle *before* `block_on` is running (e.g.,
+moving it into a task that you'll spawn from inside `block_on`). Inside a
+task, prefer `current()`.
 
 ## Driving a Pipeline From an Async Task
 
 Pipelines are just `Handler`s — the same pattern works.
 
 ```rust
-use nexus_async_rt::{Runtime, spawn_boxed, with_world};
+use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed};
 use nexus_rt::{Handler, Pipeline, Res, ResMut, Resource, WorldBuilder};
 
 #[derive(Resource, Default)]
@@ -210,8 +221,9 @@ fn main() {
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async move {
         spawn_boxed(async move {
+            let ctx = WorldCtx::current();
             for tick in 1..=10 {
-                with_world(|w| pipeline.run(w, tick));
+                ctx.with_world(|w| pipeline.run(w, tick));
             }
         }).await;
     });
@@ -226,7 +238,7 @@ here — see nexus-rt `reactors.md`).
 
 ```rust
 use nexus_async_rt::{
-    Runtime, TcpStream, spawn_boxed, with_world, shutdown_signal,
+    Runtime, ShutdownSignal, TcpStream, WorldCtx, spawn_boxed,
 };
 use nexus_rt::{Handler, IntoHandler, ResMut, Resource, WorldBuilder};
 
@@ -254,16 +266,17 @@ fn main() -> std::io::Result<()> {
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async move {
         spawn_boxed(async move {
+            let ctx = WorldCtx::current();
             let mut stream = connect_ws().await?;
             loop {
                 let q = read_quote(&mut stream).await?;
-                with_world(|w| handler.run(w, q));
+                ctx.with_world(|w| handler.run(w, q));
             }
             #[allow(unreachable_code)]
             Ok::<_, std::io::Error>(())
         });
 
-        shutdown_signal().await;
+        ShutdownSignal::current().await;
         Ok(())
     })
 }

--- a/nexus-async-rt/docs/patterns.md
+++ b/nexus-async-rt/docs/patterns.md
@@ -9,7 +9,7 @@ sketch, and the gotchas worth remembering.
 on SIGTERM.
 
 ```rust
-use nexus_async_rt::{Runtime, shutdown_signal, spawn_boxed, sleep};
+use nexus_async_rt::{Runtime, ShutdownSignal, spawn_boxed, sleep};
 use nexus_rt::WorldBuilder;
 use std::time::Duration;
 
@@ -27,7 +27,7 @@ fn main() {
             }
         });
 
-        shutdown_signal().await;
+        ShutdownSignal::current().await;
         let was_running = worker.abort();
         eprintln!("shutdown (worker_running={was_running})");
     });
@@ -36,7 +36,7 @@ fn main() {
 async fn do_work() {}
 ```
 
-**Gotchas:** `shutdown_signal()` is single-waiter. If you have multiple
+**Gotchas:** `ShutdownSignal` is single-waiter. If you have multiple
 subsystems, fan out via `CancellationToken::cancel()`.
 
 ## 2. Per-Connection Task With Cancellation
@@ -46,8 +46,8 @@ parent token tied to SIGTERM.
 
 ```rust
 use nexus_async_rt::{
-    CancellationToken, Runtime, TcpListener, TcpStream,
-    shutdown_signal, spawn_boxed,
+    CancellationToken, Runtime, ShutdownSignal, TcpListener, TcpStream,
+    spawn_boxed,
 };
 use nexus_rt::WorldBuilder;
 
@@ -80,7 +80,7 @@ fn main() -> std::io::Result<()> {
             }
         });
 
-        shutdown_signal().await;
+        ShutdownSignal::current().await;
         root.cancel();
         Ok(())
     })
@@ -135,7 +135,7 @@ fn main() {
         // Consumer — processes frames.
         let consumer = spawn_boxed(async move {
             while let Ok(_frame) = frame_rx.recv().await {
-                // dispatch via with_world(|w| handler.run(w, _frame));
+                // dispatch via WorldCtx::current().with_world(|w| handler.run(w, _frame));
             }
         });
 
@@ -236,7 +236,7 @@ stays on our executor.
 
 ```rust
 use nexus_async_rt::{
-    Runtime, interval, spawn_boxed, with_world,
+    Runtime, WorldCtx, interval, spawn_boxed,
     tokio_compat::with_tokio,
 };
 use nexus_rt::{Resource, WorldBuilder};
@@ -252,6 +252,7 @@ fn main() {
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async {
         spawn_boxed(async {
+            let ctx = WorldCtx::current();
             let mut tick = interval(Duration::from_secs(60));
             loop {
                 tick.tick().await;
@@ -261,7 +262,7 @@ fn main() {
                         .text().await.unwrap()
                 }).await;
                 let px: f64 = body.parse().unwrap_or(0.0);
-                with_world(|w| w.resource_mut::<RefPrice>().0 = px);
+                ctx.with_world(|w| w.resource_mut::<RefPrice>().0 = px);
             }
         }).await;
     });
@@ -277,7 +278,7 @@ borrow across an `.await`. The borrow checker enforces this.
 per message. Resolve once, dispatch many.
 
 ```rust
-use nexus_async_rt::{Runtime, spawn_boxed, with_world};
+use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed};
 use nexus_rt::{IntoHandler, Handler, ResMut, Resource, WorldBuilder};
 
 #[derive(Resource, Default)]
@@ -300,9 +301,10 @@ fn main() {
     let mut rt = Runtime::new(&mut world);
     rt.block_on(async move {
         spawn_boxed(async move {
+            let ctx = WorldCtx::current();
             for _ in 0..100 {
                 let t = recv_tick().await;
-                with_world(|w| handler.run(w, t));
+                ctx.with_world(|w| handler.run(w, t));
             }
         }).await;
     });

--- a/nexus-async-rt/docs/task-spawning.md
+++ b/nexus-async-rt/docs/task-spawning.md
@@ -205,7 +205,7 @@ rt.block_on(async {
         }
     });
 
-    nexus_async_rt::shutdown_signal().await;
+    nexus_async_rt::ShutdownSignal::current().await;
 });
 
 async fn recv_next() -> u64 { 0 }
@@ -262,7 +262,7 @@ fn main() -> std::io::Result<()> {
             Ok::<_, std::io::Error>(())
         });
 
-        nexus_async_rt::shutdown_signal().await;
+        nexus_async_rt::ShutdownSignal::current().await;
         Ok(())
     })
 }

--- a/nexus-async-rt/docs/tokio-compat.md
+++ b/nexus-async-rt/docs/tokio-compat.md
@@ -50,7 +50,7 @@ fn main() {
                     .text().await.unwrap()
             }).await;
 
-            nexus_async_rt::with_world(|_w| {
+            nexus_async_rt::WorldCtx::current().with_world(|_w| {
                 // parse body, update World state
                 let _ = body;
             });
@@ -175,7 +175,7 @@ you hit a cross-thread waker bug, that's the first place to look.
 ## Example: `reqwest` for REST Cold Path
 
 ```rust
-use nexus_async_rt::{Runtime, spawn_boxed, with_world, tokio_compat::with_tokio};
+use nexus_async_rt::{Runtime, WorldCtx, spawn_boxed, tokio_compat::with_tokio};
 use nexus_rt::{Resource, WorldBuilder};
 use std::time::Duration;
 
@@ -194,7 +194,7 @@ async fn refresh_prices() {
 
     // Parse & apply under a scoped World borrow.
     let price: f64 = body.parse().unwrap_or(0.0);
-    with_world(|w| {
+    WorldCtx::current().with_world(|w| {
         w.resource_mut::<RefPrices>().btc_usd = price;
     });
 }

--- a/nexus-async-rt/src/context.rs
+++ b/nexus-async-rt/src/context.rs
@@ -18,13 +18,13 @@
 //! const-initialized for zero first-access cost.
 //!
 //! ```ignore
-//! use nexus_async_rt::{spawn_boxed, sleep, IoHandle, WorldCtx, ShutdownSignal};
+//! use nexus_async_rt::{spawn_boxed, sleep, WorldCtx, ShutdownSignal, TcpListener};
 //!
 //! rt.block_on(async {
 //!     spawn_boxed(async {
 //!         WorldCtx::current().with_world(|world| { /* ... */ });
 //!         sleep(Duration::from_secs(1)).await;
-//!         let listener = TcpListener::bind(addr, IoHandle::current());
+//!         let listener = TcpListener::bind(addr);  // fetches IoHandle::current() internally
 //!     });
 //!     ShutdownSignal::current().await;
 //! });

--- a/nexus-async-rt/src/context.rs
+++ b/nexus-async-rt/src/context.rs
@@ -1,19 +1,32 @@
 //! Thread-local runtime context.
 //!
-//! All runtime state is accessible via free functions that read from
-//! thread-local storage. The TLS slots are set by [`Runtime::block_on`]
-//! and cleared on exit. All const-initialized for zero first-access cost.
+//! Two access shapes for runtime state, by intent:
+//!
+//! - **Handles for the current runtime** — [`IoHandle::current`](crate::IoHandle::current),
+//!   [`WorldCtx::current`](crate::WorldCtx::current),
+//!   [`ShutdownSignal::current`](crate::ShutdownSignal::current). Inherent
+//!   `current()` methods on the type, mirroring `tokio::runtime::Handle::current()`.
+//!   Use when you need the handle/future itself.
+//! - **Future factories and value getters** — free functions [`sleep`],
+//!   [`sleep_until`], [`interval`], [`interval_at`], [`after`],
+//!   [`after_delay`], [`timeout`], [`timeout_at`], [`yield_now`],
+//!   [`event_time`]. These produce a value and don't fit the `Type::current()`
+//!   shape (the future is the API; there's no enclosing handle to fetch).
+//!
+//! All readers panic if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+//! context. The TLS slots are installed by `block_on` and cleared on exit;
+//! const-initialized for zero first-access cost.
 //!
 //! ```ignore
-//! use nexus_async_rt::{spawn, with_world, sleep, io, shutdown_signal};
+//! use nexus_async_rt::{spawn_boxed, sleep, IoHandle, WorldCtx, ShutdownSignal};
 //!
 //! rt.block_on(async {
-//!     spawn(async {
-//!         with_world(|world| { /* ... */ });
+//!     spawn_boxed(async {
+//!         WorldCtx::current().with_world(|world| { /* ... */ });
 //!         sleep(Duration::from_secs(1)).await;
-//!         let listener = TcpListener::bind(addr, io());
+//!         let listener = TcpListener::bind(addr, IoHandle::current());
 //!     });
-//!     shutdown_signal().await;
+//!     ShutdownSignal::current().await;
 //! });
 //! ```
 
@@ -22,7 +35,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
-use crate::io::{IoDriver, IoHandle};
+use crate::io::IoDriver;
 use crate::timer::{TimerDriver, TimerHandle};
 
 // =============================================================================
@@ -100,54 +113,34 @@ pub(crate) fn assert_in_runtime(msg: &str) {
 }
 
 // =============================================================================
-// Public free functions — the user-facing API
+// pub(crate) TLS readers — back the inherent `Type::current()` methods on
+// `IoHandle`, `WorldCtx`, and `ShutdownSignal`. Kept in this module so the
+// `CTX_*` thread-locals don't need to be exposed elsewhere in the crate.
 // =============================================================================
 
-/// Access the [`World`](nexus_rt::World) with exclusive access.
-///
-/// Runs the closure synchronously inline. Must be called from within
-/// [`crate::Runtime::block_on`].
-///
-/// # Panics
-///
-/// Panics if called outside a runtime context.
-pub fn with_world<R>(f: impl FnOnce(&mut nexus_rt::World) -> R) -> R {
-    let ptr = CTX_WORLD.with(Cell::get);
-    assert!(
-        !ptr.is_null(),
-        "with_world() called outside Runtime::block_on"
-    );
-    // SAFETY: ptr set by install(), valid for Runtime lifetime.
-    // Single-threaded — exclusive access.
-    let world = unsafe { &mut *ptr };
-    f(world)
+/// Returns the raw `IoDriver` pointer installed for the current runtime, or
+/// null if outside a runtime context.
+pub(crate) fn current_io_ptr() -> *mut IoDriver {
+    CTX_IO.with(Cell::get)
 }
 
-/// Access the [`World`](nexus_rt::World) with shared access.
-///
-/// # Panics
-///
-/// Panics if called outside a runtime context.
-pub fn with_world_ref<R>(f: impl FnOnce(&nexus_rt::World) -> R) -> R {
-    let ptr = CTX_WORLD.with(Cell::get);
-    assert!(
-        !ptr.is_null(),
-        "with_world_ref() called outside Runtime::block_on"
-    );
-    let world = unsafe { &*ptr };
-    f(world)
+/// Returns the raw `World` pointer installed for the current runtime, or null
+/// if outside a runtime context.
+pub(crate) fn current_world_ptr() -> *mut nexus_rt::World {
+    CTX_WORLD.with(Cell::get)
 }
 
-/// Returns the IO handle for registering mio sources.
-///
-/// # Panics
-///
-/// Panics if called outside a runtime context.
-pub fn io() -> IoHandle {
-    let ptr = CTX_IO.with(Cell::get);
-    assert!(!ptr.is_null(), "io() called outside Runtime::block_on");
-    // SAFETY: ptr valid for Runtime lifetime.
-    IoHandle::new(unsafe { &mut *ptr })
+/// Returns `(flag, waker)` pointers for the current runtime's shutdown
+/// machinery, or `(null, null)` if outside a runtime context. Both pointers
+/// are non-null whenever the runtime is installed (`install` writes them
+/// together).
+pub(crate) fn current_shutdown_ptrs() -> (
+    *const AtomicBool,
+    *const Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+) {
+    let flag = CTX_SHUTDOWN.with(Cell::get);
+    let waker = CTX_SHUTDOWN_WAKER.with(Cell::get);
+    (flag, waker)
 }
 
 /// Create a [`Sleep`](crate::Sleep) future that completes after `duration`.
@@ -266,20 +259,4 @@ pub fn interval_at(start: Instant, period: Duration) -> crate::timer::Interval {
 /// poll. Other ready tasks get a turn before this task resumes.
 pub fn yield_now() -> crate::timer::YieldNow {
     crate::timer::YieldNow(false)
-}
-
-/// Returns a future that resolves when shutdown is triggered.
-pub fn shutdown_signal() -> crate::ShutdownSignal {
-    let ptr = CTX_SHUTDOWN.with(Cell::get);
-    assert!(
-        !ptr.is_null(),
-        "shutdown_signal() called outside Runtime::block_on"
-    );
-    let waker_ptr = CTX_SHUTDOWN_WAKER.with(Cell::get);
-    // SAFETY: waker_ptr was set by install() and is valid for Runtime lifetime.
-    let task_waker = unsafe { (*waker_ptr).clone() };
-    crate::ShutdownSignal {
-        flag: ptr,
-        task_waker,
-    }
 }

--- a/nexus-async-rt/src/context.rs
+++ b/nexus-async-rt/src/context.rs
@@ -61,8 +61,10 @@ thread_local! {
 // Install / clear (called by Runtime::block_on)
 // =============================================================================
 
-/// Install runtime context into TLS. Called by RuntimeBuilder::build().
-/// The context stays installed until the guard is dropped (Runtime::drop).
+/// Install runtime context into TLS. Called by both `Runtime::block_on`
+/// (root execution path) and `Runtime::shutdown_quiesce` (so cross-thread
+/// wakes that fire during quiesce still find a runtime context).
+/// The context stays installed until the returned guard is dropped.
 pub(crate) fn install(
     world: *mut nexus_rt::World,
     io: *mut IoDriver,

--- a/nexus-async-rt/src/io.rs
+++ b/nexus-async-rt/src/io.rs
@@ -237,7 +237,7 @@ impl IoDriver {
 /// [`Copy`] handle for IO operations from async tasks.
 ///
 /// Provides source registration with the mio reactor. Obtained from
-/// [`crate::io()`].
+/// [`IoHandle::current`].
 ///
 /// # Safety
 ///
@@ -258,6 +258,28 @@ impl IoHandle {
             registry: std::ptr::from_ref(driver.registry()),
             driver: std::ptr::from_mut(driver),
         }
+    }
+
+    /// Returns the [`IoHandle`] for the currently running runtime.
+    ///
+    /// Use when you need to register a mio source from inside an async task —
+    /// e.g., when constructing a [`TcpStream`](crate::TcpStream) or
+    /// [`UdpSocket`](crate::UdpSocket). Mirrors `tokio::runtime::Handle::current()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context.
+    #[must_use]
+    pub fn current() -> IoHandle {
+        let ptr = crate::context::current_io_ptr();
+        assert!(
+            !ptr.is_null(),
+            "IoHandle::current() called outside Runtime::block_on"
+        );
+        // SAFETY: ptr installed by Runtime::block_on, valid for Runtime lifetime.
+        // Single-threaded executor — no concurrent access.
+        IoHandle::new(unsafe { &mut *ptr })
     }
 
     /// Register a mio source with the given interest and waker.

--- a/nexus-async-rt/src/io.rs
+++ b/nexus-async-rt/src/io.rs
@@ -351,3 +351,17 @@ impl IoHandle {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "called outside Runtime::block_on")]
+    fn current_panics_outside_runtime() {
+        // Pins the documented panic contract. Most tests exercise
+        // `current()` transitively (via `TcpStream::connect`, etc.)
+        // inside `block_on`; this is the direct contract test.
+        let _ = IoHandle::current();
+    }
+}

--- a/nexus-async-rt/src/lib.rs
+++ b/nexus-async-rt/src/lib.rs
@@ -59,8 +59,8 @@ pub use alloc::SlabClaim;
 pub use backoff::{Backoff, BackoffBuilder, Exhausted};
 pub use cancel::{CancellationToken, DropGuard};
 pub use context::{
-    after, after_delay, event_time, interval, interval_at, io, shutdown_signal, sleep, sleep_until,
-    timeout, timeout_at, with_world, with_world_ref, yield_now,
+    after, after_delay, event_time, interval, interval_at, sleep, sleep_until, timeout, timeout_at,
+    yield_now,
 };
 pub use io::IoHandle;
 pub use net::{

--- a/nexus-async-rt/src/net/tcp.rs
+++ b/nexus-async-rt/src/net/tcp.rs
@@ -979,8 +979,9 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap(), crate::context::io())
-                .expect("bind failed");
+            let listener =
+                TcpListener::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
+                    .expect("bind failed");
             let addr = listener.local_addr().unwrap();
             spawn_boxed(async move {
                 let mut listener = listener;
@@ -990,7 +991,7 @@ mod tests {
                 stream.write_all(&buf[..n]).await.unwrap();
             });
 
-            let io = crate::context::io();
+            let io = crate::IoHandle::current();
             let flag = done2;
             spawn_boxed(async move {
                 crate::context::sleep(std::time::Duration::from_millis(10)).await;

--- a/nexus-async-rt/src/net/tcp.rs
+++ b/nexus-async-rt/src/net/tcp.rs
@@ -60,17 +60,26 @@ impl TcpStream {
     /// The connection completes asynchronously. The first read or write
     /// will register with mio and detect when the connection is
     /// established.
-    pub fn connect(addr: SocketAddr, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context — fetches the runtime's [`IoHandle`] internally.
+    pub fn connect(addr: SocketAddr) -> io::Result<Self> {
         let inner = mio::net::TcpStream::connect(addr)?;
-        Ok(Self::new(inner, io))
+        Ok(Self::new(inner, IoHandle::current()))
     }
 
     /// Convert from a `std::net::TcpStream`.
     ///
     /// The stream must be set to non-blocking mode before calling this.
-    pub fn from_std(stream: std::net::TcpStream, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a runtime context.
+    pub fn from_std(stream: std::net::TcpStream) -> io::Result<Self> {
         let inner = mio::net::TcpStream::from_std(stream);
-        Ok(Self::new(inner, io))
+        Ok(Self::new(inner, IoHandle::current()))
     }
 
     /// Convert into a `std::net::TcpStream`.
@@ -647,22 +656,31 @@ pub struct TcpListener {
 
 impl TcpListener {
     /// Bind to `addr`. Registration deferred to first `accept` poll.
-    pub fn bind(addr: SocketAddr, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context — fetches the runtime's [`IoHandle`] internally.
+    pub fn bind(addr: SocketAddr) -> io::Result<Self> {
         let inner = mio::net::TcpListener::bind(addr)?;
         Ok(Self {
             inner,
-            io,
+            io: IoHandle::current(),
             token: None,
             registered_task: std::ptr::null_mut(),
         })
     }
 
     /// Convert from a `std::net::TcpListener`.
-    pub fn from_std(listener: std::net::TcpListener, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a runtime context.
+    pub fn from_std(listener: std::net::TcpListener) -> io::Result<Self> {
         let inner = mio::net::TcpListener::from_std(listener);
         Ok(Self {
             inner,
-            io,
+            io: IoHandle::current(),
             token: None,
             registered_task: std::ptr::null_mut(),
         })
@@ -907,7 +925,12 @@ impl TcpSocket {
     /// The connection completes asynchronously (non-blocking socket).
     /// The first read or write will detect when the connection is
     /// established.
-    pub fn connect(self, addr: SocketAddr, io: IoHandle) -> io::Result<TcpStream> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context — fetches the runtime's [`IoHandle`] internally.
+    pub fn connect(self, addr: SocketAddr) -> io::Result<TcpStream> {
         // Non-blocking connect returns EINPROGRESS/EALREADY — that's
         // normal, not an error. Suppress these.
         match self.inner.connect(&addr.into()) {
@@ -919,17 +942,21 @@ impl TcpSocket {
         }
         let std_stream: std::net::TcpStream = self.inner.into();
         let mio_stream = mio::net::TcpStream::from_std(std_stream);
-        Ok(TcpStream::new(mio_stream, io))
+        Ok(TcpStream::new(mio_stream, IoHandle::current()))
     }
 
     /// Start listening with the given backlog and return a [`TcpListener`].
-    pub fn listen(self, backlog: i32, io: IoHandle) -> io::Result<TcpListener> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a runtime context.
+    pub fn listen(self, backlog: i32) -> io::Result<TcpListener> {
         self.inner.listen(backlog)?;
         let std_listener: std::net::TcpListener = self.inner.into();
         let mio_listener = mio::net::TcpListener::from_std(std_listener);
         Ok(TcpListener {
             inner: mio_listener,
-            io,
+            io: IoHandle::current(),
             token: None,
             registered_task: std::ptr::null_mut(),
         })
@@ -979,9 +1006,7 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let listener =
-                TcpListener::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
-                    .expect("bind failed");
+            let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).expect("bind failed");
             let addr = listener.local_addr().unwrap();
             spawn_boxed(async move {
                 let mut listener = listener;
@@ -991,11 +1016,10 @@ mod tests {
                 stream.write_all(&buf[..n]).await.unwrap();
             });
 
-            let io = crate::IoHandle::current();
             let flag = done2;
             spawn_boxed(async move {
                 crate::context::sleep(std::time::Duration::from_millis(10)).await;
-                let mut client = TcpStream::connect(addr, io).unwrap();
+                let mut client = TcpStream::connect(addr).unwrap();
                 client.write_all(b"hello").await.unwrap();
                 let mut buf = [0u8; 64];
                 let n = client.read(&mut buf).await.unwrap();

--- a/nexus-async-rt/src/net/udp.rs
+++ b/nexus-async-rt/src/net/udp.rs
@@ -33,11 +33,16 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Bind to `addr`. Registration deferred to first IO poll.
-    pub fn bind(addr: SocketAddr, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context — fetches the runtime's [`IoHandle`] internally.
+    pub fn bind(addr: SocketAddr) -> io::Result<Self> {
         let inner = mio::net::UdpSocket::bind(addr)?;
         Ok(Self {
             inner,
-            io,
+            io: IoHandle::current(),
             token: None,
             registered_task: std::ptr::null_mut(),
         })
@@ -173,11 +178,15 @@ impl UdpSocket {
     /// Convert from a `std::net::UdpSocket`.
     ///
     /// The socket must be set to non-blocking mode before calling this.
-    pub fn from_std(socket: std::net::UdpSocket, io: IoHandle) -> io::Result<Self> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a runtime context.
+    pub fn from_std(socket: std::net::UdpSocket) -> io::Result<Self> {
         let inner = mio::net::UdpSocket::from_std(socket);
         Ok(Self {
             inner,
-            io,
+            io: IoHandle::current(),
             token: None,
             registered_task: std::ptr::null_mut(),
         })
@@ -435,9 +444,7 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let recv_sock =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
-                    .unwrap();
+            let recv_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             let recv_addr = recv_sock.local_addr().unwrap();
             // Receiver task.
             let flag = done2;
@@ -452,9 +459,7 @@ mod tests {
             // Sender task.
             spawn_boxed(async move {
                 crate::context::sleep(Duration::from_millis(10)).await;
-                let mut sock =
-                    UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
-                        .unwrap();
+                let mut sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
                 sock.send_to(b"test", recv_addr).await.unwrap();
             });
 
@@ -475,9 +480,7 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let server_sock =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
-                    .expect("bind failed");
+            let server_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).expect("bind failed");
             let server_addr = server_sock.local_addr().unwrap();
 
             // Server task: receive one datagram, echo back.
@@ -493,7 +496,7 @@ mod tests {
             spawn_boxed(async move {
                 crate::context::sleep(Duration::from_millis(10)).await;
                 let client_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-                let mut client = UdpSocket::bind(client_addr, crate::IoHandle::current()).unwrap();
+                let mut client = UdpSocket::bind(client_addr).unwrap();
                 client.send_to(b"hello udp", server_addr).await.unwrap();
                 let mut buf = [0u8; 64];
                 let (n, _from) = client.recv_from(&mut buf).await.unwrap();
@@ -518,9 +521,8 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let io = crate::IoHandle::current();
-            let a_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), io).unwrap();
-            let b_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), io).unwrap();
+            let a_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let b_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             let a_addr = a_sock.local_addr().unwrap();
             let b_addr = b_sock.local_addr().unwrap();
             // A sends to B via connected mode.

--- a/nexus-async-rt/src/net/udp.rs
+++ b/nexus-async-rt/src/net/udp.rs
@@ -436,7 +436,8 @@ mod tests {
 
         rt.block_on(async move {
             let recv_sock =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::context::io()).unwrap();
+                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
+                    .unwrap();
             let recv_addr = recv_sock.local_addr().unwrap();
             // Receiver task.
             let flag = done2;
@@ -452,7 +453,8 @@ mod tests {
             spawn_boxed(async move {
                 crate::context::sleep(Duration::from_millis(10)).await;
                 let mut sock =
-                    UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::context::io()).unwrap();
+                    UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
+                        .unwrap();
                 sock.send_to(b"test", recv_addr).await.unwrap();
             });
 
@@ -473,8 +475,9 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let server_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::context::io())
-                .expect("bind failed");
+            let server_sock =
+                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), crate::IoHandle::current())
+                    .expect("bind failed");
             let server_addr = server_sock.local_addr().unwrap();
 
             // Server task: receive one datagram, echo back.
@@ -490,7 +493,7 @@ mod tests {
             spawn_boxed(async move {
                 crate::context::sleep(Duration::from_millis(10)).await;
                 let client_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-                let mut client = UdpSocket::bind(client_addr, crate::context::io()).unwrap();
+                let mut client = UdpSocket::bind(client_addr, crate::IoHandle::current()).unwrap();
                 client.send_to(b"hello udp", server_addr).await.unwrap();
                 let mut buf = [0u8; 64];
                 let (n, _from) = client.recv_from(&mut buf).await.unwrap();
@@ -515,7 +518,7 @@ mod tests {
         let done2 = done.clone();
 
         rt.block_on(async move {
-            let io = crate::context::io();
+            let io = crate::IoHandle::current();
             let a_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), io).unwrap();
             let b_sock = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), io).unwrap();
             let a_addr = a_sock.local_addr().unwrap();

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -1236,11 +1236,11 @@ mod tests {
         let mut rt = Runtime::new(&mut world);
 
         let result = rt.block_on(async move {
-            crate::context::with_world(|world| {
+            crate::WorldCtx::current().with_world(|world| {
                 let v = world.resource::<Val>().0;
                 world.resource_mut::<Out>().0 = v + 10;
             });
-            crate::context::with_world_ref(|world| world.resource::<Out>().0)
+            crate::WorldCtx::current().with_world_ref(|world| world.resource::<Out>().0)
         });
 
         assert_eq!(result, 52);
@@ -1261,8 +1261,8 @@ mod tests {
         .into_handler(world.registry());
 
         let result = rt.block_on(async move {
-            crate::context::with_world(|world| h.run(world, 10));
-            crate::context::with_world_ref(|world| world.resource::<Out>().0)
+            crate::WorldCtx::current().with_world(|world| h.run(world, 10));
+            crate::WorldCtx::current().with_world_ref(|world| world.resource::<Out>().0)
         });
 
         assert_eq!(result, 52);
@@ -1279,7 +1279,7 @@ mod tests {
         rt.block_on(async move {
             for i in 1..=3u64 {
                 spawn_boxed(async move {
-                    crate::context::with_world(|world| {
+                    crate::WorldCtx::current().with_world(|world| {
                         world.resource_mut::<Out>().0 += i;
                     });
                 });
@@ -1312,7 +1312,7 @@ mod tests {
 
         rt.block_on_busy(async move {
             spawn_boxed(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 = 99;
                 });
             });
@@ -1373,7 +1373,7 @@ mod tests {
 
         rt.block_on(async move {
             spawn_slab(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 = 77;
                 });
             });
@@ -1397,13 +1397,13 @@ mod tests {
         rt.block_on(async move {
             // Box-allocated
             spawn_boxed(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 += 10;
                 });
             });
             // Slab-allocated
             spawn_slab(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 += 20;
                 });
             });
@@ -1431,7 +1431,7 @@ mod tests {
         rt.block_on(async move {
             let claim = claim_slab();
             claim.spawn(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 = 55;
                 });
             });
@@ -1489,14 +1489,14 @@ mod tests {
 
         rt.block_on(async move {
             spawn_boxed(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 += 10;
                 });
             });
 
             let claim = claim_slab();
             claim.spawn(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 += 20;
                 });
             });
@@ -1547,7 +1547,7 @@ mod tests {
         rt.block_on(async move {
             spawn_boxed(async move {
                 crate::context::sleep(Duration::from_millis(50)).await;
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 = 42;
                 });
             });
@@ -1664,7 +1664,7 @@ mod tests {
 
         rt.block_on(async move {
             spawn_boxed(async move {
-                crate::context::with_world(|world| {
+                crate::WorldCtx::current().with_world(|world| {
                     world.resource_mut::<Out>().0 = 99;
                 });
             });
@@ -1672,7 +1672,7 @@ mod tests {
             // Yield so the spawned task gets a turn.
             crate::context::yield_now().await;
 
-            let val = crate::context::with_world_ref(|world| world.resource::<Out>().0);
+            let val = crate::WorldCtx::current().with_world_ref(|world| world.resource::<Out>().0);
             assert_eq!(val, 99);
         });
     }

--- a/nexus-async-rt/src/shutdown.rs
+++ b/nexus-async-rt/src/shutdown.rs
@@ -140,8 +140,16 @@ impl ShutdownSignal {
             !flag.is_null(),
             "ShutdownSignal::current() called outside Runtime::block_on"
         );
-        // SAFETY: install() writes flag and waker pointers together; flag
-        // non-null implies waker_ptr non-null and valid for Runtime lifetime.
+        // Defense-in-depth: flag and waker_ptr are written together by
+        // install(), so this should be unreachable — but a future refactor
+        // that splits the install path would make a null waker_ptr deref UB.
+        // Catch it at the call site instead.
+        assert!(
+            !waker_ptr.is_null(),
+            "ShutdownSignal::current(): waker_ptr null while flag non-null (runtime install bug)"
+        );
+        // SAFETY: install() writes flag and waker pointers together; both
+        // verified non-null above; pointers are valid for Runtime lifetime.
         let task_waker = unsafe { (*waker_ptr).clone() };
         ShutdownSignal { flag, task_waker }
     }
@@ -245,6 +253,41 @@ mod tests {
 
             // Root future waits for shutdown.
             shutdown.signal().await;
+            flag.set(true);
+        });
+
+        assert!(done.get());
+    }
+
+    #[test]
+    fn shutdown_signal_current_resolves_after_trigger() {
+        // Sister test to `shutdown_signal_resolves_after_trigger`, but
+        // exercises the TLS-fetcher path (`ShutdownSignal::current()`)
+        // instead of `handle.signal()`. Catches regressions in the
+        // CTX_SHUTDOWN / CTX_SHUTDOWN_WAKER install/uninstall wiring.
+        use crate::{Runtime, spawn_boxed};
+        use nexus_rt::WorldBuilder;
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let wb = WorldBuilder::new();
+        let mut world = wb.build();
+        let mut rt = Runtime::new(&mut world);
+        let shutdown = rt.shutdown_handle();
+
+        let done = Rc::new(Cell::new(false));
+        let flag = done.clone();
+
+        let sh = shutdown.clone();
+        rt.block_on(async move {
+            spawn_boxed(async move {
+                crate::context::sleep(std::time::Duration::from_millis(50)).await;
+                sh.trigger();
+            });
+
+            // Fetch the signal via the TLS-based current() rather than
+            // handle.signal() — this is the path users will hit.
+            ShutdownSignal::current().await;
             flag.set(true);
         });
 

--- a/nexus-async-rt/src/shutdown.rs
+++ b/nexus-async-rt/src/shutdown.rs
@@ -20,7 +20,7 @@
 //!     spawn_boxed(connection_tasks...);
 //!
 //!     // Wait for SIGTERM/SIGINT.
-//!     nexus_async_rt::shutdown_signal().await;
+//!     nexus_async_rt::ShutdownSignal::current().await;
 //!
 //!     // Drain connections, flush buffers, etc.
 //! });
@@ -112,6 +112,39 @@ impl ShutdownHandle {
 pub struct ShutdownSignal {
     pub(crate) flag: *const AtomicBool,
     pub(crate) task_waker: Arc<std::sync::Mutex<Option<Waker>>>,
+}
+
+impl ShutdownSignal {
+    /// Returns a [`ShutdownSignal`] future for the currently running runtime.
+    ///
+    /// The returned future resolves when shutdown is triggered — either by
+    /// a Unix signal handler installed via
+    /// [`Runtime::install_signal_handlers`](crate::Runtime::install_signal_handlers)
+    /// (SIGTERM / SIGINT) or by an explicit
+    /// [`ShutdownHandle::trigger`] call. Mirrors
+    /// `tokio::runtime::Handle::current()`. Read as
+    /// `ShutdownSignal::current().await` — "await the current shutdown
+    /// signal".
+    ///
+    /// **Single waiter only** — see the type-level docs. For multi-waiter
+    /// patterns, use [`CancellationToken`](crate::CancellationToken).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context.
+    #[must_use]
+    pub fn current() -> ShutdownSignal {
+        let (flag, waker_ptr) = crate::context::current_shutdown_ptrs();
+        assert!(
+            !flag.is_null(),
+            "ShutdownSignal::current() called outside Runtime::block_on"
+        );
+        // SAFETY: install() writes flag and waker pointers together; flag
+        // non-null implies waker_ptr non-null and valid for Runtime lifetime.
+        let task_waker = unsafe { (*waker_ptr).clone() };
+        ShutdownSignal { flag, task_waker }
+    }
 }
 
 impl Future for ShutdownSignal {

--- a/nexus-async-rt/src/shutdown.rs
+++ b/nexus-async-rt/src/shutdown.rs
@@ -260,6 +260,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "called outside Runtime::block_on")]
+    fn shutdown_signal_current_panics_outside_runtime() {
+        // Pins the documented panic contract for
+        // `ShutdownSignal::current()`. Symmetric to
+        // `IoHandle::current_panics_outside_runtime` and
+        // `WorldCtx::current_panics_outside_runtime`.
+        let _ = ShutdownSignal::current();
+    }
+
+    #[test]
     fn shutdown_signal_current_resolves_after_trigger() {
         // Sister test to `shutdown_signal_resolves_after_trigger`, but
         // exercises the TLS-fetcher path (`ShutdownSignal::current()`)

--- a/nexus-async-rt/src/world_ctx.rs
+++ b/nexus-async-rt/src/world_ctx.rs
@@ -76,6 +76,34 @@ impl WorldCtx {
         }
     }
 
+    /// Returns a [`WorldCtx`] for the currently running runtime.
+    ///
+    /// Reads the world pointer installed by
+    /// [`Runtime::block_on`](crate::Runtime::block_on). The returned handle
+    /// is the same shape as one constructed via [`WorldCtx::new`] — same
+    /// [`Copy`] semantics, same [`with_world`](Self::with_world) /
+    /// [`with_world_ref`](Self::with_world_ref) methods. Mirrors
+    /// `tokio::runtime::Handle::current()`.
+    ///
+    /// Use [`WorldCtx::new`] explicitly when constructing a handle outside
+    /// the runtime context (e.g., capturing into a task before `block_on`).
+    /// Use `current()` when you're already inside a task and want the
+    /// active runtime's world.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a [`Runtime::block_on`](crate::Runtime::block_on)
+    /// context.
+    #[must_use]
+    pub fn current() -> WorldCtx {
+        let ptr = crate::context::current_world_ptr();
+        assert!(
+            !ptr.is_null(),
+            "WorldCtx::current() called outside Runtime::block_on"
+        );
+        Self { ptr }
+    }
+
     /// Run a closure with exclusive [`World`] access.
     ///
     /// Executes synchronously inline — no await point. The closure

--- a/nexus-async-rt/src/world_ctx.rs
+++ b/nexus-async-rt/src/world_ctx.rs
@@ -148,6 +148,16 @@ mod tests {
     nexus_rt::new_resource!(Out(u64));
 
     #[test]
+    #[should_panic(expected = "called outside Runtime::block_on")]
+    fn current_panics_outside_runtime() {
+        // Pins the documented panic contract for `WorldCtx::current()`.
+        // The happy path is exercised transitively by the runtime tests
+        // (every `with_world(...)` call inside a task goes through
+        // `WorldCtx::current()`). This is the direct contract test.
+        let _ = WorldCtx::current();
+    }
+
+    #[test]
     fn with_world_raw_access() {
         let mut wb = WorldBuilder::new();
         wb.register(Val(42));

--- a/nexus-async-rt/tests/net_tcp.rs
+++ b/nexus-async-rt/tests/net_tcp.rs
@@ -23,11 +23,7 @@ fn tcp_echo_basic() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -39,7 +35,7 @@ fn tcp_echo_basic() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.write_all(b"hello world").await.unwrap();
             let mut buf = [0u8; 128];
             let n = c.read(&mut buf).await.unwrap();
@@ -62,11 +58,7 @@ fn tcp_multiple_clients() {
     let count2 = count.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -82,7 +74,7 @@ fn tcp_multiple_clients() {
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
             for i in 0..3u8 {
-                let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+                let mut c = TcpStream::connect(addr).unwrap();
                 let msg = [b'A' + i; 4];
                 c.write_all(&msg).await.unwrap();
                 let mut buf = [0u8; 64];
@@ -112,11 +104,7 @@ fn tcp_large_transfer() {
     let expected = data.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -137,7 +125,7 @@ fn tcp_large_transfer() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.write_all(&data).await.unwrap();
         });
 
@@ -160,11 +148,7 @@ fn tcp_split_borrowed() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -182,7 +166,7 @@ fn tcp_split_borrowed() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.write_all(b"split").await.unwrap();
             let mut buf = [0u8; 64];
             let n = c.read(&mut buf).await.unwrap();
@@ -203,11 +187,7 @@ fn tcp_into_split_reunite() {
     let mut rt = Runtime::new(&mut world);
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -218,7 +198,7 @@ fn tcp_into_split_reunite() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let _c = TcpStream::connect(addr).unwrap();
         });
 
         nexus_async_rt::sleep(Duration::from_secs(2)).await;
@@ -238,11 +218,7 @@ fn tcp_socket_options_on_stream() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -263,7 +239,7 @@ fn tcp_socket_options_on_stream() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let _c = TcpStream::connect(addr).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -290,9 +266,7 @@ fn tcp_socket_builder_bind_listen() {
     socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
     rt.block_on(async move {
-        let mut listener = socket
-            .listen(128, nexus_async_rt::IoHandle::current())
-            .unwrap();
+        let mut listener = socket.listen(128).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -305,7 +279,7 @@ fn tcp_socket_builder_bind_listen() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.write_all(b"via-socket").await.unwrap();
         });
 
@@ -328,11 +302,7 @@ fn tcp_try_read_write() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -347,7 +317,7 @@ fn tcp_try_read_write() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let _c = TcpStream::connect(addr).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -374,8 +344,7 @@ fn tcp_from_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::from_std(std_listener, nexus_async_rt::IoHandle::current()).unwrap();
+        let mut listener = TcpListener::from_std(std_listener).unwrap();
 
         spawn_boxed(async move {
             let (mut s, _) = listener.accept().await.unwrap();
@@ -387,7 +356,7 @@ fn tcp_from_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.write_all(b"from_std").await.unwrap();
         });
 
@@ -406,11 +375,7 @@ fn tcp_into_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -422,7 +387,7 @@ fn tcp_into_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let _c = TcpStream::connect(addr).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -450,7 +415,7 @@ fn tcp_connect_refused() {
 
     rt.block_on(async move {
         spawn_boxed(async move {
-            match TcpStream::connect(closed_addr, nexus_async_rt::IoHandle::current()) {
+            match TcpStream::connect(closed_addr) {
                 Err(_) => flag.set(true),
                 Ok(mut c) => {
                     nexus_async_rt::sleep(Duration::from_millis(50)).await;
@@ -476,11 +441,7 @@ fn tcp_read_after_peer_close() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let mut listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -489,7 +450,7 @@ fn tcp_read_after_peer_close() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(50)).await;
             let mut buf = [0u8; 64];
             let n = c.read(&mut buf).await.unwrap();
@@ -514,11 +475,7 @@ fn tcp_listener_ttl() {
     let mut rt = Runtime::new(&mut world);
 
     rt.block_on(async {
-        let listener = TcpListener::bind(
-            "127.0.0.1:0".parse().unwrap(),
-            nexus_async_rt::IoHandle::current(),
-        )
-        .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         listener.set_ttl(42).unwrap();
         assert_eq!(listener.ttl().unwrap(), 42);
     });

--- a/nexus-async-rt/tests/net_tcp.rs
+++ b/nexus-async-rt/tests/net_tcp.rs
@@ -23,8 +23,11 @@ fn tcp_echo_basic() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -36,7 +39,7 @@ fn tcp_echo_basic() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             c.write_all(b"hello world").await.unwrap();
             let mut buf = [0u8; 128];
             let n = c.read(&mut buf).await.unwrap();
@@ -59,8 +62,11 @@ fn tcp_multiple_clients() {
     let count2 = count.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -76,7 +82,7 @@ fn tcp_multiple_clients() {
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
             for i in 0..3u8 {
-                let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+                let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
                 let msg = [b'A' + i; 4];
                 c.write_all(&msg).await.unwrap();
                 let mut buf = [0u8; 64];
@@ -106,8 +112,11 @@ fn tcp_large_transfer() {
     let expected = data.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -128,7 +137,7 @@ fn tcp_large_transfer() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             c.write_all(&data).await.unwrap();
         });
 
@@ -151,8 +160,11 @@ fn tcp_split_borrowed() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -170,7 +182,7 @@ fn tcp_split_borrowed() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             c.write_all(b"split").await.unwrap();
             let mut buf = [0u8; 64];
             let n = c.read(&mut buf).await.unwrap();
@@ -191,8 +203,11 @@ fn tcp_into_split_reunite() {
     let mut rt = Runtime::new(&mut world);
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -203,7 +218,7 @@ fn tcp_into_split_reunite() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
         });
 
         nexus_async_rt::sleep(Duration::from_secs(2)).await;
@@ -223,8 +238,11 @@ fn tcp_socket_options_on_stream() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -245,7 +263,7 @@ fn tcp_socket_options_on_stream() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -272,7 +290,9 @@ fn tcp_socket_builder_bind_listen() {
     socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
     rt.block_on(async move {
-        let mut listener = socket.listen(128, nexus_async_rt::io()).unwrap();
+        let mut listener = socket
+            .listen(128, nexus_async_rt::IoHandle::current())
+            .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -285,7 +305,7 @@ fn tcp_socket_builder_bind_listen() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             c.write_all(b"via-socket").await.unwrap();
         });
 
@@ -308,8 +328,11 @@ fn tcp_try_read_write() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -324,7 +347,7 @@ fn tcp_try_read_write() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -351,7 +374,8 @@ fn tcp_from_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener = TcpListener::from_std(std_listener, nexus_async_rt::io()).unwrap();
+        let mut listener =
+            TcpListener::from_std(std_listener, nexus_async_rt::IoHandle::current()).unwrap();
 
         spawn_boxed(async move {
             let (mut s, _) = listener.accept().await.unwrap();
@@ -363,7 +387,7 @@ fn tcp_from_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             c.write_all(b"from_std").await.unwrap();
         });
 
@@ -382,8 +406,11 @@ fn tcp_into_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -395,7 +422,7 @@ fn tcp_into_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let _c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let _c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(100)).await;
         });
 
@@ -423,7 +450,7 @@ fn tcp_connect_refused() {
 
     rt.block_on(async move {
         spawn_boxed(async move {
-            match TcpStream::connect(closed_addr, nexus_async_rt::io()) {
+            match TcpStream::connect(closed_addr, nexus_async_rt::IoHandle::current()) {
                 Err(_) => flag.set(true),
                 Ok(mut c) => {
                     nexus_async_rt::sleep(Duration::from_millis(50)).await;
@@ -449,8 +476,11 @@ fn tcp_read_after_peer_close() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let mut listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let mut listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         let addr = listener.local_addr().unwrap();
 
         spawn_boxed(async move {
@@ -459,7 +489,7 @@ fn tcp_read_after_peer_close() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, nexus_async_rt::io()).unwrap();
+            let mut c = TcpStream::connect(addr, nexus_async_rt::IoHandle::current()).unwrap();
             nexus_async_rt::sleep(Duration::from_millis(50)).await;
             let mut buf = [0u8; 64];
             let n = c.read(&mut buf).await.unwrap();
@@ -484,8 +514,11 @@ fn tcp_listener_ttl() {
     let mut rt = Runtime::new(&mut world);
 
     rt.block_on(async {
-        let listener =
-            TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+        let listener = TcpListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            nexus_async_rt::IoHandle::current(),
+        )
+        .unwrap();
         listener.set_ttl(42).unwrap();
         assert_eq!(listener.ttl().unwrap(), 42);
     });

--- a/nexus-async-rt/tests/net_udp.rs
+++ b/nexus-async-rt/tests/net_udp.rs
@@ -11,7 +11,11 @@ use nexus_rt::WorldBuilder;
 
 /// Bind a UDP socket to loopback:0, return (socket, addr).
 fn bind_udp() -> (UdpSocket, std::net::SocketAddr) {
-    let s = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+    let s = UdpSocket::bind(
+        "127.0.0.1:0".parse().unwrap(),
+        nexus_async_rt::IoHandle::current(),
+    )
+    .unwrap();
     let a = s.local_addr().unwrap();
     (s, a)
 }
@@ -42,8 +46,11 @@ fn udp_send_recv_basic() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut s = UdpSocket::bind(
+                "127.0.0.1:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             s.send_to(b"hello udp", recv_addr).await.unwrap();
         });
 
@@ -115,8 +122,11 @@ fn udp_echo() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut c = UdpSocket::bind(
+                "127.0.0.1:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             c.send_to(b"echo-me", server_addr).await.unwrap();
             let mut buf = [0u8; 64];
             let (n, _) = c.recv_from(&mut buf).await.unwrap();
@@ -157,8 +167,11 @@ fn udp_multiple_datagrams() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut c = UdpSocket::bind(
+                "127.0.0.1:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             for i in 0..5u8 {
                 c.send_to(&[i; 4], recv_addr).await.unwrap();
                 nexus_async_rt::sleep(Duration::from_millis(20)).await;
@@ -271,7 +284,7 @@ fn udp_from_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let sock = UdpSocket::from_std(std_sock, nexus_async_rt::io()).unwrap();
+        let sock = UdpSocket::from_std(std_sock, nexus_async_rt::IoHandle::current()).unwrap();
 
         spawn_boxed(async move {
             let mut s = sock;
@@ -283,8 +296,11 @@ fn udp_from_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut s = UdpSocket::bind(
+                "127.0.0.1:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             s.send_to(b"from-std", addr).await.unwrap();
         });
 
@@ -335,8 +351,11 @@ fn udp_peek_from() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s =
-                UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut s = UdpSocket::bind(
+                "127.0.0.1:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             s.send_to(b"peek-data", recv_addr).await.unwrap();
         });
 
@@ -374,7 +393,7 @@ fn udp_multicast_loopback() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let recv_sock = UdpSocket::from_std(std_recv, nexus_async_rt::io()).unwrap();
+        let recv_sock = UdpSocket::from_std(std_recv, nexus_async_rt::IoHandle::current()).unwrap();
 
         spawn_boxed(async move {
             let mut s = recv_sock;
@@ -386,8 +405,11 @@ fn udp_multicast_loopback() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(50)).await;
-            let mut s =
-                UdpSocket::bind("0.0.0.0:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+            let mut s = UdpSocket::bind(
+                "0.0.0.0:0".parse().unwrap(),
+                nexus_async_rt::IoHandle::current(),
+            )
+            .unwrap();
             let target: std::net::SocketAddr = format!("239.255.0.1:{recv_port}").parse().unwrap();
             s.send_to(b"mcast", target).await.unwrap();
         });

--- a/nexus-async-rt/tests/net_udp.rs
+++ b/nexus-async-rt/tests/net_udp.rs
@@ -11,11 +11,7 @@ use nexus_rt::WorldBuilder;
 
 /// Bind a UDP socket to loopback:0, return (socket, addr).
 fn bind_udp() -> (UdpSocket, std::net::SocketAddr) {
-    let s = UdpSocket::bind(
-        "127.0.0.1:0".parse().unwrap(),
-        nexus_async_rt::IoHandle::current(),
-    )
-    .unwrap();
+    let s = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let a = s.local_addr().unwrap();
     (s, a)
 }
@@ -46,11 +42,7 @@ fn udp_send_recv_basic() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s = UdpSocket::bind(
-                "127.0.0.1:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut s = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             s.send_to(b"hello udp", recv_addr).await.unwrap();
         });
 
@@ -122,11 +114,7 @@ fn udp_echo() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = UdpSocket::bind(
-                "127.0.0.1:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut c = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             c.send_to(b"echo-me", server_addr).await.unwrap();
             let mut buf = [0u8; 64];
             let (n, _) = c.recv_from(&mut buf).await.unwrap();
@@ -167,11 +155,7 @@ fn udp_multiple_datagrams() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = UdpSocket::bind(
-                "127.0.0.1:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut c = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             for i in 0..5u8 {
                 c.send_to(&[i; 4], recv_addr).await.unwrap();
                 nexus_async_rt::sleep(Duration::from_millis(20)).await;
@@ -284,7 +268,7 @@ fn udp_from_std() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let sock = UdpSocket::from_std(std_sock, nexus_async_rt::IoHandle::current()).unwrap();
+        let sock = UdpSocket::from_std(std_sock).unwrap();
 
         spawn_boxed(async move {
             let mut s = sock;
@@ -296,11 +280,7 @@ fn udp_from_std() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s = UdpSocket::bind(
-                "127.0.0.1:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut s = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             s.send_to(b"from-std", addr).await.unwrap();
         });
 
@@ -351,11 +331,7 @@ fn udp_peek_from() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut s = UdpSocket::bind(
-                "127.0.0.1:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut s = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             s.send_to(b"peek-data", recv_addr).await.unwrap();
         });
 
@@ -393,7 +369,7 @@ fn udp_multicast_loopback() {
     let flag = done.clone();
 
     rt.block_on(async move {
-        let recv_sock = UdpSocket::from_std(std_recv, nexus_async_rt::IoHandle::current()).unwrap();
+        let recv_sock = UdpSocket::from_std(std_recv).unwrap();
 
         spawn_boxed(async move {
             let mut s = recv_sock;
@@ -405,11 +381,7 @@ fn udp_multicast_loopback() {
 
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(50)).await;
-            let mut s = UdpSocket::bind(
-                "0.0.0.0:0".parse().unwrap(),
-                nexus_async_rt::IoHandle::current(),
-            )
-            .unwrap();
+            let mut s = UdpSocket::bind("0.0.0.0:0".parse().unwrap()).unwrap();
             let target: std::net::SocketAddr = format!("239.255.0.1:{recv_port}").parse().unwrap();
             s.send_to(b"mcast", target).await.unwrap();
         });

--- a/nexus-async-rt/tests/vs_tokio.rs
+++ b/nexus-async-rt/tests/vs_tokio.rs
@@ -57,7 +57,11 @@ fn nexus_tcp_echo_samples() -> Vec<u64> {
     let mut world = wb.build();
     let mut rt = Runtime::new(&mut world);
 
-    let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+    let listener = TcpListener::bind(
+        "127.0.0.1:0".parse().unwrap(),
+        nexus_async_rt::IoHandle::current(),
+    )
+    .unwrap();
     let addr = listener.local_addr().unwrap();
 
     let samples_rc: Rc<Cell<Vec<u64>>> = Rc::new(Cell::new(Vec::new()));
@@ -80,7 +84,7 @@ fn nexus_tcp_echo_samples() -> Vec<u64> {
         });
 
         // Client
-        let io = nexus_async_rt::io();
+        let io = nexus_async_rt::IoHandle::current();
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
             let mut c = TcpStream::connect(addr, io).unwrap();
@@ -204,8 +208,16 @@ fn nexus_udp_samples() -> Vec<u64> {
     let mut world = wb.build();
     let mut rt = Runtime::new(&mut world);
 
-    let a = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
-    let b = UdpSocket::bind("127.0.0.1:0".parse().unwrap(), nexus_async_rt::io()).unwrap();
+    let a = UdpSocket::bind(
+        "127.0.0.1:0".parse().unwrap(),
+        nexus_async_rt::IoHandle::current(),
+    )
+    .unwrap();
+    let b = UdpSocket::bind(
+        "127.0.0.1:0".parse().unwrap(),
+        nexus_async_rt::IoHandle::current(),
+    )
+    .unwrap();
     let a_addr = a.local_addr().unwrap();
     let b_addr = b.local_addr().unwrap();
 

--- a/nexus-async-rt/tests/vs_tokio.rs
+++ b/nexus-async-rt/tests/vs_tokio.rs
@@ -57,17 +57,13 @@ fn nexus_tcp_echo_samples() -> Vec<u64> {
     let mut world = wb.build();
     let mut rt = Runtime::new(&mut world);
 
-    let listener = TcpListener::bind(
-        "127.0.0.1:0".parse().unwrap(),
-        nexus_async_rt::IoHandle::current(),
-    )
-    .unwrap();
-    let addr = listener.local_addr().unwrap();
-
     let samples_rc: Rc<Cell<Vec<u64>>> = Rc::new(Cell::new(Vec::new()));
     let writer = samples_rc.clone();
 
     rt.block_on(async move {
+        let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let addr = listener.local_addr().unwrap();
+
         // Server
         spawn_boxed(async move {
             let mut listener = listener;
@@ -84,10 +80,9 @@ fn nexus_tcp_echo_samples() -> Vec<u64> {
         });
 
         // Client
-        let io = nexus_async_rt::IoHandle::current();
         spawn_boxed(async move {
             nexus_async_rt::sleep(Duration::from_millis(10)).await;
-            let mut c = TcpStream::connect(addr, io).unwrap();
+            let mut c = TcpStream::connect(addr).unwrap();
             c.set_nodelay(true).unwrap();
 
             let msg = [0xABu8; MSG_SIZE];
@@ -208,23 +203,15 @@ fn nexus_udp_samples() -> Vec<u64> {
     let mut world = wb.build();
     let mut rt = Runtime::new(&mut world);
 
-    let a = UdpSocket::bind(
-        "127.0.0.1:0".parse().unwrap(),
-        nexus_async_rt::IoHandle::current(),
-    )
-    .unwrap();
-    let b = UdpSocket::bind(
-        "127.0.0.1:0".parse().unwrap(),
-        nexus_async_rt::IoHandle::current(),
-    )
-    .unwrap();
-    let a_addr = a.local_addr().unwrap();
-    let b_addr = b.local_addr().unwrap();
-
     let samples_rc: Rc<Cell<Vec<u64>>> = Rc::new(Cell::new(Vec::new()));
     let writer = samples_rc.clone();
 
     rt.block_on(async move {
+        let a = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let a_addr = a.local_addr().unwrap();
+        let b_addr = b.local_addr().unwrap();
+
         // Echo server on b
         spawn_boxed(async move {
             let mut b = b;


### PR DESCRIPTION
## Summary

Two related cleanups in `nexus-async-rt`, shipped together as the breaking 0.7.0 release. Both demote runtime-internal primitives from end-user APIs to library-author primitives.

### 1. Bare-noun context-fetcher free functions → `Type::current()` pattern

The four free functions that returned a handle or future (not a future factory) become inherent `current()` methods. Mirrors `tokio::runtime::Handle::current()` convention.

| Before | After |
|---|---|
| `nexus_async_rt::io()` | `IoHandle::current()` |
| `nexus_async_rt::with_world(\|w\| ...)` | `WorldCtx::current().with_world(\|w\| ...)` |
| `nexus_async_rt::with_world_ref(\|w\| ...)` | `WorldCtx::current().with_world_ref(\|w\| ...)` |
| `nexus_async_rt::shutdown_signal()` | `ShutdownSignal::current()` |

Future factories (`sleep`, `interval`, `timeout`, `yield_now`, etc.) and pure value getters (`event_time`) stay as free functions — idiomatic for the Rust async ecosystem.

### 2. Net constructors hide `IoHandle::current()` internally

Eight constructors on `TcpListener` / `TcpStream` / `TcpSocket` / `UdpSocket` drop their explicit `io: IoHandle` parameter and fetch it internally. Mirrors `tokio::net::TcpListener::bind` / `tokio::net::TcpStream::connect` ergonomics.

| Before | After |
|---|---|
| `TcpListener::bind(addr, io)` | `TcpListener::bind(addr)` |
| `TcpListener::from_std(listener, io)` | `TcpListener::from_std(listener)` |
| `TcpStream::connect(addr, io)` | `TcpStream::connect(addr)` |
| `TcpStream::from_std(stream, io)` | `TcpStream::from_std(stream)` |
| `UdpSocket::bind(addr, io)` | `UdpSocket::bind(addr)` |
| `UdpSocket::from_std(socket, io)` | `UdpSocket::from_std(socket)` |
| `TcpSocket::connect(self, addr, io)` | `TcpSocket::connect(self, addr)` |
| `TcpSocket::listen(self, backlog, io)` | `TcpSocket::listen(self, backlog)` |

End users now never type `IoHandle` for normal code. Library authors who genuinely need the explicit handle can call `IoHandle::current()` themselves.

## Cross-crate updates

`nexus-async-net` call sites updated in lockstep (REST + WebSocket nexus connection paths, `tls_handshake_piggyback` and `ws_nexus_integration` test suites). Dep declaration bumped `nexus-async-rt 0.6.0 → 0.7.0`.

## Versioning

- nexus-async-rt: **0.6.0 → 0.7.0** (minor with breaking, per workspace allowance). Yank 0.6.0 on publish.
- nexus-async-net: dep declaration bump only; no version change.

## Review iteration

Copilot raised 6 inline comments — 4 valid (test bind-outside-`block_on` × 2, defense-in-depth `waker_ptr` null check, missing direct test for `ShutdownSignal::current()`), 2 false positives where Copilot misread Rust's auto-trait inference (`IoHandle` and `WorldCtx` are already `!Send + !Sync` because they contain raw pointers, which Rust's stdlib explicitly negates `Send`/`Sync` for). Verified by compile-test.

John reviewed post-Copilot and surfaced 3 non-blocking nits, all fixed in the same branch:
- Stale `install()` doc claiming `RuntimeBuilder::build()` (actually called by `block_on` AND `shutdown_quiesce`)
- Missing `#[should_panic]` contract tests for the three new `current()` methods (added for `IoHandle`, `WorldCtx`, and `ShutdownSignal` for symmetry)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p nexus-async-rt` — 214 lib tests, all integration suites pass
- [x] `cargo test -p nexus-async-net` (default + `nexus,tls` features)
- [x] `cargo clippy -p nexus-async-rt -p nexus-async-net -- -D warnings`
- [x] `cargo fmt --check`
- [x] `MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p nexus-async-rt` — 67 tests across 5 suites, all green
- [x] `cargo test --doc` for both crates

Closes #245