### PR TITLE
reworking nexus-rt system scheduler to be monomorphized

### DIFF
--- a/nexus-rt-derive/src/lib.rs
+++ b/nexus-rt-derive/src/lib.rs
@@ -10,9 +10,7 @@ mod select;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::visit_mut::VisitMut;
-use syn::{
-    Data, DeriveInput, Fields, GenericParam, Lifetime, TypeParamBound, parse_macro_input,
-};
+use syn::{Data, DeriveInput, Fields, GenericParam, Lifetime, TypeParamBound, parse_macro_input};
 
 // =============================================================================
 // #[derive(Resource)]

--- a/nexus-rt/README.md
+++ b/nexus-rt/README.md
@@ -926,33 +926,33 @@ let mut system = compute_theo.into_system(registry);
 let changed = system.run(&mut world);
 ```
 
-### DAG Scheduler — topological system execution
+### Staged Scheduler — monomorphized system execution
 
-`SchedulerInstaller` builds a DAG of `System`s executed in topological order.
-Root systems (no upstreams) always run. Non-root systems run only if at
-least one upstream returned `true` (OR semantics).
+`SchedulerBuilder` creates a staged chain of `System`s. Each `.then()` call
+adds a stage. The first stage always runs. Subsequent stages run only if
+at least one system in the previous stage returned `true` (OR semantics).
 
 ```rust
-use nexus_rt::scheduler::SchedulerInstaller;
+use nexus_rt::scheduler::SchedulerBuilder;
 
