### PR TITLE
feat(nexus-decimal): power-of-2 arithmetic + checked_abs_diff

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/nexus-decimal/CHANGELOG.md
+++ b/nexus-decimal/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Power-of-2 multiplication family: `mul_pow2`, `checked_mul_pow2`,
+  `saturating_mul_pow2`, `wrapping_mul_pow2`, `try_mul_pow2`. Multiplies
+  by `2^n` via a backing-width shift; the `10^D` scale factor cancels
+  because the multiplier is dimensionless. The bare form follows stdlib
+  `*` semantics (debug-panic, release-wrap via `wrapping_shl`).
+- `div_pow2(n)` — divide by `2^n` with truncate-toward-zero rounding,
+  matching `halve` / `div10` / `div100` / the rest of the division
+  surface. Invariant: `div_pow2(1) == halve()`. Constant `n` folds to
+  shift + sign-correction; variable `n` is a real signed division.
+- `checked_abs_diff(other) -> Option<Self>` — overflow-safe absolute
+  difference. Returns `None` when the result exceeds `MAX` (operands
+  with opposite signs near the rails — `|MIN - MAX|` exceeds `MAX` on
+  every signed type). Named `checked_*` to match the crate's convention
+  for `Option`-returning operations; there is no bare `abs_diff`.
+
 ## [1.1.0] — 2026-04-23
 
 ### Added

--- a/nexus-decimal/Cargo.toml
+++ b/nexus-decimal/Cargo.toml
@@ -23,6 +23,7 @@ num-traits = { version = "0.2", default-features = false, optional = true }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 fixdec = "0.1"
+proptest = "1.4"
 rust_decimal = "1.40.0"
 serde_json = "1"
 trybuild = "1"

--- a/nexus-decimal/benches/arithmetic.rs
+++ b/nexus-decimal/benches/arithmetic.rs
@@ -162,6 +162,143 @@ fn bench_round_to_tick(c: &mut Criterion) {
 }
 
 // ============================================================================
