### PR TITLE
adding loom testing for nexus-queue hardening

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ seq-macro = "0.3"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/nexus-queue/Cargo.toml
+++ b/nexus-queue/Cargo.toml
@@ -13,9 +13,13 @@ categories = ["concurrency", "data-structures", "no-std"]
 [dependencies]
 crossbeam-utils.workspace = true
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 crossbeam-queue = "0.3"
 hdrhistogram = "7.5"
+loom = "0.7"
 rtrb = "0.3"
 
 [lints]

--- a/nexus-queue/src/lib.rs
+++ b/nexus-queue/src/lib.rs
@@ -76,6 +76,8 @@
 
 use core::fmt;
 
+mod loom_impl;
+
 pub mod mpsc;
 pub mod spmc;
 pub mod spsc;

--- a/nexus-queue/src/loom_impl.rs
+++ b/nexus-queue/src/loom_impl.rs
@@ -1,0 +1,27 @@
+#[cfg(loom)]
+pub(crate) use loom::sync::Arc;
+#[cfg(not(loom))]
+pub(crate) use std::sync::Arc;
+
+#[cfg(loom)]
+pub(crate) use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+#[cfg(not(loom))]
+pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+
+#[cfg(loom)]
+pub(crate) use loom::cell::UnsafeCell;
+
+#[cfg(not(loom))]
+pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
+
+#[cfg(not(loom))]
+impl<T> UnsafeCell<T> {
+    pub(crate) fn new(data: T) -> Self {
+        Self(std::cell::UnsafeCell::new(data))
+    }
+
+    #[inline(always)]
+    pub(crate) fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {
+        f(self.0.get())
+    }
+}

--- a/nexus-queue/src/mpsc.rs
+++ b/nexus-queue/src/mpsc.rs
@@ -63,11 +63,11 @@
 //! h2.join().unwrap();
 //! ```
 
-use std::cell::{Cell, UnsafeCell};
+use std::cell::Cell;
 use std::fmt;
 use std::mem::MaybeUninit;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::loom_impl::{Arc, AtomicUsize, Ordering, UnsafeCell};
 
 use crossbeam_utils::CachePadded;
 
@@ -181,7 +181,8 @@ impl<T> Drop for Shared<T> {
             // Only drop if the slot was actually written (turn is odd = consumer-ready)
             if slot.turn.load(Ordering::Relaxed) == turn * 2 + 1 {
                 // SAFETY: Slot contains initialized data at this turn.
-                unsafe { (*slot.data.get()).assume_init_drop() };
+                slot.data
+                    .with_mut(|ptr| unsafe { (*ptr).assume_init_drop() });
             }
             i = i.wrapping_add(1);
         }