-let mut installer = SchedulerInstaller::new();
-let theo = installer.add(compute_theo, registry);
-let quotes = installer.add(compute_quotes, registry);
-let risk = installer.add(check_risk, registry);
-installer.after(quotes, theo);   // quotes runs after theo
-installer.after(risk, quotes);   // risk runs after quotes
-
-let mut scheduler = wb.install_driver(installer);
+let mut scheduler = wb.install_driver(
+    SchedulerBuilder::new()
+        .root(compute_theo, &reg)
+        .then(compute_quotes, &reg)
+        .then(check_risk, &reg)
+);
 let mut world = wb.build();
 
 // In event loop: run scheduler after event processing
 let systems_run = scheduler.run(&mut world);
 ```
 
-Propagation is tracked via a `u64` bitmask (one bit per system), limiting
-the scheduler to `MAX_SYSTEMS` (64) systems. Systems return `bool` to
-control downstream execution — `true` means "my outputs changed, run
-downstream." For per-item change detection, use the reactor system.
+Stages can contain multiple systems via tuples (up to 8 per stage). All
+systems in a stage run regardless of individual return values — the stage
+result is the OR of all returns. The entire chain is monomorphized; no
+vtable dispatch, no system limit. Systems return `bool` to control
+downstream execution — `true` means "my outputs changed, run downstream."
+For per-item change detection, use the reactor system.
 
 ### Reactor system (feature: `reactors`)
 

--- a/nexus-rt/README.md
+++ b/nexus-rt/README.md
@@ -1266,8 +1266,9 @@ overhead. Boxing adds ~1 cycle at the boundary.
 | Skipped chain 8 (1 runs, 7 skip) | 17 | 28 | 68 |
 | Skipped chain 32 (1 runs, 31 skip) | 46 | 76 | 118 |
 
-Scheduler overhead is ~8-12 cycles per system. Skipped systems
-(upstream returned `false`) cost ~2 cycles each (bitmask check).
+Scheduler overhead is ~8-12 cycles per system. Skipped stages
+(previous stage returned all `false`) short-circuit via a single
+branch — no per-system cost for skipped stages.
 
 ## Limitations
 

--- a/nexus-rt/examples/perf_scheduler.rs
+++ b/nexus-rt/examples/perf_scheduler.rs
@@ -1,7 +1,7 @@
 //! Scheduler dispatch latency benchmark.
 //!
-//! Measures the cost of `SystemScheduler::run()` with various DAG
-//! topologies and system counts. All systems do trivial work (single
+//! Measures the cost of `SystemScheduler::run()` with various stage
+//! configurations and system counts. All systems do trivial work (single
 //! wrapping_add) to isolate scheduler overhead from system body cost.
 //!
 //! Run with:
@@ -11,7 +11,7 @@
 
 use std::hint::black_box;
 
-use nexus_rt::scheduler::SchedulerInstaller;
+use nexus_rt::scheduler::SchedulerBuilder;
 use nexus_rt::{ResMut, WorldBuilder, new_resource};
 
 new_resource!(ResU64(u64));
@@ -94,69 +94,6 @@ fn sys_false(mut val: ResMut<ResU64>) -> bool {
 }
 
 // =============================================================================
-// DAG builders
-// =============================================================================
-
-/// N independent roots (no edges). All always run.
-fn build_flat(n: usize) -> (WorldBuilder, SchedulerInstaller) {
-    let mut wb = WorldBuilder::new();
-    wb.register(ResU64(0));
-    let mut installer = SchedulerInstaller::new();
-    for _ in 0..n {
-        installer.add(sys_true, wb.registry());
-    }
-    (wb, installer)
-}
-
-/// Linear chain: A → B → C → ... All propagate true.
-fn build_chain(n: usize) -> (WorldBuilder, SchedulerInstaller) {
-    let mut wb = WorldBuilder::new();
-    wb.register(ResU64(0));
-    let mut installer = SchedulerInstaller::new();
-    let mut prev = installer.add(sys_true, wb.registry());
-    for _ in 1..n {
-        let cur = installer.add(sys_true, wb.registry());
-        installer.after(cur, prev);
-        prev = cur;
-    }
-    (wb, installer)
-}
-
-/// Diamond fan-out/fan-in: root → N middle → sink.
-/// Total systems = N + 2.
-fn build_diamond(fan: usize) -> (WorldBuilder, SchedulerInstaller) {
-    let mut wb = WorldBuilder::new();
-    wb.register(ResU64(0));
-    let mut installer = SchedulerInstaller::new();
-    let root = installer.add(sys_true, wb.registry());
-    let mut middles = Vec::with_capacity(fan);
-    for _ in 0..fan {
-        let m = installer.add(sys_true, wb.registry());
-        installer.after(m, root);
-        middles.push(m);
-    }
-    let sink = installer.add(sys_true, wb.registry());
-    for &m in &middles {
-        installer.after(sink, m);
-    }
-    (wb, installer)
-}
-
-/// Chain where root returns false — downstream skipped.
-fn build_chain_skipped(n: usize) -> (WorldBuilder, SchedulerInstaller) {
-    let mut wb = WorldBuilder::new();
-    wb.register(ResU64(0));
-    let mut installer = SchedulerInstaller::new();
-    let mut prev = installer.add(sys_false, wb.registry());
-    for _ in 1..n {
-        let cur = installer.add(sys_true, wb.registry());
-        installer.after(cur, prev);
-        prev = cur;
-    }
-    (wb, installer)
-}
-
-// =============================================================================
 // Main
 // =============================================================================
 
@@ -166,44 +103,143 @@ fn main() {
     println!("Iterations: {ITERATIONS}, Warmup: {WARMUP}, Batch: {BATCH}");
     println!("All times in CPU cycles\n");
 
-    // -- Flat (independent roots) --
+    // -- Single-system stages (linear chains) --
 
-    print_header("Flat DAG (independent roots, all run)");
+    print_header("Linear Chain (single-system stages, all propagate true)");
 
-    for n in [1, 4, 8, 16, 32] {
-        let (mut wb, installer) = build_flat(n);
-        let mut scheduler = wb.install_driver(installer);
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(SchedulerBuilder::new().root(sys_true, &reg));
         let mut world = wb.build();
-        bench_batched(&format!("flat {n} systems"), || {
+        bench_batched("chain 1 system", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg),
+        );
+        let mut world = wb.build();
+        bench_batched("chain 4 systems", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg),
+        );
+        let mut world = wb.build();
+        bench_batched("chain 8 systems", || {
             black_box(scheduler.run(&mut world));
         });
     }
 
-    // -- Linear chain (all propagate) --
+    // -- Multi-system stages (fan-out) --
 
     println!();
-    print_header("Linear Chain (all propagate true)");
+    print_header("Multi-System Stage (all in root, all propagate true)");
 
-    for n in [1, 4, 8, 16, 32] {
-        let (mut wb, installer) = build_chain(n);
-        let mut scheduler = wb.install_driver(installer);
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new().root((sys_true, sys_true, sys_true, sys_true), &reg),
+        );
         let mut world = wb.build();
-        bench_batched(&format!("chain {n} systems"), || {
+        bench_batched("stage with 4 systems", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(SchedulerBuilder::new().root(
+            (
+                sys_true, sys_true, sys_true, sys_true, sys_true, sys_true, sys_true, sys_true,
+            ),
+            &reg,
+        ));
+        let mut world = wb.build();
+        bench_batched("stage with 8 systems", || {
             black_box(scheduler.run(&mut world));
         });
     }
 
-    // -- Diamond (fan-out/fan-in) --
+    // -- Diamond (fan-out + fan-in) --
 
     println!();
-    print_header("Diamond (root → N middle → sink)");
+    print_header("Diamond (root → stage with N → sink)");
 
-    for fan in [2, 4, 8, 16] {
-        let (mut wb, installer) = build_diamond(fan);
-        let total = fan + 2;
-        let mut scheduler = wb.install_driver(installer);
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_true, &reg)
+                .then((sys_true, sys_true), &reg)
+                .then(sys_true, &reg),
+        );
         let mut world = wb.build();
-        bench_batched(&format!("diamond fan={fan} ({total} systems)"), || {
+        bench_batched("diamond fan=2 (4 systems)", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_true, &reg)
+                .then((sys_true, sys_true, sys_true, sys_true), &reg)
+                .then(sys_true, &reg),
+        );
+        let mut world = wb.build();
+        bench_batched("diamond fan=4 (6 systems)", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_true, &reg)
+                .then(
+                    (
+                        sys_true, sys_true, sys_true, sys_true, sys_true, sys_true, sys_true,
+                        sys_true,
+                    ),
+                    &reg,
+                )
+                .then(sys_true, &reg),
+        );
+        let mut world = wb.build();
+        bench_batched("diamond fan=8 (10 systems)", || {
             black_box(scheduler.run(&mut world));
         });
     }
@@ -213,16 +249,41 @@ fn main() {
     println!();
     print_header("Skipped Chain (root=false, downstream skipped)");
 
-    for n in [4, 8, 16, 32] {
-        let (mut wb, installer) = build_chain_skipped(n);
-        let mut scheduler = wb.install_driver(installer);
-        let mut world = wb.build();
-        bench_batched(
-            &format!("skipped chain {n} (1 runs, {} skip)", n - 1),
-            || {
-                black_box(scheduler.run(&mut world));
-            },
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_false, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg),
         );
+        let mut world = wb.build();
+        bench_batched("skipped chain 4 (1 runs, 3 skip)", || {
+            black_box(scheduler.run(&mut world));
+        });
+    }
+    {
+        let mut wb = WorldBuilder::new();
+        wb.register(ResU64(0));
+        let reg = wb.registry();
+        let mut scheduler = wb.install_driver(
+            SchedulerBuilder::new()
+                .root(sys_false, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg)
+                .then(sys_true, &reg),
+        );
+        let mut world = wb.build();
+        bench_batched("skipped chain 8 (1 runs, 7 skip)", || {
+            black_box(scheduler.run(&mut world));
+        });
     }
 
     println!();

--- a/nexus-rt/examples/scheduler_dag.rs
+++ b/nexus-rt/examples/scheduler_dag.rs
@@ -1,13 +1,14 @@
-//! Scheduler DAG — reconciliation systems with boolean propagation.
+//! Staged scheduler — reconciliation systems with boolean propagation.
 //!
-//! The DAG scheduler executes `System`s (not `Handler`s) in topological
+//! The staged scheduler executes `System`s (not `Handler`s) in stage
 //! order. Key differences from handlers:
 //!
 //! - **System** returns `bool` — `true` means "my outputs changed, run
 //!   downstream", `false` means "nothing changed, skip downstream".
 //! - **No event parameter** — systems read shared state, not per-event data.
-//! - **Boolean propagation** — root systems always run; non-root systems
-//!   run only if at least one upstream returned `true` (OR semantics).
+//! - **Boolean propagation** — root stage always runs; subsequent stages
+//!   run only if the previous stage returned at least one `true` (OR
+//!   semantics within a stage).
 //!
 //! Typical pattern: event handlers write resources, then the scheduler
 //! runs reconciliation after each event (or batch of events).
@@ -19,7 +20,7 @@
 
 #![allow(clippy::needless_pass_by_value)]
 
-use nexus_rt::scheduler::SchedulerInstaller;
+use nexus_rt::scheduler::SchedulerBuilder;
 use nexus_rt::{Handler, IntoHandler, Res, ResMut, Resource, WorldBuilder};
 
 // ── Domain types ────────────────────────────────────────────────────────
@@ -93,15 +94,15 @@ fn main() {
     wb.register(QuoteState { bid: 0.0, ask: 0.0 });
     wb.register(RiskFlag(false));
 
-    // Build the DAG: compute_theo → compute_quotes → check_risk
-    let mut installer = SchedulerInstaller::new();
-    let theo = installer.add(compute_theo, wb.registry());
-    let quotes = installer.add(compute_quotes, wb.registry());
-    let risk = installer.add(check_risk, wb.registry());
-    installer.after(quotes, theo);
-    installer.after(risk, quotes);
+    let reg = wb.registry();
 
-    let mut scheduler = wb.install_driver(installer);
+    // Build the staged chain: compute_theo → compute_quotes → check_risk
+    let mut scheduler = wb.install_driver(
+        SchedulerBuilder::new()
+            .root(compute_theo, &reg)
+            .then(compute_quotes, &reg)
+            .then(check_risk, &reg),
+    );
 
     // Event handler for market data
     let mut market_handler = on_market_tick.into_handler(wb.registry());

--- a/nexus-rt/src/lib.rs
+++ b/nexus-rt/src/lib.rs
@@ -220,7 +220,7 @@ pub use pipeline::{
 };
 pub use plugin::Plugin;
 pub use resource::{Res, ResMut, Seq, SeqMut};
-pub use scheduler::{MAX_SYSTEMS, SchedulerInstaller, SystemId, SystemScheduler};
+pub use scheduler::{SchedulerBuilder, SystemScheduler};
 pub use shutdown::{Shutdown, ShutdownHandle};
 pub use system::{IntoSystem, System, SystemFn};
 pub use template::{

--- a/nexus-rt/src/scheduler.rs
+++ b/nexus-rt/src/scheduler.rs
@@ -108,13 +108,13 @@ pub struct StageNode<Prev, S> {
 
 #[doc(hidden)]
 pub trait RunSchedule: Send {
-    fn run_schedule(&mut self, world: &mut World, upstream_fired: bool) -> (usize, bool);
+    fn run_schedule(&mut self, world: &mut World) -> (usize, bool);
     fn system_count(&self) -> usize;
 }
 
 impl RunSchedule for StageEnd {
     #[inline(always)]
-    fn run_schedule(&mut self, _world: &mut World, _upstream_fired: bool) -> (usize, bool) {
+    fn run_schedule(&mut self, _world: &mut World) -> (usize, bool) {
         (0, true)
     }
 
@@ -125,8 +125,8 @@ impl RunSchedule for StageEnd {
 
 impl<Prev: RunSchedule, S: StageRunner> RunSchedule for StageNode<Prev, S> {
     #[inline(always)]
-    fn run_schedule(&mut self, world: &mut World, upstream_fired: bool) -> (usize, bool) {
-        let (prev_ran, prev_fired) = self.prev.run_schedule(world, upstream_fired);
+    fn run_schedule(&mut self, world: &mut World) -> (usize, bool) {
+        let (prev_ran, prev_fired) = self.prev.run_schedule(world);
         if !prev_fired {
             return (prev_ran, false);
         }
@@ -432,7 +432,7 @@ impl<Chain: RunSchedule> SystemScheduler<Chain> {
     ///
     /// Returns the number of systems that actually ran.
     pub fn run(&mut self, world: &mut World) -> usize {
-        let (ran, _) = self.chain.run_schedule(world, true);
+        let (ran, _) = self.chain.run_schedule(world);
         ran
     }
 
@@ -703,6 +703,23 @@ mod tests {
 
         assert_eq!(scheduler.run(&mut world), 3);
         assert_eq!(*world.resource::<u64>(), 3);
+    }
+
+    #[test]
+    fn scheduler_chain_is_send() {
+        fn assert_send<T: Send>(_: &T) {}
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        builder.register::<bool>(false);
+        let reg = builder.registry();
+        let scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(increment, &reg)
+                .then((increment, set_flag), &reg)
+                .then(double, &reg),
+        );
+        assert_send(&scheduler);
     }
 
     #[test]

--- a/nexus-rt/src/scheduler.rs
+++ b/nexus-rt/src/scheduler.rs
@@ -1,24 +1,35 @@
-//! DAG scheduler with boolean propagation.
+//! Staged scheduler with boolean propagation.
 //!
-//! The scheduler is installed as a **driver** via [`SchedulerInstaller`].
+//! The scheduler is installed as a **driver** via [`SchedulerBuilder`].
 //! After event handlers process incoming data and write to resources,
-//! the scheduler runs reconciliation [`System`]s
-//! in topological order. This two-phase pattern (event → reconcile)
-//! separates reactive logic from derived-state computation.
+//! the scheduler runs reconciliation [`System`]s in stage order. This
+//! two-phase pattern (event → reconcile) separates reactive logic from
+//! derived-state computation.
 //!
-//! Root systems (no upstream dependencies) always run. Non-root
-//! systems run only if at least one upstream system returned `true`.
+//! # Staged model
+//!
+//! Systems are grouped into **stages**. Each stage runs all its systems,
+//! then propagates a `bool` to the next stage: "did any system in this
+//! stage return `true`?" If no system fired, downstream stages are
+//! skipped.
+//!
+//! Topology is implicit in builder order — each `.then()` call creates
+//! the next stage. No explicit edge declarations, no topological sort.
+//!
+//! # Monomorphization
+//!
+//! The schedule chain is fully monomorphized. Each `.root()` / `.then()`
+//! wraps the accumulator in a `StageNode<Prev, S>` type layer. The
+//! compiler inlines the recursive `run_schedule` calls, eliminating all
+//! vtable dispatch. Same pattern as [`Pipeline`](crate::Pipeline) and
+//! [`Dag`](crate::Dag).
 //!
 //! # Propagation model
 //!
 //! Each system returns `bool`. `true` means "my outputs changed, run
-//! downstream systems." `false` means "nothing changed, skip downstream."
-//! When a system has multiple upstreams, it runs if **any** upstream
-//! returned `true` (OR / `any` semantics).
-//!
-//! Propagation is checked via a `u64` bitmask — each system occupies one
-//! bit, and the upstream check is a single AND instruction. This limits
-//! the scheduler to [`MAX_SYSTEMS`] (64) systems.
+//! downstream." `false` means "nothing changed." Within a stage, all
+//! systems always run regardless of individual return values — the
+//! stage result is the OR of all system returns.
 //!
 //! # Sequence mechanics
 //!
@@ -27,97 +38,282 @@
 //!
 //! # Invariants
 //!
-//! - **Topological order**: Systems execute in an order where all
-//!   upstreams of a system have already completed. Ties are broken by
-//!   insertion order (Kahn's algorithm with FIFO queue).
-//! - **No cycles**: The edge graph must be a DAG. Cycles panic at
-//!   install time with a diagnostic message.
-//! - **Capacity**: At most [`MAX_SYSTEMS`] (64) systems. Exceeding
-//!   this panics at install time.
-//! - **Deterministic**: Same inputs produce the same execution order
-//!   and results. No randomness, no thread-dependent ordering.
+//! - **Stage order**: Stages execute in builder order. All systems
+//!   within a stage run before any system in the next stage.
+//! - **All systems in a stage run**: Even if one returns `false`,
+//!   the rest still execute (side effects matter).
+//! - **Deterministic**: Same inputs produce same results. No
+//!   randomness, no thread-dependent ordering.
 //! - **No sequence bump**: The scheduler never advances the global
 //!   sequence. Event handlers own sequencing; the scheduler observes.
+//! - **No system limit**: The nested type encodes the full schedule
+//!   at compile time. No bitmask, no capacity constant.
 //!
 //! # Examples
 //!
 //! ```
 //! use nexus_rt::{WorldBuilder, Res, ResMut, Installer, Resource};
