### PR TITLE
adding additional nexus-decimal constants

### DIFF
--- a/nexus-decimal/CHANGELOG.md
+++ b/nexus-decimal/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `EPSILON` constant — smallest positive representable value (`1 / 10^D`)
+- `HALF` constant — the value 0.5 (requires `D >= 1`, compile-time enforced)
+- `TWO` constant — the value 2.0 (compile-time overflow check)
 - Power-of-2 multiplication family: `mul_pow2`, `checked_mul_pow2`,
   `saturating_mul_pow2`, `wrapping_mul_pow2`, `try_mul_pow2`. Multiplies
   by `2^n` via a backing-width shift; the `10^D` scale factor cancels

--- a/nexus-decimal/src/constants.rs
+++ b/nexus-decimal/src/constants.rs
@@ -29,6 +29,45 @@ macro_rules! impl_decimal_constants {
             pub const MIN: Self = Self {
                 value: <$backing>::MIN,
             };
+
+            /// Smallest positive representable value (`from_raw(1)`).
+            ///
+            /// Represents `1 / 10^D` — the resolution of this decimal type.
+            pub const EPSILON: Self = Self { value: 1 };
+
+            /// One half (`0.5`).
+            ///
+            /// # Compile-time constraint
+            ///
+            /// Requires `D >= 1`. Instantiating `HALF` on a `Decimal` with
+            /// `D = 0` is a compile error — the value 0.5 is not
+            /// representable with zero fractional digits.
+            pub const HALF: Self = {
+                assert!(
+                    D >= 1,
+                    "HALF requires D >= 1: 0.5 is not representable with zero fractional digits"
+                );
+                Self {
+                    value: Self::SCALE / 2,
+                }
+            };
+
+            /// Two (`2.0`).
+            ///
+            /// # Compile-time constraint
+            ///
+            /// Requires the backing type to be wide enough that `2 * SCALE`
+            /// does not overflow. This holds for all valid `D` on `i32` and
+            /// `i64`; on `i128` it fails at `D = 38`.
+            pub const TWO: Self = {
+                assert!(
+                    Self::SCALE <= <$backing>::MAX / 2,
+                    "TWO requires 2*SCALE to fit in the backing type"
+                );
+                Self {
+                    value: Self::SCALE * 2,
+                }
+            };
         }
     };
 }

