### PR TITLE
use better fma calls in nexus-stats-regression

### DIFF
--- a/nexus-stats-regression/src/learning/huber_regression.rs
+++ b/nexus-stats-regression/src/learning/huber_regression.rs
@@ -1,8 +1,7 @@
-#![allow(clippy::suboptimal_flops)]
-
 extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
+use nexus_stats_core::math::MulAdd;
 
 /// Streaming linear regression with Huber loss.
 ///
@@ -111,7 +110,7 @@ impl HuberRegressionF64 {
         // Compute prediction: dot(weights, features)
         let mut pred = 0.0f64;
         for i in 0..self.dim {
-            pred += self.weights[i] * features[i];
+            pred = self.weights[i].fma(features[i], pred);
         }
 
         // Residual
@@ -125,8 +124,9 @@ impl HuberRegressionF64 {
         };
 
         // SGD update: w += lr * grad_scale * x
+        let step = self.lr * grad_scale;
         for i in 0..self.dim {
-            self.weights[i] += self.lr * grad_scale * features[i];
+            self.weights[i] = step.fma(features[i], self.weights[i]);
         }
 
         Ok(())
@@ -142,7 +142,7 @@ impl HuberRegressionF64 {
         assert_eq!(features.len(), self.dim);
         let mut pred = 0.0f64;
         for i in 0..self.dim {
-            pred += self.weights[i] * features[i];
+            pred = self.weights[i].fma(features[i], pred);
         }
         pred
     }

--- a/nexus-stats-regression/src/learning/lms.rs
+++ b/nexus-stats-regression/src/learning/lms.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::suboptimal_flops)]
-
 // LMS and NLMS Adaptive Filters
 //
 // Least Mean Squares (LMS): w += lr * error * x
@@ -10,6 +8,7 @@
 
 extern crate alloc;
 use alloc::boxed::Box;
+use nexus_stats_core::math::MulAdd;
 use alloc::vec;
 
 macro_rules! impl_lms_filter {
@@ -72,7 +71,7 @@ macro_rules! impl_lms_filter {
                 );
                 let mut sum = 0.0 as $ty;
                 for i in 0..self.dims {
-                    sum += self.weights[i] * features[i];
+                    sum = self.weights[i].fma(features[i], sum);
                 }
                 sum
             }
@@ -101,7 +100,7 @@ macro_rules! impl_lms_filter {
                 let error = target - prediction;
                 let step = self.learning_rate * error;
                 for i in 0..self.dims {
-                    self.weights[i] += step * features[i];
+                    self.weights[i] = step.fma(features[i], self.weights[i]);
                 }
                 self.count += 1;
                 Ok(())
@@ -259,7 +258,7 @@ macro_rules! impl_nlms_filter {
                 );
                 let mut sum = 0.0 as $ty;
                 for i in 0..self.dims {
-                    sum += self.weights[i] * features[i];
+                    sum = self.weights[i].fma(features[i], sum);
                 }
                 sum
             }