@@ -284,7 +285,7 @@ impl<T> Producer<T> {
                     .is_ok()
                 {
                     // SAFETY: We own this slot via successful CAS.
-                    unsafe { (*slot.data.get()).write(value) };
+                    slot.data.with_mut(|ptr| unsafe { (*ptr).write(value) });
 
                     // Signal ready for consumer: turn * 2 + 1
                     slot.turn.store(turn * 2 + 1, Ordering::Release);
@@ -372,7 +373,9 @@ impl<T> Consumer<T> {
         }
 
         // SAFETY: Turn counter confirms producer has written to this slot.
-        let value = unsafe { (*slot.data.get()).assume_init_read() };
+        let value = slot
+            .data
+            .with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
 
         // Signal slot is free for next lap: (turn + 1) * 2
         slot.turn.store((turn + 1) * 2, Ordering::Release);

--- a/nexus-queue/src/spmc.rs
+++ b/nexus-queue/src/spmc.rs
@@ -88,11 +88,11 @@
 //! assert_eq!(all, (0..200).collect::<Vec<_>>());
 //! ```
 
-use std::cell::{Cell, UnsafeCell};
+use std::cell::Cell;
 use std::fmt;
 use std::mem::MaybeUninit;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use crate::loom_impl::{Arc, AtomicBool, AtomicUsize, Ordering, UnsafeCell};
 
 use crossbeam_utils::CachePadded;
 
@@ -207,7 +207,8 @@ impl<T> Drop for Shared<T> {
             // Only drop if the slot was actually written (turn is odd = consumer-ready)
             if slot.turn.load(Ordering::Relaxed) == turn * 2 + 1 {
                 // SAFETY: Slot contains initialized data at this turn.
-                unsafe { (*slot.data.get()).assume_init_drop() };
+                slot.data
+                    .with_mut(|ptr| unsafe { (*ptr).assume_init_drop() });
             }
             i = i.wrapping_add(1);
         }
@@ -265,7 +266,7 @@ impl<T> Producer<T> {
         }
 
         // SAFETY: Turn counter confirms slot is free for this lap.
-        unsafe { (*slot.data.get()).write(value) };
+        slot.data.with_mut(|ptr| unsafe { (*ptr).write(value) });
 
         // Signal ready for consumer: turn * 2 + 1
         slot.turn.store(turn * 2 + 1, Ordering::Release);
@@ -371,7 +372,9 @@ impl<T> Consumer<T> {
                     .is_ok()
                 {
                     // SAFETY: We own this slot via successful CAS.
-                    let value = unsafe { (*slot.data.get()).assume_init_read() };
+                    let value = slot
+                        .data
+                        .with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
 
                     // Signal slot is free for next lap: (turn + 1) * 2
                     slot.turn.store((turn + 1) * 2, Ordering::Release);

--- a/nexus-queue/src/spsc.rs
+++ b/nexus-queue/src/spsc.rs
@@ -44,13 +44,17 @@
 
 use std::cell::Cell;
 use std::fmt;
+#[cfg(not(loom))]
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(loom)]
+use std::mem::MaybeUninit;
 
 use crossbeam_utils::CachePadded;
 
 use crate::Full;
+#[cfg(loom)]
+use crate::loom_impl::UnsafeCell;
+use crate::loom_impl::{Arc, AtomicUsize, Ordering, fence};
 
 /// Creates a bounded SPSC ring buffer with the given capacity.
 ///
@@ -59,6 +63,7 @@ use crate::Full;
 /// # Panics
 ///
 /// Panics if `capacity` is zero.
+#[cfg(not(loom))]
 pub fn ring_buffer<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
     assert!(capacity > 0, "capacity must be non-zero");
 
@@ -95,8 +100,44 @@ pub fn ring_buffer<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
     )
 }
 
-// repr(C): Guarantees field order. CachePadded<tail> and CachePadded<head>
-// must be at known offsets for cache line isolation to work correctly.
+#[cfg(loom)]
+/// Creates a bounded SPSC ring buffer with the given capacity (loom variant).
+pub fn ring_buffer<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
+    assert!(capacity > 0, "capacity must be non-zero");
+
+    let capacity = capacity
+        .checked_next_power_of_two()
+        .expect("capacity too large (must be <= usize::MAX / 2)");
+    let mask = capacity - 1;
+
+    let buffer: Vec<UnsafeCell<MaybeUninit<T>>> = (0..capacity)
+        .map(|_| UnsafeCell::new(MaybeUninit::uninit()))
+        .collect();
+
+    let shared = Arc::new(Shared {
+        tail: CachePadded::new(AtomicUsize::new(0)),
+        head: CachePadded::new(AtomicUsize::new(0)),
+        buffer: buffer.into_boxed_slice(),
+        mask,
+    });
+
+    (
+        Producer {
+            local_tail: Cell::new(0),
+            cached_head: Cell::new(0),
+            mask,
+            shared: Arc::clone(&shared),
+        },
+        Consumer {
+            local_head: Cell::new(0),
+            cached_tail: Cell::new(0),
+            mask,
+            shared,
+        },
+    )
+}
+
+#[cfg(not(loom))]
 #[repr(C)]
 struct Shared<T> {
     tail: CachePadded<AtomicUsize>,
@@ -105,12 +146,21 @@ struct Shared<T> {
     mask: usize,
 }
 
-// SAFETY: Shared only contains atomics and a raw pointer. The buffer is only
-// accessed through Producer (write) and Consumer (read), which are !Sync.
-// T: Send ensures the data can be transferred between threads.
+#[cfg(loom)]
+struct Shared<T> {
+    tail: CachePadded<AtomicUsize>,
+    head: CachePadded<AtomicUsize>,
+    buffer: Box<[UnsafeCell<MaybeUninit<T>>]>,
+    mask: usize,
+}
+
+// SAFETY: Shared only contains atomics and a raw pointer (or boxed slice under loom).
+// The buffer is only accessed through Producer (write) and Consumer (read), which
+// are !Sync. T: Send ensures the data can be transferred between threads.
 unsafe impl<T: Send> Send for Shared<T> {}
 unsafe impl<T: Send> Sync for Shared<T> {}
 
+#[cfg(not(loom))]
 impl<T> Drop for Shared<T> {
     fn drop(&mut self) {
         let head = self.head.load(Ordering::Relaxed);
@@ -133,16 +183,40 @@ impl<T> Drop for Shared<T> {
     }
 }
 
+#[cfg(loom)]
+impl<T> Drop for Shared<T> {
+    fn drop(&mut self) {
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Relaxed);
+
+        let mut i = head;
+        while i != tail {
+            self.buffer[i & self.mask].with_mut(|ptr| unsafe { (*ptr).assume_init_drop() });
+            i = i.wrapping_add(1);
+        }
+    }
+}
+
 /// The producer endpoint of an SPSC queue.
 ///
 /// This endpoint can only push values into the queue.
-// repr(C): Hot fields (local_tail, cached_head) at struct base share cache line
-// with struct pointer. Cold field (shared Arc) pushed to end.
+#[cfg(not(loom))]
 #[repr(C)]
 pub struct Producer<T> {
     local_tail: Cell<usize>,
     cached_head: Cell<usize>,
     buffer: *mut T,
+    mask: usize,
+    shared: Arc<Shared<T>>,
+}
+
+/// The producer endpoint of an SPSC queue.
+///
+/// This endpoint can only push values into the queue.
+#[cfg(loom)]
+pub struct Producer<T> {
+    local_tail: Cell<usize>,
+    cached_head: Cell<usize>,
     mask: usize,
     shared: Arc<Shared<T>>,
 }
@@ -166,7 +240,7 @@ impl<T> Producer<T> {
             self.cached_head
                 .set(self.shared.head.load(Ordering::Relaxed));
 
-            std::sync::atomic::fence(Ordering::Acquire);
+            fence(Ordering::Acquire);
             if tail.wrapping_sub(self.cached_head.get()) > self.mask {
                 return Err(Full(value));
             }
@@ -174,9 +248,15 @@ impl<T> Producer<T> {
 
         // SAFETY: We verified tail - cached_head <= mask, so the slot is not occupied
         // by unconsumed data. tail & mask gives a valid index within the buffer.
-        unsafe { self.buffer.add(tail & self.mask).write(value) };
+        #[cfg(not(loom))]
+        unsafe {
+            self.buffer.add(tail & self.mask).write(value);
+        }
+        #[cfg(loom)]
+        self.shared.buffer[tail & self.mask].with_mut(|ptr| unsafe { (*ptr).write(value) });
+
         let new_tail = tail.wrapping_add(1);
-        std::sync::atomic::fence(Ordering::Release);
+        fence(Ordering::Release);
 
         self.shared.tail.store(new_tail, Ordering::Relaxed);
         self.local_tail.set(new_tail);
@@ -208,13 +288,23 @@ impl<T> fmt::Debug for Producer<T> {
 /// The consumer endpoint of an SPSC queue.
 ///
 /// This endpoint can only pop values from the queue.
-// repr(C): Hot fields (local_head, cached_tail) at struct base share cache line
-// with struct pointer. Cold field (shared Arc) pushed to end.
+#[cfg(not(loom))]
 #[repr(C)]
 pub struct Consumer<T> {
     local_head: Cell<usize>,
     cached_tail: Cell<usize>,
     buffer: *mut T,
+    mask: usize,
+    shared: Arc<Shared<T>>,
+}
+
+/// The consumer endpoint of an SPSC queue.
+///
+/// This endpoint can only pop values from the queue.
+#[cfg(loom)]
+pub struct Consumer<T> {
+    local_head: Cell<usize>,
+    cached_tail: Cell<usize>,
     mask: usize,
     shared: Arc<Shared<T>>,
 }
@@ -235,7 +325,7 @@ impl<T> Consumer<T> {
         if head == self.cached_tail.get() {
             self.cached_tail
                 .set(self.shared.tail.load(Ordering::Relaxed));
-            std::sync::atomic::fence(Ordering::Acquire);
+            fence(Ordering::Acquire);
 
             if head == self.cached_tail.get() {
                 return None;
@@ -244,9 +334,14 @@ impl<T> Consumer<T> {
 
         // SAFETY: We verified head != cached_tail, so the slot contains valid data
         // written by the producer. head & mask gives a valid index within the buffer.
+        #[cfg(not(loom))]
         let value = unsafe { self.buffer.add(head & self.mask).read() };
+        #[cfg(loom)]
+        let value = self.shared.buffer[head & self.mask]
+            .with_mut(|ptr| unsafe { (*ptr).assume_init_read() });
+
         let new_head = head.wrapping_add(1);
-        std::sync::atomic::fence(Ordering::Release);
+        fence(Ordering::Release);
 
         self.shared.head.store(new_head, Ordering::Relaxed);
         self.local_head.set(new_head);

--- a/nexus-queue/tests/loom_mpsc.rs
+++ b/nexus-queue/tests/loom_mpsc.rs
@@ -1,0 +1,160 @@
+#![cfg(loom)]
+
+use loom::sync::Arc;
+use loom::sync::atomic::{AtomicUsize, Ordering};
+use loom::thread;
+use nexus_queue::mpsc;
+
+#[test]
+fn no_lost_items_two_producers() {
+    loom::model(|| {
+        let (tx, rx) = mpsc::ring_buffer::<u32>(2);
+        let tx2 = tx.clone();
+
+        let t1 = thread::spawn(move || {
+            while tx.push(1).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        let t2 = thread::spawn(move || {
+            while tx2.push(2).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let mut received = Vec::new();
+        while let Some(v) = rx.pop() {
+            received.push(v);
+        }
+
+        received.sort_unstable();
+        assert_eq!(received, vec![1, 2]);
+    });
+}
+
+#[test]
+fn no_duplicates() {
+    loom::model(|| {
+        let (tx, rx) = mpsc::ring_buffer::<u32>(4);
+        let tx2 = tx.clone();
+
+        let t1 = thread::spawn(move || {
+            while tx.push(10).is_err() {
+                thread::yield_now();
+            }
+            while tx.push(11).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        let t2 = thread::spawn(move || {
+            while tx2.push(20).is_err() {
+                thread::yield_now();
+            }
+            while tx2.push(21).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let mut received = Vec::new();
+        while let Some(v) = rx.pop() {
+            received.push(v);
+        }
+
+        assert_eq!(received.len(), 4);
+        received.sort_unstable();
+        assert_eq!(received, vec![10, 11, 20, 21]);
+    });
+}
+
+#[test]
+fn concurrent_push_pop() {
+    loom::model(|| {
+        let (tx, rx) = mpsc::ring_buffer::<u32>(2);
+        let tx2 = tx.clone();
+
+        let t1 = thread::spawn(move || {
+            while tx.push(1).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        let t2 = thread::spawn(move || {
+            while tx2.push(2).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        let mut received = Vec::new();
+        while received.len() < 2 {
+            if let Some(v) = rx.pop() {
+                received.push(v);
+            } else {
+                thread::yield_now();
+            }
+        }
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        received.sort_unstable();
+        assert_eq!(received, vec![1, 2]);
+    });
+}
+
+#[test]
+fn drop_with_pending_items() {
+    loom::model(|| {
+        let (tx, rx) = mpsc::ring_buffer::<Arc<u32>>(2);
+        let val = Arc::new(42);
+
+        let tx2 = tx.clone();
+        tx.push(Arc::clone(&val)).unwrap();
+        tx2.push(Arc::clone(&val)).unwrap();
+
+        drop(tx);
+        drop(tx2);
+        drop(rx);
+
+        assert_eq!(Arc::strong_count(&val), 1);
+    });
+}
+
+#[test]
+fn single_slot_two_producers() {
+    loom::model(|| {
+        let (tx, rx) = mpsc::ring_buffer::<u32>(1);
+        let tx2 = tx.clone();
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = Arc::clone(&count);
+
+        let t1 = thread::spawn(move || {
+            if tx.push(1).is_ok() {
+                count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        let t2 = thread::spawn(move || {
+            if tx2.push(2).is_ok() {
+                count2.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let mut popped = 0;
+        while rx.pop().is_some() {
+            popped += 1;
+        }
+
+        assert!(popped >= 1);
+    });
+}

--- a/nexus-queue/tests/loom_mpsc.rs
+++ b/nexus-queue/tests/loom_mpsc.rs
@@ -133,11 +133,12 @@ fn single_slot_two_producers() {
         let (tx, rx) = mpsc::ring_buffer::<u32>(1);
         let tx2 = tx.clone();
         let count = Arc::new(AtomicUsize::new(0));
+        let count1 = Arc::clone(&count);
         let count2 = Arc::clone(&count);
 
         let t1 = thread::spawn(move || {
             if tx.push(1).is_ok() {
-                count.fetch_add(1, Ordering::Relaxed);
+                count1.fetch_add(1, Ordering::Relaxed);
             }
         });
 
@@ -150,11 +151,13 @@ fn single_slot_two_producers() {
         t1.join().unwrap();
         t2.join().unwrap();
 
+        let pushed = count.load(Ordering::SeqCst);
         let mut popped = 0;
         while rx.pop().is_some() {
             popped += 1;
         }
 
         assert!(popped >= 1);
+        assert_eq!(popped, pushed);
     });
 }

--- a/nexus-queue/tests/loom_spmc.rs
+++ b/nexus-queue/tests/loom_spmc.rs
@@ -1,0 +1,148 @@
+#![cfg(loom)]
+
+use loom::sync::Arc;
+use loom::thread;
+use nexus_queue::spmc;
+
+#[test]
+fn no_lost_items_two_consumers() {
+    loom::model(|| {
+        let (tx, rx) = spmc::ring_buffer::<u32>(2);
+        let rx2 = rx.clone();
+
+        tx.push(1).unwrap();
+        tx.push(2).unwrap();
+        drop(tx);
+
+        let t1 = thread::spawn(move || {
+            let mut received = Vec::new();
+            loop {
+                if let Some(v) = rx.pop() {
+                    received.push(v);
+                } else if rx.is_disconnected() {
+                    while let Some(v) = rx.pop() {
+                        received.push(v);
+                    }
+                    break;
+                } else {
+                    thread::yield_now();
+                }
+            }
+            received
+        });
+
+        let t2 = thread::spawn(move || {
+            let mut received = Vec::new();
+            loop {
+                if let Some(v) = rx2.pop() {
+                    received.push(v);
+                } else if rx2.is_disconnected() {
+                    while let Some(v) = rx2.pop() {
+                        received.push(v);
+                    }
+                    break;
+                } else {
+                    thread::yield_now();
+                }
+            }
+            received
+        });
+
+        let mut all: Vec<_> = t1.join().unwrap();
+        all.extend(t2.join().unwrap());
+        all.sort_unstable();
+        assert_eq!(all, vec![1, 2]);
+    });
+}
+
+#[test]
+fn no_duplicates() {
+    loom::model(|| {
+        let (tx, rx) = spmc::ring_buffer::<u32>(2);
+        let rx2 = rx.clone();
+
+        tx.push(10).unwrap();
+        tx.push(11).unwrap();
+        drop(tx);
+
+        let t1 = thread::spawn(move || {
+            let mut received = Vec::new();
+            loop {
+                if let Some(v) = rx.pop() {
+                    received.push(v);
+                } else if rx.is_disconnected() {
+                    while let Some(v) = rx.pop() {
+                        received.push(v);
+                    }
+                    break;
+                } else {
+                    thread::yield_now();
+                }
+            }
+            received
+        });
+
+        let t2 = thread::spawn(move || {
+            let mut received = Vec::new();
+            loop {
+                if let Some(v) = rx2.pop() {
+                    received.push(v);
+                } else if rx2.is_disconnected() {
+                    while let Some(v) = rx2.pop() {
+                        received.push(v);
+                    }
+                    break;
+                } else {
+                    thread::yield_now();
+                }
+            }
+            received
+        });
+
+        let mut all: Vec<_> = t1.join().unwrap();
+        all.extend(t2.join().unwrap());
+        assert_eq!(all.len(), 2);
+        all.sort_unstable();
+        assert_eq!(all, vec![10, 11]);
+    });
+}
+
+#[test]
+fn concurrent_pop_cas_contention() {
+    loom::model(|| {
+        let (tx, rx) = spmc::ring_buffer::<u32>(2);
+        let rx2 = rx.clone();
+
+        tx.push(1).unwrap();
+
+        let t1 = thread::spawn(move || rx.pop());
+        let t2 = thread::spawn(move || rx2.pop());
+
+        let r1 = t1.join().unwrap();
+        let r2 = t2.join().unwrap();
+
+        let mut got = Vec::new();
+        if let Some(v) = r1 {
+            got.push(v);
+        }
+        if let Some(v) = r2 {
+            got.push(v);
+        }
+        assert_eq!(got, vec![1]);
+    });
+}
+
+#[test]
+fn drop_with_pending_items() {
+    loom::model(|| {
+        let (tx, rx) = spmc::ring_buffer::<Arc<u32>>(2);
+        let val = Arc::new(42);
+
+        tx.push(Arc::clone(&val)).unwrap();
+
+        drop(tx);
+        drop(rx);
+
+        assert_eq!(Arc::strong_count(&val), 1);
+    });
+}

--- a/nexus-queue/tests/loom_spsc.rs
+++ b/nexus-queue/tests/loom_spsc.rs
@@ -1,0 +1,123 @@
+#![cfg(loom)]
+
+use loom::sync::Arc;
+use loom::thread;
+use nexus_queue::spsc;
+
+#[test]
+fn fifo_order() {
+    loom::model(|| {
+        let (tx, rx) = spsc::ring_buffer::<u32>(2);
+
+        let t = thread::spawn(move || {
+            while tx.push(1).is_err() {
+                thread::yield_now();
+            }
+            while tx.push(2).is_err() {
+                thread::yield_now();
+            }
+        });
+
+        let mut received = Vec::new();
+        while received.len() < 2 {
+            if let Some(v) = rx.pop() {
+                received.push(v);
+            } else {
+                thread::yield_now();
+            }
+        }
+
+        t.join().unwrap();
+        assert_eq!(received, vec![1, 2]);
+    });
+}
+
+#[test]
+fn no_data_race() {
+    loom::model(|| {
+        let (tx, rx) = spsc::ring_buffer::<u32>(2);
+
+        let t = thread::spawn(move || {
+            let _ = tx.push(42);
+        });
+
+        let val = loop {
+            if let Some(v) = rx.pop() {
+                break Some(v);
+            }
+            if rx.is_disconnected() {
+                break rx.pop();
+            }
+            thread::yield_now();
+        };
+
+        t.join().unwrap();
+        if let Some(v) = val {
+            assert_eq!(v, 42);
+        }
+    });
+}
+
+#[test]
+fn full_then_pop_then_push() {
+    loom::model(|| {
+        let (tx, rx) = spsc::ring_buffer::<u32>(2);
+
+        tx.push(1).unwrap();
+        tx.push(2).unwrap();
+        assert!(tx.push(3).is_err());
+
+        let t = thread::spawn(move || {
+            let a = rx.pop();
+            let b = rx.pop();
+            (a, b)
+        });
+
+        let (a, b) = t.join().unwrap();
+        assert_eq!(a, Some(1));
+        assert_eq!(b, Some(2));
+    });
+}
+
+#[test]
+fn push_pop_wrap_around() {
+    loom::model(|| {
+        let (tx, rx) = spsc::ring_buffer::<u32>(2);
+
+        let t = thread::spawn(move || {
+            let mut received = Vec::new();
+            while received.len() < 4 {
+                if let Some(v) = rx.pop() {
+                    received.push(v);
+                } else {
+                    thread::yield_now();
+                }
+            }
+            received
+        });
+
+        for i in 1..=4u32 {
+            while tx.push(i).is_err() {
+                thread::yield_now();
+            }
+        }
+
+        let received = t.join().unwrap();
+        assert_eq!(received, vec![1, 2, 3, 4]);
+    });
+}
+
+#[test]
+fn drop_with_pending_items() {
+    loom::model(|| {
+        let (tx, rx) = spsc::ring_buffer::<Arc<u32>>(2);
+        let val = Arc::new(42);
+
+        tx.push(Arc::clone(&val)).unwrap();
+
+        drop(tx);
+        drop(rx);
+
+        assert_eq!(Arc::strong_count(&val), 1);
+    });
+}


### PR DESCRIPTION
## Summary

- Add loom model-checking tests for all three nexus-queue variants (SPSC, MPSC, SPMC)
- Minimal source changes: import swap via `loom_impl.rs` + `#[cfg(loom)]` buffer variants for UnsafeCell data race detection
- No algorithm or ordering changes — production code paths unchanged
- 14 loom tests verify FIFO order, no-loss, no-duplicates, CAS contention, and drop correctness

Partially addresses #216 (nexus-queue scope only).

## Details

Loom exhaustively explores all thread interleavings to catch memory-model bugs that miri can't detect (wrong fence placement, missed Release-before-publish). All queues use small capacities (1-4 slots) to keep the state space bounded.

| Variant | Tests | Runtime |
|---------|-------|---------|
| SPSC | 5 (FIFO, data race, full/empty, wraparound, drop) | ~23s |
| MPSC | 5 (no loss, no duplicates, concurrent push/pop, drop, single-slot) | ~2s |
| SPMC | 4 (no loss, no duplicates, CAS contention, drop) | ~2s |

Run with: `RUSTFLAGS="--cfg loom" cargo test -p nexus-queue --test loom_spsc --release`

## Test plan

- [x] `cargo test -p nexus-queue` — normal tests unaffected
- [x] `cargo clippy -p nexus-queue --lib --tests -- -D warnings` — clean
- [x] All 14 loom tests pass under `--cfg loom`
- [x] No algorithm or ordering changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)