### PR TITLE
#[cold] disconnect paths + bit-op source clarity (#267)

### DIFF
--- a/nexus-channel/src/lib.rs
+++ b/nexus-channel/src/lib.rs
@@ -188,7 +188,7 @@ impl<T> Sender<T> {
     #[inline]
     pub fn send(&self, value: T) -> Result<(), SendError<T>> {
         if self.producer.is_disconnected() {
-            return Err(SendError(value));
+            return cold_send_err(value);
         }
 
         let mut val = value;
@@ -208,7 +208,7 @@ impl<T> Sender<T> {
             backoff.snooze();
 
             if self.producer.is_disconnected() {
-                return Err(SendError(val));
+                return cold_send_err(val);
             }
 
             match self.producer.push(val) {
@@ -226,7 +226,7 @@ impl<T> Sender<T> {
 
             if self.producer.is_disconnected() {
                 self.shared.sender_parked.store(false, Ordering::Relaxed);
-                return Err(SendError(val));
+                return cold_send_err(val);
             }
 
             match self.producer.push(val) {
@@ -242,7 +242,7 @@ impl<T> Sender<T> {
             self.shared.sender_parked.store(false, Ordering::Relaxed);
 
             if self.producer.is_disconnected() {
-                return Err(SendError(val));
+                return cold_send_err(val);
             }
 
             match self.producer.push(val) {
@@ -264,7 +264,7 @@ impl<T> Sender<T> {
     #[inline]
     pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
         if self.producer.is_disconnected() {
-            return Err(TrySendError::Disconnected(value));
+            return cold_try_send_disconnected(value);
         }
 
         match self.producer.push(value) {
@@ -375,7 +375,7 @@ impl<T> Receiver<T> {
 
             if self.consumer.is_disconnected() {
                 self.shared.receiver_parked.store(false, Ordering::Relaxed);
-                return Err(RecvError);
+                return cold_recv_err();
             }
 
             self.parker.park();
@@ -387,7 +387,7 @@ impl<T> Receiver<T> {
             }
 
             if self.consumer.is_disconnected() {
-                return Err(RecvError);
+                return cold_recv_err();
             }
         }
     }
@@ -443,7 +443,7 @@ impl<T> Receiver<T> {
 
             if self.consumer.is_disconnected() {
                 self.shared.receiver_parked.store(false, Ordering::Relaxed);
-                return Err(RecvTimeoutError::Disconnected);
+                return cold_recv_timeout_disconnected();
             }
 
             let remaining = deadline - now;
@@ -456,7 +456,7 @@ impl<T> Receiver<T> {
             }
 
             if self.consumer.is_disconnected() {
-                return Err(RecvTimeoutError::Disconnected);
+                return cold_recv_timeout_disconnected();
             }
         }
     }
@@ -477,7 +477,7 @@ impl<T> Receiver<T> {
             }
             None => {
                 if self.consumer.is_disconnected() {
-                    Err(TryRecvError::Disconnected)
+                    cold_try_recv_disconnected()
                 } else {
                     Err(TryRecvError::Empty)
                 }
@@ -669,6 +669,35 @@ impl fmt::Display for RecvTimeoutError {
 }
 
 impl std::error::Error for RecvTimeoutError {}
+
+// ============================================================================
+// Cold error constructors
+// ============================================================================
+
+#[cold]
+fn cold_send_err<T>(val: T) -> Result<(), SendError<T>> {
+    Err(SendError(val))
+}
+
+#[cold]
+fn cold_try_send_disconnected<T>(val: T) -> Result<(), TrySendError<T>> {
+    Err(TrySendError::Disconnected(val))
+}
+
+#[cold]
+fn cold_recv_err<T>() -> Result<T, RecvError> {
+    Err(RecvError)
+}
+
+#[cold]
+fn cold_try_recv_disconnected<T>() -> Result<T, TryRecvError> {
+    Err(TryRecvError::Disconnected)
+}
+
+#[cold]
+fn cold_recv_timeout_disconnected<T>() -> Result<T, RecvTimeoutError> {
+    Err(RecvTimeoutError::Disconnected)
+}
 
 // ============================================================================
 // Tests

--- a/nexus-decimal/src/rounding.rs
+++ b/nexus-decimal/src/rounding.rs
@@ -136,13 +136,13 @@ macro_rules! impl_decimal_rounding {
                     quotient - 1
                 } else if remainder == half {
                     // Banker's rounding: round to even
-                    if quotient % 2 != 0 {
+                    if quotient & 1 != 0 {
                         quotient + 1
                     } else {
                         quotient
                     }
                 } else if remainder == -half {
-                    if quotient % 2 != 0 {
+                    if quotient & 1 != 0 {
                         quotient - 1
                     } else {
                         quotient
@@ -193,13 +193,13 @@ macro_rules! impl_decimal_rounding {
                 } else if remainder < -half {
                     quotient - 1
                 } else if remainder == half {
-                    if quotient % 2 != 0 {
+                    if quotient & 1 != 0 {
                         quotient + 1
                     } else {
                         quotient
                     }
                 } else if remainder == -half {
-                    if quotient % 2 != 0 {
+                    if quotient & 1 != 0 {
                         quotient - 1
                     } else {
                         quotient

--- a/nexus-net/src/ws/mask.rs
+++ b/nexus-net/src/ws/mask.rs
@@ -52,24 +52,24 @@ fn apply_mask_scalar(buf: &mut [u8], mask: [u8; 4]) {
 
     // Handle unaligned prefix
     for (i, byte) in prefix.iter_mut().enumerate() {
-        *byte ^= mask[i % 4];
+        *byte ^= mask[i & 3];
     }
 
     // Bulk XOR 8 bytes at a time
     // Rotate mask to align with prefix offset (no allocation)
-    let offset = prefix.len() % 4;
+    let offset = prefix.len() & 3;
     let aligned_mask = if offset == 0 {
         mask_u64
     } else {
         let rotated: [u8; 8] = [
-            mask[offset % 4],
-            mask[(offset + 1) % 4],
-            mask[(offset + 2) % 4],
-            mask[(offset + 3) % 4],
-            mask[offset % 4],
-            mask[(offset + 1) % 4],
-            mask[(offset + 2) % 4],
-            mask[(offset + 3) % 4],
+            mask[offset & 3],
+            mask[(offset + 1) & 3],
+            mask[(offset + 2) & 3],
+            mask[(offset + 3) & 3],
+            mask[offset & 3],
+            mask[(offset + 1) & 3],
+            mask[(offset + 2) & 3],
+            mask[(offset + 3) & 3],
         ];
         u64::from_ne_bytes(rotated)
     };
@@ -78,9 +78,9 @@ fn apply_mask_scalar(buf: &mut [u8], mask: [u8; 4]) {
     }
 
     // Handle unaligned suffix
-    let suffix_offset = (prefix.len() + middle.len() * 8) % 4;
+    let suffix_offset = (prefix.len() + middle.len() * 8) & 3;
     for (i, byte) in suffix.iter_mut().enumerate() {
-        *byte ^= mask[(suffix_offset + i) % 4];
+        *byte ^= mask[(suffix_offset + i) & 3];
     }
 }
 
@@ -118,7 +118,7 @@ unsafe fn apply_mask_sse2(buf: &mut [u8], mask: [u8; 4]) {
 
     while i < len {
         // SAFETY: i < len
-        unsafe { *buf.get_unchecked_mut(i) ^= mask[i % 4] };
+        unsafe { *buf.get_unchecked_mut(i) ^= mask[i & 3] };
         i += 1;
     }
 }
@@ -169,7 +169,7 @@ unsafe fn apply_mask_avx2(buf: &mut [u8], mask: [u8; 4]) {
 
     while i < len {
         // SAFETY: i < len
-        unsafe { *buf.get_unchecked_mut(i) ^= mask[i % 4] };
+        unsafe { *buf.get_unchecked_mut(i) ^= mask[i & 3] };
         i += 1;
     }
 }


### PR DESCRIPTION
## Summary

- **`#[cold]` on disconnect error paths (nexus-channel):** Extract disconnect `return Err(...)` into `#[cold]` helpers so LLVM keeps error construction out of hot icache lines. 5 helpers covering `send`, `try_send`, `recv`, `try_recv`, `recv_timeout`. Only disconnect paths — `Full`/`Empty`/`Timeout` are normal control flow.
- **`% 2` → `& 1` (nexus-decimal):** 4 sites in banker's rounding (`round` and `round_dp`). LLVM already optimizes but `& 1` communicates "is LSB set?" directly in `const fn` context.
- **`% 4` → `& 3` (nexus-net):** 10 sites in scalar WebSocket mask rotation. Matches the SIMD code style used elsewhere in the same file.

No behavioral changes. All three are codegen-neutral (LLVM already optimized the bit ops) except the `#[cold]` annotations which improve instruction cache layout on the hot path.

## Test plan

- [x] `cargo clippy -p nexus-channel -p nexus-decimal -p nexus-net -- -D warnings` clean
- [x] `cargo test -p nexus-channel -p nexus-decimal -p nexus-net` all pass

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)