@@ -288,11 +287,11 @@ macro_rules! impl_nlms_filter {
                 let error = target - prediction;
                 let mut norm_sq = 0.0 as $ty;
                 for i in 0..self.dims {
-                    norm_sq += features[i] * features[i];
+                    norm_sq = features[i].fma(features[i], norm_sq);
                 }
                 let step = (self.learning_rate / (norm_sq + self.epsilon)) * error;
                 for i in 0..self.dims {
-                    self.weights[i] += step * features[i];
+                    self.weights[i] = step.fma(features[i], self.weights[i]);
                 }
                 self.count += 1;
                 Ok(())

--- a/nexus-stats-regression/src/learning/rls.rs
+++ b/nexus-stats-regression/src/learning/rls.rs
@@ -1,8 +1,7 @@
-#![allow(clippy::suboptimal_flops)]
-
 extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
+use nexus_stats_core::math::MulAdd;
 
 macro_rules! impl_rls_filter {
     ($name:ident, $builder:ident, $ty:ty) => {
@@ -73,7 +72,7 @@ macro_rules! impl_rls_filter {
                 );
                 let mut sum = 0.0 as $ty;
                 for i in 0..self.dims {
-                    sum += self.weights[i] * features[i];
+                    sum = self.weights[i].fma(features[i], sum);
                 }
                 sum
             }
@@ -115,7 +114,7 @@ macro_rules! impl_rls_filter {
                 for i in 0..d {
                     let mut sum = 0.0 as $ty;
                     for j in 0..d {
-                        sum += self.p_matrix[i * d + j] * features[j];
+                        sum = self.p_matrix[i * d + j].fma(features[j], sum);
                     }
                     self.scratch_px[i] = sum;
                 }
@@ -123,7 +122,7 @@ macro_rules! impl_rls_filter {
                 // xpx = Σ x[i] * px[i]
                 let mut xpx = 0.0 as $ty;
                 for i in 0..d {
-                    xpx += features[i] * self.scratch_px[i];
+                    xpx = features[i].fma(self.scratch_px[i], xpx);
                 }
 
                 // k[i] = px[i] / (lambda + xpx)
@@ -137,13 +136,13 @@ macro_rules! impl_rls_filter {
                 // error = target - w·x
                 let mut prediction = 0.0 as $ty;
                 for i in 0..d {
-                    prediction += self.weights[i] * features[i];
+                    prediction = self.weights[i].fma(features[i], prediction);
                 }
                 let error = target - prediction;
 
                 // w += k * error
                 for i in 0..d {
-                    self.weights[i] += self.scratch_k[i] * error;
+                    self.weights[i] = self.scratch_k[i].fma(error, self.weights[i]);
                 }
 
                 // P[i][j] = (P[i][j] - k[i] * px[j]) / lambda
@@ -151,9 +150,9 @@ macro_rules! impl_rls_filter {
                 let inv_lambda = 1.0 as $ty / lambda;
                 for i in 0..d {
                     for j in 0..d {
-                        self.p_matrix[i * d + j] = (self.p_matrix[i * d + j]
-                            - self.scratch_k[i] * self.scratch_px[j])
-                            * inv_lambda;
+                        self.p_matrix[i * d + j] =
+                            (-self.scratch_k[i]).fma(self.scratch_px[j], self.p_matrix[i * d + j])
+                                * inv_lambda;
                     }
                 }
 
@@ -168,16 +167,22 @@ macro_rules! impl_rls_filter {
                         }
                     }
                     if max_diag > max {
-                        for p in self.p_matrix.iter_mut() {
-                            *p = 0.0 as $ty;
-                        }
-                        for i in 0..d {
-                            self.p_matrix[i * d + i] = self.initial_covariance;
-                        }
+                        self.reset_covariance();
                     }
                 }
 
                 Ok(())
+            }
+
+            #[cold]
+            fn reset_covariance(&mut self) {
+                let d = self.dims;
+                for p in self.p_matrix.iter_mut() {
+                    *p = 0.0 as $ty;
+                }
+                for i in 0..d {
+                    self.p_matrix[i * d + i] = self.initial_covariance;
+                }
             }
 
             /// Returns the current weight vector.

--- a/nexus-stats-regression/src/regression/ew_polynomial_regression.rs
+++ b/nexus-stats-regression/src/regression/ew_polynomial_regression.rs
@@ -4,9 +4,8 @@
 // but with exponential decay on accumulators. Recent data dominates.
 // Degree and intercept are runtime-configured via builder.
 
-#![allow(clippy::suboptimal_flops)]
-
 use super::polynomial_regression::{CoefficientsF32, CoefficientsF64};
+use nexus_stats_core::math::MulAdd;
 
 macro_rules! impl_ew_polynomial_regression {
     ($name:ident, $builder:ident, $coeff:ident, $solve_fn:path, $ty:ty) => {
@@ -81,15 +80,15 @@ macro_rules! impl_ew_polynomial_regression {
                 check_finite!(x);
                 check_finite!(y);
                 self.count += 1;
-                self.effective_n = self.one_minus_alpha * self.effective_n + 1.0 as $ty;
-                self.sum_y2 = self.one_minus_alpha * self.sum_y2 + y * y;
+                self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0 as $ty);
+                self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
 
                 let mut x_pow = 1.0 as $ty;
                 let max_pow = 2 * self.degree;
                 for j in 0..=max_pow {
-                    self.sum_x[j] = self.one_minus_alpha * self.sum_x[j] + x_pow;
+                    self.sum_x[j] = self.one_minus_alpha.fma(self.sum_x[j], x_pow);
                     if j <= self.degree {
-                        self.sum_xy[j] = self.one_minus_alpha * self.sum_xy[j] + x_pow * y;
+                        self.sum_xy[j] = self.one_minus_alpha.fma(self.sum_xy[j], x_pow * y);
                     }
                     x_pow *= x;
                 }

--- a/nexus-stats-regression/src/regression/linear_regression.rs
+++ b/nexus-stats-regression/src/regression/linear_regression.rs
@@ -3,7 +3,9 @@
 // Minimal state (5 accumulators, ~48 bytes) with direct 2×2 solve.
 // No loops, no Gaussian elimination — just arithmetic.
 
-#![allow(clippy::suboptimal_flops, clippy::float_cmp)]
+#![allow(clippy::float_cmp)]
+
+use nexus_stats_core::math::MulAdd;
 
 macro_rules! impl_linear_regression {
     ($name:ident, $builder:ident, $ty:ty) => {
@@ -102,10 +104,10 @@ macro_rules! impl_linear_regression {
                 check_finite!(y);
                 self.count += 1;
                 self.sum_x += x;
-                self.sum_x2 += x * x;
+                self.sum_x2 = x.fma(x, self.sum_x2);
                 self.sum_y += y;
-                self.sum_xy += x * y;
-                self.sum_y2 += y * y;
+                self.sum_xy = x.fma(y, self.sum_xy);
+                self.sum_y2 = y.fma(y, self.sum_y2);
                 Ok(())
             }
 
@@ -117,11 +119,11 @@ macro_rules! impl_linear_regression {
                 }
                 if self.intercept {
                     let n = self.count as $ty;
-                    let denom = n * self.sum_x2 - self.sum_x * self.sum_x;
+                    let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
                     if denom == 0.0 as $ty {
                         return Option::None;
                     }
-                    Option::Some((n * self.sum_xy - self.sum_x * self.sum_y) / denom)
+                    Option::Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
                 } else {
                     if self.sum_x2 == 0.0 as $ty {
                         return Option::None;
@@ -138,7 +140,7 @@ macro_rules! impl_linear_regression {
                 }
                 let slope = self.slope()?;
                 let n = self.count as $ty;
-                Option::Some((self.sum_y - slope * self.sum_x) / n)
+                Option::Some(slope.fma(-self.sum_x, self.sum_y) / n)
             }
 
             /// R² goodness of fit, or `None` if not enough data.
@@ -146,6 +148,7 @@ macro_rules! impl_linear_regression {
             /// With intercept: centered R² = 1 - SS_res/SS_tot.
             /// Without intercept: uncentered R² = 1 - SS_res/Σy².
             #[must_use]
+            #[allow(clippy::suboptimal_flops)]
             pub fn r_squared(&self) -> Option<$ty> {
                 let slope = self.slope()?;
                 let n = self.count as $ty;
@@ -182,7 +185,7 @@ macro_rules! impl_linear_regression {
                 let slope = self.slope()?;
                 if self.intercept {
                     let intercept = self.intercept_value()?;
-                    Option::Some(slope * x + intercept)
+                    Option::Some(slope.fma(x, intercept))
                 } else {
                     Option::Some(slope * x)
                 }
@@ -333,12 +336,12 @@ macro_rules! impl_ew_linear_regression {
                 check_finite!(x);
                 check_finite!(y);
                 self.count += 1;
-                self.effective_n = self.one_minus_alpha * self.effective_n + 1.0 as $ty;
-                self.sum_x = self.one_minus_alpha * self.sum_x + x;
-                self.sum_x2 = self.one_minus_alpha * self.sum_x2 + x * x;
-                self.sum_y = self.one_minus_alpha * self.sum_y + y;
-                self.sum_xy = self.one_minus_alpha * self.sum_xy + x * y;
-                self.sum_y2 = self.one_minus_alpha * self.sum_y2 + y * y;
+                self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0 as $ty);
+                self.sum_x = self.one_minus_alpha.fma(self.sum_x, x);
+                self.sum_x2 = self.one_minus_alpha.fma(self.sum_x2, x * x);
+                self.sum_y = self.one_minus_alpha.fma(self.sum_y, y);
+                self.sum_xy = self.one_minus_alpha.fma(self.sum_xy, x * y);
+                self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
                 Ok(())
             }
 
@@ -350,11 +353,11 @@ macro_rules! impl_ew_linear_regression {
                 }
                 if self.intercept {
                     let n = self.effective_n;
-                    let denom = n * self.sum_x2 - self.sum_x * self.sum_x;
+                    let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
                     if denom == 0.0 as $ty {
                         return Option::None;
                     }
-                    Option::Some((n * self.sum_xy - self.sum_x * self.sum_y) / denom)
+                    Option::Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
                 } else {
                     if self.sum_x2 == 0.0 as $ty {
                         return Option::None;
@@ -370,11 +373,12 @@ macro_rules! impl_ew_linear_regression {
                     return Option::None;
                 }
                 let slope = self.slope()?;
-                Option::Some((self.sum_y - slope * self.sum_x) / self.effective_n)
+                Option::Some(slope.fma(-self.sum_x, self.sum_y) / self.effective_n)
             }
 
             /// R² goodness of fit.
             #[must_use]
+            #[allow(clippy::suboptimal_flops)]
             pub fn r_squared(&self) -> Option<$ty> {
                 let slope = self.slope()?;
                 let n = self.effective_n;
@@ -409,7 +413,7 @@ macro_rules! impl_ew_linear_regression {
                 let slope = self.slope()?;
                 if self.intercept {
                     let intercept = self.intercept_value()?;
-                    Option::Some(slope * x + intercept)
+                    Option::Some(slope.fma(x, intercept))
                 } else {
                     Option::Some(slope * x)
                 }

--- a/nexus-stats-regression/src/regression/logistic_regression.rs
+++ b/nexus-stats-regression/src/regression/logistic_regression.rs
@@ -1,8 +1,7 @@
-#![allow(clippy::suboptimal_flops)]
-
 extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
+use nexus_stats_core::math::MulAdd;
 
 /// Numerically stable sigmoid function.
 ///
@@ -79,7 +78,7 @@ impl LogisticRegressionF64 {
         );
         let mut z = 0.0_f64;
         for i in 0..self.dims {
-            z += self.weights[i] * features[i];
+            z = self.weights[i].fma(features[i], z);
         }
         sigmoid(z)
     }
@@ -106,13 +105,13 @@ impl LogisticRegressionF64 {
         );
         let mut z = 0.0_f64;
         for i in 0..self.dims {
-            z += self.weights[i] * features[i];
+            z = self.weights[i].fma(features[i], z);
         }
         let p = sigmoid(z);
         let error = (outcome as u8 as f64) - p;
         let step = self.learning_rate * error;
         for i in 0..self.dims {
-            self.weights[i] += step * features[i];
+            self.weights[i] = step.fma(features[i], self.weights[i]);
         }
         self.count += 1;
     }


### PR DESCRIPTION
## Summary

FMA sweep across nexus-stats-regression. Replaces `a * b + c` patterns with `.fma()` (via `MulAdd` trait from nexus-stats-core) for fused multiply-add on hardware with FMA support.

- **6 files, ~25 call sites** converted to `.fma()`
- Removed `#![allow(clippy::suboptimal_flops)]` from 4 files (rls, lms, huber, logistic)
- Replaced file-level allow in linear_regression with method-level `#[allow(clippy::suboptimal_flops)]` on `r_squared()` (formula too complex for readable FMA)
- Extracted `#[cold] fn reset_covariance()` in RLS (max_covariance reset path)
- Hoisted loop-invariant `self.lr * grad_scale` in Huber update

### Files changed

| File | Sites | Notes |
|------|-------|-------|
| `rls.rs` | ~8 | P-matrix inner loop (O(d²)), dot products, weight update, `#[cold]` reset |
| `lms.rs` | ~5 | LMS + NLMS predict/update dot products, norm_sq, weight updates |
| `linear_regression.rs` | ~12 | OLS + EW update accumulators, slope, intercept, predict |
| `ew_polynomial_regression.rs` | ~3 | Decay accumulation in power loop |
| `huber_regression.rs` | ~3 | Predict + update dot products, hoisted step |
| `logistic_regression.rs` | ~3 | Predict + update dot products, weight update |

### Build-flag caveat

`.fma()` without `-C target-feature=+fma` or `-C target-cpu=native` emits a soft-FMA call (~20-50x slower than `a*b+c`). Workspace convention is `RUSTFLAGS='-C target-cpu=native'` — same as every other nexus-stats subcrate that uses `.fma()`.

### Numerical impact

FMA is a strict precision improvement (single rounding instead of two). RLS specifically benefits — tighter rounding reduces P-matrix divergence rate.

Closes #180