+// mul_pow2 — constant n (LLVM should fold to single shift)
+// ============================================================================
+
+fn bench_mul_pow2_const(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mul_pow2_const_n");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D32", |b| {
+        let a = D32::new(12, 3456);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).mul_pow2(3)));
+    });
+
+    group.bench_function("D64", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).mul_pow2(3)));
+    });
+
+    group.bench_function("D128", |b| {
+        let a = D128::new(123, 456_789_000_000_000_000);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).mul_pow2(3)));
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// mul_pow2 — variable n (black_box defeats const-folding)
+// ============================================================================
+
+fn bench_mul_pow2_var(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mul_pow2_var_n");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D64", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| {
+            let n = std::hint::black_box(3u32);
+            std::hint::black_box(std::hint::black_box(a).mul_pow2(n))
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// checked_mul_pow2 — constant n vs variable n
+// ============================================================================
+
+fn bench_checked_mul_pow2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("checked_mul_pow2");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D64_const_n", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).checked_mul_pow2(3)));
+    });
+
+    group.bench_function("D64_var_n", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| {
+            let n = std::hint::black_box(3u32);
+            std::hint::black_box(std::hint::black_box(a).checked_mul_pow2(n))
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// div_pow2 — constant n folds to shift + sign-correct; variable n is real div
+// ============================================================================
+
+fn bench_div_pow2_const(c: &mut Criterion) {
+    let mut group = c.benchmark_group("div_pow2_const_n");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D32", |b| {
+        let a = D32::new(12, 3456);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).div_pow2(3)));
+    });
+
+    group.bench_function("D64", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).div_pow2(3)));
+    });
+
+    group.bench_function("D128", |b| {
+        let a = D128::new(123, 456_789_000_000_000_000);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).div_pow2(3)));
+    });
+
+    group.finish();
+}
+
+fn bench_div_pow2_var(c: &mut Criterion) {
+    let mut group = c.benchmark_group("div_pow2_var_n");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D64", |b| {
+        let a = D64::new(123, 45_678_900);
+        b.iter(|| {
+            let n = std::hint::black_box(3u32);
+            std::hint::black_box(std::hint::black_box(a).div_pow2(n))
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// checked_abs_diff — overflow-safe |a - b|. Baseline = naive (a-b).abs().
+// ============================================================================
+
+fn bench_checked_abs_diff(c: &mut Criterion) {
+    let mut group = c.benchmark_group("checked_abs_diff");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("D64", |b| {
+        let a = D64::new(123, 45_678_900);
+        let b_val = D64::new(89, 12_345_600);
+        b.iter(|| std::hint::black_box(std::hint::black_box(a).checked_abs_diff(b_val)));
+    });
+
+    // Baseline: naive (a - b).abs() — overflows on opposite signs near rails.
+    group.bench_function("D64_baseline_naive", |b| {
+        let a = D64::new(123, 45_678_900);
+        let b_val = D64::new(89, 12_345_600);
+        b.iter(|| {
+            let diff = std::hint::black_box(a).checked_sub(b_val);
+            std::hint::black_box(diff.and_then(D64::checked_abs))
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -173,5 +310,11 @@ criterion_group!(
     bench_mul_int,
     bench_midpoint,
     bench_round_to_tick,
+    bench_mul_pow2_const,
+    bench_mul_pow2_var,
+    bench_checked_mul_pow2,
+    bench_div_pow2_const,
+    bench_div_pow2_var,
+    bench_checked_abs_diff,
 );
 criterion_main!(benches);

--- a/nexus-decimal/src/arithmetic.rs
+++ b/nexus-decimal/src/arithmetic.rs
@@ -195,6 +195,186 @@ macro_rules! impl_decimal_arithmetic {
                     None => Err(OverflowError),
                 }
             }
+
+            // ========================================================
+            // Power-of-2 multiplication
+            // ========================================================
+
+            /// Multiply by `2^n` (left shift on the backing value).
+            ///
+            /// The `10^D` scale factor cancels because the multiplier is
+            /// dimensionless — multiplying the represented value by `2^n` is
+            /// exactly a left shift on the backing.
+            ///
+            /// # Overflow behavior
+            ///
+            /// Matches `<backing>::mul` semantics: debug builds panic on
+            /// overflow, release builds wrap (`wrapping_shl`, which masks
+            /// `n` to `n mod <backing>::BITS`). Use
+            /// [`checked_mul_pow2`](Self::checked_mul_pow2),
+            /// [`saturating_mul_pow2`](Self::saturating_mul_pow2), or
+            /// [`wrapping_mul_pow2`](Self::wrapping_mul_pow2) for explicit
+            /// overflow policies.
+            ///
+            /// # Codegen
+            ///
+            /// Lowers to a single backing-width shift in release builds
+            /// (both constant and variable `n`). For `i32` / `i64`
+            /// backings this is one instruction; for `i128` it expands
+            /// to the wide-shift sequence the platform uses for 128-bit
+            /// shifts.
+            #[inline(always)]
+            pub const fn mul_pow2(self, n: u32) -> Self {
+                // `cfg!()` is const-evaluable; the unused branch is removed.
+                if cfg!(debug_assertions) {
+                    match self.checked_mul_pow2(n) {
+                        Some(v) => v,
+                        None => panic!("attempt to multiply with overflow"),
+                    }
+                } else {
+                    Self {
+                        value: self.value.wrapping_shl(n),
+                    }
+                }
+            }
+
+            /// Checked multiplication by `2^n`. Returns `None` on overflow.
+            ///
+            /// Uses leading-zero counting to detect overflow without
+            /// performing the shift first. For positive `v`, requires
+            /// `n < v.leading_zeros()`; for negative `v`, requires
+            /// `n < (!v).leading_zeros()`.
+            #[inline(always)]
+            pub const fn checked_mul_pow2(self, n: u32) -> Option<Self> {
+                if self.value == 0 {
+                    return Some(self);
+                }
+                let leading_sign_bits = if self.value >= 0 {
+                    self.value.leading_zeros()
+                } else {
+                    (!self.value).leading_zeros()
+                };
+                if n < leading_sign_bits {
+                    Some(Self {
+                        value: self.value.wrapping_shl(n),
+                    })
+                } else {
+                    None
+                }
+            }
+
+            /// Saturating multiplication by `2^n`. Clamps to
+            /// [`MAX`](Self::MAX) / [`MIN`](Self::MIN) on overflow.
+            #[inline(always)]
+            pub const fn saturating_mul_pow2(self, n: u32) -> Self {
+                match self.checked_mul_pow2(n) {
+                    Some(v) => v,
+                    None => {
+                        if self.value >= 0 {
+                            Self::MAX
+                        } else {
+                            Self::MIN
+                        }
+                    }
+                }
+            }
+
+            /// Wrapping multiplication by `2^n`.
+            ///
+            /// Silently wraps on overflow. Note that `wrapping_shl` masks
+            /// `n` to `n mod <backing>::BITS`, so e.g. shifting by `BITS`
+            /// is a no-op rather than zeroing the value.
+            #[inline(always)]
+            pub const fn wrapping_mul_pow2(self, n: u32) -> Self {
+                Self {
+                    value: self.value.wrapping_shl(n),
+                }
+            }
+
+            /// Multiplication by `2^n` returning `Result`.
+            #[inline(always)]
+            pub const fn try_mul_pow2(self, n: u32) -> Result<Self, OverflowError> {
+                match self.checked_mul_pow2(n) {
+                    Some(v) => Ok(v),
+                    None => Err(OverflowError),
+                }
+            }
+
+            // ========================================================
+            // Power-of-2 division
+            // ========================================================
+
+            /// Divide by `2^n` (truncate toward zero).
+            ///
+            /// Semantically identical to `/ 2^n`: truncates toward zero,
+            /// matching [`halve`](Self::halve), [`div10`](Self::div10),
+            /// [`div100`](Self::div100), and the rest of the division
+            /// surface. Invariant: `div_pow2(1) == halve()`.
+            ///
+            /// # Codegen
+            ///
+            /// Constant `n` folds to shift + sign-correction (~3 cycles).
+            /// Variable `n` compiles to a real signed division
+            /// (hardware-divider-dependent, typically ~10-25 cycles) —
+            /// use a constant when the shift amount is known.
+            ///
+            /// # Panics
+            ///
+            /// Debug builds panic if `n >= <backing>::BITS`. Release
+            /// builds return [`ZERO`](Self::ZERO), which is the
+            /// mathematically correct result under truncate-toward-zero:
+            /// any value divided by `2^n` larger than its magnitude is 0.
+            #[inline(always)]
+            pub const fn div_pow2(self, n: u32) -> Self {
+                debug_assert!(n < <$backing>::BITS, "shift amount out of range");
+
+                if n >= <$backing>::BITS {
+                    // Release-mode safety net.
+                    return Self { value: 0 };
+                }
+                if n == <$backing>::BITS - 1 {
+                    // 2^(BITS-1) doesn't fit as positive signed.
+                    // value / 2^(BITS-1) truncated toward zero:
+                    //   value == MIN → -1; otherwise → 0
+                    return Self {
+                        value: if self.value == <$backing>::MIN { -1 } else { 0 },
+                    };
+                }
+                // n < BITS - 1: (1 << n) fits as positive signed.
+                Self {
+                    value: self.value / (1 << n),
+                }
+            }
+
+            // ========================================================
+            // Absolute difference
+            // ========================================================
+
+            /// Overflow-safe absolute difference: `|self - other|`.
+            ///
+            /// Returns `None` when the result would exceed
+            /// [`MAX`](Self::MAX) — this happens when the operands have
+            /// opposite signs near the rails, since `|MIN - MAX|` exceeds
+            /// `MAX` on every signed type.
+            ///
+            /// Named `checked_abs_diff` to match the crate's `checked_*`
+            /// convention for `Option`-returning operations. There is no
+            /// bare `abs_diff` — every call site must acknowledge the
+            /// overflow case. Stdlib's `<backing>::abs_diff` returns an
+            /// unsigned type to avoid overflow; since `Decimal` has no
+            /// unsigned variant, this returns `Option<Self>` instead.
+            #[inline(always)]
+            pub const fn checked_abs_diff(self, other: Self) -> Option<Self> {
+                let diff = if self.value >= other.value {
+                    self.value.checked_sub(other.value)
+                } else {
+                    other.value.checked_sub(self.value)
+                };
+                match diff {
+                    Some(v) => Some(Self { value: v }),
+                    None => None,
+                }
+            }
         }
     };
 }

--- a/nexus-decimal/src/arithmetic.rs
+++ b/nexus-decimal/src/arithmetic.rs
@@ -216,13 +216,16 @@ macro_rules! impl_decimal_arithmetic {
             /// [`wrapping_mul_pow2`](Self::wrapping_mul_pow2) for explicit
             /// overflow policies.
             ///
+            /// In particular, `mul_pow2(v, BITS)` in release returns `v`
+            /// unchanged — the mask makes this a no-op, not a zeroing.
+            ///
             /// # Codegen
             ///
             /// Lowers to a single backing-width shift in release builds
             /// (both constant and variable `n`). For `i32` / `i64`
-            /// backings this is one instruction; for `i128` it expands
-            /// to the wide-shift sequence the platform uses for 128-bit
-            /// shifts.
+            /// backings this is one instruction (~1 cycle); for `i128`
+            /// it expands to a branchless wide-shift sequence (`shld` +
+            /// `shl` on x86-64, ~4-5 cycles).
             #[inline(always)]
             pub const fn mul_pow2(self, n: u32) -> Self {
                 // `cfg!()` is const-evaluable; the unused branch is removed.
@@ -313,10 +316,11 @@ macro_rules! impl_decimal_arithmetic {
             ///
             /// # Codegen
             ///
-            /// Constant `n` folds to shift + sign-correction (~3 cycles).
-            /// Variable `n` compiles to a real signed division
-            /// (hardware-divider-dependent, typically ~10-25 cycles) —
-            /// use a constant when the shift amount is known.
+            /// Constant `n` folds to a branchless shift + sign-correction
+            /// sequence (~2 cycles on modern x86-64). Variable `n`
+            /// compiles to a hardware signed division (~8-12 cycles on
+            /// Ice Lake+ / Zen 3+) — use a constant when the shift
+            /// amount is known.
             ///
             /// # Panics
             ///

--- a/nexus-decimal/tests/arithmetic.rs
+++ b/nexus-decimal/tests/arithmetic.rs
@@ -686,3 +686,325 @@ mod d96_rounding {
         }
     }
 }
+
+// ============================================================================
+// Power-of-2 multiplication (mul_pow2 family)
+// ============================================================================
+
+mod mul_pow2 {
+    use super::{D32, D64, D96, D128};
+    use nexus_decimal::{Decimal, OverflowError};
+
+    // ------- identity -------
+
+    #[test]
+    fn shift_by_zero_is_identity() {
+        assert_eq!(D32::ONE.mul_pow2(0), D32::ONE);
+        assert_eq!(D64::ONE.mul_pow2(0), D64::ONE);
+        assert_eq!(D96::ONE.mul_pow2(0), D96::ONE);
+        assert_eq!(D128::ONE.mul_pow2(0), D128::ONE);
+        assert_eq!(D64::ZERO.mul_pow2(0), D64::ZERO);
+        assert_eq!(D64::NEG_ONE.mul_pow2(0), D64::NEG_ONE);
+    }
+
+    #[test]
+    fn checked_zero_is_always_some_zero() {
+        // 0 << n is always 0 for any n, including n == BITS-1.
+        assert_eq!(D32::ZERO.checked_mul_pow2(31), Some(D32::ZERO));
+        assert_eq!(D64::ZERO.checked_mul_pow2(63), Some(D64::ZERO));
+        assert_eq!(D96::ZERO.checked_mul_pow2(127), Some(D96::ZERO));
+    }
+
+    // ------- basic shifts -------
+
+    #[test]
+    fn checked_small_shifts() {
+        // 1 << 3 == 8 on the backing
+        assert_eq!(D64::from_raw(1).checked_mul_pow2(3), Some(D64::from_raw(8)));
+        assert_eq!(
+            D64::from_raw(-1).checked_mul_pow2(3),
+            Some(D64::from_raw(-8))
+        );
+        // 5 << 4 == 80
+        assert_eq!(
+            D32::from_raw(5).checked_mul_pow2(4),
+            Some(D32::from_raw(80))
+        );
+    }
+
+    // ------- per-backing boundaries: MAX, MIN, NEG_ONE -------
+
+    #[test]
+    fn i32_boundaries() {
+        type T = Decimal<i32, 0>;
+        let bits = i32::BITS;
+
+        assert_eq!(T::MAX.checked_mul_pow2(1), None);
+        assert_eq!(T::MIN.checked_mul_pow2(1), None);
+
+        // -1 << (BITS-1) == MIN, exact, no overflow.
+        assert_eq!(T::from_raw(-1).checked_mul_pow2(bits - 1), Some(T::MIN));
+        // 1 << (BITS-1) would land on MIN (reinterpreted), overflow.
+        assert_eq!(T::from_raw(1).checked_mul_pow2(bits - 1), None);
+        // 1 << (BITS-2) fits as positive signed.
+        assert_eq!(
+            T::from_raw(1).checked_mul_pow2(bits - 2),
+            Some(T::from_raw(i32::MAX / 2 + 1))
+        );
+    }
+
+    #[test]
+    fn i64_boundaries() {
+        type T = Decimal<i64, 0>;
+        let bits = i64::BITS;
+
+        assert_eq!(T::MAX.checked_mul_pow2(1), None);
+        assert_eq!(T::MIN.checked_mul_pow2(1), None);
+        assert_eq!(T::from_raw(-1).checked_mul_pow2(bits - 1), Some(T::MIN));
+        assert_eq!(T::from_raw(1).checked_mul_pow2(bits - 1), None);
+        assert_eq!(
+            T::from_raw(1).checked_mul_pow2(bits - 2),
+            Some(T::from_raw(i64::MAX / 2 + 1))
+        );
+    }
+
+    #[test]
+    fn i128_boundaries() {
+        type T = Decimal<i128, 0>;
+        let bits = i128::BITS;
+
+        assert_eq!(T::MAX.checked_mul_pow2(1), None);
+        assert_eq!(T::MIN.checked_mul_pow2(1), None);
+        assert_eq!(T::from_raw(-1).checked_mul_pow2(bits - 1), Some(T::MIN));
+        assert_eq!(T::from_raw(1).checked_mul_pow2(bits - 1), None);
+        assert_eq!(
+            T::from_raw(1).checked_mul_pow2(bits - 2),
+            Some(T::from_raw(i128::MAX / 2 + 1))
+        );
+    }
+
+    // ------- saturating clamps to MAX / MIN -------
+
+    #[test]
+    fn saturating_clamps() {
+        assert_eq!(D64::MAX.saturating_mul_pow2(1), D64::MAX);
+        assert_eq!(D64::MIN.saturating_mul_pow2(1), D64::MIN);
+        assert_eq!(D32::MAX.saturating_mul_pow2(1), D32::MAX);
+        assert_eq!(D32::MIN.saturating_mul_pow2(1), D32::MIN);
+        assert_eq!(D128::MAX.saturating_mul_pow2(1), D128::MAX);
+        assert_eq!(D128::MIN.saturating_mul_pow2(1), D128::MIN);
+
+        // Positive non-overflow case unaffected.
+        assert_eq!(D64::from_raw(3).saturating_mul_pow2(2), D64::from_raw(12));
+    }
+
+    // ------- wrapping: shift-by-BITS is a no-op (n mod BITS == 0) -------
+
+    #[test]
+    fn wrapping_at_bits_boundary() {
+        // wrapping_shl masks n mod BITS — shifting by BITS is a no-op.
+        assert_eq!(D64::from_raw(7).wrapping_mul_pow2(64), D64::from_raw(7));
+        assert_eq!(D32::from_raw(5).wrapping_mul_pow2(32), D32::from_raw(5));
+    }
+
+    // ------- try_* mirrors checked_* -------
+
+    #[test]
+    fn try_form() {
+        assert_eq!(D64::from_raw(1).try_mul_pow2(3), Ok(D64::from_raw(8)));
+        assert_eq!(D64::MAX.try_mul_pow2(1), Err(OverflowError));
+    }
+}
+
+// ============================================================================
+// Power-of-2 division (div_pow2)
+// ============================================================================
+
+mod div_pow2 {
+    use super::{D32, D64, D96, D128};
+    use nexus_decimal::Decimal;
+
+    // ------- identity -------
+
+    #[test]
+    fn shift_by_zero_is_identity() {
+        assert_eq!(D32::ONE.div_pow2(0), D32::ONE);
+        assert_eq!(D64::ONE.div_pow2(0), D64::ONE);
+        assert_eq!(D96::ONE.div_pow2(0), D96::ONE);
+        assert_eq!(D128::ONE.div_pow2(0), D128::ONE);
+        assert_eq!(D64::NEG_ONE.div_pow2(0), D64::NEG_ONE);
+        assert_eq!(D64::ZERO.div_pow2(0), D64::ZERO);
+    }
+
+    // ------- invariant: div_pow2(1) == halve() -------
+
+    #[test]
+    fn matches_halve() {
+        let cases = [
+            D64::ZERO,
+            D64::ONE,
+            D64::NEG_ONE,
+            D64::from_raw(7),
+            D64::from_raw(-7),
+            D64::from_raw(123_456),
+            D64::from_raw(-123_456),
+            D64::MAX,
+            D64::MIN,
+        ];
+        for d in cases {
+            assert_eq!(
+                d.div_pow2(1),
+                d.halve(),
+                "div_pow2(1) != halve() for raw={}",
+                d.to_raw()
+            );
+        }
+    }
+
+    // ------- truncate toward zero -------
+
+    #[test]
+    fn truncates_toward_zero() {
+        // 7 / 2 = 3 (positive truncation)
+        assert_eq!(D64::from_raw(7).div_pow2(1), D64::from_raw(3));
+        // -7 / 2 = -3 (truncate toward zero, NOT floor: -7/2 == -3.5 → -3)
+        assert_eq!(D64::from_raw(-7).div_pow2(1), D64::from_raw(-3));
+        // 15 / 8 = 1; -15 / 8 = -1
+        assert_eq!(D64::from_raw(15).div_pow2(3), D64::from_raw(1));
+        assert_eq!(D64::from_raw(-15).div_pow2(3), D64::from_raw(-1));
+    }
+
+    // ------- per-backing boundaries at n == BITS-1 -------
+
+    #[test]
+    fn i32_bits_minus_one() {
+        type T = Decimal<i32, 0>;
+        let n = i32::BITS - 1;
+        // MIN / 2^(BITS-1): mathematically -1.0 exactly, truncates to -1.
+        assert_eq!(T::MIN.div_pow2(n), T::from_raw(-1));
+        // MAX / 2^(BITS-1): mathematically just under 1.0, truncates to 0.
+        assert_eq!(T::MAX.div_pow2(n), T::ZERO);
+        // Any non-MIN value truncates to 0.
+        assert_eq!(T::from_raw(-1).div_pow2(n), T::ZERO);
+        assert_eq!(T::from_raw(1).div_pow2(n), T::ZERO);
+        assert_eq!(T::ZERO.div_pow2(n), T::ZERO);
+    }
+
+    #[test]
+    fn i64_bits_minus_one() {
+        type T = Decimal<i64, 0>;
+        let n = i64::BITS - 1;
+        assert_eq!(T::MIN.div_pow2(n), T::from_raw(-1));
+        assert_eq!(T::MAX.div_pow2(n), T::ZERO);
+        assert_eq!(T::from_raw(-1).div_pow2(n), T::ZERO);
+    }
+
+    #[test]
+    fn i128_bits_minus_one() {
+        type T = Decimal<i128, 0>;
+        let n = i128::BITS - 1;
+        assert_eq!(T::MIN.div_pow2(n), T::from_raw(-1));
+        assert_eq!(T::MAX.div_pow2(n), T::ZERO);
+        assert_eq!(T::from_raw(-1).div_pow2(n), T::ZERO);
+    }
+
+    // ------- round-trip mul ↔ div -------
+
+    #[test]
+    fn mul_div_roundtrip_when_no_overflow() {
+        // For each n where checked_mul_pow2(v, n) succeeds, div_pow2(_, n)
+        // recovers v.
+        let cases = [
+            (D64::from_raw(1), 5),
+            (D64::from_raw(-1), 5),
+            (D64::from_raw(123_456_789), 10),
+            (D64::from_raw(-123_456_789), 10),
+            (D64::from_raw(3), 30),
+        ];
+        for (v, n) in cases {
+            let shifted = v.checked_mul_pow2(n).expect("setup: no overflow");
+            assert_eq!(
+                shifted.div_pow2(n),
+                v,
+                "round-trip failed for raw={}, n={}",
+                v.to_raw(),
+                n
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Absolute difference (checked_abs_diff)
+// ============================================================================
+
+mod checked_abs_diff {
+    use super::{D32, D64, D96, D128};
+
+    // ------- symmetry -------
+
+    #[test]
+    fn symmetric() {
+        let pairs = [
+            (D64::from_raw(100), D64::from_raw(30)),
+            (D64::from_raw(-50), D64::from_raw(20)),
+            (D64::from_raw(-100), D64::from_raw(-30)),
+            (D64::ZERO, D64::from_raw(7)),
+            (D64::MAX, D64::from_raw(1)),
+            (D64::MIN, D64::from_raw(-1)),
+        ];
+        for (a, b) in pairs {
+            assert_eq!(
+                a.checked_abs_diff(b),
+                b.checked_abs_diff(a),
+                "asymmetric for ({}, {})",
+                a.to_raw(),
+                b.to_raw()
+            );
+        }
+    }
+
+    // ------- basic correctness -------
+
+    #[test]
+    fn basic_values() {
+        assert_eq!(
+            D64::from_raw(100).checked_abs_diff(D64::from_raw(30)),
+            Some(D64::from_raw(70))
+        );
+        assert_eq!(
+            D64::from_raw(30).checked_abs_diff(D64::from_raw(100)),
+            Some(D64::from_raw(70))
+        );
+        // Opposite signs, no overflow.
+        assert_eq!(
+            D64::from_raw(50).checked_abs_diff(D64::from_raw(-50)),
+            Some(D64::from_raw(100))
+        );
+    }
+
+    // ------- self-diff is zero -------
+
+    #[test]
+    fn self_diff_is_zero() {
+        assert_eq!(D32::MAX.checked_abs_diff(D32::MAX), Some(D32::ZERO));
+        assert_eq!(D64::MAX.checked_abs_diff(D64::MAX), Some(D64::ZERO));
+        assert_eq!(D96::MAX.checked_abs_diff(D96::MAX), Some(D96::ZERO));
+        assert_eq!(D128::MAX.checked_abs_diff(D128::MAX), Some(D128::ZERO));
+        assert_eq!(D64::MIN.checked_abs_diff(D64::MIN), Some(D64::ZERO));
+        assert_eq!(D64::ZERO.checked_abs_diff(D64::ZERO), Some(D64::ZERO));
+    }
+
+    // ------- overflow at the rails -------
+
+    #[test]
+    fn max_minus_min_overflows() {
+        // |MAX - MIN| > MAX on every signed type → None.
+        assert_eq!(D32::MAX.checked_abs_diff(D32::MIN), None);
+        assert_eq!(D64::MAX.checked_abs_diff(D64::MIN), None);
+        assert_eq!(D96::MAX.checked_abs_diff(D96::MIN), None);
+        assert_eq!(D128::MAX.checked_abs_diff(D128::MIN), None);
+        // Symmetric form.
+        assert_eq!(D64::MIN.checked_abs_diff(D64::MAX), None);
+    }
+}

--- a/nexus-decimal/tests/mul_div.rs
+++ b/nexus-decimal/tests/mul_div.rs
@@ -404,7 +404,7 @@ fn mul_correctness_sweep_d64() {
             // Allow 1 ULP of the decimal + f64 rounding
             let tolerance = 2.0 / D64::SCALE as f64;
             assert!(
-                diff < tolerance + expected_f.abs() * 1e-10,
+                diff < expected_f.abs().mul_add(1e-10, tolerance),
                 "mul mismatch: {a:?} * {b:?} = {result:?}, expected ≈ {expected_f}"
             );
         }

--- a/nexus-decimal/tests/pow2_props.rs
+++ b/nexus-decimal/tests/pow2_props.rs
@@ -1,0 +1,84 @@
+//! Property-based tests for the power-of-2 arithmetic and `checked_abs_diff`.
+//!
+//! Three properties:
+//! - Round-trip: when `checked_mul_pow2(v, n)` succeeds, `div_pow2(_, n) == v`.
+//! - Symmetry:   `checked_abs_diff(a, b) == checked_abs_diff(b, a)`.
+//! - Halve:      `div_pow2(v, 1) == halve(v)` for all `v`.
+
+use nexus_decimal::Decimal;
+use proptest::prelude::*;
+
+type D32 = Decimal<i32, 0>;
+type D64 = Decimal<i64, 0>;
+type D128 = Decimal<i128, 0>;
+
+proptest! {
+    // ------- round-trip on every backing -------
+
+    #[test]
+    fn mul_div_roundtrip_i32(raw: i32, n in 0u32..i32::BITS) {
+        let v = D32::from_raw(raw);
+        if let Some(shifted) = v.checked_mul_pow2(n) {
+            prop_assert_eq!(shifted.div_pow2(n), v);
+        }
+    }
+
+    #[test]
+    fn mul_div_roundtrip_i64(raw: i64, n in 0u32..i64::BITS) {
+        let v = D64::from_raw(raw);
+        if let Some(shifted) = v.checked_mul_pow2(n) {
+            prop_assert_eq!(shifted.div_pow2(n), v);
+        }
+    }
+
+    #[test]
+    fn mul_div_roundtrip_i128(raw: i128, n in 0u32..i128::BITS) {
+        let v = D128::from_raw(raw);
+        if let Some(shifted) = v.checked_mul_pow2(n) {
+            prop_assert_eq!(shifted.div_pow2(n), v);
+        }
+    }
+
+    // ------- checked_abs_diff is symmetric -------
+
+    #[test]
+    fn abs_diff_symmetric_i32(a: i32, b: i32) {
+        let a = D32::from_raw(a);
+        let b = D32::from_raw(b);
+        prop_assert_eq!(a.checked_abs_diff(b), b.checked_abs_diff(a));
+    }
+
+    #[test]
+    fn abs_diff_symmetric_i64(a: i64, b: i64) {
+        let a = D64::from_raw(a);
+        let b = D64::from_raw(b);
+        prop_assert_eq!(a.checked_abs_diff(b), b.checked_abs_diff(a));
+    }
+
+    #[test]
+    fn abs_diff_symmetric_i128(a: i128, b: i128) {
+        let a = D128::from_raw(a);
+        let b = D128::from_raw(b);
+        prop_assert_eq!(a.checked_abs_diff(b), b.checked_abs_diff(a));
+    }
+
+    // ------- div_pow2(v, 1) == halve(v) on every backing -------
+
+    #[test]
+    fn div_pow2_one_equals_halve_i32(raw: i32) {
+        let v = D32::from_raw(raw);
+        prop_assert_eq!(v.div_pow2(1), v.halve());
+    }
+
+    #[test]
+    fn div_pow2_one_equals_halve_i64(raw: i64) {
+        let v = D64::from_raw(raw);
+        prop_assert_eq!(v.div_pow2(1), v.halve());
+    }
+
+    #[test]
+    fn div_pow2_one_equals_halve_i128(raw: i128) {
+        let v = D128::from_raw(raw);
+        prop_assert_eq!(v.div_pow2(1), v.halve());
+    }
+}


### PR DESCRIPTION
## Summary

- Add 7 new arithmetic methods to `Decimal<Backing, D>` for all signed backings (i32/i64/i128): `mul_pow2`, `checked_mul_pow2`, `saturating_mul_pow2`, `wrapping_mul_pow2`, `try_mul_pow2`, `div_pow2`, `checked_abs_diff`
- `mul_pow2` lowers to a single shift (i32/i64) or branchless wide-shift (i128); `div_pow2` uses truncate-toward-zero semantics matching `halve()`/`div10()`/`div100()`
- Pin CI to rustc 1.94.0 to prevent trybuild snapshot drift

## Details

Power-of-2 multiplication is a pure left shift on the backing — the `10^D` scale factor cancels because the multiplier is dimensionless. Division uses `value / (1 << n)` for correct truncate-toward-zero rounding (not floor/shift).

`checked_abs_diff` returns `Option<Self>` because `|MIN - MAX|` exceeds `MAX` on every signed type and there is no unsigned `Decimal` variant.

Codegen verified via `cargo-asm`: all methods emit optimal instruction sequences. Criterion measurements confirm cost-model claims (sub-5ns ops hit the framework measurement floor).

## Test plan

- [x] 19 unit tests across `tests/arithmetic.rs` (mul_pow2, div_pow2, checked_abs_diff)
- [x] 9 proptest properties in `tests/pow2_props.rs` (round-trip, symmetry, halve invariant)
- [x] Criterion benchmarks for all new ops
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test -p nexus-decimal` passes

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)