### PR TITLE
nexus-rt eventless handler ergonomics

### DIFF
--- a/nexus-rt/src/callback.rs
+++ b/nexus-rt/src/callback.rs
@@ -158,7 +158,7 @@ pub struct Callback<C, F, Params: Param> {
 #[diagnostic::on_unimplemented(
     message = "this function cannot be converted into a callback",
     note = "callback signature: `fn(&mut Context, Res<A>, ..., Event)` — context first, then resources, event last",
-    note = "for Handler<()>, you can omit the event: `fn(&mut Context, Res<A>, ...)`",
+    note = "for Handler<()> with params, wrap with `no_event(fn_name)` to omit the event parameter",
     note = "closures with resource parameters are not supported — use a named `fn` when using Param resources"
 )]
 pub trait IntoCallback<C, E, Params> {

--- a/nexus-rt/src/callback.rs
+++ b/nexus-rt/src/callback.rs
@@ -125,14 +125,14 @@ pub struct Callback<C, F, Params: Param> {
 /// # Examples
 ///
 /// ```
-/// use nexus_rt::{WorldBuilder, ResMut, IntoCallback, Handler, Resource};
+/// use nexus_rt::{WorldBuilder, ResMut, IntoCallback, Handler, Resource, no_event};
 ///
 /// #[derive(Resource)]
 /// struct Counter(u64);
 ///
 /// struct TimerCtx { order_id: u64, fires: u64 }
 ///
-/// fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<Counter>, _event: ()) {
+/// fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<Counter>) {
 ///     ctx.fires += 1;
 ///     counter.0 += ctx.order_id;
 /// }
@@ -141,7 +141,7 @@ pub struct Callback<C, F, Params: Param> {
 /// builder.register(Counter(0));
 /// let mut world = builder.build();
 ///
-/// let mut cb = on_timeout.into_callback(
+/// let mut cb = no_event(on_timeout).into_callback(
 ///     TimerCtx { order_id: 42, fires: 0 },
 ///     world.registry(),
 /// );
@@ -366,7 +366,7 @@ all_tuples!(impl_into_callback_no_event);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Local, Res, ResMut, WorldBuilder};
+    use crate::{Local, Res, ResMut, WorldBuilder, no_event};
 
     // -- Helper types ---------------------------------------------------------
 
@@ -603,11 +603,11 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn bad(_ctx: &mut u64, a: Res<u64>, b: ResMut<u64>, _e: ()) {
+        fn bad(_ctx: &mut u64, a: Res<u64>, b: ResMut<u64>) {
             let _ = (*a, &*b);
         }
 
-        let _cb = bad.into_callback(0u64, world.registry_mut());
+        let _cb = no_event(bad).into_callback(0u64, world.registry_mut());
     }
 
     // -- Handler<E> interface -------------------------------------------------
@@ -635,15 +635,15 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn add(ctx: &mut u64, mut val: ResMut<u64>, _e: ()) {
+        fn add(ctx: &mut u64, mut val: ResMut<u64>) {
             *val += *ctx;
         }
-        fn mul(ctx: &mut u64, mut val: ResMut<u64>, _e: ()) {
+        fn mul(ctx: &mut u64, mut val: ResMut<u64>) {
             *val *= *ctx;
         }
 
-        let cb_add = add.into_callback(3u64, world.registry_mut());
-        let cb_mul = mul.into_callback(2u64, world.registry_mut());
+        let cb_add = no_event(add).into_callback(3u64, world.registry_mut());
+        let cb_mul = no_event(mul).into_callback(2u64, world.registry_mut());
 
         let mut handlers: Vec<Box<dyn Handler<()>>> = vec![Box::new(cb_add), Box::new(cb_mul)];
 
@@ -654,7 +654,7 @@ mod tests {
         assert_eq!(*world.resource::<u64>(), 6);
     }
 
-    fn with_local(_ctx: &mut u64, mut local: Local<u64>, mut val: ResMut<u64>, _e: ()) {
+    fn with_local(_ctx: &mut u64, mut local: Local<u64>, mut val: ResMut<u64>) {
         *local += 1;
         *val = *local;
     }
@@ -665,7 +665,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let mut cb = with_local.into_callback(0u64, world.registry_mut());
+        let mut cb = no_event(with_local).into_callback(0u64, world.registry_mut());
         cb.run(&mut world, ());
         cb.run(&mut world, ());
         cb.run(&mut world, ());

--- a/nexus-rt/src/callback.rs
+++ b/nexus-rt/src/callback.rs
@@ -158,6 +158,7 @@ pub struct Callback<C, F, Params: Param> {
 #[diagnostic::on_unimplemented(
     message = "this function cannot be converted into a callback",
     note = "callback signature: `fn(&mut Context, Res<A>, ..., Event)` — context first, then resources, event last",
+    note = "for Handler<()>, you can omit the event: `fn(&mut Context, Res<A>, ...)`",
     note = "closures with resource parameters are not supported — use a named `fn` when using Param resources"
 )]
 pub trait IntoCallback<C, E, Params> {
@@ -264,6 +265,99 @@ macro_rules! impl_into_callback {
 }
 
 all_tuples!(impl_into_callback);
+
+// =============================================================================
+// No-event callback impls — Handler<()> without trailing `_: ()` parameter
+// =============================================================================
+
+use crate::handler::NoEvent;
+
+// Arity 0: fn(&mut C) → Handler<()>
+impl<C: Send + 'static, F: FnMut(&mut C) + Send + 'static> IntoCallback<C, (), NoEvent<F>> for F {
+    type Callback = Callback<C, NoEvent<F>, ()>;
+
+    fn into_callback(self, ctx: C, registry: &Registry) -> Self::Callback {
+        Callback {
+            ctx,
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+impl<C: Send + 'static, F: FnMut(&mut C) + Send + 'static> Handler<()>
+    for Callback<C, NoEvent<F>, ()>
+{
+    fn run(&mut self, _world: &mut World, _event: ()) {
+        (self.f.0)(&mut self.ctx);
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+macro_rules! impl_into_callback_no_event {
+    ($($P:ident),+) => {
+        impl<C: Send + 'static, F: Send + 'static, $($P: Param + 'static),+>
+            IntoCallback<C, (), ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut(&mut C, $($P,)+) +
+                FnMut(&mut C, $($P::Item<'a>,)+),
+        {
+            type Callback = Callback<C, NoEvent<F>, ($($P,)+)>;
+
+            fn into_callback(self, ctx: C, registry: &Registry) -> Self::Callback {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Callback { ctx, f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+
+        impl<C: Send + 'static, F: Send + 'static, $($P: Param + 'static),+>
+            Handler<()> for Callback<C, NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut(&mut C, $($P,)+) +
+                FnMut(&mut C, $($P::Item<'a>,)+),
+        {
+            #[allow(non_snake_case)]
+            fn run(&mut self, world: &mut World, _event: ()) {
+                fn call_inner<Ctx, $($P),+>(
+                    mut f: impl FnMut(&mut Ctx, $($P),+),
+                    ctx: &mut Ctx,
+                    $($P: $P,)+
+                ) {
+                    f(ctx, $($P),+);
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, &mut self.ctx, $($P,)+);
+            }
+
+            fn name(&self) -> &'static str {
+                self.name
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_callback_no_event);
 
 // =============================================================================
 // Tests
@@ -605,5 +699,99 @@ mod tests {
         }
         // 0 + 5 = 5, then 5 * 3 = 15
         assert_eq!(*world.resource::<u64>(), 15);
+    }
+
+    // =========================================================================
+    // NoEvent — Callback<C, NoEvent<F>, P> as Handler<()>
+    // =========================================================================
+
+    fn no_event_ctx_only(ctx: &mut TimerCtx) {
+        ctx.call_count += 1;
+    }
+
+    #[test]
+    fn no_event_callback_arity_0() {
+        let mut world = WorldBuilder::new().build();
+        let mut cb = no_event_ctx_only.into_callback(
+            TimerCtx {
+                order_id: 1,
+                call_count: 0,
+            },
+            world.registry_mut(),
+        );
+        cb.run(&mut world, ());
+        cb.run(&mut world, ());
+        assert_eq!(cb.ctx.call_count, 2);
+    }
+
+    fn no_event_ctx_one_res(ctx: &mut TimerCtx, mut val: ResMut<u64>) {
+        *val += ctx.order_id;
+        ctx.call_count += 1;
+    }
+
+    #[test]
+    fn no_event_callback_arity_1() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let mut cb = no_event(no_event_ctx_one_res).into_callback(
+            TimerCtx {
+                order_id: 42,
+                call_count: 0,
+            },
+            world.registry_mut(),
+        );
+        cb.run(&mut world, ());
+        assert_eq!(cb.ctx.call_count, 1);
+        assert_eq!(*world.resource::<u64>(), 42);
+    }
+
+    fn no_event_ctx_two_params(ctx: &mut TimerCtx, src: Res<u32>, mut dst: ResMut<u64>) {
+        *dst += *src as u64 + ctx.order_id;
+        ctx.call_count += 1;
+    }
+
+    #[test]
+    fn no_event_callback_arity_2() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u32>(10);
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let mut cb = no_event(no_event_ctx_two_params).into_callback(
+            TimerCtx {
+                order_id: 5,
+                call_count: 0,
+            },
+            world.registry_mut(),
+        );
+        cb.run(&mut world, ());
+        assert_eq!(cb.ctx.call_count, 1);
+        assert_eq!(*world.resource::<u64>(), 15); // 10 + 5
+    }
+
+    #[test]
+    fn no_event_callback_boxed() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let cb = no_event(no_event_ctx_one_res).into_callback(
+            TimerCtx {
+                order_id: 7,
+                call_count: 0,
+            },
+            world.registry_mut(),
+        );
+        let mut boxed: Box<dyn Handler<()>> = Box::new(cb);
+        boxed.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 7);
     }
 }

--- a/nexus-rt/src/ctx_pipeline.rs
+++ b/nexus-rt/src/ctx_pipeline.rs
@@ -226,6 +226,93 @@ macro_rules! impl_into_ctx_step {
 
 all_tuples!(impl_into_ctx_step);
 
+// =============================================================================
+// No-input impls — IntoCtxStep with In = (), no trailing input parameter
+// =============================================================================
+
+use crate::handler::NoEvent;
+
+// Arity 0: fn(&mut C) -> Out — no params, no input
+impl<C, Out, F: FnMut(&mut C) -> Out + 'static> CtxStepCall<C, ()> for CtxStep<NoEvent<F>, ()> {
+    type Out = Out;
+    #[inline(always)]
+    fn call(&mut self, ctx: &mut C, _world: &mut World, _input: ()) -> Out {
+        (self.f.0)(ctx)
+    }
+}
+
+impl<C, Out, F: FnMut(&mut C) -> Out + 'static> IntoCtxStep<C, (), Out, NoEvent<F>> for F {
+    type Step = CtxStep<NoEvent<F>, ()>;
+
+    fn into_ctx_step(self, registry: &Registry) -> Self::Step {
+        CtxStep {
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+// Arities 1-8: fn(&mut C, Params...) -> Out — no trailing input
+macro_rules! impl_into_ctx_step_no_event {
+    ($($P:ident),+) => {
+        impl<C, Out, F: 'static, $($P: Param + 'static),+>
+            CtxStepCall<C, ()> for CtxStep<NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut(&mut C, $($P,)+) -> Out +
+                FnMut(&mut C, $($P::Item<'a>,)+) -> Out,
+        {
+            type Out = Out;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn call(&mut self, ctx: &mut C, world: &mut World, _input: ()) -> Out {
+                fn call_inner<Ctx, $($P,)+ Output>(
+                    mut f: impl FnMut(&mut Ctx, $($P,)+) -> Output,
+                    ctx: &mut Ctx,
+                    $($P: $P,)+
+                ) -> Output {
+                    f(ctx, $($P,)+)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, ctx, $($P,)+)
+            }
+        }
+
+        impl<C, Out, F: 'static, $($P: Param + 'static),+>
+            IntoCtxStep<C, (), Out, ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut(&mut C, $($P,)+) -> Out +
+                FnMut(&mut C, $($P::Item<'a>,)+) -> Out,
+        {
+            type Step = CtxStep<NoEvent<F>, ($($P,)+)>;
+
+            fn into_ctx_step(self, registry: &Registry) -> Self::Step {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                CtxStep { f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_ctx_step_no_event);
+
 // -- Opaque: FnMut(&mut C, &mut World, In) -> Out ----------------------------
 
 /// Internal: wrapper for opaque closures used as context-aware steps.

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -564,7 +564,7 @@ pub type HandlerFn<F, Params> = Callback<(), CtxFree<F>, Params>;
 #[diagnostic::on_unimplemented(
     message = "this function cannot be converted into a handler",
     note = "handler signature: `fn(Res<A>, ResMut<B>, ..., Event)` — resources first, event last",
-    note = "for Handler<()>, you can omit the event: `fn(Res<A>, ResMut<B>, ...)`",
+    note = "for Handler<()> with params, wrap with `no_event(fn_name)` to omit the event parameter",
     note = "closures with resource parameters (Res<T>, ResMut<T>) are not supported — use a named `fn`",
     note = "arity-0 closures (`fn(Event)` with no resources) ARE supported"
 )]

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -1162,11 +1162,11 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn bad(a: Res<u64>, b: Res<u64>, _e: ()) {
+        fn bad(a: Res<u64>, b: Res<u64>) {
             let _ = (*a, *b);
         }
 
-        let _sys = bad.into_handler(world.registry_mut());
+        let _sys = no_event(bad).into_handler(world.registry_mut());
     }
 
     #[test]
@@ -1176,11 +1176,11 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn bad(a: ResMut<u64>, b: ResMut<u64>, _e: ()) {
+        fn bad(a: ResMut<u64>, b: ResMut<u64>) {
             let _ = (&*a, &*b);
         }
 
-        let _sys = bad.into_handler(world.registry_mut());
+        let _sys = no_event(bad).into_handler(world.registry_mut());
     }
 
     #[test]
@@ -1190,11 +1190,11 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn bad(a: Res<u64>, b: ResMut<u64>, _e: ()) {
+        fn bad(a: Res<u64>, b: ResMut<u64>) {
             let _ = (*a, &*b);
         }
 
-        let _sys = bad.into_handler(world.registry_mut());
+        let _sys = no_event(bad).into_handler(world.registry_mut());
     }
 
     #[test]
@@ -1204,11 +1204,11 @@ mod tests {
         builder.register::<u32>(0);
         let mut world = builder.build();
 
-        fn ok(a: Res<u64>, b: ResMut<u32>, _e: ()) {
+        fn ok(a: Res<u64>, b: ResMut<u32>) {
             let _ = (*a, &*b);
         }
 
-        let _sys = ok.into_handler(world.registry_mut());
+        let _sys = no_event(ok).into_handler(world.registry_mut());
     }
 
     #[test]
@@ -1217,11 +1217,11 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        fn ok(local: Local<u64>, val: ResMut<u64>, _e: ()) {
+        fn ok(local: Local<u64>, val: ResMut<u64>) {
             let _ = (&*local, &*val);
         }
 
-        let _sys = ok.into_handler(world.registry_mut());
+        let _sys = no_event(ok).into_handler(world.registry_mut());
     }
 
     // -- OpaqueHandler tests --------------------------------------------------
@@ -1264,7 +1264,7 @@ mod tests {
 
     #[test]
     fn seq_reads_current() {
-        fn check(seq: Seq, mut out: ResMut<i64>, _event: ()) {
+        fn check(seq: Seq, mut out: ResMut<i64>) {
             *out = seq.get().as_i64();
         }
 
@@ -1273,14 +1273,14 @@ mod tests {
         let mut world = builder.build();
         world.next_sequence(); // seq=1
 
-        let mut handler = check.into_handler(world.registry_mut());
+        let mut handler = no_event(check).into_handler(world.registry_mut());
         handler.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 1);
     }
 
     #[test]
     fn seq_mut_advances() {
-        fn stamp(mut seq: SeqMut, mut counter: ResMut<u64>, _event: ()) {
+        fn stamp(mut seq: SeqMut, mut counter: ResMut<u64>) {
             let a = seq.advance();
             let b = seq.advance();
             *counter = a.as_i64() as u64 * 100 + b.as_i64() as u64;
@@ -1290,7 +1290,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
         // seq starts at 0, handler advances twice → 1, 2
-        let mut handler = stamp.into_handler(world.registry_mut());
+        let mut handler = no_event(stamp).into_handler(world.registry_mut());
         handler.run(&mut world, ());
         assert_eq!(*world.resource::<u64>(), 100 + 2);
         // World sequence is now 2
@@ -1299,13 +1299,13 @@ mod tests {
 
     #[test]
     fn seq_mut_persistent_across_dispatches() {
-        fn advance(mut seq: SeqMut, _event: ()) {
+        fn advance(mut seq: SeqMut) {
             seq.advance();
         }
 
         let builder = WorldBuilder::new();
         let mut world = builder.build();
-        let mut handler = advance.into_handler(world.registry_mut());
+        let mut handler = no_event(advance).into_handler(world.registry_mut());
         handler.run(&mut world, ());
         handler.run(&mut world, ());
         handler.run(&mut world, ());
@@ -1316,19 +1316,19 @@ mod tests {
 
     #[test]
     fn seq_only_param() {
-        fn handle(seq: Seq, _event: ()) {
+        fn handle(seq: Seq) {
             assert!(seq.get().as_i64() >= 0);
         }
 
         let builder = WorldBuilder::new();
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
     }
 
     #[test]
     fn seq_first_with_res() {
-        fn handle(seq: Seq, config: Res<u64>, mut out: ResMut<i64>, _event: ()) {
+        fn handle(seq: Seq, config: Res<u64>, mut out: ResMut<i64>) {
             *out = seq.get().as_i64() + *config as i64;
         }
 
@@ -1337,14 +1337,14 @@ mod tests {
         builder.register::<i64>(0);
         let mut world = builder.build();
         world.next_sequence();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 101);
     }
 
     #[test]
     fn seq_middle_position() {
-        fn handle(config: Res<u64>, seq: Seq, mut out: ResMut<i64>, _event: ()) {
+        fn handle(config: Res<u64>, seq: Seq, mut out: ResMut<i64>) {
             *out = *config as i64 + seq.get().as_i64();
         }
 
@@ -1353,14 +1353,14 @@ mod tests {
         builder.register::<i64>(0);
         let mut world = builder.build();
         world.next_sequence(); // seq=1
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 51);
     }
 
     #[test]
     fn seq_last_position() {
-        fn handle(mut out: ResMut<i64>, seq: Seq, _event: ()) {
+        fn handle(mut out: ResMut<i64>, seq: Seq) {
             *out = seq.get().as_i64();
         }
 
@@ -1369,27 +1369,27 @@ mod tests {
         let mut world = builder.build();
         world.next_sequence();
         world.next_sequence(); // seq=2
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 2);
     }
 
     #[test]
     fn seq_mut_only_param() {
-        fn handle(mut seq: SeqMut, _event: ()) {
+        fn handle(mut seq: SeqMut) {
             seq.advance();
         }
 
         let builder = WorldBuilder::new();
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(world.current_sequence(), Sequence(1));
     }
 
     #[test]
     fn seq_mut_first_with_res() {
-        fn handle(mut seq: SeqMut, mut out: ResMut<i64>, _event: ()) {
+        fn handle(mut seq: SeqMut, mut out: ResMut<i64>) {
             let s = seq.advance();
             *out = s.0;
         }
@@ -1397,14 +1397,14 @@ mod tests {
         let mut builder = WorldBuilder::new();
         builder.register::<i64>(0);
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 1);
     }
 
     #[test]
     fn seq_mut_middle_position() {
-        fn handle(config: Res<u64>, mut seq: SeqMut, mut out: ResMut<i64>, _event: ()) {
+        fn handle(config: Res<u64>, mut seq: SeqMut, mut out: ResMut<i64>) {
             let s = seq.advance();
             *out = s.0 + *config as i64;
         }
@@ -1413,14 +1413,14 @@ mod tests {
         builder.register::<u64>(10);
         builder.register::<i64>(0);
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 11);
     }
 
     #[test]
     fn seq_mut_last_position() {
-        fn handle(mut out: ResMut<i64>, mut seq: SeqMut, _event: ()) {
+        fn handle(mut out: ResMut<i64>, mut seq: SeqMut) {
             let s = seq.advance();
             *out = s.0;
         }
@@ -1428,14 +1428,14 @@ mod tests {
         let mut builder = WorldBuilder::new();
         builder.register::<i64>(0);
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<i64>(), 1);
     }
 
     #[test]
     fn seq_mut_multiple_advances_in_one_dispatch() {
-        fn handle(mut seq: SeqMut, mut out: ResMut<Vec<i64>>, _event: ()) {
+        fn handle(mut seq: SeqMut, mut out: ResMut<Vec<i64>>) {
             out.push(seq.advance().0);
             out.push(seq.advance().0);
             out.push(seq.advance().0);
@@ -1444,7 +1444,7 @@ mod tests {
         let mut builder = WorldBuilder::new();
         builder.register::<Vec<i64>>(Vec::new());
         let mut world = builder.build();
-        let mut h = handle.into_handler(world.registry_mut());
+        let mut h = no_event(handle).into_handler(world.registry_mut());
         h.run(&mut world, ());
         assert_eq!(*world.resource::<Vec<i64>>(), vec![1, 2, 3]);
         assert_eq!(world.current_sequence(), Sequence(3));

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -435,6 +435,65 @@ impl<E> Handler<E> for Box<dyn Handler<E>> {
 #[doc(hidden)]
 pub struct CtxFree<F>(pub(crate) F);
 
+/// Wrapper that marks a function as taking no event parameter.
+///
+/// Used in the `F` position of [`Callback`] and [`Step`](crate::pipeline::Step)
+/// to add `Handler<()>` / `StepCall<()>` impls that don't pass `()` to the
+/// user function. Same coherence trick as [`CtxFree`]: `NoEvent<F>` is a
+/// plain struct and never satisfies `FnMut`, so the new impls are provably
+/// disjoint from the existing ones.
+///
+/// For arity-0 functions (`fn()` with no parameters), the compiler can
+/// distinguish `FnMut()` from `FnMut(())` and picks the no-event impl
+/// automatically. For arities 1+, wrap the function with [`no_event()`]
+/// to disambiguate from the event-taking impls:
+///
+/// ```ignore
+/// // Arity 0 — works directly:
+/// fn standalone() { }
+/// let h = standalone.into_handler(reg);
+///
+/// // Arities 1+ — wrap with no_event():
+/// fn tick(mut counter: ResMut<Counter>) { counter.0 += 1; }
+/// let h = no_event(tick).into_handler(reg);
+/// ```
+pub struct NoEvent<F>(pub(crate) F);
+
+/// Wrap a function for use as a no-event handler, callback, or pipeline step.
+///
+/// When `E = ()`, functions with 1+ parameters are ambiguous: the compiler
+/// can't tell if the last parameter is the event or a [`Param`]. Wrapping
+/// with `no_event()` resolves this — the function receives only its
+/// [`Param`] parameters, no event.
+///
+/// Arity-0 functions (`fn()`) don't need this wrapper — the compiler can
+/// distinguish `FnMut()` from `FnMut(())` automatically.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_rt::{no_event, ResMut, IntoHandler, Handler, WorldBuilder, Resource};
+///
+/// #[derive(Resource)]
+/// struct Counter(u64);
+///
+/// fn tick(mut counter: ResMut<Counter>) {
+///     counter.0 += 1;
+/// }
+///
+/// let mut builder = WorldBuilder::new();
+/// builder.register(Counter(0));
+/// let mut world = builder.build();
+///
+/// let mut h = no_event(tick).into_handler(world.registry());
+/// h.run(&mut world, ());
+///
+/// assert_eq!(world.resource::<Counter>().0, 1);
+/// ```
+pub fn no_event<F>(f: F) -> NoEvent<F> {
+    NoEvent(f)
+}
+
 /// Type alias for context-free handlers (no owned context).
 ///
 /// This is `Callback<(), CtxFree<F>, Params>` — the `ctx: ()` field
@@ -505,6 +564,7 @@ pub type HandlerFn<F, Params> = Callback<(), CtxFree<F>, Params>;
 #[diagnostic::on_unimplemented(
     message = "this function cannot be converted into a handler",
     note = "handler signature: `fn(Res<A>, ResMut<B>, ..., Event)` — resources first, event last",
+    note = "for Handler<()>, you can omit the event: `fn(Res<A>, ResMut<B>, ...)`",
     note = "closures with resource parameters (Res<T>, ResMut<T>) are not supported — use a named `fn`",
     note = "arity-0 closures (`fn(Event)` with no resources) ARE supported"
 )]
@@ -615,6 +675,95 @@ macro_rules! impl_into_handler {
 }
 
 all_tuples!(impl_into_handler);
+
+// =============================================================================
+// No-event impls — Handler<()> without trailing `_: ()` parameter
+// =============================================================================
+
+// Arity 0: fn() → Handler<()>
+impl<F: FnMut() + Send + 'static> IntoHandler<(), NoEvent<F>> for F {
+    type Handler = Callback<(), CtxFree<NoEvent<F>>, ()>;
+
+    fn into_handler(self, registry: &Registry) -> Self::Handler {
+        Callback {
+            ctx: (),
+            f: CtxFree(NoEvent(self)),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+impl<F: FnMut() + Send + 'static> Handler<()> for Callback<(), CtxFree<NoEvent<F>>, ()> {
+    fn run(&mut self, _world: &mut World, _event: ()) {
+        (self.f.0.0)();
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+macro_rules! impl_into_handler_no_event {
+    ($($P:ident),+) => {
+        impl<F: Send + 'static, $($P: Param + 'static),+>
+            IntoHandler<(), ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+        {
+            type Handler = Callback<(), CtxFree<NoEvent<F>>, ($($P,)+)>;
+
+            fn into_handler(self, registry: &Registry) -> Self::Handler {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Callback {
+                    ctx: (),
+                    f: CtxFree(self),
+                    state,
+                    name: std::any::type_name::<F>(),
+                }
+            }
+        }
+
+        impl<F: Send + 'static, $($P: Param + 'static),+> Handler<()>
+            for Callback<(), CtxFree<NoEvent<F>>, ($($P,)+)>
+        where
+            for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+        {
+            #[allow(non_snake_case)]
+            fn run(&mut self, world: &mut World, _event: ()) {
+                fn call_inner<$($P),+>(
+                    mut f: impl FnMut($($P),+),
+                    $($P: $P,)+
+                ) {
+                    f($($P),+)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0 .0, $($P,)+);
+            }
+
+            fn name(&self) -> &'static str {
+                self.name
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_handler_no_event);
 
 // =============================================================================
 // Opaque — marker for closures with unresolved dependencies
@@ -1341,5 +1490,90 @@ mod tests {
 
         resolved.run(&mut world, 42);
         assert_eq!(*world.resource::<u64>(), 42);
+    }
+
+    // =========================================================================
+    // NoEvent — Handler<()> without trailing `_: ()`
+    // =========================================================================
+
+    fn no_event_standalone() {}
+
+    #[test]
+    fn no_event_arity_0() {
+        let mut world = WorldBuilder::new().build();
+        let mut h = no_event_standalone.into_handler(world.registry_mut());
+        h.run(&mut world, ());
+    }
+
+    fn no_event_tick(mut counter: ResMut<u64>) {
+        *counter += 1;
+    }
+
+    #[test]
+    fn no_event_arity_1() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let mut h = no_event(no_event_tick).into_handler(world.registry_mut());
+        h.run(&mut world, ());
+        h.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 2);
+    }
+
+    fn no_event_two_params(src: Res<u32>, mut dst: ResMut<u64>) {
+        *dst += *src as u64;
+    }
+
+    #[test]
+    fn no_event_arity_2() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u32>(7);
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let mut h = no_event(no_event_two_params).into_handler(world.registry_mut());
+        h.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 7);
+    }
+
+    #[test]
+    fn no_event_boxed() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let h = no_event(no_event_tick).into_handler(world.registry_mut());
+        let mut boxed: Box<dyn Handler<()>> = Box::new(h);
+        boxed.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 1);
+    }
+
+    #[test]
+    fn no_event_coexists_with_event_handler() {
+        use crate::no_event;
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        // No-event handler
+        let mut h1 = no_event(no_event_tick).into_handler(world.registry_mut());
+        h1.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 1);
+
+        // Event handler on same resource — still works
+        fn add_event(mut val: ResMut<u64>, event: u64) {
+            *val += event;
+        }
+        let mut h2 = add_event.into_handler(world.registry_mut());
+        h2.run(&mut world, 10);
+        assert_eq!(*world.resource::<u64>(), 11);
     }
 }

--- a/nexus-rt/src/lib.rs
+++ b/nexus-rt/src/lib.rs
@@ -192,8 +192,8 @@ pub use combinator::{Broadcast, FanOut};
 pub use dag::{BatchDag, Dag, DagBuilder, resolve_arm};
 pub use driver::Installer;
 pub use handler::{
-    CtxFree, Handler, HandlerFn, IntoHandler, Local, Opaque, OpaqueHandler, Param, RegistryRef,
-    Resolved,
+    CtxFree, Handler, HandlerFn, IntoHandler, Local, NoEvent, Opaque, OpaqueHandler, Param,
+    RegistryRef, Resolved, no_event,
 };
 #[cfg(feature = "reactors")]
 pub use reactor::{

--- a/nexus-rt/src/pipeline.rs
+++ b/nexus-rt/src/pipeline.rs
@@ -271,6 +271,91 @@ macro_rules! impl_into_step {
 all_tuples!(impl_into_step);
 
 // =============================================================================
+// No-event Step — IntoStep<(), Out, _> without passing `()` to the function
+// =============================================================================
+
+use crate::handler::NoEvent;
+
+// Arity 0: fn() -> Out
+impl<Out, F: FnMut() -> Out + 'static> StepCall<()> for Step<NoEvent<F>, ()> {
+    type Out = Out;
+    #[inline(always)]
+    fn call(&mut self, _world: &mut World, _input: ()) -> Out {
+        (self.f.0)()
+    }
+}
+
+impl<Out, F: FnMut() -> Out + 'static> IntoStep<(), Out, NoEvent<F>> for F {
+    type Step = Step<NoEvent<F>, ()>;
+
+    fn into_step(self, registry: &Registry) -> Self::Step {
+        Step {
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+macro_rules! impl_into_step_no_event {
+    ($($P:ident),+) => {
+        impl<Out, F: 'static, $($P: Param + 'static),+>
+            StepCall<()> for Step<NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+) -> Out +
+                FnMut($($P::Item<'a>,)+) -> Out,
+        {
+            type Out = Out;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn call(&mut self, world: &mut World, _input: ()) -> Out {
+                fn call_inner<$($P,)+ Output>(
+                    mut f: impl FnMut($($P,)+) -> Output,
+                    $($P: $P,)+
+                ) -> Output {
+                    f($($P,)+)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, $($P,)+)
+            }
+        }
+
+        impl<Out, F: 'static, $($P: Param + 'static),+>
+            IntoStep<(), Out, ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+) -> Out +
+                FnMut($($P::Item<'a>,)+) -> Out,
+        {
+            type Step = Step<NoEvent<F>, ($($P,)+)>;
+
+            fn into_step(self, registry: &Registry) -> Self::Step {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Step { f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_step_no_event);
+
+// =============================================================================
 // OpaqueStep — wrapper for opaque closures as steps
 // =============================================================================
 
@@ -429,6 +514,89 @@ macro_rules! impl_into_ref_step {
 }
 
 all_tuples!(impl_into_ref_step);
+
+// =============================================================================
+// No-event RefStep — IntoRefStep<(), Out, _> without passing `&()` to function
+// =============================================================================
+
+// Arity 0: fn() -> Out
+impl<Out, F: FnMut() -> Out + 'static> RefStepCall<()> for Step<NoEvent<F>, ()> {
+    type Out = Out;
+    #[inline(always)]
+    fn call(&mut self, _world: &mut World, _input: &()) -> Out {
+        (self.f.0)()
+    }
+}
+
+impl<Out, F: FnMut() -> Out + 'static> IntoRefStep<(), Out, NoEvent<F>> for F {
+    type Step = Step<NoEvent<F>, ()>;
+
+    fn into_ref_step(self, registry: &Registry) -> Self::Step {
+        Step {
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+macro_rules! impl_into_ref_step_no_event {
+    ($($P:ident),+) => {
+        impl<Out, F: 'static, $($P: Param + 'static),+>
+            RefStepCall<()> for Step<NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+) -> Out +
+                FnMut($($P::Item<'a>,)+) -> Out,
+        {
+            type Out = Out;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn call(&mut self, world: &mut World, _input: &()) -> Out {
+                fn call_inner<$($P,)+ Output>(
+                    mut f: impl FnMut($($P,)+) -> Output,
+                    $($P: $P,)+
+                ) -> Output {
+                    f($($P,)+)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, $($P,)+)
+            }
+        }
+
+        impl<Out, F: 'static, $($P: Param + 'static),+>
+            IntoRefStep<(), Out, ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+) -> Out +
+                FnMut($($P::Item<'a>,)+) -> Out,
+        {
+            type Step = Step<NoEvent<F>, ($($P,)+)>;
+
+            fn into_ref_step(self, registry: &Registry) -> Self::Step {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Step { f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_ref_step_no_event);
 
 // -- Opaque: FnMut(&mut World, &In) -> Out ---------------------------------
 
@@ -771,6 +939,90 @@ macro_rules! impl_into_scan_step {
 
 all_tuples!(impl_into_scan_step);
 
+// =============================================================================
+// No-event ScanStep — IntoScanStep<Acc, (), Out, _> without passing `()` input
+// =============================================================================
+
+// Arity 0: fn(&mut Acc) -> Out
+impl<Acc, Out, F: FnMut(&mut Acc) -> Out + 'static> ScanStepCall<Acc, ()> for Step<NoEvent<F>, ()> {
+    type Out = Out;
+    #[inline(always)]
+    fn call(&mut self, _world: &mut World, acc: &mut Acc, _input: ()) -> Out {
+        (self.f.0)(acc)
+    }
+}
+
+impl<Acc, Out, F: FnMut(&mut Acc) -> Out + 'static> IntoScanStep<Acc, (), Out, NoEvent<F>> for F {
+    type Step = Step<NoEvent<F>, ()>;
+
+    fn into_scan_step(self, registry: &Registry) -> Self::Step {
+        Step {
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+macro_rules! impl_into_scan_step_no_event {
+    ($($P:ident),+) => {
+        impl<Acc, Out, F: 'static, $($P: Param + 'static),+>
+            ScanStepCall<Acc, ()> for Step<NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+ &mut Acc) -> Out +
+                FnMut($($P::Item<'a>,)+ &mut Acc) -> Out,
+        {
+            type Out = Out;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn call(&mut self, world: &mut World, acc: &mut Acc, _input: ()) -> Out {
+                fn call_inner<$($P,)+ Accumulator, Output>(
+                    mut f: impl FnMut($($P,)+ &mut Accumulator) -> Output,
+                    $($P: $P,)+
+                    acc: &mut Accumulator,
+                ) -> Output {
+                    f($($P,)+ acc)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, $($P,)+ acc)
+            }
+        }
+
+        impl<Acc, Out, F: 'static, $($P: Param + 'static),+>
+            IntoScanStep<Acc, (), Out, ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+ &mut Acc) -> Out +
+                FnMut($($P::Item<'a>,)+ &mut Acc) -> Out,
+        {
+            type Step = Step<NoEvent<F>, ($($P,)+)>;
+
+            fn into_scan_step(self, registry: &Registry) -> Self::Step {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Step { f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_scan_step_no_event);
+
 // -- Opaque: FnMut(&mut World, &mut Acc, In) -> Out --------------------------
 
 /// Internal: wrapper for opaque closures used as scan steps.
@@ -948,6 +1200,94 @@ macro_rules! impl_into_ref_scan_step {
 }
 
 all_tuples!(impl_into_ref_scan_step);
+
+// =============================================================================
+// No-event RefScanStep — IntoRefScanStep<Acc, (), Out, _> without `&()` input
+// =============================================================================
+
+// Arity 0: fn(&mut Acc) -> Out
+impl<Acc, Out, F: FnMut(&mut Acc) -> Out + 'static> RefScanStepCall<Acc, ()>
+    for Step<NoEvent<F>, ()>
+{
+    type Out = Out;
+    #[inline(always)]
+    fn call(&mut self, _world: &mut World, acc: &mut Acc, _input: &()) -> Out {
+        (self.f.0)(acc)
+    }
+}
+
+impl<Acc, Out, F: FnMut(&mut Acc) -> Out + 'static> IntoRefScanStep<Acc, (), Out, NoEvent<F>>
+    for F
+{
+    type Step = Step<NoEvent<F>, ()>;
+
+    fn into_ref_scan_step(self, registry: &Registry) -> Self::Step {
+        Step {
+            f: NoEvent(self),
+            state: <() as Param>::init(registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+macro_rules! impl_into_ref_scan_step_no_event {
+    ($($P:ident),+) => {
+        impl<Acc, Out, F: 'static, $($P: Param + 'static),+>
+            RefScanStepCall<Acc, ()> for Step<NoEvent<F>, ($($P,)+)>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+ &mut Acc) -> Out +
+                FnMut($($P::Item<'a>,)+ &mut Acc) -> Out,
+        {
+            type Out = Out;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            fn call(&mut self, world: &mut World, acc: &mut Acc, _input: &()) -> Out {
+                fn call_inner<$($P,)+ Accumulator, Output>(
+                    mut f: impl FnMut($($P,)+ &mut Accumulator) -> Output,
+                    $($P: $P,)+
+                    acc: &mut Accumulator,
+                ) -> Output {
+                    f($($P,)+ acc)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f.0, $($P,)+ acc)
+            }
+        }
+
+        impl<Acc, Out, F: 'static, $($P: Param + 'static),+>
+            IntoRefScanStep<Acc, (), Out, ($($P,)+)> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut($($P,)+ &mut Acc) -> Out +
+                FnMut($($P::Item<'a>,)+ &mut Acc) -> Out,
+        {
+            type Step = Step<NoEvent<F>, ($($P,)+)>;
+
+            fn into_ref_scan_step(self, registry: &Registry) -> Self::Step {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                Step { f: self, state, name: std::any::type_name::<F>() }
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_ref_scan_step_no_event);
 
 // -- Opaque: FnMut(&mut World, &mut Acc, &In) -> Out ------------------------
 
@@ -5461,5 +5801,75 @@ mod tests {
         assert_eq!(*world.resource::<u64>(), 0);
         p.run(&mut world, &data); // Some(3)
         assert_eq!(*world.resource::<u64>(), 3);
+    }
+
+    // =========================================================================
+    // NoEvent — pipeline steps with In = () that omit the input parameter
+    // =========================================================================
+
+    #[test]
+    fn no_event_step_arity_0() {
+        let mut world = WorldBuilder::new().build();
+        let r = world.registry_mut();
+        let mut p = PipelineBuilder::<()>::new().then(|| 42u64, r);
+        assert_eq!(p.run(&mut world, ()), 42);
+    }
+
+    #[test]
+    fn no_event_step_arity_1() {
+        use crate::no_event;
+
+        let mut wb = WorldBuilder::new();
+        wb.register::<u32>(10);
+        let mut world = wb.build();
+
+        fn read_config(config: Res<u32>) -> u64 {
+            *config as u64
+        }
+
+        let r = world.registry_mut();
+        let mut p = PipelineBuilder::<()>::new().then(no_event(read_config), r);
+        assert_eq!(p.run(&mut world, ()), 10);
+    }
+
+    #[test]
+    fn no_event_step_chained() {
+        use crate::no_event;
+
+        let mut wb = WorldBuilder::new();
+        wb.register::<u32>(5);
+        let mut world = wb.build();
+
+        fn read_val(val: Res<u32>) -> u64 {
+            *val as u64
+        }
+
+        let r = world.registry_mut();
+        let mut p = PipelineBuilder::<()>::new()
+            .then(no_event(read_val), r)
+            .then(|x: u64| x * 2, r);
+        assert_eq!(p.run(&mut world, ()), 10);
+    }
+
+    #[test]
+    fn no_event_step_as_handler() {
+        use crate::no_event;
+
+        let mut wb = WorldBuilder::new();
+        wb.register::<u64>(0);
+        let mut world = wb.build();
+
+        fn write_val(mut out: ResMut<u64>) {
+            *out += 1;
+        }
+
+        let r = world.registry_mut();
+        let mut p = PipelineBuilder::<()>::new()
+            .then(no_event(write_val), r)
+            .build();
+
+        p.run(&mut world, ());
+        p.run(&mut world, ());
+        assert_eq!(*world.resource::<u64>(), 2);
     }
 }

--- a/nexus-rt/src/reactor.rs
+++ b/nexus-rt/src/reactor.rs
@@ -2675,7 +2675,7 @@ mod tests {
             _reactor_id: Token,
         }
 
-        fn read(ctx: &mut Ctx, val: Res<u64>, _: ()) -> u64 {
+        fn read(ctx: &mut Ctx, val: Res<u64>) -> u64 {
             let _ = ctx;
             *val
         }
@@ -2695,7 +2695,7 @@ mod tests {
         // Phase 2: build pipeline + wrap in PipelineReactor (needs registry)
         let reg = world.registry();
         let pipeline = CtxPipelineBuilder::<Ctx, ()>::new()
-            .then(read, reg)
+            .then(crate::no_event(read), reg)
             .then(double, reg)
             .then(store, reg)
             .build();

--- a/nexus-rt/src/resource.rs
+++ b/nexus-rt/src/resource.rs
@@ -12,14 +12,14 @@
 //! # Examples
 //!
 //! ```
-//! use nexus_rt::{WorldBuilder, Res, ResMut, IntoHandler, Handler, Resource};
+//! use nexus_rt::{WorldBuilder, Res, ResMut, IntoHandler, Handler, Resource, no_event};
 //!
 //! #[derive(Resource)]
 //! struct Config(u64);
 //! #[derive(Resource)]
 //! struct Flag(bool);
 //!
-//! fn process(config: Res<Config>, mut state: ResMut<Flag>, _event: ()) {
+//! fn process(config: Res<Config>, mut state: ResMut<Flag>) {
 //!     if config.0 > 10 {
 //!         state.0 = true;
 //!     }
@@ -30,7 +30,7 @@
 //! builder.register(Flag(false));
 //! let mut world = builder.build();
 //!
-//! let mut handler = process.into_handler(world.registry());
+//! let mut handler = no_event(process).into_handler(world.registry());
 //! handler.run(&mut world, ());
 //!
 //! assert!(world.resource::<Flag>().0);

--- a/nexus-rt/src/shutdown.rs
+++ b/nexus-rt/src/shutdown.rs
@@ -5,15 +5,15 @@
 //! shutdown via [`Shutdown::trigger`]:
 //!
 //! ```
-//! use nexus_rt::{WorldBuilder, IntoHandler, Handler};
+//! use nexus_rt::{WorldBuilder, IntoHandler, Handler, no_event};
 //! use nexus_rt::shutdown::Shutdown;
 //!
-//! fn on_fatal(shutdown: Shutdown, _event: ()) {
+//! fn on_fatal(shutdown: Shutdown) {
 //!     shutdown.trigger();
 //! }
 //!
 //! let mut world = WorldBuilder::new().build();
-//! let mut handler = on_fatal.into_handler(world.registry());
+//! let mut handler = no_event(on_fatal).into_handler(world.registry());
 //! handler.run(&mut world, ());
 //! assert!(world.shutdown_handle().is_shutdown());
 //! ```
@@ -155,14 +155,14 @@ mod tests {
     fn shutdown_in_handler() {
         use crate::{Handler, IntoHandler};
 
-        fn trigger_shutdown(shutdown: Shutdown, _event: ()) {
+        fn trigger_shutdown(shutdown: Shutdown) {
             shutdown.trigger();
         }
 
         let mut world = crate::WorldBuilder::new().build();
         let handle = world.shutdown_handle();
 
-        let mut handler = trigger_shutdown.into_handler(world.registry());
+        let mut handler = crate::no_event(trigger_shutdown).into_handler(world.registry());
         assert!(!handle.is_shutdown());
         handler.run(&mut world, ());
         assert!(handle.is_shutdown());

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -309,6 +309,154 @@ macro_rules! impl_template_dispatch {
 all_tuples!(impl_template_dispatch);
 
 // =============================================================================
+// No-event TemplateDispatch / CallbackTemplateDispatch — E = (), no event param
+// =============================================================================
+
+use crate::handler::NoEvent;
+
+// Arity 0: fn() with no event and no params
+impl<F: FnMut() + Send + 'static> TemplateDispatch<(), ()> for NoEvent<F> {
+    fn run_fn_ptr() -> unsafe fn(&mut (), &mut World, ()) {
+        /// # Safety
+        ///
+        /// `F` must be a ZST (enforced by `HandlerTemplate::new`).
+        unsafe fn run<F: FnMut() + Send>(_state: &mut (), _world: &mut World, _event: ()) {
+            // SAFETY: F is ZST — zeroed() produces the unique value.
+            let mut f: F = unsafe { std::mem::zeroed() };
+            f();
+        }
+        run::<F>
+    }
+
+    fn validate(_state: &(), _registry: &Registry) {}
+}
+
+impl<C: Send + 'static, F: FnMut(&mut C) + Send + 'static> CallbackTemplateDispatch<C, (), ()>
+    for NoEvent<F>
+{
+    fn run_fn_ptr() -> unsafe fn(&mut C, &mut (), &mut World, ()) {
+        /// # Safety
+        ///
+        /// `F` must be a ZST (enforced by `CallbackTemplate::stamp`).
+        unsafe fn run<C: Send, F: FnMut(&mut C) + Send>(
+            ctx: &mut C,
+            _state: &mut (),
+            _world: &mut World,
+            _event: (),
+        ) {
+            // SAFETY: F is ZST — zeroed() produces the unique value.
+            let mut f: F = unsafe { std::mem::zeroed() };
+            f(ctx);
+        }
+        run::<C, F>
+    }
+
+    fn validate(_state: &(), _registry: &Registry) {}
+}
+
+// Arities 1-8: fn(Params...) with no event
+macro_rules! impl_template_dispatch_no_event {
+    ($($P:ident),+) => {
+        impl<F: Send + 'static, $($P: Param + 'static),+> TemplateDispatch<($($P,)+), ()>
+            for NoEvent<F>
+        where
+            for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+        {
+            fn run_fn_ptr() -> unsafe fn(&mut ($($P::State,)+), &mut World, ()) {
+                /// # Safety
+                ///
+                /// - `F` must be a ZST (enforced by `HandlerTemplate::new`).
+                /// - `state` must have been produced by `Param::init` on the
+                ///   same registry that built `world`.
+                #[allow(non_snake_case)]
+                unsafe fn run<F: Send + 'static, $($P: Param + 'static),+>(
+                    state: &mut ($($P::State,)+),
+                    world: &mut World,
+                    _event: (),
+                ) where
+                    for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+                {
+                    fn call_inner<$($P),+>(
+                        mut f: impl FnMut($($P),+),
+                        $($P: $P,)+
+                    ) {
+                        f($($P),+);
+                    }
+
+                    #[cfg(debug_assertions)]
+                    world.clear_borrows();
+                    let ($($P,)+) = unsafe {
+                        <($($P,)+) as Param>::fetch(world, state)
+                    };
+                    // SAFETY: F is ZST — zeroed() produces the unique value.
+                    let mut f: F = unsafe { std::mem::zeroed() };
+                    call_inner(&mut f, $($P,)+);
+                }
+                run::<F, $($P),+>
+            }
+
+            #[allow(non_snake_case)]
+            fn validate(state: &($($P::State,)+), registry: &Registry) {
+                let ($($P,)+) = state;
+                registry.check_access(&[
+                    $((<$P as Param>::resource_id($P), std::any::type_name::<$P>()),)+
+                ]);
+            }
+        }
+
+        impl<C: Send + 'static, F: Send + 'static, $($P: Param + 'static),+>
+            CallbackTemplateDispatch<C, ($($P,)+), ()> for NoEvent<F>
+        where
+            for<'a> &'a mut F:
+                FnMut(&mut C, $($P,)+) +
+                FnMut(&mut C, $($P::Item<'a>,)+),
+        {
+            fn run_fn_ptr() -> unsafe fn(&mut C, &mut ($($P::State,)+), &mut World, ()) {
+                #[allow(non_snake_case)]
+                unsafe fn run<C: Send, F: Send + 'static, $($P: Param + 'static),+>(
+                    ctx: &mut C,
+                    state: &mut ($($P::State,)+),
+                    world: &mut World,
+                    _event: (),
+                ) where
+                    for<'a> &'a mut F:
+                        FnMut(&mut C, $($P,)+) +
+                        FnMut(&mut C, $($P::Item<'a>,)+),
+                {
+                    fn call_inner<Ctx, $($P),+>(
+                        mut f: impl FnMut(&mut Ctx, $($P),+),
+                        ctx: &mut Ctx,
+                        $($P: $P,)+
+                    ) {
+                        f(ctx, $($P),+);
+                    }
+
+                    #[cfg(debug_assertions)]
+                    world.clear_borrows();
+                    let ($($P,)+) = unsafe {
+                        <($($P,)+) as Param>::fetch(world, state)
+                    };
+                    // SAFETY: F is ZST — zeroed() produces the unique value.
+                    let mut f: F = unsafe { std::mem::zeroed() };
+                    call_inner(&mut f, ctx, $($P,)+);
+                }
+                run::<C, F, $($P),+>
+            }
+
+            #[allow(non_snake_case)]
+            fn validate(state: &($($P::State,)+), registry: &Registry) {
+                let ($($P,)+) = state;
+                registry.check_access(&[
+                    $((<$P as Param>::resource_id($P), std::any::type_name::<$P>()),)+
+                ]);
+            }
+        }
+    };
+}
+
+all_tuples!(impl_template_dispatch_no_event);
+
+// =============================================================================
 // HandlerTemplate<K>
 // =============================================================================
 
@@ -462,7 +610,7 @@ type CallbackRunFn<K> = unsafe fn(
 /// # Examples
 ///
 /// ```
-/// use nexus_rt::{WorldBuilder, ResMut, Handler, Resource};
+/// use nexus_rt::{WorldBuilder, ResMut, Handler, Resource, no_event};
 /// use nexus_rt::template::{Blueprint, CallbackBlueprint, CallbackTemplate};
 ///
 /// #[derive(Resource)]
@@ -479,7 +627,7 @@ type CallbackRunFn<K> = unsafe fn(
 ///     type Context = TimerCtx;
 /// }
 ///
-/// fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<Counter>, _event: ()) {
+/// fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<Counter>) {
 ///     ctx.fires += 1;
 ///     counter.0 += ctx.order_id;
 /// }
@@ -488,7 +636,7 @@ type CallbackRunFn<K> = unsafe fn(
 /// builder.register(Counter(0));
 /// let world = builder.build();
 ///
-/// let template = CallbackTemplate::<OnTimeout>::new(on_timeout, world.registry());
+/// let template = CallbackTemplate::<OnTimeout>::new(no_event(on_timeout), world.registry());
 /// let mut cb1 = template.generate(TimerCtx { order_id: 10, fires: 0 });
 /// let mut cb2 = template.generate(TimerCtx { order_id: 20, fires: 0 });
 ///
@@ -654,7 +802,7 @@ macro_rules! callback_blueprint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Res, ResMut, WorldBuilder};
+    use crate::{Res, ResMut, WorldBuilder, no_event};
 
     // -- Blueprint definitions ------------------------------------------------
 
@@ -721,7 +869,7 @@ mod tests {
         h.run(&mut world, 42);
     }
 
-    fn two_params_fn(counter: Res<u64>, mut flag: ResMut<bool>, _event: ()) {
+    fn two_params_fn(counter: Res<u64>, mut flag: ResMut<bool>) {
         if *counter > 0 {
             *flag = true;
         }
@@ -734,7 +882,7 @@ mod tests {
         builder.register::<bool>(false);
         let mut world = builder.build();
 
-        let template = HandlerTemplate::<TwoParams>::new(two_params_fn, world.registry());
+        let template = HandlerTemplate::<TwoParams>::new(no_event(two_params_fn), world.registry());
         let mut h = template.generate();
         h.run(&mut world, ());
         assert!(*world.resource::<bool>());
@@ -786,14 +934,14 @@ mod tests {
             type Params = (Res<'static, u64>, ResMut<'static, u64>);
         }
 
-        fn bad(a: Res<u64>, b: ResMut<u64>, _e: ()) {
+        fn bad(a: Res<u64>, b: ResMut<u64>) {
             let _ = (*a, &*b);
         }
 
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
         let world = builder.build();
-        let _template = HandlerTemplate::<BadBlueprint>::new(bad, world.registry());
+        let _template = HandlerTemplate::<BadBlueprint>::new(no_event(bad), world.registry());
     }
 
     // -- CallbackTemplate tests -----------------------------------------------
@@ -812,7 +960,7 @@ mod tests {
         type Context = TimerCtx;
     }
 
-    fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<u64>, _event: ()) {
+    fn on_timeout(ctx: &mut TimerCtx, mut counter: ResMut<u64>) {
         ctx.fires += 1;
         *counter += ctx.order_id;
     }
@@ -823,7 +971,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<OnTimeout>::new(on_timeout, world.registry());
+        let template = CallbackTemplate::<OnTimeout>::new(no_event(on_timeout), world.registry());
         let mut cb = template.generate(TimerCtx {
             order_id: 42,
             fires: 0,
@@ -839,7 +987,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<OnTimeout>::new(on_timeout, world.registry());
+        let template = CallbackTemplate::<OnTimeout>::new(no_event(on_timeout), world.registry());
         let mut cb1 = template.generate(TimerCtx {
             order_id: 10,
             fires: 0,
@@ -884,7 +1032,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<OnTimeout>::new(on_timeout, world.registry());
+        let template = CallbackTemplate::<OnTimeout>::new(no_event(on_timeout), world.registry());
         let cb = template.generate(TimerCtx {
             order_id: 7,
             fires: 0,
@@ -900,7 +1048,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<OnTimeout>::new(on_timeout, world.registry());
+        let template = CallbackTemplate::<OnTimeout>::new(no_event(on_timeout), world.registry());
         let mut cb = template.generate(TimerCtx {
             order_id: 42,
             fires: 0,
@@ -999,7 +1147,8 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<MacroOnTimeout>::new(on_timeout, world.registry());
+        let template =
+            CallbackTemplate::<MacroOnTimeout>::new(no_event(on_timeout), world.registry());
         let mut cb = template.generate(TimerCtx {
             order_id: 5,
             fires: 0,

--- a/nexus-rt/tests/compile_tests.rs
+++ b/nexus-rt/tests/compile_tests.rs
@@ -3515,14 +3515,14 @@ fn run_startup_bool_returning_also_works() {
 
 #[test]
 fn resolved_res_param() {
-    fn read_val(val: Res<ResU32>, mut out: ResMut<ResU64>, _e: ()) {
+    fn read_val(val: Res<ResU32>, mut out: ResMut<ResU64>) {
         **out = **val as u64;
     }
     let mut wb = WorldBuilder::new();
     wb.register(ResU32(42));
     wb.register(ResU64(0));
     let mut world = wb.build();
-    let mut h = read_val
+    let mut h = nexus_rt::no_event(read_val)
         .into_handler(world.registry())
         .into_handler(world.registry());
     h.run(&mut world, ());
@@ -3561,7 +3561,7 @@ fn resolved_seq_mut_param() {
 
 #[test]
 fn resolved_optional_res() {
-    fn maybe(v: Option<Res<ResU32>>, mut out: ResMut<ResU64>, _e: ()) {
+    fn maybe(v: Option<Res<ResU32>>, mut out: ResMut<ResU64>) {
         if let Some(v) = v {
             **out = **v as u64;
         }
@@ -3570,7 +3570,7 @@ fn resolved_optional_res() {
     wb.register(ResU32(55));
     wb.register(ResU64(0));
     let mut world = wb.build();
-    let mut h = maybe
+    let mut h = nexus_rt::no_event(maybe)
         .into_handler(world.registry())
         .into_handler(world.registry());
     h.run(&mut world, ());
@@ -3596,14 +3596,14 @@ fn resolved_optional_resmut() {
 
 #[test]
 fn resolved_local_preserves_state() {
-    fn counter(mut l: Local<u64>, mut out: ResMut<ResU64>, _e: ()) {
+    fn counter(mut l: Local<u64>, mut out: ResMut<ResU64>) {
         *l += 1;
         **out = *l;
     }
     let mut wb = WorldBuilder::new();
     wb.register(ResU64(0));
     let mut world = wb.build();
-    let mut h = counter
+    let mut h = nexus_rt::no_event(counter)
         .into_handler(world.registry())
         .into_handler(world.registry());
     h.run(&mut world, ());
@@ -5414,7 +5414,6 @@ mod reactors {
             mut notify: ResMut<ReactorNotify>,
             sources: Res<SourceRegistry>,
             reg: RegistryRef<'_>,
-            _event: (),
         ) {
             let md = sources.get(&"BTC").expect("BTC not listed");
             notify
@@ -5431,7 +5430,7 @@ mod reactors {
 
         // Build the handler (compile test: RegistryRef works as Param alongside
         // ResMut<ReactorNotify> and Res<SourceRegistry>)
-        let mut handler = on_admin_add_twap.into_handler(world.registry());
+        let mut handler = nexus_rt::no_event(on_admin_add_twap).into_handler(world.registry());
 
         // Simulate admin command arriving — handler registers the reactor
         handler.run(&mut world, ());
@@ -5471,7 +5470,7 @@ mod reactors {
             multiplier: u64,
         }
 
-        fn read(_ctx: &mut Ctx, counter: Res<Counter>, _: ()) -> u64 {
+        fn read(_ctx: &mut Ctx, counter: Res<Counter>) -> u64 {
             counter.0
         }
 
@@ -5490,7 +5489,7 @@ mod reactors {
         let token = world.resource_mut::<ReactorNotify>().create_reactor();
         let reg = world.registry();
         let pipeline = CtxPipelineBuilder::<Ctx, ()>::new()
-            .then(read, reg)
+            .then(nexus_rt::no_event(read), reg)
             .then(multiply, reg)
             .then(store, reg)
             .build();
@@ -5532,7 +5531,7 @@ mod reactors {
             _rereactor_id: Token,
         }
 
-        fn double(_ctx: &mut Ctx, counter: Res<Counter>, _: ()) -> u64 {
+        fn double(_ctx: &mut Ctx, counter: Res<Counter>) -> u64 {
             counter.0 * 2
         }
 
@@ -5541,9 +5540,9 @@ mod reactors {
         }
 
         // Handler that builds a pipeline reactor at runtime
-        fn on_admin(mut notify: ResMut<ReactorNotify>, reg: RegistryRef<'_>, _event: ()) {
+        fn on_admin(mut notify: ResMut<ReactorNotify>, reg: RegistryRef<'_>) {
             let pipeline = CtxPipelineBuilder::<Ctx, ()>::new()
-                .then(double, &reg)
+                .then(nexus_rt::no_event(double), &reg)
                 .then(store, &reg)
                 .build();
 
@@ -5559,7 +5558,7 @@ mod reactors {
                 .subscribe(DataSource(0));
         }
 
-        let mut handler = on_admin.into_handler(world.registry());
+        let mut handler = nexus_rt::no_event(on_admin).into_handler(world.registry());
         handler.run(&mut world, ());
 
         world.resource_mut::<Counter>().0 = 5;

--- a/nexus-rt/tests/derive_param.rs
+++ b/nexus-rt/tests/derive_param.rs
@@ -1,6 +1,6 @@
 //! Integration tests for #[derive(Param)].
 
-use nexus_rt::{Handler, IntoHandler, Local, Param, Res, ResMut, Resource, WorldBuilder};
+use nexus_rt::{Handler, IntoHandler, Local, Param, Res, ResMut, Resource, WorldBuilder, no_event};
 
 // =========================================================================
 // Test types
@@ -63,7 +63,7 @@ struct ParamsWithLocal<'w> {
     call_count: Local<'w, u64>,
 }
 
-fn handler_with_local(mut params: ParamsWithLocal<'_>, _event: ()) {
+fn handler_with_local(mut params: ParamsWithLocal<'_>) {
     *params.call_count += 1;
     let _ = params.config.max_exposure;
 }
@@ -76,7 +76,7 @@ fn with_local() {
     });
     let mut world = wb.build();
 
-    let mut h = handler_with_local.into_handler(world.registry());
+    let mut h = no_event(handler_with_local).into_handler(world.registry());
     h.run(&mut world, ());
     h.run(&mut world, ());
     h.run(&mut world, ());
@@ -94,7 +94,7 @@ struct OptionalParams<'w> {
     risk: ResMut<'w, RiskState>,
 }
 
-fn handler_optional(mut params: OptionalParams<'_>, _event: ()) {
+fn handler_optional(mut params: OptionalParams<'_>) {
     if let Some(config) = params.config {
         params.risk.exposure = config.max_exposure;
     }
@@ -107,7 +107,7 @@ fn with_optional_res() {
     wb.register(RiskState::default());
     let mut world = wb.build();
 
-    let mut h = handler_optional.into_handler(world.registry());
+    let mut h = no_event(handler_optional).into_handler(world.registry());
     h.run(&mut world, ());
     assert_eq!(world.resource::<RiskState>().exposure, 0.0); // no config
 
@@ -119,7 +119,7 @@ fn with_optional_res() {
     });
     let mut world2 = wb2.build();
 
-    let mut h2 = handler_optional.into_handler(world2.registry());
+    let mut h2 = no_event(handler_optional).into_handler(world2.registry());
     h2.run(&mut world2, ());
     assert_eq!(world2.resource::<RiskState>().exposure, 500.0);
 }
@@ -135,7 +135,7 @@ struct ParamsWithIgnored<'w> {
     _marker: std::marker::PhantomData<u32>,
 }
 
-fn handler_ignored(mut params: ParamsWithIgnored<'_>, _event: ()) {
+fn handler_ignored(mut params: ParamsWithIgnored<'_>) {
     params.risk.exposure += 1.0;
 }
 
@@ -145,7 +145,7 @@ fn with_ignored_field() {
     wb.register(RiskState::default());
     let mut world = wb.build();
 
-    let mut h = handler_ignored.into_handler(world.registry());
+    let mut h = no_event(handler_ignored).into_handler(world.registry());
     h.run(&mut world, ());
     assert_eq!(world.resource::<RiskState>().exposure, 1.0);
 }
@@ -165,7 +165,7 @@ struct OuterParams<'w> {
     config: Res<'w, Config>,
 }
 
-fn handler_nested(mut params: OuterParams<'_>, _event: ()) {
+fn handler_nested(mut params: OuterParams<'_>) {
     params.inner.risk.exposure = params.config.max_exposure;
 }
 
@@ -178,7 +178,7 @@ fn nested_params() {
     });
     let mut world = wb.build();
 
-    let mut h = handler_nested.into_handler(world.registry());
+    let mut h = no_event(handler_nested).into_handler(world.registry());
     h.run(&mut world, ());
     assert_eq!(world.resource::<RiskState>().exposure, 999.0);
 }
@@ -193,7 +193,7 @@ struct TradingParams<'w> {
     risk: ResMut<'w, RiskState>,
 }
 
-fn handler_mixed(mut params: TradingParams<'_>, config: Res<Config>, _event: ()) {
+fn handler_mixed(mut params: TradingParams<'_>, config: Res<Config>) {
     params.risk.exposure = params.book.best_bid * config.max_exposure;
 }
 
@@ -208,7 +208,7 @@ fn param_plus_additional_resources() {
     wb.register(Config { max_exposure: 2.0 });
     let mut world = wb.build();
 
-    let mut h = handler_mixed.into_handler(world.registry());
+    let mut h = no_event(handler_mixed).into_handler(world.registry());
     h.run(&mut world, ());
     assert_eq!(world.resource::<RiskState>().exposure, 100.0);
 }

--- a/nexus-rt/tests/ui/callback_wrong_sig.stderr
+++ b/nexus-rt/tests/ui/callback_wrong_sig.stderr
@@ -7,7 +7,7 @@ error[E0277]: this function cannot be converted into a callback
    |     required by a bound introduced by this call
    |
    = note: callback signature: `fn(&mut Context, Res<A>, ..., Event)` — context first, then resources, event last
-   = note: for Handler<()>, you can omit the event: `fn(&mut Context, Res<A>, ...)`
+   = note: for Handler<()> with params, wrap with `no_event(fn_name)` to omit the event parameter
    = note: closures with resource parameters are not supported — use a named `fn` when using Param resources
    = help: the following other types implement trait `IntoCallback<C, E, Params>`:
              `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1)>`

--- a/nexus-rt/tests/ui/callback_wrong_sig.stderr
+++ b/nexus-rt/tests/ui/callback_wrong_sig.stderr
@@ -7,7 +7,17 @@ error[E0277]: this function cannot be converted into a callback
    |     required by a bound introduced by this call
    |
    = note: callback signature: `fn(&mut Context, Res<A>, ..., Event)` — context first, then resources, event last
+   = note: for Handler<()>, you can omit the event: `fn(&mut Context, Res<A>, ...)`
    = note: closures with resource parameters are not supported — use a named `fn` when using Param resources
+   = help: the following other types implement trait `IntoCallback<C, E, Params>`:
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoCallback<C, (), (P0,)>`
 note: required by a bound in `register_callback`
   --> tests/ui/callback_wrong_sig.rs:13:39
    |

--- a/nexus-rt/tests/ui/ctx_pipeline_missing_ctx.stderr
+++ b/nexus-rt/tests/ui/ctx_pipeline_missing_ctx.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a context-aware pipeline step
    = note: ctx step signature: `fn(&mut C, Params..., In) -> Out` — context first, resources, input last
    = note: for raw World access: `fn(&mut C, &mut World, In) -> Out`
    = note: closures with resource parameters are not supported — use a named `fn`
+   = help: the following other types implement trait `IntoCtxStep<C, In, Out, Params>`:
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoCtxStep<C, (), Out, (P0,)>`
 note: required by a bound in `CtxPipelineBuilder::<C, In>::then`
   --> src/ctx_pipeline.rs
    |

--- a/nexus-rt/tests/ui/dag_merge_mismatch.stderr
+++ b/nexus-rt/tests/ui/dag_merge_mismatch.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a pipeline step for this input typ
    = note: if the pipeline output is `Option<T>`, use `.map()` to operate on the inner `T`
    = note: if the pipeline output is `Result<T, E>`, use `.map()` for `Ok` or `.catch()` for `Err`
    = note: if using a closure with resource params (Res<T>, ResMut<T>), that isn't supported — use a named `fn`
+   = help: the following other types implement trait `IntoStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0,)>`
 note: required by a bound in `DagArmSeed::<In>::then`
   --> src/dag.rs
    |
@@ -29,6 +38,15 @@ error[E0277]: this function cannot be used as a pipeline step for this input typ
    = note: if the pipeline output is `Option<T>`, use `.map()` to operate on the inner `T`
    = note: if the pipeline output is `Result<T, E>`, use `.map()` for `Ok` or `.catch()` for `Err`
    = note: if using a closure with resource params (Res<T>, ResMut<T>), that isn't supported — use a named `fn`
+   = help: the following other types implement trait `IntoStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0,)>`
 note: required by a bound in `DagArmSeed::<In>::then`
   --> src/dag.rs
    |

--- a/nexus-rt/tests/ui/guard_takes_value.stderr
+++ b/nexus-rt/tests/ui/guard_takes_value.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a reference step for this input ty
    = note: reference steps (guard, filter, tap, inspect) take `&In`, not `In`
    = note: if the pipeline output is `Option<T>`, `.filter()` operates on `&T` inside the Option
    = note: closures with resource parameters are not supported — use a named `fn`
+   = help: the following other types implement trait `IntoRefStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0,)>`
 note: required by a bound in `PipelineChain::<In, Out, Chain>::guard`
   --> src/pipeline.rs
    |

--- a/nexus-rt/tests/ui/guard_wrong_ref.stderr
+++ b/nexus-rt/tests/ui/guard_wrong_ref.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a reference step for this input ty
    = note: reference steps (guard, filter, tap, inspect) take `&In`, not `In`
    = note: if the pipeline output is `Option<T>`, `.filter()` operates on `&T` inside the Option
    = note: closures with resource parameters are not supported — use a named `fn`
+   = help: the following other types implement trait `IntoRefStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0,)>`
 note: required by a bound in `PipelineChain::<In, Out, Chain>::guard`
   --> src/pipeline.rs
    |

--- a/nexus-rt/tests/ui/scan_wrong_acc.stderr
+++ b/nexus-rt/tests/ui/scan_wrong_acc.stderr
@@ -8,6 +8,15 @@ error[E0277]: this function cannot be used as a scan step
    |
    = note: scan steps take `&mut Accumulator` as first param, then resources, then input last
    = note: closures with resource parameters are not supported — use a named `fn`
+   = help: the following other types implement trait `IntoScanStep<Acc, In, Out, Params>`:
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoScanStep<Acc, (), Out, (P0,)>`
 note: required by a bound in `PipelineBuilder::<In>::scan`
   --> src/pipeline.rs
    |

--- a/nexus-rt/tests/ui/then_on_option.stderr
+++ b/nexus-rt/tests/ui/then_on_option.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a pipeline step for this input typ
    = note: if the pipeline output is `Option<T>`, use `.map()` to operate on the inner `T`
    = note: if the pipeline output is `Result<T, E>`, use `.map()` for `Ok` or `.catch()` for `Err`
    = note: if using a closure with resource params (Res<T>, ResMut<T>), that isn't supported — use a named `fn`
+   = help: the following other types implement trait `IntoStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0,)>`
 note: required by a bound in `PipelineChain::<In, Out, Chain>::then`
   --> src/pipeline.rs
    |

--- a/nexus-rt/tests/ui/then_on_result.stderr
+++ b/nexus-rt/tests/ui/then_on_result.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a pipeline step for this input typ
    = note: if the pipeline output is `Option<T>`, use `.map()` to operate on the inner `T`
    = note: if the pipeline output is `Result<T, E>`, use `.map()` for `Ok` or `.catch()` for `Err`
    = note: if using a closure with resource params (Res<T>, ResMut<T>), that isn't supported — use a named `fn`
+   = help: the following other types implement trait `IntoStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoStep<(), Out, (P0,)>`
 note: required by a bound in `PipelineChain::<In, Out, Chain>::then`
   --> src/pipeline.rs
    |

--- a/nexus-rt/tests/ui/view_wrong_handler_type.stderr
+++ b/nexus-rt/tests/ui/view_wrong_handler_type.stderr
@@ -9,6 +9,15 @@ error[E0277]: this function cannot be used as a reference step for this input ty
    = note: reference steps (guard, filter, tap, inspect) take `&In`, not `In`
    = note: if the pipeline output is `Option<T>`, `.filter()` operates on `&T` inside the Option
    = note: closures with resource parameters are not supported — use a named `fn`
+   = help: the following other types implement trait `IntoRefStep<In, Out, Params>`:
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoRefStep<(), Out, (P0,)>`
 note: required by a bound in `ViewScope::<In, Out, V, PrevChain, InnerSteps>::tap`
   --> src/view.rs
    |

--- a/nexus-rt/tests/ui/wrong_param_order.stderr
+++ b/nexus-rt/tests/ui/wrong_param_order.stderr
@@ -7,7 +7,7 @@ error[E0277]: this function cannot be converted into a handler
    |     required by a bound introduced by this call
    |
    = note: handler signature: `fn(Res<A>, ResMut<B>, ..., Event)` — resources first, event last
-   = note: for Handler<()>, you can omit the event: `fn(Res<A>, ResMut<B>, ...)`
+   = note: for Handler<()> with params, wrap with `no_event(fn_name)` to omit the event parameter
    = note: closures with resource parameters (Res<T>, ResMut<T>) are not supported — use a named `fn`
    = note: arity-0 closures (`fn(Event)` with no resources) ARE supported
    = help: the following other types implement trait `IntoHandler<E, Params>`:

--- a/nexus-rt/tests/ui/wrong_param_order.stderr
+++ b/nexus-rt/tests/ui/wrong_param_order.stderr
@@ -7,8 +7,18 @@ error[E0277]: this function cannot be converted into a handler
    |     required by a bound introduced by this call
    |
    = note: handler signature: `fn(Res<A>, ResMut<B>, ..., Event)` — resources first, event last
+   = note: for Handler<()>, you can omit the event: `fn(Res<A>, ResMut<B>, ...)`
    = note: closures with resource parameters (Res<T>, ResMut<T>) are not supported — use a named `fn`
    = note: arity-0 closures (`fn(Event)` with no resources) ARE supported
+   = help: the following other types implement trait `IntoHandler<E, Params>`:
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2, P3)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2, P3, P4)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2, P3, P4, P5)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2, P3, P4, P5, P6)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0, P1, P2, P3, P4, P5, P6, P7)>`
+             `NoEvent<F>` implements `IntoHandler<(), (P0,)>`
 note: required by a bound in `register_handler`
   --> tests/ui/wrong_param_order.rs:14:35
    |


### PR DESCRIPTION
## Summary

- Adds `NoEvent<F>` wrapper and `no_event()` helper for ergonomic `Handler<()>` registration without the trailing `_: ()` parameter
- Migrates all existing `_event: ()` / `_: ()` / `_e: ()` handlers in the codebase to use the new pattern
- Covers all dispatch paths: Handler, Callback, Pipeline (Step/RefStep/ScanStep/RefScanStep), CtxPipeline, and Templates

### Before / After

```rust
// Before:
fn on_tick(clock: Res<Clock>, _event: ()) { ... }
let h = on_tick.into_handler(&reg);

// After — arity 0 (no wrapper needed):
fn standalone() { ... }
let h = standalone.into_handler(&reg);

// After — arities 1+ (wrap with no_event):
fn on_tick(clock: Res<Clock>) { ... }
let h = no_event(on_tick).into_handler(&reg);
```

### Design

`NoEvent<F>` wraps the user's function in the F position of `Callback`/`Step` (same coherence trick as `CtxFree<F>`). Since `NoEvent<F>` never satisfies `FnMut` bounds, the new `Handler<()>` impls are provably disjoint from existing event-taking impls.

Arity-0 works directly because `FnMut()` and `FnMut(())` are genuinely different traits. Arities 1+ require `no_event()` because `()` implements `Param`, creating ambiguity — the compiler can't tell if a trailing `()` is an event or a unit Param.

## Test plan

- [x] `cargo test -p nexus-rt` — 675 tests pass
- [x] No-event handlers at arities 0, 1, 2+ (named functions)
- [x] No-event callbacks at arities 0, 1, 2+ (context-owning)
- [x] No-event pipeline steps (Step, RefStep, ScanStep)
- [x] No-event templates (HandlerTemplate, CallbackTemplate)
- [x] No-event CtxPipeline steps
- [x] Boxed `dyn Handler<()>` works with no-event handlers
- [x] Existing event-taking handlers unbroken (coexistence test)
- [x] UI test snapshots re-blessed
- [x] Zero remaining user-facing `_event: ()` in codebase

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)