--- a/nexus-decimal/src/constants.rs
+++ b/nexus-decimal/src/constants.rs
@@ -39,7 +39,7 @@ macro_rules! impl_decimal_constants {
             ///
             /// # Compile-time constraint
             ///
-            /// Requires `D >= 1`. Instantiating `HALF` on a `Decimal` with
+            /// Requires `D >= 1`. Referencing `HALF` on a `Decimal` with
             /// `D = 0` is a compile error — the value 0.5 is not
             /// representable with zero fractional digits.
             pub const HALF: Self = {

--- a/nexus-decimal/tests/arithmetic.rs
+++ b/nexus-decimal/tests/arithmetic.rs
@@ -62,6 +62,69 @@ fn custom_precision() {
     assert_eq!(Usd::new(19, 99).to_raw(), 1999);
 }
 
+#[test]
+fn epsilon_value() {
+    assert_eq!(D64::EPSILON.to_raw(), 1);
+    assert_eq!(D64::EPSILON, D64::from_raw(1));
+    assert_eq!(D32::EPSILON.to_raw(), 1);
+    assert_eq!(D128::EPSILON.to_raw(), 1);
+}
+
+#[test]
+fn half_value() {
+    assert_eq!(D64::HALF.to_raw(), 50_000_000); // 10^8 / 2
+    assert_eq!(D32::HALF.to_raw(), 5_000); // 10^4 / 2
+    assert_eq!(D96::HALF.to_raw(), 500_000_000_000); // 10^12 / 2
+    assert_eq!(D128::HALF.to_raw(), 500_000_000_000_000_000); // 10^18 / 2
+    // HALF + HALF == ONE
+    assert_eq!(D64::HALF.checked_add(D64::HALF), Some(D64::ONE));
+}
+
+#[test]
+fn two_value() {
+    assert_eq!(D64::TWO.to_raw(), 200_000_000); // 2 * 10^8
+    assert_eq!(D32::TWO.to_raw(), 20_000); // 2 * 10^4
+    assert_eq!(D128::TWO.to_raw(), 2_000_000_000_000_000_000); // 2 * 10^18
+    // ONE + ONE == TWO
+    assert_eq!(D64::ONE.checked_add(D64::ONE), Some(D64::TWO));
+}
+
+#[test]
+fn constants_cross_backing() {
+    type X32 = Decimal<i32, 4>;
+    type X64 = Decimal<i64, 4>;
+    type X128 = Decimal<i128, 4>;
+
+    assert_eq!(X32::EPSILON.to_raw() as i64, X64::EPSILON.to_raw());
+    assert_eq!(X64::EPSILON.to_raw() as i128, X128::EPSILON.to_raw());
+
+    assert_eq!(X32::HALF.to_raw() as i64, X64::HALF.to_raw());
+    assert_eq!(X64::HALF.to_raw() as i128, X128::HALF.to_raw());
+
+    assert_eq!(X32::TWO.to_raw() as i64, X64::TWO.to_raw());
+    assert_eq!(X64::TWO.to_raw() as i128, X128::TWO.to_raw());
+}
+
+#[test]
+fn half_d0_is_not_representable() {
+    // Decimal<i64, 0>::HALF would fail to compile — 0.5 is not
+    // representable with zero fractional digits.
+    // Verified by: const assert in HALF definition.
+    type D0 = Decimal<i64, 0>;
+    assert_eq!(D0::SCALE, 1); // confirms D=0 means integer-only
+}
+
+#[test]
+fn half_relationships() {
+    // halve(ONE) == HALF
+    assert_eq!(D64::ONE.halve(), D64::HALF);
+    // TWO * HALF (via mul) == ONE
+    assert_eq!(D64::TWO.checked_mul(D64::HALF), Some(D64::ONE));
+    // EPSILON is smallest positive
+    assert!(D64::EPSILON.to_raw() > 0);
+    assert_eq!(D64::EPSILON.to_raw(), 1);
+}
+
 // ============================================================================
 // Constructors
 // ============================================================================

--- a/nexus-decimal/tests/arithmetic.rs
+++ b/nexus-decimal/tests/arithmetic.rs
@@ -106,12 +106,9 @@ fn constants_cross_backing() {
 }
 
 #[test]
-fn half_d0_is_not_representable() {
-    // Decimal<i64, 0>::HALF would fail to compile — 0.5 is not
-    // representable with zero fractional digits.
-    // Verified by: const assert in HALF definition.
+fn d0_scale_is_integer_only() {
     type D0 = Decimal<i64, 0>;
-    assert_eq!(D0::SCALE, 1); // confirms D=0 means integer-only
+    assert_eq!(D0::SCALE, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add 3 scale-aware constants to `Decimal<Backing, D>` for all signed backings (i32/i64/i128): `EPSILON`, `HALF`, `TWO`
- Compile-time enforcement: `HALF` requires `D >= 1`, `TWO` requires `2 * SCALE` fits in backing
- Uses const `assert!()` in initializers — same pattern as existing `SCALE` validation

## Details

- `EPSILON` = `from_raw(1)` — smallest positive representable value (resolution of the type)
- `HALF` = `SCALE / 2` — the value 0.5. Compile error if `D = 0` (0.5 not representable)
- `TWO` = `2 * SCALE` — the value 2.0. Compile error on i128 at D=38 (overflow)

## Test plan

- [x] 6 unit tests: value correctness, cross-backing consistency, relationship invariants (halve(ONE) == HALF, TWO * HALF == ONE)
- [x] `cargo clippy -p nexus-decimal -- -D warnings` clean
- [x] `cargo test -p nexus-decimal` passes

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)