### PR TITLE
adding loom testing for nexus-notify and nexus-pool

### DIFF
--- a/nexus-notify/Cargo.toml
+++ b/nexus-notify/Cargo.toml
@@ -14,8 +14,12 @@ readme = "README.md"
 nexus-queue = { version = "1.2.0", path = "../nexus-queue" }
 crossbeam-utils.workspace = true
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+loom = "0.7"
 
 [[bench]]
 name = "event_queue"

--- a/nexus-notify/src/event_channel.rs
+++ b/nexus-notify/src/event_channel.rs
@@ -356,7 +356,7 @@ mod tests {
         let handle = std::thread::spawn(move || {
             let mut events = Events::with_capacity(64);
             receiver.recv(&mut events);
-            events.iter().map(|t| t.index()).collect::<Vec<_>>()
+            events.iter().map(Token::index).collect::<Vec<_>>()
         });
 
         // Small delay to let receiver park
@@ -374,7 +374,7 @@ mod tests {
         let handle = std::thread::spawn(move || {
             let mut events = Events::with_capacity(64);
             receiver.recv_limit(&mut events, 2);
-            events.iter().map(|t| t.index()).collect::<Vec<_>>()
+            events.iter().map(Token::index).collect::<Vec<_>>()
         });
 
         std::thread::sleep(Duration::from_millis(50));
@@ -418,7 +418,7 @@ mod tests {
             let got_data = receiver.recv_timeout(&mut events, Duration::from_secs(5));
             (
                 got_data,
-                events.iter().map(|t| t.index()).collect::<Vec<_>>(),
+                events.iter().map(Token::index).collect::<Vec<_>>(),
             )
         });
 
@@ -455,7 +455,7 @@ mod tests {
         }
 
         receiver.recv(&mut events);
-        let indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let indices: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(indices, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 

--- a/nexus-notify/src/event_queue.rs
+++ b/nexus-notify/src/event_queue.rs
@@ -1,5 +1,4 @@
-use core::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use crate::loom_impl::{Flags, Ordering};
 
 use nexus_queue::mpsc;
 
@@ -72,14 +71,14 @@ impl From<usize> for Token {
 ///
 /// Obtained from [`event_queue()`].
 pub struct Notifier {
-    flags: Arc<[AtomicBool]>,
+    flags: Flags,
     tx: mpsc::Producer<usize>,
 }
 
 impl Clone for Notifier {
     fn clone(&self) -> Self {
         Self {
-            flags: Arc::clone(&self.flags),
+            flags: self.flags.clone(),
             tx: self.tx.clone(),
         }
     }
@@ -118,14 +117,14 @@ impl Notifier {
         // models the Release flag clear can propagate before the queue's
         // turn counter store). Release side is not needed — no downstream
         // consumer reads depend on writes before this swap.
-        if self.flags[idx].swap(true, Ordering::Acquire) {
+        if self.flags.get(idx).swap(true, Ordering::Acquire) {
             return Ok(());
         }
 
         // Newly ready — push index to FIFO queue.
         self.tx.push(idx).map_err(|_| {
             // Invariant violated. Clear flag so future notifies can retry.
-            self.flags[idx].store(false, Ordering::Relaxed);
+            self.flags.get(idx).store(false, Ordering::Relaxed);
             NotifyError { token }
         })
     }
@@ -142,7 +141,7 @@ impl Notifier {
 ///
 /// Obtained from [`event_queue()`].
 pub struct Poller {
-    flags: Arc<[AtomicBool]>,
+    flags: Flags,
     rx: mpsc::Consumer<usize>,
 }
 
@@ -183,7 +182,7 @@ impl Poller {
                 Some(idx) => {
                     // Release: ensures the queue pop's slot-free writes are
                     // ordered before this flag clear becomes visible to producers.
-                    self.flags[idx].store(false, Ordering::Release);
+                    self.flags.get(idx).store(false, Ordering::Release);
                     events.tokens.push(Token(idx));
                 }
                 None => break,
@@ -318,14 +317,11 @@ impl<'a> IntoIterator for &'a Events {
 #[cold]
 pub fn event_queue(max_tokens: usize) -> (Notifier, Poller) {
     assert!(max_tokens > 0, "event queue capacity must be non-zero");
-    let flags: Arc<[AtomicBool]> = (0..max_tokens)
-        .map(|_| AtomicBool::new(false))
-        .collect::<Vec<_>>()
-        .into();
+    let flags = Flags::new(max_tokens);
     let (tx, rx) = mpsc::ring_buffer(max_tokens);
     (
         Notifier {
-            flags: Arc::clone(&flags),
+            flags: flags.clone(),
             tx,
         },
         Poller { flags, rx },
@@ -376,7 +372,7 @@ mod tests {
         poller.poll(&mut events);
         assert_eq!(events.len(), 3);
 
-        let indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let indices: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(indices, vec![0, 3, 63]);
     }
 
@@ -561,15 +557,15 @@ mod tests {
         }
 
         poller.poll_limit(&mut events, 2);
-        let indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let indices: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(indices, vec![10, 20]);
 
         poller.poll_limit(&mut events, 2);
-        let indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let indices: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(indices, vec![30, 40]);
 
         poller.poll(&mut events);
-        let indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let indices: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(indices, vec![50]);
     }
 
@@ -605,7 +601,7 @@ mod tests {
         }
 
         poller.poll_limit(&mut events, 3);
-        let drained: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let drained: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(drained.len(), 3);
 
         // Re-notify a token NOT yet drained — flag is still true. Conflated.

--- a/nexus-notify/src/lib.rs
+++ b/nexus-notify/src/lib.rs
@@ -150,6 +150,7 @@
 mod event_channel;
 mod event_queue;
 pub mod local;
+mod loom_impl;
 
 pub use event_channel::{Receiver, Sender, event_channel};
 pub use event_queue::{Events, Notifier, NotifyError, Poller, Token, event_queue};

--- a/nexus-notify/src/local.rs
+++ b/nexus-notify/src/local.rs
@@ -252,12 +252,12 @@ mod tests {
         let mut events = Events::with_capacity(4);
 
         let t0 = notify.register();
-        let t1 = notify.register();
+        let _t1 = notify.register();
         let t2 = notify.register();
 
         notify.mark(t0);
         notify.mark(t2);
-        // t1 not marked
+        // _t1 not marked
 
         notify.poll(&mut events);
         assert_eq!(events.len(), 2);

--- a/nexus-notify/src/loom_impl.rs
+++ b/nexus-notify/src/loom_impl.rs
@@ -1,0 +1,53 @@
+#[cfg(loom)]
+pub(crate) use loom::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(not(loom))]
+pub(crate) use core::sync::atomic::{AtomicBool, Ordering};
+
+// =============================================================================
+// Flags — abstracts Arc<[AtomicBool]> vs Arc<Vec<AtomicBool>> under loom
+// =============================================================================
+
+#[cfg(not(loom))]
+#[derive(Clone)]
+pub(crate) struct Flags(std::sync::Arc<[AtomicBool]>);
+
+#[cfg(not(loom))]
+impl Flags {
+    pub(crate) fn new(count: usize) -> Self {
+        let vec: Vec<AtomicBool> = (0..count).map(|_| AtomicBool::new(false)).collect();
+        Self(vec.into())
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline(always)]
+    pub(crate) fn get(&self, idx: usize) -> &AtomicBool {
+        &self.0[idx]
+    }
+}
+
+#[cfg(loom)]
+#[derive(Clone)]
+pub(crate) struct Flags(loom::sync::Arc<Vec<AtomicBool>>);
+
+#[cfg(loom)]
+impl Flags {
+    pub(crate) fn new(count: usize) -> Self {
+        let vec: Vec<AtomicBool> = (0..count).map(|_| AtomicBool::new(false)).collect();
+        Self(loom::sync::Arc::new(vec))
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline(always)]
+    pub(crate) fn get(&self, idx: usize) -> &AtomicBool {
+        &self.0[idx]
+    }
+}

--- a/nexus-notify/tests/event_queue.rs
+++ b/nexus-notify/tests/event_queue.rs
@@ -7,10 +7,9 @@ fn two_thread_no_lost_tokens() {
     let mut events = Events::with_capacity(64);
 
     let tokens: Vec<Token> = (0..64).map(Token::new).collect();
-    let producer_tokens = tokens.clone();
 
     let handle = thread::spawn(move || {
-        for t in &producer_tokens {
+        for t in &tokens {
             notifier.notify(*t).unwrap();
         }
     });
@@ -18,7 +17,7 @@ fn two_thread_no_lost_tokens() {
     handle.join().unwrap();
     poller.poll(&mut events);
 
-    let mut indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+    let mut indices: Vec<usize> = events.iter().map(Token::index).collect();
     indices.sort_unstable();
     let expected: Vec<usize> = (0..64).collect();
     assert_eq!(indices, expected);
@@ -52,7 +51,7 @@ fn mpsc_two_producers() {
 
     poller.poll(&mut events);
 
-    let mut indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+    let mut indices: Vec<usize> = events.iter().map(Token::index).collect();
     indices.sort_unstable();
     let expected: Vec<usize> = (0..128).collect();
     assert_eq!(indices, expected);
@@ -94,11 +93,10 @@ fn stress_no_lost_tokens() {
     let mut events = Events::with_capacity(64);
 
     let tokens: Vec<Token> = (0..8).map(Token::new).collect();
-    let producer_tokens = tokens.clone();
 
     let handle = thread::spawn(move || {
         for _ in 0..ROUNDS {
-            for t in &producer_tokens {
+            for t in &tokens {
                 notifier.notify(*t).unwrap();
             }
         }
@@ -135,7 +133,7 @@ fn stress_poll_limit_fifo() {
     let mut all_indices = Vec::new();
     for _ in 0..4 {
         poller.poll_limit(&mut events, 5);
-        let chunk: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        let chunk: Vec<usize> = events.iter().map(Token::index).collect();
         assert_eq!(chunk.len(), 5);
         all_indices.extend(chunk);
     }
@@ -155,7 +153,7 @@ fn large_capacity() {
 
     poller.poll(&mut events);
 
-    let mut indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+    let mut indices: Vec<usize> = events.iter().map(Token::index).collect();
     indices.sort_unstable();
     let expected: Vec<usize> = (0..4096).collect();
     assert_eq!(indices, expected);

--- a/nexus-notify/tests/loom_event_queue.rs
+++ b/nexus-notify/tests/loom_event_queue.rs
@@ -1,0 +1,111 @@
+#![cfg(loom)]
+
+use loom::thread;
+use nexus_notify::{Events, Token, event_queue};
+
+#[test]
+fn notify_poll_roundtrip() {
+    loom::model(|| {
+        let (notifier, poller) = event_queue(4);
+        let mut events = Events::with_capacity(4);
+
+        let handle = thread::spawn(move || {
+            notifier.notify(Token::new(1)).unwrap();
+        });
+
+        handle.join().unwrap();
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events.as_slice()[0].index(), 1);
+    });
+}
+
+#[test]
+fn conflation() {
+    loom::model(|| {
+        let (notifier, poller) = event_queue(4);
+        let mut events = Events::with_capacity(4);
+
+        let n2 = notifier.clone();
+        let handle = thread::spawn(move || {
+            n2.notify(Token::new(0)).unwrap();
+        });
+
+        notifier.notify(Token::new(0)).unwrap();
+        handle.join().unwrap();
+
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events.as_slice()[0].index(), 0);
+    });
+}
+
+#[test]
+fn multi_producer_different_tokens() {
+    loom::model(|| {
+        let (notifier, poller) = event_queue(4);
+        let mut events = Events::with_capacity(4);
+
+        let n2 = notifier.clone();
+        let h1 = thread::spawn(move || {
+            notifier.notify(Token::new(0)).unwrap();
+        });
+        let h2 = thread::spawn(move || {
+            n2.notify(Token::new(1)).unwrap();
+        });
+
+        h1.join().unwrap();
+        h2.join().unwrap();
+
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 2);
+
+        let mut indices: Vec<usize> = events.iter().map(|t| t.index()).collect();
+        indices.sort();
+        assert_eq!(indices, vec![0, 1]);
+    });
+}
+
+#[test]
+fn re_notification_after_poll() {
+    loom::model(|| {
+        let (notifier, poller) = event_queue(4);
+        let mut events = Events::with_capacity(4);
+
+        notifier.notify(Token::new(2)).unwrap();
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+
+        let handle = thread::spawn(move || {
+            notifier.notify(Token::new(2)).unwrap();
+        });
+
+        handle.join().unwrap();
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events.as_slice()[0].index(), 2);
+    });
+}
+
+#[test]
+fn concurrent_notify_and_poll() {
+    loom::model(|| {
+        let (notifier, poller) = event_queue(4);
+
+        let handle = thread::spawn(move || {
+            notifier.notify(Token::new(0)).unwrap();
+            notifier.notify(Token::new(1)).unwrap();
+        });
+
+        let mut events = Events::with_capacity(4);
+        poller.poll(&mut events);
+        let first_poll = events.len();
+
+        handle.join().unwrap();
+
+        poller.poll(&mut events);
+        let second_poll = events.len();
+
+        assert_eq!(first_poll + second_poll, 2);
+    });
+}

--- a/nexus-pool/Cargo.toml
+++ b/nexus-pool/Cargo.toml
@@ -13,8 +13,12 @@ categories.workspace = true
 [lints]
 workspace = true
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 hdrhistogram = "7.5"
+loom = "0.7"
 
 [[bench]]
 name = "perf_local_pool"

--- a/nexus-pool/src/lib.rs
+++ b/nexus-pool/src/lib.rs
@@ -133,4 +133,5 @@
 #![warn(missing_docs)]
 
 pub mod local;
+mod loom_impl;
 pub mod sync;

--- a/nexus-pool/src/loom_impl.rs
+++ b/nexus-pool/src/loom_impl.rs
@@ -1,0 +1,27 @@
+#[cfg(loom)]
+pub(crate) use loom::sync::Arc;
+#[cfg(not(loom))]
+pub(crate) use std::sync::Arc;
+
+#[cfg(loom)]
+pub(crate) use loom::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(not(loom))]
+pub(crate) use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(loom)]
+pub(crate) use loom::cell::UnsafeCell;
+
+#[cfg(not(loom))]
+pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
+
+#[cfg(not(loom))]
+impl<T> UnsafeCell<T> {
+    pub(crate) fn new(data: T) -> Self {
+        Self(std::cell::UnsafeCell::new(data))
+    }
+
+    #[inline(always)]
+    pub(crate) fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {
+        f(self.0.get())
+    }
+}

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -5,11 +5,10 @@
 //!
 //! Uses LIFO ordering for cache locality.
 
-use std::cell::UnsafeCell;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::loom_impl::{Arc, AtomicUsize, Ordering, UnsafeCell};
 
 const NONE: usize = usize::MAX;
 
@@ -49,9 +48,9 @@ impl<T> Inner<T> {
         // SAFETY: We own this slot (it was popped from the free list via CAS).
         // No other thread can access it until we push it back. MaybeUninit::write
         // initializes the slot for the next acquirer.
-        unsafe {
-            (*self.slots[idx].value.get()).write(value);
-        }
+        self.slots[idx].value.with_mut(|ptr| unsafe {
+            (*ptr).write(value);
+        });
 
         // Link into free list with CAS loop
         loop {
@@ -112,7 +111,9 @@ impl<T> Inner<T> {
         // written by new() or push(). assume_init_read moves the value out without
         // dropping the MaybeUninit, which is correct since the slot will be rewritten
         // on the next push.
-        unsafe { (*self.slots[idx].value.get()).assume_init_read() }
+        self.slots[idx]
+            .value
+            .with_mut(|ptr| unsafe { (*ptr).assume_init_read() })
     }
 }
 
@@ -127,16 +128,16 @@ impl<T> Drop for Inner<T> {
         // reset closure panicked during a guard's drop — that path
         // leaks the value (documented in caveats.md §1) and is the
         // same as the 1.0.x behavior.
-        let mut idx = *self.free_head.get_mut();
+        let mut idx = self.free_head.load(Ordering::Relaxed);
         while idx != NONE {
             // SAFETY: Slots in the free list contain valid values (written by new()
             // or push()). Slots NOT in the free list have been moved out via
-            // assume_init_read in pop and are handled by Pooled's Drop. get_mut is
-            // safe because we have &mut self (exclusive access during drop).
-            unsafe {
-                (*self.slots[idx].value.get()).assume_init_drop();
-            }
-            idx = *self.slots[idx].next.get_mut();
+            // assume_init_read in pop and are handled by Pooled's Drop. We have
+            // &mut self (exclusive access during drop), so Relaxed load is correct.
+            self.slots[idx].value.with_mut(|ptr| unsafe {
+                (*ptr).assume_init_drop();
+            });
+            idx = self.slots[idx].next.load(Ordering::Relaxed);
         }
         // MaybeUninit doesn't drop contents, so Box<[Slot<T>]> will just
         // deallocate memory without double-dropping.

--- a/nexus-pool/tests/loom_sync.rs
+++ b/nexus-pool/tests/loom_sync.rs
@@ -1,0 +1,105 @@
+#![cfg(loom)]
+
+use loom::thread;
+use nexus_pool::sync::Pool;
+
+#[test]
+fn acquire_return_roundtrip() {
+    loom::model(|| {
+        let pool = Pool::new(2, || 42u32, |_| {});
+
+        let item = pool.try_acquire().unwrap();
+        assert_eq!(*item, 42);
+        drop(item);
+
+        let item2 = pool.try_acquire().unwrap();
+        assert_eq!(*item2, 42);
+    });
+}
+
+#[test]
+fn cross_thread_return() {
+    loom::model(|| {
+        let pool = Pool::new(2, || 0u32, |v| *v = 0);
+
+        let mut item = pool.try_acquire().unwrap();
+        *item = 99;
+
+        let handle = thread::spawn(move || {
+            assert_eq!(*item, 99);
+            drop(item);
+        });
+
+        handle.join().unwrap();
+
+        let reacquired = pool.try_acquire().unwrap();
+        assert_eq!(*reacquired, 0); // reset was called
+    });
+}
+
+#[test]
+fn no_double_issue() {
+    loom::model(|| {
+        let pool = Pool::new(2, || 0u32, |_| {});
+
+        let a = pool.try_acquire().unwrap();
+        let b = pool.try_acquire().unwrap();
+        assert!(pool.try_acquire().is_none());
+
+        drop(a);
+
+        let c = pool.try_acquire().unwrap();
+        assert!(pool.try_acquire().is_none());
+
+        drop(b);
+        drop(c);
+    });
+}
+
+#[test]
+fn concurrent_returns() {
+    loom::model(|| {
+        let pool = Pool::new(2, || 0u32, |_| {});
+
+        let a = pool.try_acquire().unwrap();
+        let b = pool.try_acquire().unwrap();
+        assert!(pool.try_acquire().is_none());
+
+        let h1 = thread::spawn(move || {
+            drop(a);
+        });
+        let h2 = thread::spawn(move || {
+            drop(b);
+        });
+
+        h1.join().unwrap();
+        h2.join().unwrap();
+
+        let c = pool.try_acquire().unwrap();
+        let d = pool.try_acquire().unwrap();
+        assert!(pool.try_acquire().is_none());
+
+        drop(c);
+        drop(d);
+    });
+}
+
+#[test]
+fn reset_called_on_return() {
+    loom::model(|| {
+        let pool = Pool::new(2, || Vec::<u8>::with_capacity(4), |v| v.clear());
+
+        let mut item = pool.try_acquire().unwrap();
+        item.push(1);
+        item.push(2);
+
+        let handle = thread::spawn(move || {
+            drop(item);
+        });
+
+        handle.join().unwrap();
+
+        let reacquired = pool.try_acquire().unwrap();
+        assert!(reacquired.is_empty());
+    });
+}


### PR DESCRIPTION
## Summary

- Adds loom model-checking tests for **nexus-notify** (event_queue flag protocol) and **nexus-pool** (sync Treiber stack)
- Creates `loom_impl.rs` in each crate with cfg-gated atomic/Arc/UnsafeCell re-exports
- Production code changes are import-only — no algorithm changes

### nexus-notify (5 tests)
- Notify-poll roundtrip
- Conflation (notify same token twice → polled once)
- Multi-producer different tokens
- Re-notification after poll (flag cleared correctly)
- Concurrent notify + poll (no lost notifications)

### nexus-pool (5 tests)
- Acquire-return roundtrip
- Cross-thread return
- No double-issue (exhaustion + return + re-acquire)
- Concurrent returns (CAS contention on free_head)
- Reset called on return

## Notes

Both crates use struct-field atomics, so the loom import swap exercises the actual production atomic operations (unlike nexus-logbuf which uses in-band pointer casts that loom can't intercept).

## Test plan

- [x] `cargo test -p nexus-notify` passes
- [x] `cargo test -p nexus-pool` passes
- [x] `RUSTFLAGS="--cfg loom" cargo test -p nexus-notify --test loom_event_queue --release` passes
- [x] `RUSTFLAGS="--cfg loom" cargo test -p nexus-pool --test loom_sync --release` passes
- [x] `cargo clippy -p nexus-notify --lib --tests -- -D warnings` clean
- [x] `cargo clippy -p nexus-pool --lib --tests -- -D warnings` clean

Partially addresses #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)