-//! use nexus_rt::scheduler::SchedulerInstaller;
-//! use nexus_rt::system::IntoSystem;
+//! use nexus_rt::scheduler::SchedulerBuilder;
 //!
 //! #[derive(Resource)]
 //! struct Val(u64);
 //!
-//! fn source(mut val: ResMut<Val>) -> bool {
+//! fn step_a(mut val: ResMut<Val>) -> bool {
 //!     val.0 += 1;
 //!     true
 //! }
 //!
-//! fn sink(val: Res<Val>) -> bool {
+//! fn step_b(val: Res<Val>) -> bool {
 //!     val.0 > 0
 //! }
 //!
 //! let mut builder = WorldBuilder::new();
 //! builder.register(Val(0));
+//! let reg = builder.registry();
 //!
-//! let mut installer = SchedulerInstaller::new();
-//! let a = installer.add(source, builder.registry());
-//! let b = installer.add(sink, builder.registry());
-//! installer.after(b, a);
-//!
-//! let mut scheduler = builder.install_driver(installer);
+//! let mut scheduler = builder.install_driver(
+//!     SchedulerBuilder::new()
+//!         .root(step_a, &reg)
+//!         .then(step_b, &reg)
+//! );
 //! let mut world = builder.build();
 //!
 //! assert_eq!(scheduler.run(&mut world), 2);
 //! ```
