### PR TITLE
improvements to views in nexus-rt

### DIFF
--- a/nexus-rt-derive/src/lib.rs
+++ b/nexus-rt-derive/src/lib.rs
@@ -10,7 +10,9 @@ mod select;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::visit_mut::VisitMut;
-use syn::{Data, DeriveInput, Fields, GenericParam, Lifetime, parse_macro_input};
+use syn::{
+    Data, DeriveInput, Fields, GenericParam, Lifetime, TypeParamBound, parse_macro_input,
+};
 
 // =============================================================================
 // #[derive(Resource)]
@@ -434,6 +436,9 @@ impl VisitMut for LifetimeReplacer {
 /// for each `#[source(Type)]` attribute. Use with `.view::<AsViewName>()`
 /// in pipeline and DAG builders.
 ///
+/// Type and const generic parameters are supported. Non-`#[borrow]` fields
+/// with generic types must be `Copy` (they are copied from `&source`).
+///
 /// # Attributes
 ///
 /// **On the struct:**
@@ -525,6 +530,32 @@ fn derive_view_impl(input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn
         .into_iter()
         .filter(|p| !matches!(p, GenericParam::Lifetime(_)))
         .collect();
+    // Strip lifetime bounds from type params (e.g., T: 'a + Copy → T: Copy)
+    for param in &mut marker_generics.params {
+        if let GenericParam::Type(tp) = param {
+            tp.bounds = tp
+                .bounds
+                .iter()
+                .filter(|b| !matches!(b, TypeParamBound::Lifetime(_)))
+                .cloned()
+                .collect();
+        }
+    }
+    // Strip where-clause predicates referencing the view lifetime
+    if let Some(lt) = &lifetime_param {
+        if let Some(where_clause) = &mut marker_generics.where_clause {
+            let lt_ident = lt.ident.to_string();
+            where_clause.predicates = where_clause
+                .predicates
+                .iter()
+                .filter(|pred| {
+                    let tokens = quote! { #pred }.to_string();
+                    !tokens.contains(&lt_ident)
+                })
+                .cloned()
+                .collect();
+        }
+    }
     // View::StaticViewType: 'static requires all type params to be 'static
     {
         let where_clause = marker_generics.make_where_clause();

--- a/nexus-rt-derive/src/lib.rs
+++ b/nexus-rt-derive/src/lib.rs
@@ -10,7 +10,7 @@ mod select;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::visit_mut::VisitMut;
-use syn::{Data, DeriveInput, Fields, Lifetime, parse_macro_input};
+use syn::{Data, DeriveInput, Fields, GenericParam, Lifetime, parse_macro_input};
 
 // =============================================================================
 // #[derive(Resource)]
@@ -503,20 +503,6 @@ fn derive_view_impl(input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn
         ));
     }
 
-    // Reject type and const generics
-    if input.generics.type_params().count() > 0 {
-        return Err(syn::Error::new_spanned(
-            &input.generics,
-            "#[derive(View)] does not support type parameters",
-        ));
-    }
-    if input.generics.const_params().count() > 0 {
-        return Err(syn::Error::new_spanned(
-            &input.generics,
-            "#[derive(View)] does not support const parameters",
-        ));
-    }
-
     // Detect lifetime: 0 or 1 lifetime param
     let lifetime_param = match input.generics.lifetimes().count() {
         0 => None,
@@ -532,30 +518,77 @@ fn derive_view_impl(input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn
     // Marker name: As{ViewName}
     let marker_name = format_ident!("As{}", view_name);
 
-    // Build ViewType<'a>, StaticViewType, and tick-lifetime tokens
-    let (view_type_with_a, static_view_type, view_type_tick) = lifetime_param.as_ref().map_or_else(
-        || {
-            (
-                quote! { #view_name },
-                quote! { #view_name },
-                quote! { #view_name },
-            )
-        },
-        |lt| {
-            let lt_ident = &lt.ident;
-            let mut static_generics = input.generics.clone();
-            LifetimeReplacer {
-                from: lt_ident.to_string(),
+    // Build marker generics (type + const params only, no lifetimes)
+    let mut marker_generics = input.generics.clone();
+    marker_generics.params = marker_generics
+        .params
+        .into_iter()
+        .filter(|p| !matches!(p, GenericParam::Lifetime(_)))
+        .collect();
+    // View::StaticViewType: 'static requires all type params to be 'static
+    {
+        let where_clause = marker_generics.make_where_clause();
+        for tp in input.generics.type_params() {
+            let ident = &tp.ident;
+            where_clause
+                .predicates
+                .push(syn::parse_quote!(#ident: 'static));
+        }
+    }
+    let (marker_impl_generics, marker_ty_generics, marker_where) = marker_generics.split_for_impl();
+
+    // PhantomData fields for type params (const params don't need phantom data)
+    let phantom_fields: Vec<proc_macro2::TokenStream> = input
+        .generics
+        .type_params()
+        .map(|tp| {
+            let ident = &tp.ident;
+            quote! { ::core::marker::PhantomData<fn() -> #ident> }
+        })
+        .collect();
+
+    // Non-lifetime param idents for use in type position (no bounds)
+    let non_lt_params: Vec<proc_macro2::TokenStream> = input
+        .generics
+        .params
+        .iter()
+        .filter_map(|p| match p {
+            GenericParam::Type(tp) => {
+                let ident = &tp.ident;
+                Some(quote! { #ident })
             }
-            .visit_generics_mut(&mut static_generics);
-            let (_, static_ty_generics, _) = static_generics.split_for_impl();
-            (
-                quote! { #view_name<'a> },
-                quote! { #view_name #static_ty_generics },
-                quote! { #view_name<'_> },
-            )
-        },
-    );
+            GenericParam::Const(cp) => {
+                let ident = &cp.ident;
+                Some(quote! { #ident })
+            }
+            GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+
+    // Build ViewType<'a>, StaticViewType, and tick-lifetime tokens
+    let has_non_lt = !non_lt_params.is_empty();
+    let (view_type_with_a, static_view_type, view_type_tick) = match (&lifetime_param, has_non_lt) {
+        (Some(_), true) => (
+            quote! { #view_name<'a, #(#non_lt_params),*> },
+            quote! { #view_name<'static, #(#non_lt_params),*> },
+            quote! { #view_name<'_, #(#non_lt_params),*> },
+        ),
+        (Some(_), false) => (
+            quote! { #view_name<'a> },
+            quote! { #view_name<'static> },
+            quote! { #view_name<'_> },
+        ),
+        (None, true) => (
+            quote! { #view_name<#(#non_lt_params),*> },
+            quote! { #view_name<#(#non_lt_params),*> },
+            quote! { #view_name<#(#non_lt_params),*> },
+        ),
+        (None, false) => (
+            quote! { #view_name },
+            quote! { #view_name },
+            quote! { #view_name },
+        ),
+    };
 
     // Parse field info
     let field_infos: Vec<FieldInfo> = fields
@@ -588,7 +621,10 @@ fn derive_view_impl(input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn
         impls.push(quote! {
             // SAFETY: ViewType<'a> and StaticViewType are the same struct
             // with different lifetime parameters. Layout-identical by construction.
-            unsafe impl ::nexus_rt::View<#source_type> for #marker_name {
+            unsafe impl #marker_impl_generics ::nexus_rt::View<#source_type>
+                for #marker_name #marker_ty_generics
+                #marker_where
+            {
                 type ViewType<'a> = #view_type_with_a where #source_type: 'a;
                 type StaticViewType = #static_view_type;
 
@@ -601,9 +637,22 @@ fn derive_view_impl(input: &DeriveInput) -> Result<proc_macro2::TokenStream, syn
         });
     }
 
+    let marker_struct = if phantom_fields.is_empty() {
+        quote! {
+            /// View marker generated by `#[derive(View)]`.
+            #vis struct #marker_name #marker_impl_generics #marker_where;
+        }
+    } else {
+        quote! {
+            /// View marker generated by `#[derive(View)]`.
+            #vis struct #marker_name #marker_impl_generics (
+                #(#phantom_fields),*
+            ) #marker_where;
+        }
+    };
+
     Ok(quote! {
-        /// View marker generated by `#[derive(View)]`.
-        #vis struct #marker_name;
+        #marker_struct
 
         #(#impls)*
     })

--- a/nexus-rt/tests/compile_tests.rs
+++ b/nexus-rt/tests/compile_tests.rs
@@ -4698,7 +4698,6 @@ mod view_derive {
     fn derive_generic_view_pipeline_integration() {
         let mut wb = WorldBuilder::new();
         wb.register(AuditLog(Vec::new()));
-        wb.register(RiskLimits { max_qty: 100 });
         let mut world = wb.build();
         let reg = world.registry();
 
@@ -4735,6 +4734,41 @@ mod view_derive {
         assert!(result.is_none());
 
         assert_eq!(world.resource::<AuditLog>().0, vec!["passed: good val=10"]);
+    }
+
+    // Lifetime bound on type param — T: 'a gets stripped from marker struct,
+    // 'static is auto-inserted on the impl.
+    struct LifetimeBoundEvent<T: 'static> {
+        value: T,
+    }
+
+    #[derive(View)]
+    #[source(LifetimeBoundEvent<T>)]
+    struct LifetimeBoundView<'a, T: 'a + Copy> {
+        #[borrow]
+        value: &'a T,
+    }
+
+    #[test]
+    fn derive_lifetime_bound_type_param() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_lb(mut log: ResMut<AuditLog>, v: &LifetimeBoundView<u64>) {
+            log.0.push(format!("val={}", v.value));
+        }
+
+        let mut p = PipelineBuilder::<LifetimeBoundEvent<u64>>::new()
+            .view::<AsLifetimeBoundView<u64>>()
+            .tap(log_lb, reg)
+            .end_view()
+            .then(|_: LifetimeBoundEvent<u64>| {}, reg);
+
+        p.run(&mut world, LifetimeBoundEvent { value: 77u64 });
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["val=77"]);
     }
 }
 

--- a/nexus-rt/tests/compile_tests.rs
+++ b/nexus-rt/tests/compile_tests.rs
@@ -4500,6 +4500,242 @@ mod view_derive {
 
         assert_eq!(world.resource::<AuditLog>().0, vec!["SOL-USD qty=100 @150"]);
     }
+
+    // -- Generic views --
+
+    struct TypedEvent<T> {
+        name: String,
+        value: T,
+    }
+
+    #[derive(View)]
+    #[source(TypedEvent<T>)]
+    struct TypedView<'a, T: Copy> {
+        #[borrow]
+        name: &'a str,
+        value: T,
+    }
+
+    #[test]
+    fn derive_type_param_view() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_typed(mut log: ResMut<AuditLog>, v: &TypedView<u64>) {
+            log.0.push(format!("{} val={}", v.name, v.value));
+        }
+
+        let mut p = PipelineBuilder::<TypedEvent<u64>>::new()
+            .view::<AsTypedView<u64>>()
+            .tap(log_typed, reg)
+            .end_view()
+            .then(|_: TypedEvent<u64>| {}, reg);
+
+        p.run(
+            &mut world,
+            TypedEvent {
+                name: "test".into(),
+                value: 42u64,
+            },
+        );
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["test val=42"]);
+    }
+
+    struct SizedBuffer<const N: usize> {
+        data: [u8; N],
+        len: usize,
+    }
+
+    #[derive(View)]
+    #[source(SizedBuffer<N>)]
+    struct SizedView<'a, const N: usize> {
+        #[borrow]
+        data: &'a [u8; N],
+        len: usize,
+    }
+
+    #[test]
+    fn derive_const_param_view() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_sized(mut log: ResMut<AuditLog>, v: &SizedView<4>) {
+            log.0.push(format!("data={:?} len={}", v.data, v.len));
+        }
+
+        let mut p = PipelineBuilder::<SizedBuffer<4>>::new()
+            .view::<AsSizedView<4>>()
+            .tap(log_sized, reg)
+            .end_view()
+            .then(|_: SizedBuffer<4>| {}, reg);
+
+        p.run(
+            &mut world,
+            SizedBuffer {
+                data: [1, 2, 3, 4],
+                len: 4,
+            },
+        );
+
+        assert_eq!(
+            world.resource::<AuditLog>().0,
+            vec!["data=[1, 2, 3, 4] len=4"]
+        );
+    }
+
+    struct CopyEvent<T: Copy> {
+        x: T,
+        y: T,
+    }
+
+    #[derive(View)]
+    #[source(CopyEvent<T>)]
+    struct CopyView<T: Copy> {
+        x: T,
+        y: T,
+    }
+
+    #[test]
+    fn derive_no_lifetime_generic_view() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_copy(mut log: ResMut<AuditLog>, v: &CopyView<f64>) {
+            log.0.push(format!("x={} y={}", v.x, v.y));
+        }
+
+        let mut p = PipelineBuilder::<CopyEvent<f64>>::new()
+            .view::<AsCopyView<f64>>()
+            .tap(log_copy, reg)
+            .end_view()
+            .then(|_: CopyEvent<f64>| {}, reg);
+
+        p.run(&mut world, CopyEvent { x: 1.5, y: 2.5 });
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["x=1.5 y=2.5"]);
+    }
+
+    struct PairEvent<K, V> {
+        key: K,
+        value: V,
+    }
+
+    #[derive(View)]
+    #[source(PairEvent<K, V>)]
+    struct PairView<K: Copy, V: Copy> {
+        key: K,
+        value: V,
+    }
+
+    #[test]
+    fn derive_multi_type_param_view() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_pair(mut log: ResMut<AuditLog>, v: &PairView<u32, i64>) {
+            log.0.push(format!("key={} val={}", v.key, v.value));
+        }
+
+        let mut p = PipelineBuilder::<PairEvent<u32, i64>>::new()
+            .view::<AsPairView<u32, i64>>()
+            .tap(log_pair, reg)
+            .end_view()
+            .then(|_: PairEvent<u32, i64>| {}, reg);
+
+        p.run(
+            &mut world,
+            PairEvent {
+                key: 7u32,
+                value: -99i64,
+            },
+        );
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["key=7 val=-99"]);
+    }
+
+    struct DisplayEvent<T: std::fmt::Display> {
+        item: T,
+    }
+
+    #[derive(View)]
+    #[source(DisplayEvent<T>)]
+    struct DisplayView<T: std::fmt::Display + Copy> {
+        item: T,
+    }
+
+    #[test]
+    fn derive_bounded_type_param_view() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn log_display(mut log: ResMut<AuditLog>, v: &DisplayView<i32>) {
+            log.0.push(format!("item={}", v.item));
+        }
+
+        let mut p = PipelineBuilder::<DisplayEvent<i32>>::new()
+            .view::<AsDisplayView<i32>>()
+            .tap(log_display, reg)
+            .end_view()
+            .then(|_: DisplayEvent<i32>| {}, reg);
+
+        p.run(&mut world, DisplayEvent { item: 42 });
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["item=42"]);
+    }
+
+    #[test]
+    fn derive_generic_view_pipeline_integration() {
+        let mut wb = WorldBuilder::new();
+        wb.register(AuditLog(Vec::new()));
+        wb.register(RiskLimits { max_qty: 100 });
+        let mut world = wb.build();
+        let reg = world.registry();
+
+        fn check_typed(v: &TypedView<u64>) -> bool {
+            v.value > 0
+        }
+
+        fn log_typed_tap(mut log: ResMut<AuditLog>, v: &TypedView<u64>) {
+            log.0.push(format!("passed: {} val={}", v.name, v.value));
+        }
+
+        let mut p = PipelineBuilder::<TypedEvent<u64>>::new()
+            .view::<AsTypedView<u64>>()
+            .guard(check_typed, reg)
+            .tap(log_typed_tap, reg)
+            .end_view_guarded();
+
+        let result = p.run(
+            &mut world,
+            TypedEvent {
+                name: "good".into(),
+                value: 10,
+            },
+        );
+        assert!(result.is_some());
+
+        let result = p.run(
+            &mut world,
+            TypedEvent {
+                name: "bad".into(),
+                value: 0,
+            },
+        );
+        assert!(result.is_none());
+
+        assert_eq!(world.resource::<AuditLog>().0, vec!["passed: good val=10"]);
+    }
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- `#[derive(View)]` now supports type and const generic parameters (#215)
- Previously the macro rejected any type/const generics, forcing users to write `unsafe impl View<Source>` manually — risking UB if the layout-identical contract was violated
- Marker struct (`AsViewName<T>`) threads generics through with `PhantomData<fn() -> T>` for type params; const params appear directly
- Auto-inserts `T: 'static` where predicates on the generated impl (required by `View::StaticViewType: 'static`)
- Only `nexus-rt-derive/src/lib.rs` changed — no modifications to the `View` trait, `with_view`, or pipeline/DAG integration

## Test plan

- [x] 6 new tests in `compile_tests.rs::view_derive`:
  - Type param view (`TypedView<'a, T: Copy>`)
  - Const param view (`SizedView<'a, const N: usize>`)
  - No-lifetime generic view (`CopyView<T: Copy>`)
  - Multiple type params (`PairView<K: Copy, V: Copy>`)
  - Bounded type param (`DisplayView<T: Display + Copy>`)
  - Pipeline integration with generic view (guard + tap through view scope)
- [x] All 9 existing view_derive tests pass (no regression)
- [x] `cargo test -p nexus-rt` — all green
- [x] `cargo clippy -p nexus-rt-derive -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)