-
-use std::collections::VecDeque;
 
 use crate::driver::Installer;
 use crate::system::{IntoSystem, System};
 use crate::world::{Registry, World, WorldBuilder};
 
 // =============================================================================
-// SystemId
+// StageEnd — terminal node
 // =============================================================================
 
-/// Opaque handle identifying a system within a [`SchedulerInstaller`].
-///
-/// Used with [`after`](SchedulerInstaller::after) and
-/// [`before`](SchedulerInstaller::before) to declare ordering.
-///
-/// # Type-tag intent
-///
-/// `SystemId` is a `usize` newtype with no invariants beyond what the
-/// underlying integer provides. The newtype exists purely to prevent
-/// accidentally passing some other identifier where a `SystemId` is
-/// expected. Don't reduce it to a type alias and don't add invariants
-/// the rest of the crate doesn't enforce.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct SystemId(usize);
+#[doc(hidden)]
+pub struct StageEnd;
 
 // =============================================================================
-// SchedulerInstaller
+// StageNode — one stage in the schedule chain
 // =============================================================================
 
-/// Builder for a [`SystemScheduler`].
+#[doc(hidden)]
+pub struct StageNode<Prev, S> {
+    prev: Prev,
+    stage: S,
+}
+
+// =============================================================================
+// RunSchedule — chain dispatch trait
+// =============================================================================
+
+#[doc(hidden)]
+pub trait RunSchedule: Send {
+    fn run_schedule(&mut self, world: &mut World, upstream_fired: bool) -> (usize, bool);
+    fn system_count(&self) -> usize;
+}
+
+impl RunSchedule for StageEnd {
+    #[inline(always)]
+    fn run_schedule(&mut self, _world: &mut World, _upstream_fired: bool) -> (usize, bool) {
+        (0, true)
+    }
+
+    fn system_count(&self) -> usize {
+        0
+    }
+}
+
+impl<Prev: RunSchedule, S: StageRunner> RunSchedule for StageNode<Prev, S> {
+    #[inline(always)]
+    fn run_schedule(&mut self, world: &mut World, upstream_fired: bool) -> (usize, bool) {
+        let (prev_ran, prev_fired) = self.prev.run_schedule(world, upstream_fired);
+        if !prev_fired {
+            return (prev_ran, false);
+        }
+        let (stage_ran, stage_fired) = self.stage.run_all(world);
+        (prev_ran + stage_ran, stage_fired)
+    }
+
+    fn system_count(&self) -> usize {
+        self.prev.system_count() + self.stage.system_count()
+    }
+}
+
+// =============================================================================
+// StageRunner — per-stage dispatch trait
+// =============================================================================
+
+#[doc(hidden)]
+pub trait StageRunner: Send {
+    fn run_all(&mut self, world: &mut World) -> (usize, bool);
+    fn system_count(&self) -> usize;
+}
+
+// =============================================================================
+// Stage1..Stage8 — macro-generated stage wrappers
+// =============================================================================
+
+macro_rules! impl_stage {
+    ($name:ident, $count:expr, $(($idx:tt, $S:ident)),+) => {
+        #[doc(hidden)]
+        pub struct $name<$($S),+>($(pub(crate) $S),+);
+
+        impl<$($S: System),+> StageRunner for $name<$($S),+> {
+            #[inline(always)]
+            fn run_all(&mut self, world: &mut World) -> (usize, bool) {
+                let mut fired = false;
+                $(fired |= self.$idx.run(world);)+
+                ($count, fired)
+            }
+
+            fn system_count(&self) -> usize {
+                $count
+            }
+        }
+    };
+}
+
+impl_stage!(Stage1, 1, (0, S0));
+impl_stage!(Stage2, 2, (0, S0), (1, S1));
+impl_stage!(Stage3, 3, (0, S0), (1, S1), (2, S2));
+impl_stage!(Stage4, 4, (0, S0), (1, S1), (2, S2), (3, S3));
+impl_stage!(Stage5, 5, (0, S0), (1, S1), (2, S2), (3, S3), (4, S4));
+impl_stage!(
+    Stage6,
+    6,
+    (0, S0),
+    (1, S1),
+    (2, S2),
+    (3, S3),
+    (4, S4),
+    (5, S5)
+);
+impl_stage!(
+    Stage7,
+    7,
+    (0, S0),
+    (1, S1),
+    (2, S2),
+    (3, S3),
+    (4, S4),
+    (5, S5),
+    (6, S6)
+);
+impl_stage!(
+    Stage8,
+    8,
+    (0, S0),
+    (1, S1),
+    (2, S2),
+    (3, S3),
+    (4, S4),
+    (5, S5),
+    (6, S6),
+    (7, S7)
+);
+
+// =============================================================================
+// IntoStage — converts functions/tuples into stages
+// =============================================================================
+
+/// Converts a single function or tuple of functions into a stage.
 ///
-/// Systems are added with [`add`](Self::add) and ordering declared with
-/// [`after`](Self::after) / [`before`](Self::before). On
-/// [`install`](Installer::install), a topological sort (Kahn's algorithm
-/// with FIFO queue for deterministic insertion-order tie-breaking)
-/// determines execution order.
-///
-/// Implements [`Installer`] — consume via
-/// [`WorldBuilder::install_driver`](crate::WorldBuilder::install_driver).
+/// The `Params` type parameter is inference-only — same pattern as
+/// [`IntoHandler<E, Params>`](crate::IntoHandler). Never constructed,
+/// just guides the compiler to the right impl.
+pub trait IntoStage<Params> {
+    /// The concrete stage type produced.
+    type Stage: StageRunner + 'static;
+    /// Convert into a stage, resolving system parameters from the registry.
+    fn into_stage(self, registry: &Registry) -> Self::Stage;
+}
+
+impl<F, P, M> IntoStage<(P, M)> for F
+where
+    F: IntoSystem<P, M>,
+    F::System: 'static,
+{
+    type Stage = Stage1<F::System>;
+
+    fn into_stage(self, registry: &Registry) -> Self::Stage {
+        Stage1(self.into_system(registry))
+    }
+}
+
+macro_rules! impl_into_stage {
+    ($stage:ident, $(($F:ident, $P:ident, $M:ident, $idx:tt)),+) => {
+        impl<$($F, $P, $M),+> IntoStage<($(($P, $M),)+)> for ($($F,)+)
+        where
+            $($F: IntoSystem<$P, $M>, $F::System: 'static,)+
+        {
+            type Stage = $stage<$($F::System),+>;
+
+            fn into_stage(self, registry: &Registry) -> Self::Stage {
+                $stage($(self.$idx.into_system(registry)),+)
+            }
+        }
+    };
+}
+
+impl_into_stage!(Stage2, (F0, P0, M0, 0), (F1, P1, M1, 1));
+impl_into_stage!(Stage3, (F0, P0, M0, 0), (F1, P1, M1, 1), (F2, P2, M2, 2));
+impl_into_stage!(
+    Stage4,
+    (F0, P0, M0, 0),
+    (F1, P1, M1, 1),
+    (F2, P2, M2, 2),
+    (F3, P3, M3, 3)
+);
+impl_into_stage!(
+    Stage5,
+    (F0, P0, M0, 0),
+    (F1, P1, M1, 1),
+    (F2, P2, M2, 2),
+    (F3, P3, M3, 3),
+    (F4, P4, M4, 4)
+);
+impl_into_stage!(
+    Stage6,
+    (F0, P0, M0, 0),
+    (F1, P1, M1, 1),
+    (F2, P2, M2, 2),
+    (F3, P3, M3, 3),
+    (F4, P4, M4, 4),
+    (F5, P5, M5, 5)
+);
+impl_into_stage!(
+    Stage7,
+    (F0, P0, M0, 0),
+    (F1, P1, M1, 1),
+    (F2, P2, M2, 2),
+    (F3, P3, M3, 3),
+    (F4, P4, M4, 4),
+    (F5, P5, M5, 5),
+    (F6, P6, M6, 6)
+);
+impl_into_stage!(
+    Stage8,
+    (F0, P0, M0, 0),
+    (F1, P1, M1, 1),
+    (F2, P2, M2, 2),
+    (F3, P3, M3, 3),
+    (F4, P4, M4, 4),
+    (F5, P5, M5, 5),
+    (F6, P6, M6, 6),
+    (F7, P7, M7, 7)
+);
+
+// =============================================================================
+// SchedulerBuilder — entry point
+// =============================================================================
+
+/// Entry point for building a monomorphized schedule.
 ///
 /// # Examples
 ///
 /// ```
-/// use nexus_rt::{WorldBuilder, Res, ResMut, Installer, Resource};
-/// use nexus_rt::scheduler::SchedulerInstaller;
-/// use nexus_rt::system::IntoSystem;
+/// use nexus_rt::{WorldBuilder, ResMut, Resource};
+/// use nexus_rt::scheduler::SchedulerBuilder;
 ///
 /// #[derive(Resource)]
 /// struct Val(u64);
@@ -127,254 +323,127 @@ pub struct SystemId(usize);
 ///     true
 /// }
 ///
-/// fn step_b(val: Res<Val>) -> bool {
+/// fn step_b(val: nexus_rt::Res<Val>) -> bool {
 ///     val.0 > 0
 /// }
 ///
 /// let mut builder = WorldBuilder::new();
 /// builder.register(Val(0));
+/// let reg = builder.registry();
 ///
-/// let mut installer = SchedulerInstaller::new();
-/// let a = installer.add(step_a, builder.registry());
-/// let b = installer.add(step_b, builder.registry());
-/// installer.after(b, a);
-///
-/// let mut scheduler = builder.install_driver(installer);
+/// let mut scheduler = builder.install_driver(
+///     SchedulerBuilder::new()
+///         .root(step_a, &reg)
+///         .then(step_b, &reg)
+/// );
 /// let mut world = builder.build();
-///
 /// assert_eq!(scheduler.run(&mut world), 2);
 /// ```
-///
-/// # Panics
-///
-/// [`install`](Installer::install) panics if:
-/// - The declared edges form a cycle.
-/// - More than [`MAX_SYSTEMS`] (64) systems were added.
-pub struct SchedulerInstaller {
-    systems: Vec<Box<dyn System>>,
-    edges: Vec<(usize, usize)>, // (upstream, downstream)
-}
+pub struct SchedulerBuilder;
 
-impl SchedulerInstaller {
-    /// Create an empty installer.
+impl SchedulerBuilder {
+    /// Create a new scheduler builder.
     pub fn new() -> Self {
-        Self {
-            systems: Vec::new(),
-            edges: Vec::new(),
+        Self
+    }
+
+    /// Create the first stage from a system or tuple of systems.
+    pub fn root<S, Params>(self, stage: S, registry: &Registry) -> StageNode<StageEnd, S::Stage>
+    where
+        S: IntoStage<Params>,
+    {
+        StageNode {
+            prev: StageEnd,
+            stage: stage.into_stage(registry),
         }
     }
-
-    /// Add a system, returning a [`SystemId`] for ordering.
-    ///
-    /// The function is converted via [`IntoSystem`] and parameters
-    /// are resolved from the registry immediately.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any [`Param`](crate::Param) resource required by `f`
-    /// is not registered in the [`Registry`], or if parameters create
-    /// a conflicting access (e.g. `Res<T>` + `ResMut<T>`).
-    pub fn add<F, Params>(&mut self, f: F, registry: &Registry) -> SystemId
-    where
-        F: IntoSystem<Params>,
-        F::System: 'static,
-    {
-        let id = SystemId(self.systems.len());
-        self.systems.push(Box::new(f.into_system(registry)));
-        id
-    }
-
-    /// Declare that `downstream` runs after `upstream`.
-    ///
-    /// If `upstream` returns `false`, `downstream` is skipped — unless
-    /// another upstream of `downstream` returned `true` (`any` semantics).
-    pub fn after(&mut self, downstream: SystemId, upstream: SystemId) {
-        self.edges.push((upstream.0, downstream.0));
-    }
-
-    /// Declare that `upstream` runs before `downstream`.
-    ///
-    /// Equivalent to `self.after(downstream, upstream)`.
-    pub fn before(&mut self, upstream: SystemId, downstream: SystemId) {
-        self.after(downstream, upstream);
-    }
 }
 
-impl Default for SchedulerInstaller {
+impl Default for SchedulerBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Maximum number of systems supported by the scheduler.
-///
-/// Propagation uses a `u64` bitmask where each bit represents one
-/// system's result. The upstream check for any system is a single AND
-/// against this bitmask — no iteration over dependency lists.
-///
-/// 64 systems is well beyond typical reconciliation DAG sizes. If a
-/// future use case requires more, the bitmask can be widened to `u128`
-/// or `[u64; N]` without changing the public API.
-pub const MAX_SYSTEMS: usize = 64;
+// =============================================================================
+// StageNode builder methods
+// =============================================================================
 
-impl Installer for SchedulerInstaller {
-    type Poller = SystemScheduler;
-
-    fn install(self, _world: &mut WorldBuilder) -> SystemScheduler {
-        let n = self.systems.len();
-
-        assert!(
-            n <= MAX_SYSTEMS,
-            "system scheduler supports at most {MAX_SYSTEMS} systems, got {n}",
-        );
-
-        // Build adjacency list and in-degree counts.
-        let mut in_degree = vec![0usize; n];
-        let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-
-        for &(up, down) in &self.edges {
-            adj[up].push(down);
-            in_degree[down] += 1;
-        }
-
-        // Kahn's algorithm — FIFO queue for stable insertion-order.
-        let mut queue = VecDeque::new();
-        for (i, deg) in in_degree.iter().enumerate() {
-            if *deg == 0 {
-                queue.push_back(i);
-            }
-        }
-
-        let mut order: Vec<usize> = Vec::with_capacity(n);
-        while let Some(node) = queue.pop_front() {
-            order.push(node);
-            for &succ in &adj[node] {
-                in_degree[succ] -= 1;
-                if in_degree[succ] == 0 {
-                    queue.push_back(succ);
-                }
-            }
-        }
-
-        assert!(
-            order.len() == n,
-            "cycle detected in system scheduler: {} systems in graph, \
-             but only {} reachable in topological order",
-            n,
-            order.len(),
-        );
-
-        // Build the old→new position mapping.
-        let mut old_to_new = vec![0usize; n];
-        for (new_pos, &old_pos) in order.iter().enumerate() {
-            old_to_new[old_pos] = new_pos;
-        }
-
-        // Reorder systems into topological order.
-        let mut sorted_systems: Vec<Option<Box<dyn System>>> =
-            self.systems.into_iter().map(Some).collect();
-        let systems: Vec<Box<dyn System>> = order
-            .iter()
-            .map(|&old_pos| sorted_systems[old_pos].take().unwrap())
-            .collect();
-
-        // Build upstream bitmasks: for each system in topological order,
-        // a u64 where bit j is set if system j is an upstream dependency.
-        // Roots have mask 0 (always run).
-        let mut upstream_masks = vec![0u64; n];
-        for &(up, down) in &self.edges {
-            upstream_masks[old_to_new[down]] |= 1 << old_to_new[up];
-        }
-
-        SystemScheduler {
-            systems,
-            upstream_masks,
+impl<Prev, S> StageNode<Prev, S>
+where
+    Prev: RunSchedule + 'static,
+    S: StageRunner + 'static,
+{
+    /// Append a stage that runs after the current chain.
+    pub fn then<Next, Params>(
+        self,
+        stage: Next,
+        registry: &Registry,
+    ) -> StageNode<Self, Next::Stage>
+    where
+        Next: IntoStage<Params>,
+    {
+        StageNode {
+            prev: self,
+            stage: stage.into_stage(registry),
         }
     }
 }
 
 // =============================================================================
-// SystemScheduler
+// Installer impl on StageNode
 // =============================================================================
 
-/// DAG scheduler that runs systems in topological order with boolean
-/// propagation.
+impl<Prev, S> Installer for StageNode<Prev, S>
+where
+    Self: RunSchedule + 'static,
+{
+    type Poller = SystemScheduler<Self>;
+
+    fn install(self, _world: &mut WorldBuilder) -> Self::Poller {
+        SystemScheduler { chain: self }
+    }
+}
+
+// =============================================================================
+// SystemScheduler<Chain> — final type
+// =============================================================================
+
+/// Monomorphized staged scheduler. Created via [`SchedulerBuilder`].
 ///
-/// Created by [`SchedulerInstaller`] via
-/// [`WorldBuilder::install_driver`](crate::WorldBuilder::install_driver).
-/// This is a user-space driver — the caller decides when and whether
-/// to call [`run`](Self::run).
+/// All system calls are direct (no vtable dispatch). The `Chain` type
+/// parameter encodes the full schedule — the compiler inlines the
+/// recursive `run_schedule` chain.
 ///
 /// # Propagation
 ///
-/// Root systems (no upstream) always run. Non-root systems run only if
-/// at least one upstream returned `true`.
+/// The first stage always runs. Each subsequent stage runs only if
+/// the previous stage's systems returned at least one `true` (OR
+/// semantics within a stage).
 ///
-/// # Bitmask implementation
-///
-/// Each system occupies one bit position in a `u64`. During
-/// [`run`](Self::run), a local `results: u64` accumulates which systems
-/// returned `true`. Each system's upstream check is:
-///
-/// ```text
-/// mask == 0              → root, always run
-/// (mask & results) != 0  → at least one upstream returned true
-/// ```
-///
-/// One load, one AND, one branch per system — no heap access for the
-/// propagation check itself. The `results` bitmask lives in a register
-/// for the duration of the loop.
-pub struct SystemScheduler {
-    systems: Vec<Box<dyn System>>,
-    /// Per-system: bit `j` set means system `j` is an upstream dependency.
-    /// `0` = root (always runs).
-    upstream_masks: Vec<u64>,
+/// Does NOT call [`next_sequence`](World::next_sequence) — the global
+/// sequence is event-only.
+pub struct SystemScheduler<Chain> {
+    chain: Chain,
 }
 
-impl SystemScheduler {
-    /// Run all systems with boolean propagation.
-    ///
-    /// Iterates systems in topological order. For each system:
-    ///
-    /// 1. **Root** (`upstream_mask == 0`): always runs.
-    /// 2. **Non-root** (`upstream_mask & results != 0`): runs if any
-    ///    upstream returned `true`. Skipped otherwise.
-    /// 3. If the system runs and returns `true`, its bit is set in
-    ///    `results`, enabling downstream systems to run.
-    ///
-    /// The `results` bitmask is a local `u64` — the entire propagation
-    /// state fits in a single register. Per-system overhead is one
-    /// load + one AND + one branch (~4 cycles).
-    ///
-    /// Does NOT call [`next_sequence`](World::next_sequence) — the global
-    /// sequence is event-only.
+impl<Chain: RunSchedule> SystemScheduler<Chain> {
+    /// Run all stages with boolean propagation.
     ///
     /// Returns the number of systems that actually ran.
     pub fn run(&mut self, world: &mut World) -> usize {
-        let mut ran = 0;
-        let mut results: u64 = 0;
-
-        for i in 0..self.systems.len() {
-            let mask = self.upstream_masks[i];
-            if mask == 0 || (mask & results) != 0 {
-                if self.systems[i].run(world) {
-                    results |= 1 << i;
-                }
-                ran += 1;
-            }
-        }
-
+        let (ran, _) = self.chain.run_schedule(world, true);
         ran
     }
 
-    /// Returns the number of systems in the scheduler.
+    /// Returns the total number of systems across all stages.
     pub fn len(&self) -> usize {
-        self.systems.len()
+        self.chain.system_count()
     }
 
     /// Returns `true` if the scheduler contains no systems.
     pub fn is_empty(&self) -> bool {
-        self.systems.is_empty()
+        self.chain.system_count() == 0
     }
 }
 
@@ -383,44 +452,30 @@ mod tests {
     use super::*;
     use crate::ResMut;
 
-    // -- Empty scheduler --------------------------------------------------
-
-    #[test]
-    fn empty_scheduler() {
-        let mut builder = WorldBuilder::new();
-        let installer = SchedulerInstaller::new();
-        let mut scheduler = builder.install_driver(installer);
-        let mut world = builder.build();
-
-        assert_eq!(scheduler.run(&mut world), 0);
-        assert!(scheduler.is_empty());
-    }
-
-    // -- Single root ------------------------------------------------------
+    // -- Helpers ----------------------------------------------------------
 
     fn increment(mut val: ResMut<u64>) -> bool {
         *val += 1;
         true
     }
 
-    #[test]
-    fn single_root_always_runs() {
-        let mut builder = WorldBuilder::new();
-        builder.register::<u64>(0);
-        let mut installer = SchedulerInstaller::new();
-        installer.add(increment, builder.registry());
-        let mut scheduler = builder.install_driver(installer);
-        let mut world = builder.build();
-
-        assert_eq!(scheduler.run(&mut world), 1);
-        assert_eq!(*world.resource::<u64>(), 1);
+    fn set_flag(mut flag: ResMut<bool>) -> bool {
+        *flag = true;
+        true
     }
 
-    // -- Linear chain: A → B → C -----------------------------------------
+    fn false_source() -> bool {
+        false
+    }
+
+    fn should_not_run(mut val: ResMut<u64>) -> bool {
+        *val = 999;
+        true
+    }
 
     fn source(mut val: ResMut<u64>) -> bool {
         *val += 1;
-        *val <= 2 // propagate first two times
+        *val <= 2
     }
 
     fn middle(mut val: ResMut<u64>) -> bool {
@@ -433,122 +488,96 @@ mod tests {
         true
     }
 
+    fn double(mut val: ResMut<u64>) -> bool {
+        *val *= 2;
+        true
+    }
+
+    // -- Migrated tests ---------------------------------------------------
+
+    #[test]
+    fn single_root_always_runs() {
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(SchedulerBuilder::new().root(increment, &reg));
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 1);
+        assert_eq!(*world.resource::<u64>(), 1);
+    }
+
     #[test]
     fn linear_chain_propagation() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
-        let mut installer = SchedulerInstaller::new();
-        let a = installer.add(source, builder.registry());
-        let b = installer.add(middle, builder.registry());
-        let c = installer.add(leaf, builder.registry());
-        installer.after(b, a);
-        installer.after(c, b);
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(source, &reg)
+                .then(middle, &reg)
+                .then(leaf, &reg),
+        );
         let mut world = builder.build();
 
-        // Pass 1: source returns true → all 3 run
         assert_eq!(scheduler.run(&mut world), 3);
-        // 0 + 1 + 10 + 100 = 111
         assert_eq!(*world.resource::<u64>(), 111);
-    }
-
-    // -- Propagation stops ------------------------------------------------
-
-    fn false_source() -> bool {
-        false
-    }
-
-    fn should_not_run(mut val: ResMut<u64>) -> bool {
-        *val = 999;
-        true
     }
 
     #[test]
     fn propagation_stops_on_false() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
-        let mut installer = SchedulerInstaller::new();
-        let a = installer.add(false_source, builder.registry());
-        let b = installer.add(should_not_run, builder.registry());
-        installer.after(b, a);
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(false_source, &reg)
+                .then(should_not_run, &reg),
+        );
         let mut world = builder.build();
 
-        // Only root runs, downstream skipped
         assert_eq!(scheduler.run(&mut world), 1);
         assert_eq!(*world.resource::<u64>(), 0);
     }
 
-    // -- Diamond DAG: A → B, A → C, B → D, C → D -------------------------
-
-    fn set_flag(mut flag: ResMut<bool>) -> bool {
-        *flag = true;
-        true
-    }
-
     #[test]
-    fn diamond_dag() {
+    fn staged_diamond() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
         builder.register::<bool>(false);
-        let mut installer = SchedulerInstaller::new();
-        let a = installer.add(increment, builder.registry());
-        let b = installer.add(increment, builder.registry());
-        let c = installer.add(set_flag, builder.registry());
-        let d = installer.add(increment, builder.registry());
-        installer.after(b, a);
-        installer.after(c, a);
-        installer.after(d, b);
-        installer.after(d, c);
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(increment, &reg)
+                .then((increment, set_flag), &reg)
+                .then(increment, &reg),
+        );
         let mut world = builder.build();
 
         assert_eq!(scheduler.run(&mut world), 4);
         assert!(*world.resource::<bool>());
-        // u64: increment runs 3 times (a, b, d) → 3
         assert_eq!(*world.resource::<u64>(), 3);
     }
-
-    // -- Multiple roots ---------------------------------------------------
 
     #[test]
     fn multiple_roots() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
-        let mut installer = SchedulerInstaller::new();
-        installer.add(increment, builder.registry());
-        installer.add(increment, builder.registry());
-        installer.add(increment, builder.registry());
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder
+            .install_driver(SchedulerBuilder::new().root((increment, increment, increment), &reg));
         let mut world = builder.build();
 
         assert_eq!(scheduler.run(&mut world), 3);
         assert_eq!(*world.resource::<u64>(), 3);
     }
 
-    // -- Cycle detection --------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "cycle detected")]
-    fn cycle_panics() {
-        let mut builder = WorldBuilder::new();
-        let mut installer = SchedulerInstaller::new();
-        let a = installer.add(false_source, builder.registry());
-        let b = installer.add(false_source, builder.registry());
-        installer.after(b, a);
-        installer.after(a, b);
-        let _scheduler = builder.install_driver(installer);
-    }
-
-    // -- Sequence not bumped by scheduler ---------------------------------
-
     #[test]
     fn scheduler_does_not_bump_sequence() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(0);
-        let mut installer = SchedulerInstaller::new();
-        installer.add(increment, builder.registry());
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(SchedulerBuilder::new().root(increment, &reg));
         let mut world = builder.build();
 
         let before = world.current_sequence();
@@ -556,39 +585,143 @@ mod tests {
         assert_eq!(world.current_sequence(), before);
     }
 
-    // -- System mutations visible to later systems ------------------------
-
-    fn double(mut val: ResMut<u64>) -> bool {
-        *val *= 2;
-        true
-    }
-
     #[test]
     fn mutations_visible_downstream() {
         let mut builder = WorldBuilder::new();
         builder.register::<u64>(1);
-        let mut installer = SchedulerInstaller::new();
-        let a = installer.add(double, builder.registry());
-        let b = installer.add(double, builder.registry());
-        installer.after(b, a);
-        let mut scheduler = builder.install_driver(installer);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(double, &reg)
+                .then(double, &reg),
+        );
         let mut world = builder.build();
 
         scheduler.run(&mut world);
-        // 1 * 2 = 2, then 2 * 2 = 4
         assert_eq!(*world.resource::<u64>(), 4);
     }
 
-    // -- Capacity limit ---------------------------------------------------
+    // -- New tests --------------------------------------------------------
 
     #[test]
-    #[should_panic(expected = "at most 64 systems")]
-    fn exceeding_max_systems_panics() {
+    fn multi_system_stage_all_run() {
         let mut builder = WorldBuilder::new();
-        let mut installer = SchedulerInstaller::new();
-        for _ in 0..=MAX_SYSTEMS {
-            installer.add(false_source, builder.registry());
+        builder.register::<u64>(0);
+        builder.register::<bool>(false);
+        let reg = builder.registry();
+        let mut scheduler = builder
+            .install_driver(SchedulerBuilder::new().root((increment, increment, set_flag), &reg));
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 3);
+        assert_eq!(*world.resource::<u64>(), 2);
+        assert!(*world.resource::<bool>());
+    }
+
+    #[test]
+    fn stage_propagation_any_semantics() {
+        fn false_increment(mut val: ResMut<u64>) -> bool {
+            *val += 1;
+            false
         }
-        let _scheduler = builder.install_driver(installer);
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root((false_increment, increment), &reg)
+                .then(increment, &reg),
+        );
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 3);
+        assert_eq!(*world.resource::<u64>(), 3);
+    }
+
+    #[test]
+    fn stage_propagation_all_false_stops() {
+        fn false_increment(mut val: ResMut<u64>) -> bool {
+            *val += 1;
+            false
+        }
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root((false_increment, false_increment), &reg)
+                .then(should_not_run, &reg),
+        );
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 2);
+        assert_eq!(*world.resource::<u64>(), 2);
+    }
+
+    #[test]
+    fn void_systems_in_stage() {
+        fn void_increment(mut val: ResMut<u64>) {
+            *val += 1;
+        }
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(void_increment, &reg)
+                .then(increment, &reg),
+        );
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 2);
+        assert_eq!(*world.resource::<u64>(), 2);
+    }
+
+    #[test]
+    fn mixed_bool_void_stage() {
+        fn void_increment(mut val: ResMut<u64>) {
+            *val += 1;
+        }
+
+        fn false_increment(mut val: ResMut<u64>) -> bool {
+            *val += 1;
+            false
+        }
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root((false_increment, void_increment), &reg)
+                .then(increment, &reg),
+        );
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 3);
+        assert_eq!(*world.resource::<u64>(), 3);
+    }
+
+    #[test]
+    fn three_stage_linear() {
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        builder.register::<bool>(false);
+        let reg = builder.registry();
+        let mut scheduler = builder.install_driver(
+            SchedulerBuilder::new()
+                .root(increment, &reg)
+                .then((increment, set_flag), &reg)
+                .then(double, &reg),
+        );
+        let mut world = builder.build();
+
+        assert_eq!(scheduler.run(&mut world), 4);
+        assert!(*world.resource::<bool>());
+        // u64: 0 +1 (root) +1 (stage1) = 2, then *2 (stage2) = 4
+        assert_eq!(*world.resource::<u64>(), 4);
     }
 }

--- a/nexus-rt/src/system.rs
+++ b/nexus-rt/src/system.rs
@@ -12,9 +12,9 @@
 //! have been processed. The typical pattern:
 //!
 //! 1. Event handler writes to resources (`ResMut<MidPrice>`)
-//! 2. Scheduler runs systems in topological order
+//! 2. Scheduler runs systems in stage order
 //! 3. Systems read upstream resources, compute derived state, return
-//!    `bool` to propagate or skip downstream
+//!    `bool` to propagate or skip downstream stages
 //!
 //! Systems are converted from plain functions via [`IntoSystem`], using
 //! the same HRTB double-bound pattern as [`IntoHandler`](crate::IntoHandler).
@@ -22,7 +22,7 @@
 //! # Supported signatures
 //!
 //! - `fn(params...) -> bool` — returns propagation decision for
-//!   scheduler DAGs
+//!   staged scheduling
 //! - `fn(params...)` — void return, always propagates (`true`). Useful
 //!   for [`World::run_startup`] and systems that unconditionally
 //!   propagate.


### PR DESCRIPTION
## Summary

- Monomorphize `SystemScheduler` — eliminates `Vec<Box<dyn System>>` vtable dispatch, aligning with Pipeline and DAG's one-virtual-call-at-root philosophy (#185)
- Systems grouped into **stages**: each `.then()` wraps the chain in a new `StageNode<Prev, S>` type layer, compiler inlines the full `run_schedule` recursion
- Staged propagation: per-stage `bool` (any system returned true → next stage runs) replaces per-system `u64` bitmask
- Builder API: `SchedulerBuilder::new().root(a, &reg).then(b, &reg).then((c, d), &reg)` — topology implicit in call order, no `after()`/`before()`, no Kahn's sort
- Single fns and tuples of fns (up to 8) accepted via `IntoStage` trait
- Deleted: `SystemId`, `SchedulerInstaller`, `MAX_SYSTEMS`, Kahn's algorithm, bitmask propagation

## Test plan

- [x] 7 migrated tests (single root, linear chain, propagation stops, diamond, multiple roots, sequence invariant, mutation visibility)
- [x] 6 new tests (multi-system stage, any-semantics propagation, all-false stops, void systems, mixed bool/void, three-stage chain)
- [x] 3 dropped tests (empty scheduler, cycle detection, capacity limit — no longer applicable)
- [x] `cargo test -p nexus-rt` — all green
- [x] `cargo clippy -p nexus-rt -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Examples updated (`scheduler_dag.rs`, `perf_scheduler.rs`)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)