### PR TITLE
adding safety comments to unsafe blocks

### DIFF
--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -661,6 +661,9 @@ mod tests {
         }
         const VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
 
+        // SAFETY: The vtable functions (clone/wake/wake_by_ref/drop) are all no-ops
+        // that never dereference the data pointer, so the null data pointer is sound.
+        // The vtable is 'static (const) and correctly returns a valid RawWaker on clone.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
         let mut cx = Context::from_waker(&waker);
         let mut f = std::pin::pin!(f);

--- a/nexus-async-net/src/wire.rs
+++ b/nexus-async-net/src/wire.rs
@@ -354,6 +354,9 @@ mod tests {
             RawWaker::new(p, &VTABLE)
         }
         const VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
+        // SAFETY: The vtable functions (clone/wake/wake_by_ref/drop) are all no-ops
+        // that never dereference the data pointer, so the null data pointer is sound.
+        // The vtable is 'static (const) and correctly returns a valid RawWaker on clone.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
         let mut cx = Context::from_waker(&waker);
         let mut f = std::pin::pin!(f);

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -776,6 +776,9 @@ mod tests {
         }
         const VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
 
+        // SAFETY: The vtable functions (clone/wake/wake_by_ref/drop) are all no-ops
+        // that never dereference the data pointer, so the null data pointer is sound.
+        // The vtable is 'static (const) and correctly returns a valid RawWaker on clone.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
         let mut cx = Context::from_waker(&waker);
         let mut f = std::pin::pin!(f);

--- a/nexus-async-net/src/ws/tokio/stream.rs
+++ b/nexus-async-net/src/ws/tokio/stream.rs
@@ -1021,6 +1021,9 @@ mod tests {
         use std::task::{RawWaker, RawWakerVTable, Waker};
         const VTABLE: RawWakerVTable =
             RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| {}, |_| {}, |_| {});
+        // SAFETY: The vtable functions (clone/wake/wake_by_ref/drop) are all no-ops
+        // that never dereference the data pointer, so the null data pointer is sound.
+        // The vtable is 'static (const) and correctly returns a valid RawWaker on clone.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
         // Leak the waker to get 'static — fine for tests
         let waker = Box::leak(Box::new(waker));

--- a/nexus-async-rt/src/alloc.rs
+++ b/nexus-async-rt/src/alloc.rs
@@ -169,7 +169,10 @@ where
     let src = std::ptr::from_ref(&task).cast::<u8>();
 
     let claim = SLAB_CLAIM.with(Cell::get);
-    // SAFETY: claim copies `size` bytes from `src` into a slab slot.
+    // SAFETY: claim was installed by `install_slab` during Runtime
+    // construction and copies `size` bytes from `src` (the on-stack
+    // Task) into a vacant slab slot. The slab is alive for the
+    // duration of block_on (Runtime owns the SlabGuard).
     let ptr = unsafe { claim(src, size) };
     assert!(!ptr.is_null(), "slab full — spawn_slab failed");
 
@@ -180,8 +183,15 @@ where
 }
 
 /// Free function stored in slab-allocated task headers.
+///
+/// # Safety
+///
+/// `ptr` must point to a slab-allocated task slot that is ready to be freed
+/// (terminal state, no outstanding references).
 unsafe fn slab_free_task(ptr: *mut u8) {
     let free = SLAB_FREE.with(Cell::get);
+    // SAFETY: free was installed by `install_slab` during Runtime construction.
+    // The slab is alive (Runtime owns the SlabGuard, which drops AFTER the executor).
     unsafe { free(ptr) };
 }
 
@@ -287,7 +297,8 @@ impl std::fmt::Debug for SlabClaim {
 /// - If no slab is configured.
 pub(crate) fn try_claim() -> Option<SlabClaim> {
     let try_claim_fn = SLAB_TRY_CLAIM.with(Cell::get);
-    // SAFETY: try_claim_fn claims a slot from the slab.
+    // SAFETY: try_claim_fn was installed by `install_slab` during Runtime
+    // construction. The slab is alive for the duration of block_on.
     let (ptr, chunk_idx) = unsafe { try_claim_fn() };
     if ptr.is_null() {
         return None;
@@ -350,19 +361,26 @@ pub(crate) fn make_bounded_config<const S: usize>(slab_ptr: *const u8) -> SlabTl
 
 unsafe fn unbounded_claim<const S: usize>(src: *const u8, size: usize) -> *mut u8 {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr was set by install_slab to point to a live unbounded::Slab<S>.
+    // The slab is alive for the duration of block_on (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::unbounded::Slab<S>) };
+    // SAFETY: src has `size` valid bytes (the on-stack Task). Slab allocates a slot.
     unsafe { slab.alloc_raw(src, size) }
 }
 
 unsafe fn unbounded_free<const S: usize>(ptr: *mut u8) {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr points to a live unbounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::unbounded::Slab<S>) };
+    // SAFETY: ptr was allocated by this slab's alloc_raw. Reconstructing
+    // the Slot gives ownership back so free can return it to the freelist.
     let slot = unsafe { nexus_slab::byte::Slot::<u8>::from_raw(ptr) };
     slab.free(slot);
 }
 
 unsafe fn unbounded_try_claim<const S: usize>() -> (*mut u8, usize) {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr points to a live unbounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::unbounded::Slab<S>) };
     let claim = slab.claim();
     let ptr = claim.as_ptr();
@@ -377,8 +395,11 @@ unsafe fn unbounded_claim_free<const S: usize>(
     ptr: *mut u8,
     chunk_idx: usize,
 ) {
+    // SAFETY: slab_ptr was captured at claim time and points to a live
+    // unbounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::unbounded::Slab<S>) };
     // O(1) — goes directly to the correct chunk's freelist.
+    // SAFETY: ptr was claimed from this slab and never written to (SlabClaim::Drop path).
     unsafe { slab.free_raw_in_chunk(ptr, chunk_idx) };
 }
 
@@ -386,19 +407,26 @@ unsafe fn unbounded_claim_free<const S: usize>(
 
 unsafe fn bounded_claim<const S: usize>(src: *const u8, size: usize) -> *mut u8 {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr was set by install_slab to point to a live bounded::Slab<S>.
+    // The slab is alive for the duration of block_on (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::bounded::Slab<S>) };
+    // SAFETY: src has `size` valid bytes (the on-stack Task). Returns null if full.
     unsafe { slab.alloc_raw(src, size) }
 }
 
 unsafe fn bounded_free<const S: usize>(ptr: *mut u8) {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr points to a live bounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::bounded::Slab<S>) };
+    // SAFETY: ptr was allocated by this slab's alloc_raw. Reconstructing
+    // the Slot gives ownership back so free can return it to the freelist.
     let slot = unsafe { nexus_slab::byte::Slot::<u8>::from_raw(ptr) };
     slab.free(slot);
 }
 
 unsafe fn bounded_try_claim<const S: usize>() -> (*mut u8, usize) {
     let slab_ptr = SLAB_PTR.with(Cell::get);
+    // SAFETY: slab_ptr points to a live bounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::bounded::Slab<S>) };
     slab.try_claim().map_or((std::ptr::null_mut(), 0), |claim| {
         let ptr = claim.as_ptr();
@@ -408,6 +436,9 @@ unsafe fn bounded_try_claim<const S: usize>() -> (*mut u8, usize) {
 }
 
 unsafe fn bounded_claim_free<const S: usize>(slab_ptr: *const u8, ptr: *mut u8, _chunk_idx: usize) {
+    // SAFETY: slab_ptr was captured at claim time and points to a live
+    // bounded::Slab<S> (Runtime owns SlabGuard).
     let slab = unsafe { &*(slab_ptr as *const nexus_slab::byte::bounded::Slab<S>) };
+    // SAFETY: ptr was claimed from this slab and never written to (SlabClaim::Drop path).
     unsafe { slab.free_raw(ptr) };
 }

--- a/nexus-async-rt/src/cancel.rs
+++ b/nexus-async-rt/src/cancel.rs
@@ -378,6 +378,9 @@ impl Inner {
             }
 
             let head = self.child_head.load(Ordering::Acquire);
+            // SAFETY: node was just allocated via Box::into_raw above.
+            // Writing next before CAS is safe — no one else can see the
+            // node until the CAS succeeds.
             unsafe { (*node).next = head };
             if self
                 .child_head
@@ -403,6 +406,7 @@ impl Drop for Inner {
         // point, no waiter nodes can possibly still be in the list.
         #[cfg(debug_assertions)]
         {
+            // SAFETY: &mut self in Drop — exclusive access, no lock needed.
             let head = unsafe { *self.head.get() };
             debug_assert!(
                 head.is_null(),
@@ -416,6 +420,8 @@ impl Drop for Inner {
         // without ever being cancelled.
         let mut child = *self.child_head.get_mut();
         while !child.is_null() {
+            // SAFETY: each ChildNode was allocated via Box::into_raw in add_child.
+            // We own them exclusively (&mut self in Drop).
             let node = unsafe { Box::from_raw(child) };
             child = node.next;
         }
@@ -728,6 +734,8 @@ mod tests {
             RawWaker::new(p, &VTABLE)
         }
         const VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
+        // SAFETY: all vtable functions are no-ops or trivial clones; the
+        // null data pointer is never dereferenced.
         unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
     }
 

--- a/nexus-async-rt/src/channel/local.rs
+++ b/nexus-async-rt/src/channel/local.rs
@@ -584,6 +584,8 @@ mod tests {
             RawWaker::new(p, &VTABLE)
         }
         const VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
+        // SAFETY: all vtable functions are no-ops or trivial clones; the
+        // null data pointer is never dereferenced.
         unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
     }
 

--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -47,6 +47,9 @@ struct SenderWakerNode {
     cancelled: AtomicBool,
 }
 
+// SAFETY: SenderWakerNode fields use atomics (next, queued, cancelled) for
+// cross-thread access. The waker UnsafeCell is only written when the node
+// is NOT in any shared list (exclusive access enforced by the queued flag).
 unsafe impl Send for SenderWakerNode {}
 unsafe impl Sync for SenderWakerNode {}
 
@@ -87,9 +90,13 @@ impl SenderWaitList {
         // Bump refcount: the list now holds a reference.
         std::mem::forget(Arc::clone(node));
 
+        // SAFETY: ptr is derived from Arc::as_ptr — valid for the Arc's
+        // lifetime. The refcount was just bumped via forget(clone), so
+        // the node won't be freed. No concurrent reader yet (not linked).
         unsafe { (*ptr).queued.store(true, Ordering::Relaxed) };
         loop {
             let head = self.head.load(Ordering::Acquire);
+            // SAFETY: same ptr validity — setting next before CAS-linking.
             unsafe { (*ptr).next.store(head, Ordering::Relaxed) };
             if self
                 .head
@@ -114,9 +121,13 @@ impl SenderWaitList {
         let mut cursor = head;
         let mut woken = false;
         while !cursor.is_null() {
+            // SAFETY: cursor was in the linked list — its Arc refcount was
+            // bumped in push(), so the node is alive. Atomic loads are safe.
             let next = unsafe { (*cursor).next.load(Ordering::Acquire) };
             let cancelled = unsafe { (*cursor).cancelled.load(Ordering::Acquire) };
 
+            // SAFETY: node removed from list (head swapped to null above).
+            // Single consumer (receiver thread). No concurrent readers.
             unsafe {
                 (*cursor).queued.store(false, Ordering::Release);
                 (*cursor)
@@ -125,10 +136,12 @@ impl SenderWaitList {
             }
 
             if !cancelled && !woken {
+                // SAFETY: node is unlinked — exclusive access to the waker
+                // UnsafeCell. Read moves the waker out, write clears it.
                 let waker = unsafe { (*cursor).waker.get().read() };
                 unsafe { (*cursor).waker.get().write(None) };
-                // Drop the list's Arc refcount for this node.
-                // SAFETY: refcount was bumped in push().
+                // SAFETY: refcount was bumped in push(). Decrementing
+                // releases the list's ownership of this node.
                 unsafe { Arc::decrement_strong_count(cursor) };
                 if let Some(w) = waker {
                     w.wake();
@@ -139,6 +152,7 @@ impl SenderWaitList {
                 // Keep the refcount (list still owns it).
                 loop {
                     let cur_head = self.head.load(Ordering::Acquire);
+                    // SAFETY: cursor is unlinked and alive (refcount held).
                     unsafe { (*cursor).next.store(cur_head, Ordering::Relaxed) };
                     unsafe { (*cursor).queued.store(true, Ordering::Relaxed) };
                     if self
@@ -155,7 +169,8 @@ impl SenderWaitList {
                     }
                 }
             } else {
-                // Cancelled: drop the list's Arc refcount.
+                // SAFETY: cancelled node — drop the list's Arc refcount.
+                // Refcount was bumped in push().
                 unsafe { Arc::decrement_strong_count(cursor) };
             }
 
@@ -173,20 +188,24 @@ impl SenderWaitList {
     fn wake_all(&self) {
         let mut node = self.head.swap(std::ptr::null_mut(), Ordering::AcqRel);
         while !node.is_null() {
+            // SAFETY: node was in the linked list — Arc refcount bumped in
+            // push(), so memory is alive. Atomic loads are safe.
             let next = unsafe { (*node).next.load(Ordering::Acquire) };
             let cancelled = unsafe { (*node).cancelled.load(Ordering::Acquire) };
+            // SAFETY: node unlinked (head swapped to null). Exclusive access.
             unsafe {
                 (*node).next.store(std::ptr::null_mut(), Ordering::Relaxed);
                 (*node).queued.store(false, Ordering::Release);
             }
             if !cancelled {
+                // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*node).waker.get().read() };
                 unsafe { (*node).waker.get().write(None) };
                 if let Some(w) = waker {
                     w.wake();
                 }
             }
-            // Drop the list's Arc refcount.
+            // SAFETY: drop the list's Arc refcount. Bumped in push().
             unsafe { Arc::decrement_strong_count(node) };
             node = next;
         }
@@ -374,6 +393,8 @@ impl<T: Send> Future for SendFut<'_, T> {
     type Output = Result<(), SendError<T>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: SendFut has no self-referential fields and does not
+        // require pinning guarantees. Unpinning is safe.
         let this = unsafe { self.get_unchecked_mut() };
         let inner = &this.sender.inner;
 
@@ -409,6 +430,8 @@ impl<T: Send> Future for SendFut<'_, T> {
     }
 }
 
+// SAFETY: SendFut borrows a Sender (which is Send+Sync) and holds an
+// Option<T> where T: Send. All fields are Send-safe.
 unsafe impl<T: Send> Send for SendFut<'_, T> {}
 
 // =============================================================================
@@ -459,6 +482,8 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
+// SAFETY: Receiver holds Arc<Inner<T>> where T: Send. Arc is Send when T
+// is Send. Single-consumer semantics enforced by the API (no Clone).
 unsafe impl<T: Send> Send for Receiver<T> {}
 
 // =============================================================================
@@ -515,6 +540,7 @@ impl<T: Send> Future for RecvFut<'_, T> {
     }
 }
 
+// SAFETY: RecvFut borrows a Receiver (Send). No non-Send fields.
 unsafe impl<T: Send> Send for RecvFut<'_, T> {}
 
 // =============================================================================

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -51,6 +51,9 @@ struct SenderWakerNode {
     cancelled: AtomicBool,
 }
 
+// SAFETY: SenderWakerNode fields use atomics (next, queued, cancelled) for
+// cross-thread access. The waker UnsafeCell is only written when the node
+// is NOT in any shared list (exclusive access enforced by the queued flag).
 unsafe impl Send for SenderWakerNode {}
 unsafe impl Sync for SenderWakerNode {}
 
@@ -91,9 +94,11 @@ impl SenderWaitList {
         // Bump refcount: the list now holds a reference.
         std::mem::forget(Arc::clone(node));
 
+        // SAFETY: ptr from Arc::as_ptr — valid, refcount bumped via forget(clone).
         unsafe { (*ptr).queued.store(true, Ordering::Relaxed) };
         loop {
             let head = self.head.load(Ordering::Acquire);
+            // SAFETY: same ptr validity — setting next before CAS-linking.
             unsafe { (*ptr).next.store(head, Ordering::Relaxed) };
             if self
                 .head
@@ -117,9 +122,13 @@ impl SenderWaitList {
         let mut cursor = head;
         let mut woken = false;
         while !cursor.is_null() {
+            // SAFETY: cursor was in the linked list — Arc refcount bumped in
+            // push(), so the node is alive. Atomic loads are safe.
             let next = unsafe { (*cursor).next.load(Ordering::Acquire) };
             let cancelled = unsafe { (*cursor).cancelled.load(Ordering::Acquire) };
 
+            // SAFETY: node removed from list (head swapped to null above).
+            // Single consumer (receiver thread). No concurrent readers.
             unsafe {
                 (*cursor).queued.store(false, Ordering::Release);
                 (*cursor)
@@ -128,9 +137,11 @@ impl SenderWaitList {
             }
 
             if !cancelled && !woken {
+                // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*cursor).waker.get().read() };
                 unsafe { (*cursor).waker.get().write(None) };
-                // Drop the list's Arc refcount for this node.
+                // SAFETY: refcount was bumped in push(). Decrementing
+                // releases the list's ownership of this node.
                 unsafe { Arc::decrement_strong_count(cursor) };
                 if let Some(w) = waker {
                     w.wake();
@@ -141,6 +152,7 @@ impl SenderWaitList {
                 // Keep the refcount (list still owns it).
                 loop {
                     let cur_head = self.head.load(Ordering::Acquire);
+                    // SAFETY: cursor is unlinked and alive (refcount held).
                     unsafe { (*cursor).next.store(cur_head, Ordering::Relaxed) };
                     unsafe { (*cursor).queued.store(true, Ordering::Relaxed) };
                     if self
@@ -157,7 +169,7 @@ impl SenderWaitList {
                     }
                 }
             } else {
-                // Cancelled: drop the list's Arc refcount.
+                // SAFETY: cancelled node — drop the list's Arc refcount.
                 unsafe { Arc::decrement_strong_count(cursor) };
             }
 
@@ -175,20 +187,24 @@ impl SenderWaitList {
     fn wake_all(&self) {
         let mut node = self.head.swap(std::ptr::null_mut(), Ordering::AcqRel);
         while !node.is_null() {
+            // SAFETY: node was in the linked list — Arc refcount bumped in
+            // push(), so memory is alive. Atomic loads are safe.
             let next = unsafe { (*node).next.load(Ordering::Acquire) };
             let cancelled = unsafe { (*node).cancelled.load(Ordering::Acquire) };
+            // SAFETY: node unlinked (head swapped to null). Exclusive access.
             unsafe {
                 (*node).next.store(std::ptr::null_mut(), Ordering::Relaxed);
                 (*node).queued.store(false, Ordering::Release);
             }
             if !cancelled {
+                // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*node).waker.get().read() };
                 unsafe { (*node).waker.get().write(None) };
                 if let Some(w) = waker {
                     w.wake();
                 }
             }
-            // Drop the list's Arc refcount.
+            // SAFETY: drop the list's Arc refcount. Bumped in push().
             unsafe { Arc::decrement_strong_count(node) };
             node = next;
         }
@@ -208,6 +224,8 @@ struct Inner {
     rx_closed: AtomicBool,
 }
 
+// SAFETY: All fields use atomics or are designed for cross-thread use
+// (TaskWakerSlot, FallbackWaker, SenderWaitList). No raw non-atomic state.
 unsafe impl Send for Inner {}
 unsafe impl Sync for Inner {}
 
@@ -491,6 +509,7 @@ impl<'a> Future for ClaimFut<'a> {
     type Output = Result<WriteClaim<'a>, ClaimError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: ClaimFut has no self-referential fields — unpinning is safe.
         let this = unsafe { &mut *std::pin::Pin::into_inner_unchecked(self) };
         // SAFETY: Extend the reborrow lifetime to 'a. This is sound because:
         // - ClaimFut holds &'a mut Sender, so the Sender lives for 'a
@@ -529,6 +548,7 @@ impl<'a> Future for ClaimFut<'a> {
     }
 }
 
+// SAFETY: ClaimFut borrows a Sender (Send) and holds a usize. All Send-safe.
 unsafe impl Send for ClaimFut<'_> {}
 
 // =============================================================================
@@ -610,6 +630,7 @@ impl<'a> Future for RecvFut<'a> {
     }
 }
 
+// SAFETY: RecvFut borrows a Receiver (Send). No non-Send fields.
 unsafe impl Send for RecvFut<'_> {}
 
 impl Drop for Receiver {
@@ -619,6 +640,7 @@ impl Drop for Receiver {
     }
 }
 
+// SAFETY: Receiver holds a Consumer (Send) and Arc<Inner> (Send+Sync).
 unsafe impl Send for Receiver {}
 
 // =============================================================================

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -48,6 +48,9 @@ struct Inner<T> {
     rx_closed: AtomicBool,
 }
 
+// SAFETY: All cross-thread fields use atomics (tx_alive, rx_closed) or
+// are designed for cross-thread use (TaskWakerSlot, FallbackWaker, TxWakerSlot).
+// Producer and Consumer from nexus_queue::spsc are Send.
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Send> Sync for Inner<T> {}
 
@@ -150,6 +153,8 @@ impl<T> Drop for Sender<T> {
     }
 }
 
+// SAFETY: Sender holds Arc<Inner<T>> where Inner<T>: Send+Sync for T: Send.
+// Single-producer semantics enforced by the API (no Clone).
 unsafe impl<T: Send> Send for Sender<T> {}
 
 // =============================================================================
@@ -166,6 +171,7 @@ impl<T: Send> Future for SendFut<'_, T> {
     type Output = Result<(), SendError<T>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: SendFut has no self-referential fields — unpinning is safe.
         let this = unsafe { self.get_unchecked_mut() };
         let inner = &this.sender.inner;
 
@@ -191,6 +197,7 @@ impl<T: Send> Future for SendFut<'_, T> {
     }
 }
 
+// SAFETY: SendFut borrows a Sender (Send) and holds an Option<T> where T: Send.
 unsafe impl<T: Send> Send for SendFut<'_, T> {}
 
 // =============================================================================
@@ -238,6 +245,8 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
+// SAFETY: Receiver holds Arc<Inner<T>> where Inner<T>: Send+Sync for T: Send.
+// Single-consumer semantics enforced by the API (no Clone).
 unsafe impl<T: Send> Send for Receiver<T> {}
 
 // =============================================================================
@@ -297,6 +306,7 @@ impl<T: Send> Future for RecvFut<'_, T> {
     }
 }
 
+// SAFETY: RecvFut borrows a Receiver (Send). No non-Send fields.
 unsafe impl<T: Send> Send for RecvFut<'_, T> {}
 
 // =============================================================================

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -47,6 +47,8 @@ struct Inner {
     rx_closed: AtomicBool,
 }
 
+// SAFETY: All fields use atomics or are designed for cross-thread use
+// (TaskWakerSlot, FallbackWaker, TxWakerSlot). No raw non-atomic state.
 unsafe impl Send for Inner {}
 unsafe impl Sync for Inner {}
 
@@ -303,7 +305,12 @@ impl<'a> Future for ClaimFut<'a> {
     type Output = Result<WriteClaim<'a>, ClaimError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: ClaimFut has no self-referential fields — unpinning is safe.
         let this = unsafe { &mut *std::pin::Pin::into_inner_unchecked(self) };
+        // SAFETY: Extend the reborrow lifetime to 'a. This is sound because:
+        // - ClaimFut holds &'a mut Sender, so the Sender lives for 'a
+        // - WriteClaim borrows &mut Producer from that Sender
+        // - The future won't be polled again after returning Ready
         let sender: &'a mut Sender = unsafe { &mut *(this.sender as *mut Sender) };
 
         // Precondition check before any state inspection — `len == 0` is a
@@ -331,6 +338,7 @@ impl<'a> Future for ClaimFut<'a> {
     }
 }
 
+// SAFETY: ClaimFut borrows a Sender (Send) and holds a usize. All Send-safe.
 unsafe impl Send for ClaimFut<'_> {}
 
 impl Drop for Sender {
@@ -340,6 +348,7 @@ impl Drop for Sender {
     }
 }
 
+// SAFETY: Sender holds a Producer (Send) and Arc<Inner> (Send+Sync).
 unsafe impl Send for Sender {}
 
 // =============================================================================
@@ -421,6 +430,7 @@ impl<'a> Future for RecvFut<'a> {
     }
 }
 
+// SAFETY: RecvFut borrows a Receiver (Send). No non-Send fields.
 unsafe impl Send for RecvFut<'_> {}
 
 impl Drop for Receiver {
@@ -430,6 +440,7 @@ impl Drop for Receiver {
     }
 }
 
+// SAFETY: Receiver holds a Consumer (Send) and Arc<Inner> (Send+Sync).
 unsafe impl Send for Receiver {}
 
 // =============================================================================

--- a/nexus-async-rt/src/context.rs
+++ b/nexus-async-rt/src/context.rs
@@ -153,7 +153,9 @@ pub(crate) fn current_shutdown_ptrs() -> (
 pub fn sleep(duration: Duration) -> crate::Sleep {
     let ptr = CTX_TIMER.with(Cell::get);
     assert!(!ptr.is_null(), "sleep() called outside Runtime::block_on");
-    // SAFETY: ptr valid for Runtime lifetime.
+    // SAFETY: ptr was installed by install() from a &mut TimerDriver owned
+    // by the Runtime. Valid for Runtime lifetime (block_on borrows &mut self).
+    // Single-threaded — no concurrent access.
     let handle = TimerHandle::new(unsafe { &mut *ptr });
     handle.sleep(duration)
 }
@@ -165,6 +167,8 @@ pub fn sleep_until(deadline: Instant) -> crate::Sleep {
         !ptr.is_null(),
         "sleep_until() called outside Runtime::block_on"
     );
+    // SAFETY: ptr was installed by install() from a &mut TimerDriver owned
+    // by the Runtime. Valid for Runtime lifetime. Single-threaded.
     let handle = TimerHandle::new(unsafe { &mut *ptr });
     handle.sleep_until(deadline)
 }
@@ -179,7 +183,9 @@ pub fn event_time() -> Instant {
         !ptr.is_null(),
         "event_time() called outside Runtime::block_on"
     );
-    // SAFETY: ptr valid for Runtime lifetime.
+    // SAFETY: ptr was installed by install() from a &Cell<Instant> owned
+    // by the Runtime. Valid for Runtime lifetime. Cell::get() is a read
+    // (no mutation), single-threaded.
     unsafe { &*ptr }.get()
 }
 

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -624,6 +624,9 @@ pub(crate) struct FallbackWaker {
     waker: UnsafeCell<Option<std::task::Waker>>,
 }
 
+// SAFETY: Access to the UnsafeCell<Option<Waker>> is coordinated by
+// the atomic state field (REGISTERING excludes concurrent writes,
+// CAS STORED→EMPTY excludes concurrent reads).
 unsafe impl Send for FallbackWaker {}
 unsafe impl Sync for FallbackWaker {}
 
@@ -638,6 +641,10 @@ impl FallbackWaker {
     pub(crate) fn register(&self, waker: &std::task::Waker) {
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
+        // SAFETY: REGISTERING state excludes concurrent access to the
+        // UnsafeCell. Only one thread can pass the swap-to-REGISTERING
+        // gate (single-registerer contract), and wake() CAS only succeeds
+        // from STORED, not REGISTERING.
         unsafe { *self.waker.get() = Some(waker.clone()) };
         self.state.store(STORED, Ordering::Release);
     }
@@ -648,6 +655,10 @@ impl FallbackWaker {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
+            // SAFETY: CAS STORED→EMPTY succeeded, giving us exclusive
+            // access to the UnsafeCell. No other thread can CAS from
+            // STORED (it's now EMPTY), and register swaps to REGISTERING
+            // first.
             let waker = unsafe { (*self.waker.get()).take() };
             if let Some(w) = waker {
                 w.wake();
@@ -681,6 +692,8 @@ pub(crate) struct TxWakerSlot {
     waker: UnsafeCell<Option<std::task::Waker>>,
 }
 
+// SAFETY: Access to the UnsafeCell<Option<Waker>> is coordinated by
+// the atomic state field. Single-sender register, single-receiver wake.
 unsafe impl Send for TxWakerSlot {}
 unsafe impl Sync for TxWakerSlot {}
 
@@ -696,6 +709,9 @@ impl TxWakerSlot {
     pub(crate) fn register(&self, waker: &std::task::Waker) {
         let prev = self.state.swap(REGISTERING, Ordering::Acquire);
         debug_assert_ne!(prev, REGISTERING);
+        // SAFETY: REGISTERING state excludes concurrent access to the
+        // UnsafeCell. Single-sender contract means no concurrent register,
+        // and wake() CAS only succeeds from STORED, not REGISTERING.
         unsafe { *self.waker.get() = Some(waker.clone()) };
         self.state.store(STORED, Ordering::Release);
     }
@@ -707,6 +723,10 @@ impl TxWakerSlot {
             .compare_exchange(STORED, EMPTY, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
         {
+            // SAFETY: CAS STORED→EMPTY succeeded, giving exclusive access
+            // to the UnsafeCell. No concurrent register (state is EMPTY,
+            // not STORED or REGISTERING) and no concurrent wake (single
+            // receiver thread).
             if let Some(w) = unsafe { (*self.waker.get()).take() } {
                 w.wake();
                 return true;
@@ -796,6 +816,7 @@ pub(crate) mod uaf_scenarios {
         let task_ptr = make_uaf_task();
 
         // Sanity: starting refcount is 1 (Task::new_boxed initial state).
+        // SAFETY: task_ptr was just created by make_uaf_task; valid task.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             1,
@@ -825,6 +846,9 @@ pub(crate) mod uaf_scenarios {
         // the task, which atomically sets COMPLETED and decrements the
         // executor's ref. Pre-fix this is the last ref → FreeBox.
         // Post-fix the slot still holds a ref → Retain.
+        // SAFETY: task_ptr is a valid task created by make_uaf_task. The
+        // executor-style ref (rc=1 or 2 depending on fix) is being
+        // decremented as part of the simulated completion path.
         let action = unsafe { task::complete_and_unref(task_ptr) };
 
         // Track which path we're on — the test must clean up differently
@@ -842,6 +866,8 @@ pub(crate) mod uaf_scenarios {
                 );
                 #[cfg(miri)]
                 {
+                    // SAFETY: FreeBox indicates rc=0 and task is terminal;
+                    // free_task reclaims the Box allocation.
                     unsafe { task::free_task(task_ptr) };
                     true
                 }
@@ -855,12 +881,16 @@ pub(crate) mod uaf_scenarios {
         // Sender continues with the captured pointer.
         // PRE-FIX: derefs freed memory → tree-borrows UAF.
         // POST-FIX: derefs alive task, observes COMPLETED, returns early.
+        // SAFETY: captured is a valid task pointer (post-fix: kept alive
+        // by the slot's ref_inc; pre-fix: freed — UAF under miri).
         unsafe { wake_task_cross_thread(captured, &cross_ctx) };
 
         if !pre_fix {
             // POST-FIX cleanup: release the slot's captured ref via
             // TaskRef. In real code this is `wake()`'s drop after
             // wake_task_cross_thread returns.
+            // SAFETY: captured is a valid task with rc >= 1 (the slot's
+            // ref). from_owned reconstructs the TaskRef for the drop.
             drop(unsafe { TaskRef::from_owned(captured) });
             // captured was the only remaining ref; now freed. Don't
             // touch task_ptr again.
@@ -886,9 +916,13 @@ pub(crate) mod uaf_scenarios {
         // Mark the task COMPLETED first via complete_and_unref. Bump the
         // ref to 2 so complete_and_unref returns Retain (rather than
         // freeing). After: refcount = 1, COMPLETED set.
+        // SAFETY: task_ptr is a valid task from make_uaf_task with rc=1.
+        // ref_inc brings rc to 2; complete_and_unref sets COMPLETED and
+        // decrements rc back to 1, returning Retain.
         unsafe { task::ref_inc(task_ptr) };
         let action = unsafe { task::complete_and_unref(task_ptr) };
         assert!(matches!(action, FreeAction::Retain));
+        // SAFETY: task_ptr is still valid (Retain means no free).
         let baseline_refcount = unsafe { task::ref_count(task_ptr) };
         assert_eq!(baseline_refcount, 1, "after complete_and_unref, refcount=1");
 
@@ -896,12 +930,14 @@ pub(crate) mod uaf_scenarios {
         slot.register(task_ptr);
         // Post-fix: register ref_inc → refcount = 2.
         // Pre-fix: register did NOT ref_inc → refcount = 1.
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         let after_register = unsafe { task::ref_count(task_ptr) };
 
         // Drop the slot WITHOUT calling wake() or clear().
         // Post-fix: Drop sees state == STORED, ref_dec → refcount = 1, returns Retain.
         // Pre-fix: no Drop impl → refcount unchanged.
         drop(slot);
+        // SAFETY: task_ptr valid (rc >= 1 in both pre/post-fix paths).
         let after_drop = unsafe { task::ref_count(task_ptr) };
 
         // The strengthened assertion: register-then-drop must net to
@@ -924,6 +960,8 @@ pub(crate) mod uaf_scenarios {
 
         // Cleanup: refcount is 1 (post-fix or pre-fix), COMPLETED set.
         // Final ref_dec should return FreeBox; free the allocation.
+        // SAFETY: task_ptr valid with rc=1, COMPLETED. ref_dec brings
+        // rc to 0 → FreeBox. free_task reclaims the Box allocation.
         let action = unsafe { task::ref_dec(task_ptr) };
         match action {
             FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
@@ -953,9 +991,12 @@ pub(crate) mod uaf_scenarios {
         // Bump the ref so the test's manual ref_decs don't trigger
         // free mid-test. After complete_and_unref, refcount = 1 with
         // COMPLETED set — this is our baseline.
+        // SAFETY: task_ptr valid from make_uaf_task (rc=1). ref_inc
+        // brings rc to 2; complete_and_unref sets COMPLETED, rc → 1.
         unsafe { task::ref_inc(task_ptr) };
         let action = unsafe { task::complete_and_unref(task_ptr) };
         assert!(matches!(action, FreeAction::Retain));
+        // SAFETY: task_ptr valid (Retain, rc=1).
         let baseline = unsafe { task::ref_count(task_ptr) };
         assert_eq!(baseline, 1, "baseline must be 1 (executor-style ref)");
 
@@ -963,6 +1004,7 @@ pub(crate) mod uaf_scenarios {
 
         // ---- T0: initial register ----
         slot.register(task_ptr);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             baseline + 1,
@@ -984,6 +1026,7 @@ pub(crate) mod uaf_scenarios {
         // — same task_ptr. Pre-fix: register's gate sees prev==EMPTY,
         // skips the release, leaks the old ref. Post-fix: release fires.
         slot.register(task_ptr);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             baseline + 1,
@@ -998,8 +1041,11 @@ pub(crate) mod uaf_scenarios {
         // wake's release-after-dispatch semantics).
         let captured = slot.task_ptr.swap(std::ptr::null_mut(), Ordering::Acquire);
         assert_eq!(captured, task_ptr);
+        // SAFETY: captured is a valid task pointer with the ref that
+        // register acquired. from_owned + drop releases that ref.
         drop(unsafe { TaskRef::from_owned(captured) });
 
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             baseline,
@@ -1013,13 +1059,15 @@ pub(crate) mod uaf_scenarios {
         // nothing — confirms the Drop impl correctly handles this
         // benign "post-race" inconsistency.
         drop(slot);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             baseline,
             "Drop on a STORED-but-null-task_ptr slot must be a no-op for refcount"
         );
 
-        // Final ref_dec → FreeBox.
+        // SAFETY: task_ptr valid with rc=baseline (1), COMPLETED.
+        // ref_dec → rc=0 → FreeBox. free_task reclaims the allocation.
         match unsafe { task::ref_dec(task_ptr) } {
             FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
             other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
@@ -1061,10 +1109,13 @@ mod tests {
         let q = CrossWakeQueue::new();
         let t1 = make_task();
 
+        // SAFETY: t1 is a valid task pointer from make_task with a
+        // valid cross_next field. Not already in the queue.
         unsafe { q.push(t1) };
         assert_eq!(q.pop(), Some(t1));
         assert_eq!(q.pop(), None);
 
+        // SAFETY: t1 was popped from the queue; free reclaims the Box.
         unsafe { free(t1) };
     }
 
@@ -1075,6 +1126,8 @@ mod tests {
         let t2 = make_task();
         let t3 = make_task();
 
+        // SAFETY: t1, t2, t3 are valid task pointers with valid
+        // cross_next fields. Each pushed once, not already in queue.
         unsafe { q.push(t1) };
         unsafe { q.push(t2) };
         unsafe { q.push(t3) };
@@ -1084,6 +1137,7 @@ mod tests {
         assert_eq!(q.pop(), Some(t3));
         assert_eq!(q.pop(), None);
 
+        // SAFETY: all popped from queue; free reclaims each Box.
         unsafe { free(t1) };
         unsafe { free(t2) };
         unsafe { free(t3) };
@@ -1095,13 +1149,16 @@ mod tests {
         let t1 = make_task();
         let t2 = make_task();
 
+        // SAFETY: valid task pointers, not already in queue.
         unsafe { q.push(t1) };
         assert_eq!(q.pop(), Some(t1));
 
+        // SAFETY: valid task pointer, not already in queue.
         unsafe { q.push(t2) };
         assert_eq!(q.pop(), Some(t2));
         assert_eq!(q.pop(), None);
 
+        // SAFETY: both popped; free reclaims each Box.
         unsafe { free(t1) };
         unsafe { free(t2) };
     }
@@ -1119,11 +1176,14 @@ mod tests {
         let t1 = make_task();
 
         for _ in 0..100 {
+            // SAFETY: t1 is a valid task, popped before each re-push
+            // so it's never double-queued.
             unsafe { q.push(t1) };
             assert_eq!(q.pop(), Some(t1));
         }
         assert_eq!(q.pop(), None);
 
+        // SAFETY: t1 was popped on the last iteration; free reclaims it.
         unsafe { free(t1) };
     }
 
@@ -1174,6 +1234,9 @@ mod tests {
     /// then invokes `dispose_terminal(ptr)` directly to exercise the
     /// routing — no re-acquire (would violate ref_inc's >=1 contract).
     unsafe fn drive_to_terminal(ptr: *mut u8) {
+        // SAFETY: caller guarantees ptr is a freshly-spawned joinable
+        // task (rc=2, HAS_JOIN set). Each step is valid given the
+        // preceding state transitions documented inline.
         unsafe {
             crate::task::drop_task_future(ptr);
             assert!(matches!(
@@ -1205,6 +1268,10 @@ mod tests {
         let task = Box::new(crate::task::Task::new_boxed(Noop, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid box-allocated task (rc=1, no HAS_JOIN).
+        // drop_task_future drops the inner future. complete_and_unref
+        // sets COMPLETED + rc → 0 → FreeBox (terminal). dispose_terminal
+        // with null ctx + no TLS leaks intentionally. free_task reclaims.
         unsafe {
             // Walk to terminal: rc 1 → 0, COMPLETED, no lifecycle.
             crate::task::drop_task_future(ptr);
@@ -1237,6 +1304,9 @@ mod tests {
         let mut ready: Vec<*mut u8> = Vec::new();
         let _poll_guard = crate::waker::set_poll_context(&raw mut ready, &raw mut deferred);
 
+        // SAFETY: ptr is a valid spawned task (rc=2, HAS_JOIN).
+        // drive_to_terminal walks to terminal state. dispose_terminal
+        // defers to the deferred_free Vec via TLS.
         unsafe {
             drive_to_terminal(ptr);
             dispose_terminal(ptr);
@@ -1246,7 +1316,7 @@ mod tests {
         assert_eq!(deferred.len(), 1);
         assert_eq!(deferred[0], ptr);
 
-        // Cleanup: free the task ourselves (we own the deferred entry).
+        // SAFETY: ptr was deferred (not freed); free_task reclaims it.
         unsafe { crate::task::free_task(ptr) };
     }
 
@@ -1260,6 +1330,9 @@ mod tests {
         let _guard = install_runtime_cross_wake(&ctx);
         let ptr = make_spawned_task(&ctx);
 
+        // SAFETY: ptr is a valid spawned task. drive_to_terminal walks
+        // to terminal. dispose_terminal with matching TLS but null
+        // DEFERRED_FREE leaks intentionally.
         unsafe {
             drive_to_terminal(ptr);
             // No poll context installed → DEFERRED_FREE TLS stays null.
@@ -1267,8 +1340,10 @@ mod tests {
         }
 
         // Task header still valid (we leaked, didn't free).
+        // SAFETY: ptr was leaked, not freed; header is readable.
         assert!(unsafe { crate::task::is_terminal(ptr) });
 
+        // SAFETY: ptr leaked above; free_task reclaims the Box.
         unsafe { crate::task::free_task(ptr) };
     }
 
@@ -1280,6 +1355,9 @@ mod tests {
         let ctx = make_ctx();
         let ptr = make_spawned_task(&ctx);
 
+        // SAFETY: ptr is a valid spawned task. drive_to_terminal walks
+        // to terminal. dispose_terminal with non-null ctx but no
+        // matching TLS takes the off-thread path → cross-queue push.
         unsafe {
             drive_to_terminal(ptr);
             // No install_runtime_cross_wake → TLS null.
@@ -1289,8 +1367,10 @@ mod tests {
         // Verify push to cross-queue.
         let popped = ctx.queue.pop();
         assert_eq!(popped, Some(ptr));
+        // SAFETY: ptr was pushed to cross-queue, still valid.
         assert!(unsafe { crate::task::is_queued(ptr) });
 
+        // SAFETY: ptr popped from queue; clear queued flag and free.
         unsafe {
             crate::task::clear_queued(ptr);
             crate::task::free_task(ptr);
@@ -1378,6 +1458,9 @@ mod tests {
         //     route (which goes through dispose_terminal locally) and
         //     manually push to simulate the off-thread case.
         std::mem::forget(kept_handle);
+        // SAFETY: task_ptr is the raw pointer from the forgotten
+        // JoinHandle. Task is COMPLETED with rc=1. clear_has_join
+        // clears the lifecycle flag; ref_dec brings rc → 0 → terminal.
         unsafe {
             crate::task::clear_has_join(task_ptr);
             let action = crate::task::ref_dec(task_ptr);
@@ -1386,6 +1469,9 @@ mod tests {
         // Task is now in TERMINAL state, allocation alive, in all_tasks.
         // Set QUEUED + push to cross_queue to mirror the off-thread
         // dispose_terminal scenario.
+        // SAFETY: task_ptr is terminal but allocation is alive (no one
+        // freed it). try_set_queued is an atomic on the header. push
+        // uses the cross_next intrusive link.
         unsafe {
             assert!(crate::task::try_set_queued(task_ptr));
             ctx.queue.push(task_ptr);

--- a/nexus-async-rt/src/io.rs
+++ b/nexus-async-rt/src/io.rs
@@ -333,6 +333,7 @@ impl IoHandle {
 
     /// Clear the writable flag for a token.
     pub fn clear_writable(&self, token: Token) {
+        // SAFETY: driver pointer valid for Runtime lifetime. Single-threaded.
         let driver = unsafe { &mut *self.driver };
         driver.clear_writable(token);
     }

--- a/nexus-async-rt/src/lib.rs
+++ b/nexus-async-rt/src/lib.rs
@@ -313,8 +313,11 @@ impl Executor {
     /// Common enqueue logic for spawn and spawn_raw.
     fn enqueue(&mut self, ptr: *mut u8) {
         self.all_tasks.insert(ptr);
+        // SAFETY: ptr is a freshly constructed task. set_queued marks the
+        // dedup flag so the task isn't double-queued by a concurrent wake.
         unsafe { task::set_queued(ptr, true) };
         // SAFETY: single-threaded, no concurrent access during enqueue.
+        // UnsafeCell grants interior mutability for TLS pointer aliasing.
         unsafe { &mut *self.incoming.get() }.push(ptr);
         self.live_count += 1;
     }
@@ -335,16 +338,20 @@ impl Executor {
         while drained < limit {
             match inbox.pop() {
                 Some(task_ptr) => {
-                    // Clear QUEUED flag now that we've popped it.
+                    // SAFETY: task_ptr is a live task pushed by a cross-thread waker.
+                    // clear_queued clears the QUEUED dedup flag so the task can be re-queued.
                     unsafe { task::clear_queued(task_ptr) };
 
                     // Check if TERMINAL was reached (e.g., cross-thread waker
                     // produced TERMINAL via ref_dec while the task was queued).
                     // Only TERMINAL tasks go to deferred_free. Completed tasks
                     // with outstanding refs must NOT be freed prematurely.
+                    // SAFETY: task_ptr is a live task; is_terminal reads the packed state.
                     if unsafe { task::is_terminal(task_ptr) } {
+                        // SAFETY: UnsafeCell interior mutability; single-threaded.
                         unsafe { &mut *self.deferred_free.get() }.push(task_ptr);
                     } else {
+                        // SAFETY: UnsafeCell interior mutability; single-threaded.
                         unsafe { &mut *self.incoming.get() }.push(task_ptr);
                     }
                     drained += 1;
@@ -361,9 +368,12 @@ impl Executor {
 
         // Drain deferred frees from last cycle.
         // SAFETY: single-threaded, TLS not yet set for this cycle.
+        // UnsafeCell grants interior mutability.
         for ptr in unsafe { &mut *self.deferred_free.get() }.drain(..) {
+            // SAFETY: ptr is a terminal task; tracker_key reads offset 60 of the header.
             let key = unsafe { task::tracker_key(ptr) } as usize;
-            // SAFETY: free_fn was set at spawn time.
+            // SAFETY: ptr is terminal (refcount 0, COMPLETED set). free_fn was
+            // set at spawn time and dispatches to Box::dealloc or slab free.
             unsafe { task::free_task(ptr) };
             if self.all_tasks.contains(key) {
                 self.all_tasks.remove(key);
@@ -371,6 +381,7 @@ impl Executor {
         }
 
         // SAFETY: single-threaded, swapping before TLS is set.
+        // UnsafeCell grants interior mutability for incoming.
         std::mem::swap(unsafe { &mut *self.incoming.get() }, &mut self.draining);
 
         // Derive TLS pointers from UnsafeCell — NOT from &mut self field borrows.
@@ -381,13 +392,19 @@ impl Executor {
 
         let limit = self.tasks_per_cycle.min(self.draining.len());
         let draining_ptr: *const Vec<*mut u8> = &raw const self.draining;
+        // SAFETY: draining_ptr is derived from &raw const on a field we own.
+        // Slicing to limit avoids out-of-bounds.
         let drain_slice = unsafe { &(&*draining_ptr)[..limit] };
 
         for &ptr in drain_slice {
+            // SAFETY: ptr is a live task in all_tasks. is_completed reads
+            // the packed state word at offset 24.
             if unsafe { task::is_completed(ptr) } {
                 continue;
             }
 
+            // SAFETY: ptr is a live, non-completed task. Clearing the QUEUED
+            // dedup flag allows future wakes to re-queue it.
             unsafe { task::set_queued(ptr, false) };
 
             // SAFETY: ptr is a live task, ref_count >= 1 (executor holds a ref).
@@ -395,6 +412,8 @@ impl Executor {
             let waker = unsafe { crate::waker::task_waker(ptr) };
             let mut cx = Context::from_waker(&waker);
 
+            // SAFETY: ptr points to a live, non-completed task. poll_task
+            // pins the future and polls it with the provided context.
             let poll_result = unsafe { task::poll_task(ptr, &mut cx) };
 
             drop(waker);
@@ -409,7 +428,9 @@ impl Executor {
         }
 
         if limit < self.draining.len() {
-            // SAFETY: single-threaded, TLS guard is about to drop.
+            // SAFETY: single-threaded, UnsafeCell interior mutability.
+            // TLS guard is about to drop; remaining un-polled tasks are
+            // moved back to incoming for the next cycle.
             unsafe { &mut *self.incoming.get() }.extend_from_slice(&self.draining[limit..]);
         }
         self.draining.clear();
@@ -519,24 +540,33 @@ impl Executor {
     ///
     /// `ptr` must point to a task that just returned `Poll::Ready(())` from poll_task.
     fn complete_task(&mut self, ptr: *mut u8) {
+        // SAFETY: ptr just returned Poll::Ready from poll_task; the task is
+        // live and all header fields are valid for the state reads below.
         let aborted = unsafe { task::is_aborted(ptr) };
 
         if aborted {
             // Aborted: poll_join saw ABORTED and returned Ready without polling F.
             // F is still live in the union. drop_fn still targets F.
+            // SAFETY: F is live in the FutureOrOutput union; drop_fn targets F.
             unsafe { task::drop_task_future(ptr) };
             self.live_count -= 1;
 
+            // SAFETY: has_join reads a flag in the packed state word.
             if unsafe { task::has_join(ptr) } {
+                // SAFETY: take_join_waker reads the join waker slot at offset 40.
                 let waker = unsafe { task::take_join_waker(ptr) };
                 if let Some(w) = waker {
                     w.wake();
                 }
             }
 
+            // SAFETY: complete_and_unref atomically sets COMPLETED and
+            // decrements the executor's reference in one CAS.
             match unsafe { task::complete_and_unref(ptr) } {
                 task::FreeAction::Retain => {}
                 task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
+                    // SAFETY: terminal state; tracker_key at offset 60, free_task
+                    // dispatches through the header's free_fn.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
@@ -548,16 +578,20 @@ impl Executor {
             self.live_count -= 1;
 
             // Wake the joiner so it can poll the JoinHandle and read T.
+            // SAFETY: take_join_waker reads the join waker slot at offset 40.
             let waker = unsafe { task::take_join_waker(ptr) };
             if let Some(w) = waker {
                 w.wake();
             }
 
+            // SAFETY: see above -- complete_and_unref CAS on the packed state.
             match unsafe { task::complete_and_unref(ptr) } {
                 task::FreeAction::Retain => {}
                 task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
                     // Terminal — JoinHandle already dropped (detached). Drop output.
+                    // SAFETY: T is live in the union; drop_fn now targets T.
                     unsafe { task::drop_task_future(ptr) };
+                    // SAFETY: terminal state; read tracker_key then free.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
@@ -565,12 +599,15 @@ impl Executor {
             }
         } else {
             // Fire-and-forget or detached (HAS_JOIN cleared by JoinHandle::Drop).
+            // SAFETY: the value (F or T) in the union must be dropped.
             unsafe { task::drop_task_future(ptr) };
             self.live_count -= 1;
 
+            // SAFETY: see above -- complete_and_unref CAS on the packed state.
             match unsafe { task::complete_and_unref(ptr) } {
                 task::FreeAction::Retain => {}
                 task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
+                    // SAFETY: terminal state; read tracker_key then free.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
@@ -591,11 +628,12 @@ impl Executor {
     #[allow(dead_code)]
     pub(crate) fn cancel(&mut self, id: task::TaskId) {
         let ptr = id.0;
-        // Skip if already completed (e.g. double-cancel or cancel after poll).
+        // SAFETY: ptr is a task pointer; is_completed reads the packed state.
         if unsafe { task::is_completed(ptr) } {
             return;
         }
         // SAFETY: single-threaded, no TLS active during cancel.
+        // UnsafeCell grants interior mutability.
         unsafe { &mut *self.incoming.get() }.retain(|p| *p != ptr);
         self.draining.retain(|p| *p != ptr);
         self.complete_task(ptr);
@@ -649,18 +687,21 @@ impl Drop for Executor {
         // complete + maybe free), outstanding-refs (route to unwinding
         // or normal-shutdown handlers), or zero-refs (free).
         for (_, &ptr) in &self.all_tasks {
+            // SAFETY: ptr is a live task pointer tracked in all_tasks.
+            // is_terminal reads the packed state word.
             if unsafe { task::is_terminal(ptr) } {
                 // TERMINAL: completed, zero refs, all flags cleared.
-                // Happens when a cross-thread waker produced TERMINAL
-                // via ref_dec but the executor hadn't scanned yet.
+                // SAFETY: terminal state — safe to free via the header's free_fn.
                 unsafe { task::free_task(ptr) };
                 continue;
             }
 
+            // SAFETY: is_completed reads the packed state word.
             if !unsafe { task::is_completed(ptr) } && Self::drop_complete_and_maybe_free(ptr) {
                 continue;
             }
 
+            // SAFETY: ref_count reads bits 6+ of the packed state word.
             let rc = unsafe { task::ref_count(ptr) };
             if rc > 0 {
                 if std::thread::panicking() {
@@ -671,6 +712,7 @@ impl Drop for Executor {
                 continue;
             }
 
+            // SAFETY: completed with zero refs — terminal. Free via header's free_fn.
             unsafe { task::free_task(ptr) };
         }
     }
@@ -687,8 +729,12 @@ impl Executor {
     ///
     /// SAFETY: `&mut self` in Drop, no concurrent access.
     fn drop_drain_deferred_free(&mut self) {
+        // SAFETY: &mut self in Drop, single-threaded. UnsafeCell interior mutability.
         for ptr in unsafe { &mut *self.deferred_free.get() }.drain(..) {
+            // SAFETY: ptr is a terminal task. Read tracker_key (offset 60)
+            // before freeing the allocation.
             let key = unsafe { task::tracker_key(ptr) } as usize;
+            // SAFETY: terminal state — free via the header's free_fn.
             unsafe { task::free_task(ptr) };
             if self.all_tasks.contains(key) {
                 self.all_tasks.remove(key);
@@ -707,10 +753,15 @@ impl Executor {
     /// SAFETY: caller guarantees `ptr` references a not-yet-completed
     /// task with the executor's ref still held.
     fn drop_complete_and_maybe_free(ptr: *mut u8) -> bool {
+        // SAFETY: ptr is a live, not-yet-completed task. drop_task_future
+        // drops F (the future) via the header's drop_fn.
         unsafe { task::drop_task_future(ptr) };
+        // SAFETY: complete_and_unref atomically sets COMPLETED and decrements
+        // the executor's reference.
         match unsafe { task::complete_and_unref(ptr) } {
             task::FreeAction::Retain => false,
             task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
+                // SAFETY: terminal state — free via header's free_fn.
                 unsafe { task::free_task(ptr) };
                 true
             }
@@ -739,6 +790,8 @@ impl Executor {
     /// SAFETY: caller guarantees `ptr` references a completed task
     /// with rc > 0, called during unwind.
     fn drop_outstanding_unwinding(&self, ptr: *mut u8, rc: usize) {
+        // SAFETY: ptr is a completed task with outstanding refs.
+        // is_slab_allocated reads the SLAB_ALLOCATED flag in the packed state.
         if unsafe { task::is_slab_allocated(ptr) } {
             self.drop_outstanding_slab_unwinding(ptr);
         } else {
@@ -753,6 +806,9 @@ impl Executor {
     /// the counter via shared memory or memory-mapped logging.
     fn drop_outstanding_slab_unwinding(&self, ptr: *mut u8) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(100);
+        // SAFETY: ref_count reads bits 6+ of the packed state word. The
+        // task allocation is alive (we haven't freed it). Spinning waits
+        // for cross-thread holders to release their refs.
         while unsafe { task::ref_count(ptr) } > 0 && std::time::Instant::now() < deadline {
             std::thread::yield_now();
         }
@@ -770,6 +826,7 @@ impl Executor {
             std::process::abort();
         }
         // Refs settled — free cleanly. Avoid the panic path.
+        // SAFETY: refcount settled to 0; terminal state. Free via header's free_fn.
         unsafe { task::free_task(ptr) };
     }
 
@@ -1053,7 +1110,9 @@ mod tests {
     fn refcount_starts_at_one() {
         let task = Box::new(Task::new_boxed(async {}, 0));
         let ptr = Box::into_raw(task) as *mut u8;
+        // SAFETY: ptr is a valid task just created above.
         assert_eq!(unsafe { task::ref_count(ptr) }, 1);
+        // SAFETY: freeing the only reference; terminal state.
         unsafe { task::free_task(ptr) };
     }
 

--- a/nexus-async-rt/src/net/tcp.rs
+++ b/nexus-async-rt/src/net/tcp.rs
@@ -87,12 +87,14 @@ impl TcpStream {
     /// Deregisters from mio. The returned stream is still non-blocking.
     pub fn into_std(mut self) -> io::Result<std::net::TcpStream> {
         if let Some(token) = self.token.take() {
-            // SAFETY: IoHandle valid (Runtime lifetime).
+            // SAFETY: IoHandle's raw pointers are valid for the Runtime
+            // lifetime (block_on borrows &mut Runtime which outlives all IO).
             let _ = unsafe { self.io.deregister(&mut self.inner, token) };
         }
         let fd = self.inner.as_raw_fd();
         std::mem::forget(self); // skip Drop (already deregistered)
-        // SAFETY: fd is valid, we own it.
+        // SAFETY: fd is valid — we own it via mio::net::TcpStream and
+        // just prevented Drop from closing it via mem::forget.
         Ok(unsafe { std::net::TcpStream::from_raw_fd(fd) })
     }
 
@@ -200,7 +202,9 @@ impl TcpStream {
 
     /// Read without consuming from the buffer (MSG_PEEK).
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        // SAFETY: u8 and MaybeUninit<u8> have the same layout.
+        // SAFETY: u8 and MaybeUninit<u8> have identical layout (size, alignment).
+        // Transmuting an initialized &mut [u8] to &mut [MaybeUninit<u8>] is
+        // sound — the bytes are initialized, and peek() will read into them.
         let buf = unsafe { &mut *(buf as *mut [u8] as *mut [std::mem::MaybeUninit<u8>]) };
         self.socket_ref().peek(buf)
     }
@@ -454,7 +458,9 @@ impl AsRawFd for TcpStream {
 impl Drop for TcpStream {
     fn drop(&mut self) {
         if let Some(token) = self.token {
-            // SAFETY: IoHandle valid (Runtime lifetime).
+            // SAFETY: IoHandle's raw pointers are valid for the Runtime
+            // lifetime. The stream is being dropped, so deregistering
+            // from mio is the correct cleanup.
             let _ = unsafe { self.io.deregister(&mut self.inner, token) };
         }
     }
@@ -479,7 +485,11 @@ pub struct ReadHalf<'a> {
 // aliased mutation of the same fields. Single-threaded.
 impl ReadHalf<'_> {
     fn stream(&mut self) -> &mut TcpStream {
-        // SAFETY: Borrowed from split(), single-threaded, read-only side.
+        // SAFETY: Borrowed from split(), single-threaded. ReadHalf and
+        // WriteHalf hold raw pointers to the same TcpStream, but
+        // ReadHalf only calls poll_read and WriteHalf only calls
+        // poll_write — no aliased mutation of the same mio fields.
+        // The PhantomData<&'a mut TcpStream> ties the lifetime.
         unsafe { &mut *self.stream }
     }
 }
@@ -506,7 +516,9 @@ pub struct WriteHalf<'a> {
 
 impl WriteHalf<'_> {
     fn stream(&mut self) -> &mut TcpStream {
-        // SAFETY: Borrowed from split(), single-threaded, write-only side.
+        // SAFETY: Borrowed from split(), single-threaded. WriteHalf only
+        // calls poll_write/poll_flush/poll_shutdown — disjoint from
+        // ReadHalf's poll_read. No aliased mutation.
         unsafe { &mut *self.stream }
     }
 }
@@ -559,12 +571,14 @@ impl OwnedReadHalf {
 
     /// Returns the peer address.
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        // SAFETY: single-threaded, immutable field access.
+        // SAFETY: single-threaded runtime. Shared ref to immutable fields
+        // (peer_addr reads from the kernel, doesn't mutate TcpStream).
         unsafe { &*self.stream.get() }.peer_addr()
     }
 
     /// Returns the local address.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        // SAFETY: same as peer_addr — single-threaded, immutable access.
         unsafe { &*self.stream.get() }.local_addr()
     }
 }
@@ -575,7 +589,9 @@ impl AsyncRead for OwnedReadHalf {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        // SAFETY: single-threaded. Only the read half calls poll_read.
+        // SAFETY: single-threaded runtime. OwnedReadHalf is the only
+        // half that calls poll_read; OwnedWriteHalf only calls poll_write.
+        // No aliased mutation of the same TcpStream fields.
         let stream = unsafe { &mut *self.stream.get() };
         Pin::new(stream).poll_read(cx, buf)
     }
@@ -596,11 +612,13 @@ impl OwnedWriteHalf {
 
     /// Returns the peer address.
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        // SAFETY: single-threaded, immutable access to kernel state.
         unsafe { &*self.stream.get() }.peer_addr()
     }
 
     /// Returns the local address.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        // SAFETY: same as peer_addr — single-threaded, immutable access.
         unsafe { &*self.stream.get() }.local_addr()
     }
 }
@@ -611,17 +629,20 @@ impl AsyncWrite for OwnedWriteHalf {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        // SAFETY: single-threaded. Only the write half calls poll_write.
+        // SAFETY: single-threaded. OwnedWriteHalf is the only half that
+        // calls poll_write; OwnedReadHalf only calls poll_read.
         let stream = unsafe { &mut *self.stream.get() };
         Pin::new(stream).poll_write(cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // SAFETY: same as poll_write — single-threaded, write-side only.
         let stream = unsafe { &mut *self.stream.get() };
         Pin::new(stream).poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // SAFETY: same as poll_write — single-threaded, write-side only.
         let stream = unsafe { &mut *self.stream.get() };
         Pin::new(stream).poll_shutdown(cx)
     }
@@ -755,6 +776,9 @@ impl AsRawFd for TcpListener {
 impl Drop for TcpListener {
     fn drop(&mut self) {
         if let Some(token) = self.token {
+            // SAFETY: IoHandle's raw pointers are valid for the Runtime
+            // lifetime. The listener is being dropped, so deregistering
+            // from mio is the correct cleanup.
             let _ = unsafe { self.io.deregister(&mut self.inner, token) };
         }
     }

--- a/nexus-async-rt/src/net/udp.rs
+++ b/nexus-async-rt/src/net/udp.rs
@@ -197,11 +197,14 @@ impl UdpSocket {
     /// Deregisters from mio. The returned socket is still non-blocking.
     pub fn into_std(mut self) -> io::Result<std::net::UdpSocket> {
         if let Some(token) = self.token.take() {
+            // SAFETY: IoHandle's raw pointers are valid for the Runtime
+            // lifetime. Deregistering before conversion.
             let _ = unsafe { self.io.deregister(&mut self.inner, token) };
         }
         let fd = self.inner.as_raw_fd();
         std::mem::forget(self);
-        // SAFETY: fd is valid, we own it.
+        // SAFETY: fd is valid — we own it via mio::net::UdpSocket and
+        // prevented Drop from closing it via mem::forget.
         Ok(unsafe { std::net::UdpSocket::from_raw_fd(fd) })
     }
 

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -64,7 +64,8 @@ where
             !ptr.is_null(),
             "spawn_boxed() called outside of Runtime::block_on"
         );
-        // SAFETY: pointer valid for duration of block_on. Single-threaded.
+        // SAFETY: pointer was set by RuntimeGuard::enter at the start of
+        // block_on and is valid for the duration of block_on. Single-threaded.
         let executor = unsafe { &mut *ptr };
         executor.spawn_boxed(future)
     })
@@ -93,6 +94,7 @@ where
             !ptr.is_null(),
             "spawn_slab() called outside of Runtime::block_on"
         );
+        // SAFETY: pointer valid for duration of block_on. Single-threaded.
         let executor = unsafe { &mut *ptr };
         let tracker_key = executor.next_tracker_key();
         let task_ptr = crate::alloc::slab_spawn(future, tracker_key);
@@ -106,6 +108,7 @@ pub(crate) fn with_executor<R>(f: impl FnOnce(&mut Executor) -> R) -> R {
     CURRENT.with(|cell| {
         let ptr = cell.get();
         assert!(!ptr.is_null(), "called outside of Runtime::block_on");
+        // SAFETY: pointer valid for duration of block_on. Single-threaded.
         let executor = unsafe { &mut *ptr };
         f(executor)
     })
@@ -432,6 +435,7 @@ impl Runtime {
     /// Install signal handlers for SIGTERM and SIGINT.
     pub fn install_signal_handlers(&self) {
         // SAFETY: single-threaded, called during setup before block_on.
+        // UnsafeCell deref is safe because no TLS aliases exist yet.
         crate::shutdown::install_signal_handlers(
             &self.shutdown.flag_ptr(),
             &unsafe { &*self.io.get() }.mio_waker(),
@@ -932,7 +936,8 @@ impl Runtime {
         let woken = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let root_waker = Waker::from(std::sync::Arc::new(RootWake {
             woken: std::sync::Arc::clone(&woken),
-            // SAFETY: single-threaded, called during block_on setup.
+            // SAFETY: single-threaded runtime; UnsafeCell deref is safe because
+            // we have exclusive access during setup (TLS not yet installed).
             mio_waker: unsafe { &*self.io.get() }.mio_waker(),
         }));
         let mut root_cx = Context::from_waker(&root_waker);
@@ -974,6 +979,7 @@ impl Runtime {
 
             // 4. Fire expired timers.
             // SAFETY: single-threaded runtime, no concurrent access.
+            // UnsafeCell deref for interior mutability (TLS pointer aliasing).
             unsafe { &mut *self.timers.get() }.fire_expired(Instant::now());
 
             // 4.5. Set parked early (park mode only) so cross-thread
@@ -993,6 +999,7 @@ impl Runtime {
             // 6. Periodic non-blocking IO check every event_interval ticks.
             //    Prevents IO starvation under sustained task load.
             if tick % self.event_interval == 0 {
+                // SAFETY: single-threaded; UnsafeCell deref for interior mutability.
                 if let Err(e) = unsafe { &mut *self.io.get() }.poll_io(Some(Duration::ZERO)) {
                     assert!(
                         e.kind() == std::io::ErrorKind::Interrupted,
@@ -1019,6 +1026,7 @@ impl Runtime {
             match mode {
                 ParkMode::Spin => {
                     // Non-blocking IO check before spinning again.
+                    // SAFETY: single-threaded; UnsafeCell deref for interior mutability.
                     if let Err(e) = unsafe { &mut *self.io.get() }.poll_io(Some(Duration::ZERO)) {
                         assert!(
                             e.kind() == std::io::ErrorKind::Interrupted,
@@ -1032,10 +1040,12 @@ impl Runtime {
                     // Park in epoll_wait until IO, timer, or cross-thread
                     // eventfd wakes us.
                     // SAFETY: single-threaded, no concurrent timer access.
+                    // UnsafeCell deref for interior mutability (shared ref for read).
                     let timeout = unsafe { &*self.timers.get() }
                         .next_deadline()
                         .map(|d| d.saturating_duration_since(Instant::now()));
 
+                    // SAFETY: single-threaded; UnsafeCell deref for interior mutability.
                     if let Err(e) = unsafe { &mut *self.io.get() }.poll_io(timeout) {
                         assert!(
                             e.kind() == std::io::ErrorKind::Interrupted,

--- a/nexus-async-rt/src/shutdown.rs
+++ b/nexus-async-rt/src/shutdown.rs
@@ -148,8 +148,10 @@ impl ShutdownSignal {
             !waker_ptr.is_null(),
             "ShutdownSignal::current(): waker_ptr null while flag non-null (runtime install bug)"
         );
-        // SAFETY: install() writes flag and waker pointers together; both
-        // verified non-null above; pointers are valid for Runtime lifetime.
+        // SAFETY: install() writes flag and waker_ptr together; both verified
+        // non-null above. waker_ptr points to the Arc<Mutex<Option<Waker>>>
+        // inside the Runtime's ShutdownHandle. Valid for Runtime lifetime
+        // (block_on borrows &mut Runtime, which outlives all tasks).
         let task_waker = unsafe { (*waker_ptr).clone() };
         ShutdownSignal { flag, task_waker }
     }
@@ -160,8 +162,9 @@ impl Future for ShutdownSignal {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         // SAFETY: flag points to the AtomicBool inside the Runtime's
-        // ShutdownHandle (Arc-allocated, stable address). Valid for
-        // Runtime lifetime.
+        // ShutdownHandle (Arc-allocated, heap-stable address). Valid for
+        // Runtime lifetime — block_on borrows &mut Runtime which outlives
+        // all tasks. AtomicBool access is inherently thread-safe.
         if unsafe { &*self.flag }.load(Ordering::Acquire) {
             return Poll::Ready(());
         }
@@ -173,7 +176,8 @@ impl Future for ShutdownSignal {
             *guard = Some(cx.waker().clone());
         }
 
-        // Double-check after registration (lost wakeup prevention).
+        // SAFETY: Same pointer, same invariant as above — flag is valid
+        // for the Runtime lifetime.
         if unsafe { &*self.flag }.load(Ordering::Acquire) {
             Poll::Ready(())
         } else {
@@ -201,6 +205,9 @@ pub fn install_signal_handlers(flag: &Arc<AtomicBool>, mio_waker: &Arc<mio::Wake
     // signal-hook::flag::register sets the AtomicBool on signal, but
     // we also need to break epoll_wait. Register a second handler that
     // fires the mio waker.
+    // SAFETY: The closure is async-signal-safe — mio::Waker::wake() is
+    // an eventfd write (single syscall, no locks, no allocations). The
+    // Arc is cloned before registration so the waker outlives the handler.
     unsafe {
         signal_hook::low_level::register(signal_hook::consts::SIGTERM, move || {
             let _ = waker_ref.wake();
@@ -208,6 +215,7 @@ pub fn install_signal_handlers(flag: &Arc<AtomicBool>, mio_waker: &Arc<mio::Wake
         .expect("failed to register SIGTERM waker");
     }
     let waker_ref2 = Arc::clone(mio_waker);
+    // SAFETY: Same as above — async-signal-safe eventfd write only.
     unsafe {
         signal_hook::low_level::register(signal_hook::consts::SIGINT, move || {
             let _ = waker_ref2.wake();
@@ -313,6 +321,7 @@ mod tests {
         let mut signal = Box::pin(handle.signal());
 
         // First poll with noop waker — registers it.
+        // SAFETY: all vtable fns are no-ops; null data is never deref'd.
         let noop = unsafe {
             static V: RawWakerVTable =
                 RawWakerVTable::new(|p| RawWaker::new(p, &V), |_| {}, |_| {}, |_| {});
@@ -324,10 +333,16 @@ mod tests {
         // Second poll with a tracking waker — should overwrite.
         let woke = std::cell::Cell::new(false);
         let flag_ptr = &woke as *const std::cell::Cell<bool> as *const ();
+        // SAFETY: flag_ptr points to the stack-local `woke` Cell which
+        // outlives the waker. The vtable wake/wake_by_ref cast back to
+        // Cell<bool> and set true. clone copies the raw pointer. drop
+        // is a no-op.
         let tracking = unsafe {
             static V2: RawWakerVTable = RawWakerVTable::new(
                 |p| RawWaker::new(p, &V2),
+                // SAFETY: p is flag_ptr, valid for the test's lifetime.
                 |p| unsafe { (*(p as *const std::cell::Cell<bool>)).set(true) },
+                // SAFETY: p is flag_ptr, valid for the test's lifetime.
                 |p| unsafe { (*(p as *const std::cell::Cell<bool>)).set(true) },
                 |_| {},
             );
@@ -350,6 +365,7 @@ mod tests {
         handle.trigger();
 
         let mut signal = Box::pin(handle.signal());
+        // SAFETY: all vtable fns are no-ops; null data is never deref'd.
         let waker = unsafe {
             static V: RawWakerVTable =
                 RawWakerVTable::new(|p| RawWaker::new(p, &V), |_| {}, |_| {}, |_| {});

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -1042,6 +1042,8 @@ mod tests {
         let task = Box::new(Task::new_boxed(Noop, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid task created above via Box::into_raw.
+        // All task:: functions are called on this live task pointer.
         unsafe {
             // Initial state: 1 ref, no flags
             assert_eq!(ref_count(ptr), 1);
@@ -1076,6 +1078,8 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 7, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. All task:: functions are
+        // called on this live task pointer through its lifecycle.
         unsafe {
             assert!(has_join(ptr));
             assert!(!is_aborted(ptr));
@@ -1107,6 +1111,8 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. All task:: functions are
+        // called on this live task pointer through its lifecycle.
         unsafe {
             // complete_and_unref with 2 refs → not terminal
             drop_task_future(ptr);
@@ -1134,6 +1140,9 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Simulating the cross-thread
+        // waker lifecycle: ref_inc for waker clone, complete_and_unref for
+        // executor, ref_dec for handle and waker drops.
         unsafe {
             // Waker clone: ref_inc
             ref_inc(ptr);
@@ -1185,6 +1194,7 @@ mod tests {
 
         static NOOP_VTABLE: RawWakerVTable =
             RawWakerVTable::new(|p| RawWaker::new(p, &NOOP_VTABLE), |_| {}, |_| {}, |_| {});
+        // SAFETY: all vtable functions are no-ops; null data is never dereferenced.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &NOOP_VTABLE)) };
         let mut cx = Context::from_waker(&waker);
 
@@ -1208,6 +1218,8 @@ mod tests {
         assert_eq!(drop_count, 1, "future should be dropped exactly once");
 
         // drop_fn should now be drop_noop — calling it must NOT double-drop F.
+        // SAFETY: ptr is a valid task; drop_fn was transitioned to drop_noop
+        // after the panic in poll_join.
         unsafe { drop_task_future(ptr) };
         assert_eq!(
             drop_count, 1,
@@ -1215,6 +1227,7 @@ mod tests {
         );
 
         // Clean up: dec both refs (executor + JoinHandle), then free.
+        // SAFETY: ptr is a valid task; decrementing both refs to reach terminal.
         unsafe {
             ref_dec(ptr);
             ref_dec(ptr);
@@ -1228,6 +1241,7 @@ mod tests {
 
         static NOOP_VTABLE: RawWakerVTable =
             RawWakerVTable::new(|p| RawWaker::new(p, &NOOP_VTABLE), |_| {}, |_| {}, |_| {});
+        // SAFETY: all vtable functions are no-ops; null data is never dereferenced.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &NOOP_VTABLE)) };
         let mut cx = Context::from_waker(&waker);
 
@@ -1254,15 +1268,19 @@ mod tests {
         assert!(result.is_ready());
 
         // drop_fn should now target T (TrackedOutput).
+        // SAFETY: static mut access in single-threaded test.
         unsafe { OUTPUT_DROP_COUNT = 0 };
+        // SAFETY: ptr is a valid completed task; drop_fn now targets the output T.
         unsafe { drop_task_future(ptr) };
         assert_eq!(
+            // SAFETY: static mut access in single-threaded test.
             unsafe { OUTPUT_DROP_COUNT },
             1,
             "drop_fn should drop the output exactly once"
         );
 
         // Clean up.
+        // SAFETY: ptr is a valid task; decrementing both refs to reach terminal.
         unsafe {
             ref_dec(ptr);
             ref_dec(ptr);
@@ -1289,6 +1307,8 @@ mod tests {
         let task = Box::new(Task::new_boxed(Noop, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid fire-and-forget task created above.
+        // Exercising the full lifecycle: drop future, complete, free.
         unsafe {
             assert_eq!(ref_count(ptr), 1);
             assert!(!has_join(ptr));
@@ -1329,6 +1349,8 @@ mod tests {
         let task = new_joinable_slab(Noop, 0, slab_free, std::ptr::null());
         let ptr = Box::into_raw(Box::new(task)) as *mut u8;
 
+        // SAFETY: ptr is a valid slab-flagged joinable task. Exercising the
+        // full lifecycle: handle detach, executor completion, free.
         unsafe {
             assert_eq!(ref_count(ptr), 2); // executor + JoinHandle
             assert!(has_join(ptr));
@@ -1370,6 +1392,7 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Exercising handle-drops-first lifecycle.
         unsafe {
             assert_eq!(ref_count(ptr), 2);
             assert!(has_join(ptr));
@@ -1403,6 +1426,7 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Exercising completion-first lifecycle.
         unsafe {
             // complete_and_unref: sets COMPLETED, dec ref → 1 ref remains
             drop_task_future(ptr);
@@ -1434,6 +1458,8 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Exercising waker-clone lifecycle:
+        // 3 refs (executor + handle + waker), completion, handle drop, waker drop.
         unsafe {
             // Waker clone: ref_inc
             ref_inc(ptr);
@@ -1472,6 +1498,8 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Testing that a leaked
+        // HAS_JOIN flag prevents terminal state (safety net against misuse).
         unsafe {
             // complete_and_unref with 2 refs → Retain
             drop_task_future(ptr);
@@ -1510,6 +1538,7 @@ mod tests {
         let task = Box::new(Task::new_boxed(async {}, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid task. Testing acquire/drop refcount balance.
         unsafe {
             assert_eq!(ref_count(ptr), 1);
             let task_ref = TaskRef::acquire(ptr);
@@ -1532,6 +1561,8 @@ mod tests {
         let task = Box::new(Task::new_boxed(async {}, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid task. Testing from_owned wraps a
+        // pre-incremented pointer without extra ref_inc.
         unsafe {
             assert_eq!(ref_count(ptr), 1);
             ref_inc(ptr); // simulate handoff (e.g. RawWaker::data ownership)
@@ -1557,6 +1588,8 @@ mod tests {
         let task = Box::new(Task::new_boxed(async {}, 0));
         let ptr = Box::into_raw(task) as *mut u8;
 
+        // SAFETY: ptr is a valid task. Verifying that dropping a TaskRef
+        // when refcount > 1 does NOT invoke dispose_terminal.
         unsafe {
             // rc=1, acquire to rc=2, drop to rc=1. Not terminal (no
             // COMPLETED, lifecycle flags clear). Drop hits the Retain
@@ -1589,6 +1622,8 @@ mod tests {
         }
 
         let ptr = box_spawn_joinable(Noop, 0, std::ptr::null());
+        // SAFETY: ptr is a valid joinable task. Stress-testing convergence
+        // of 10 waker refs to terminal state.
         unsafe {
             // 10 waker clones: ref 2 → 12
             for _ in 0..10 {

--- a/nexus-async-rt/src/timer.rs
+++ b/nexus-async-rt/src/timer.rs
@@ -174,7 +174,9 @@ impl<F: Future> Future for Timeout<F> {
     type Output = Result<F::Output, Elapsed>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // SAFETY: we never move the inner fields out of the Pin.
+        // SAFETY: Pin projection — we never move `future` or `sleep` out
+        // of the struct. `sleep` is Unpin (no self-referential data), so
+        // Pin::new is fine. `future` may not be Unpin, hence new_unchecked.
         let this = unsafe { self.get_unchecked_mut() };
 
         // Check the deadline first so already-expired timeouts reliably
@@ -183,7 +185,9 @@ impl<F: Future> Future for Timeout<F> {
             return Poll::Ready(Err(Elapsed));
         }
 
-        // SAFETY: this.future is pinned because self is pinned.
+        // SAFETY: `this.future` is structurally pinned — self is pinned
+        // and we never move future out (only into_inner consumes by value,
+        // which requires ownership of Self, not Pin<&mut Self>).
         if let Poll::Ready(val) = unsafe { Pin::new_unchecked(&mut this.future) }.poll(cx) {
             return Poll::Ready(Ok(val));
         }
@@ -376,6 +380,7 @@ mod tests {
             RawWaker::new(p, &VTABLE)
         }
         static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        // SAFETY: all vtable fns are no-ops; null data is never deref'd.
         unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
     }
 

--- a/nexus-async-rt/src/tokio_compat.rs
+++ b/nexus-async-rt/src/tokio_compat.rs
@@ -144,7 +144,8 @@ impl<F: Future> Future for TokioCompat<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // SAFETY: we only project to `future` (structurally pinned).
+        // SAFETY: structural pin projection to `future`. We never move
+        // `future` out of the struct.
         let this = unsafe { self.get_unchecked_mut() };
 
         // Build a cross-thread waker for this task.
@@ -153,6 +154,8 @@ impl<F: Future> Future for TokioCompat<F> {
 
         // Poll the inner future with cross-thread waker.
         // Tokio context installed via TLS (ensure_tokio_context).
+        // SAFETY: `this.future` is structurally pinned — self is pinned
+        // and we never move future out.
         let future = unsafe { Pin::new_unchecked(&mut this.future) };
         future.poll(&mut cross_cx)
     }
@@ -219,8 +222,9 @@ fn make_cross_task_waker(
     task_ptr: *mut u8,
     ctx: std::sync::Arc<crate::cross_wake::CrossWakeContext>,
 ) -> Waker {
-    // SAFETY: caller (make_cross_waker → task_ptr_from_local_waker)
+    // SAFETY: caller (make_cross_waker -> task_ptr_from_local_waker)
     // returned task_ptr from a live local waker, refcount >= 1.
+    // TaskRef::acquire increments the task's refcount.
     let inner = std::sync::Arc::new(CrossTaskWakerInner {
         task_ref: unsafe { crate::task::TaskRef::acquire(task_ptr) },
         ctx,
@@ -229,15 +233,18 @@ fn make_cross_task_waker(
         std::sync::Arc::into_raw(inner).cast::<()>(),
         &CROSS_TASK_VTABLE,
     );
+    // SAFETY: raw was constructed from a valid Arc and our CROSS_TASK_VTABLE.
+    // The vtable functions correctly manage the Arc's refcount.
     unsafe { Waker::from_raw(raw) }
 }
 
 /// Clone: bump the Arc refcount. No allocation, no task-level ref_inc
 /// (the inner already holds one TaskRef shared by all clones).
 unsafe fn cross_task_clone(data: *const ()) -> RawWaker {
-    // Reconstruct the Arc from the raw pointer. We MUST NOT drop it —
-    // the original Arc still belongs to whoever holds the RawWaker we
-    // were derived from.
+    // SAFETY: data was produced by Arc::into_raw in make_cross_task_waker
+    // or a previous clone. Reconstruct the Arc to clone it, then
+    // immediately into_raw the original to avoid dropping it (the source
+    // RawWaker still owns that ref).
     let arc = unsafe { std::sync::Arc::from_raw(data.cast::<CrossTaskWakerInner>()) };
     let cloned = std::sync::Arc::clone(&arc);
     // Hand the original Arc back to its owner (the source RawWaker).
@@ -252,6 +259,8 @@ unsafe fn cross_task_clone(data: *const ()) -> RawWaker {
 /// last ref, `Inner::drop` runs — `task_ref` drops first (releasing the
 /// task ref via `dispose_terminal` if terminal), then `ctx` drops.
 unsafe fn cross_task_wake(data: *const ()) {
+    // SAFETY: data was produced by Arc::into_raw. Reconstruct the Arc
+    // to consume it (wake by value).
     let arc = unsafe { std::sync::Arc::from_raw(data.cast::<CrossTaskWakerInner>()) };
     // SAFETY: arc.task_ref holds one ref on the task — alive across
     // this call. Same for arc.ctx (Arc).
@@ -264,7 +273,12 @@ unsafe fn cross_task_wake(data: *const ()) {
 
 /// Wake by ref: dispatch only. No Arc takeover, no ref change.
 unsafe fn cross_task_wake_by_ref(data: *const ()) {
+    // SAFETY: data was produced by Arc::into_raw. The Arc is still alive
+    // (wake_by_ref borrows, doesn't consume). Reading through the raw
+    // pointer is valid because Arc guarantees the allocation is live while
+    // any strong ref exists.
     let inner = unsafe { &*data.cast::<CrossTaskWakerInner>() };
+    // SAFETY: inner.task_ref holds a ref on the task; inner.ctx is an Arc.
     unsafe {
         crate::cross_wake::wake_task_cross_thread(inner.task_ref.as_ptr(), &inner.ctx);
     }
@@ -273,6 +287,9 @@ unsafe fn cross_task_wake_by_ref(data: *const ()) {
 /// Drop: drop our Arc. If we held the last ref, `Inner::drop` runs —
 /// see `cross_task_wake` for the cascade.
 unsafe fn cross_task_drop(data: *const ()) {
+    // SAFETY: data was produced by Arc::into_raw. Reconstruct the Arc
+    // to drop it. If this is the last Arc, Inner::drop runs: task_ref
+    // drops first (ref_dec), then ctx drops.
     let _arc = unsafe { std::sync::Arc::from_raw(data.cast::<CrossTaskWakerInner>()) };
     // _arc drops at end of scope.
 }
@@ -485,11 +502,13 @@ mod arc_tests {
         let task_ptr = make_test_task();
 
         // Baseline: rc = 1 (Task::new_boxed initial executor-style ref).
+        // SAFETY: task_ptr valid from make_test_task; reading refcount.
         assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
 
         // Construct the cross-task waker. ONE task-level ref_inc fires
         // here (TaskRef::acquire inside make_cross_task_waker).
         let waker0 = make_cross_task_waker(task_ptr, StdArc::clone(&ctx));
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             2,
@@ -503,6 +522,7 @@ mod arc_tests {
         let waker2 = waker0.clone();
         let waker3 = waker0.clone();
         let waker4 = waker0.clone();
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             2,
@@ -515,6 +535,7 @@ mod arc_tests {
         drop(waker4);
         drop(waker0);
         drop(waker1);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             2,
@@ -525,6 +546,7 @@ mod arc_tests {
         // → if terminal, dispose_terminal (here: not terminal because
         // the original executor-style ref still exists, so rc 2 → 1).
         drop(waker3);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             1,
@@ -533,6 +555,9 @@ mod arc_tests {
 
         // Cleanup: drop the executor-style ref via complete_and_unref →
         // terminal → free.
+        // SAFETY: task_ptr valid with rc=1. drop_task_future drops the
+        // inner future. complete_and_unref sets COMPLETED + rc → 0 →
+        // FreeBox. free_task reclaims the Box allocation.
         unsafe {
             task::drop_task_future(task_ptr);
             assert!(matches!(
@@ -554,12 +579,14 @@ mod arc_tests {
         let waker1 = waker0.clone();
 
         // After construction + clone: task rc=2, Arc strong=2.
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(unsafe { task::ref_count(task_ptr) }, 2);
 
         // wake() consumes waker0 → cross_task_wake → Arc::from_raw +
         // wake_task_cross_thread + Arc drop. Since waker1 still holds
         // an Arc, Inner::drop does NOT run; task ref_count unchanged.
         waker0.wake();
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
             unsafe { task::ref_count(task_ptr) },
             2,
@@ -568,16 +595,20 @@ mod arc_tests {
 
         // Drop the survivor → last Arc → Inner::drop → ref_dec.
         drop(waker1);
+        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(unsafe { task::ref_count(task_ptr) }, 1);
 
         // After wake(), the task is in the cross-queue. Drain it so
         // Drop on ctx doesn't leak the entry. (Stub-aware pop.)
         let _ = ctx.queue.pop();
         // Clear queued so cleanup works.
+        // SAFETY: task_ptr valid; reading and clearing atomic flag.
         if unsafe { task::is_queued(task_ptr) } {
             unsafe { task::clear_queued(task_ptr) };
         }
 
+        // SAFETY: task_ptr valid with rc=1. drop_task_future +
+        // complete_and_unref → FreeBox. free_task reclaims.
         unsafe {
             task::drop_task_future(task_ptr);
             assert!(matches!(
@@ -634,6 +665,8 @@ mod arc_tests {
 
         // Cleanup.
         drop(waker);
+        // SAFETY: task_ptr valid with rc=1 after last waker dropped.
+        // drop_task_future + complete_and_unref → free_task reclaims.
         unsafe {
             task::drop_task_future(task_ptr);
             let _ = task::complete_and_unref(task_ptr);

--- a/nexus-async-rt/src/waker.rs
+++ b/nexus-async-rt/src/waker.rs
@@ -150,6 +150,8 @@ mod tests {
     #[test]
     fn task_ptr_from_local_waker_roundtrip() {
         let sentinel = 0xDEAD_BEEF_usize as *mut u8;
+        // SAFETY: sentinel is not a real task pointer but we wrap it in
+        // ManuallyDrop so vtable functions (which would deref it) are never called.
         let waker = unsafe { Waker::from_raw(RawWaker::new(sentinel.cast(), &VTABLE)) };
         let waker = std::mem::ManuallyDrop::new(waker);
 
@@ -161,6 +163,7 @@ mod tests {
     fn task_ptr_from_foreign_waker_returns_none() {
         static OTHER: RawWakerVTable =
             RawWakerVTable::new(|p| RawWaker::new(p, &OTHER), |_| {}, |_| {}, |_| {});
+        // SAFETY: all vtable functions are no-ops; null data is never dereferenced.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &OTHER)) };
         let waker = std::mem::ManuallyDrop::new(waker);
 

--- a/nexus-async-rt/src/world_ctx.rs
+++ b/nexus-async-rt/src/world_ctx.rs
@@ -122,7 +122,8 @@ impl WorldCtx {
     pub fn with_world<R>(&self, f: impl FnOnce(&mut World) -> R) -> R {
         // SAFETY: Single-threaded executor guarantees only one task polls
         // at a time, so only one with_world is active. World outlives all
-        // tasks (caller invariant from WorldCtx::new).
+        // tasks (caller invariant from WorldCtx::new). The exclusive ref
+        // is valid because no other code holds a ref during this closure.
         let world = unsafe { &mut *self.ptr };
         f(world)
     }
@@ -131,8 +132,8 @@ impl WorldCtx {
     ///
     /// Use when you only need to read resources.
     pub fn with_world_ref<R>(&self, f: impl FnOnce(&World) -> R) -> R {
-        // SAFETY: Same invariants as with_world. Shared ref is strictly
-        // less powerful.
+        // SAFETY: Same invariants as with_world — single-threaded, World
+        // outlives tasks. Shared ref is strictly less powerful than &mut.
         let world = unsafe { &*self.ptr };
         f(world)
     }

--- a/nexus-channel/benches/perf_channel_latency.rs
+++ b/nexus-channel/benches/perf_channel_latency.rs
@@ -62,6 +62,8 @@ fn main() {
 #[inline]
 fn rdtsc() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: __rdtscp is supported on all x86_64 CPUs with RDTSCP (Intel Nehalem+,
+    // AMD Barcelona+). aux receives the IA32_TSC_AUX value which we discard.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-channel/benches/perf_crossbeam_channel_latency.rs
+++ b/nexus-channel/benches/perf_crossbeam_channel_latency.rs
@@ -62,6 +62,8 @@ fn main() {
 #[inline]
 fn rdtsc() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: __rdtscp is supported on all x86_64 CPUs with RDTSCP (Intel Nehalem+,
+    // AMD Barcelona+). aux receives the IA32_TSC_AUX value which we discard.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-channel/benches/profile_channel.rs
+++ b/nexus-channel/benches/profile_channel.rs
@@ -18,6 +18,8 @@ const THROUGHPUT_COUNT: u64 = 10_000_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: __rdtscp is supported on all x86_64 CPUs with RDTSCP (Intel Nehalem+,
+    // AMD Barcelona+). aux receives the IA32_TSC_AUX value which we discard.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-channel/benches/profile_crossbeam_channel.rs
+++ b/nexus-channel/benches/profile_crossbeam_channel.rs
@@ -18,6 +18,8 @@ const THROUGHPUT_COUNT: u64 = 10_000_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: __rdtscp is supported on all x86_64 CPUs with RDTSCP (Intel Nehalem+,
+    // AMD Barcelona+). aux receives the IA32_TSC_AUX value which we discard.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-collections/src/btree.rs
+++ b/nexus-collections/src/btree.rs
@@ -428,19 +428,25 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let mut current = self.root;
 
         loop {
+            // SAFETY: current is non-null — initialized from self.root (checked above)
+            // or from child_at on a valid internal node. search_in_node requires a
+            // valid node pointer.
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
             if found {
+                // SAFETY: current is a valid node, idx < node.len (found == true).
                 let result = unsafe { self.remove_found(slab, current, idx, &path, path_len) };
                 self.len -= 1;
 
                 return Some(result);
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 return None;
             }
             debug_assert!(path_len < MAX_DEPTH);
             path[path_len] = (current, idx);
             path_len += 1;
+            // SAFETY: current is a valid internal node, idx <= node.len.
             let next = unsafe { child_at(current, idx) };
             current = next;
         }
@@ -456,6 +462,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let mut path_len = 0usize;
         let mut current = self.root;
 
+        // SAFETY: all node_is_leaf/child_at calls below operate on `current`,
+        // which starts as self.root (non-null, checked above) and each iteration
+        // replaces it with a valid child pointer from a valid internal node.
         while !unsafe { node_is_leaf(current) } {
             debug_assert!(path_len < MAX_DEPTH);
             path[path_len] = (current, 0);
@@ -464,6 +473,8 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             current = next;
         }
 
+        // SAFETY: current is a valid leaf node with at least 1 key (tree is non-empty).
+        // take_kv reads initialized key/value at index 0. shift_left closes the gap.
         let result = unsafe { take_kv(current, 0) };
         unsafe { shift_left(current, 0) };
         self.fixup_after_remove(slab, current, &path, path_len);
@@ -482,6 +493,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let mut path_len = 0usize;
         let mut current = self.root;
 
+        // SAFETY: all node_is_leaf/node_len/child_at calls below operate on `current`,
+        // which starts as self.root (non-null, checked above) and each iteration
+        // replaces it with a valid child pointer from a valid internal node.
         while !unsafe { node_is_leaf(current) } {
             let len = unsafe { node_len(current) };
             debug_assert!(path_len < MAX_DEPTH);
@@ -491,6 +505,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             current = next;
         }
 
+        // SAFETY: current is a valid leaf with at least 1 key (tree is non-empty).
+        // take_kv reads initialized key/value at the last index. Decrementing len
+        // logically removes the last slot (already moved out by take_kv).
         let last = unsafe { node_len(current) } - 1;
         let result = unsafe { take_kv(current, last) };
         unsafe { (*node_deref_mut(current)).len -= 1 };
@@ -546,6 +563,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
     ) -> Entry<'a, K, V, B, C, S> {
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, &key) };
             if found {
                 drop(key);
@@ -556,9 +574,11 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     idx,
                 });
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 break;
             }
+            // SAFETY: current is a valid internal node, idx <= node.len.
             let next = unsafe { child_at(current, idx) };
             current = next;
         }
@@ -794,13 +814,16 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
     fn find(&self, key: &K) -> Option<(NodePtr<K, V, B>, usize)> {
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
             if found {
                 return Some((current, idx));
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 return None;
             }
+            // SAFETY: current is a valid internal node, idx <= node.len.
             let next = unsafe { child_at(current, idx) };
             current = next;
         }
@@ -1240,11 +1263,14 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     self.root = ptr;
                     self.len += 1;
                     self.depth = 0;
+                    // SAFETY: ptr is freshly allocated with len=1, so values[0] is initialized.
                     let val_ptr = unsafe { (*node_deref_mut(ptr)).values[0].as_mut_ptr() };
                     return Ok((val_ptr, None));
                 }
                 Err(full) => {
                     let node = full.into_inner();
+                    // SAFETY: we initialized keys[0] and values[0] above before try_alloc.
+                    // The alloc failed, returning the node. Read back the initialized slots.
                     let k = unsafe { node.keys[0].assume_init_read() };
                     let v = unsafe { node.values[0].assume_init_read() };
                     return Err(Full((k, v)));
@@ -1252,15 +1278,18 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             }
         }
 
+        // SAFETY: self.root is non-null (checked above). node_len reads the len field.
         if unsafe { node_len(self.root) } == B - 1 {
             let new_root = match slab.try_alloc(BTreeNode::new_internal()) {
                 Ok(slot) => slot.into_raw(),
                 Err(_) => return Err(Full((key, value))),
             };
+            // SAFETY: new_root is freshly allocated. Set its first child to old root.
             unsafe { (*node_deref_mut(new_root)).children[0] = self.root };
             let old_root = self.root;
             self.root = new_root;
 
+            // SAFETY: old_root is a valid node.
             let right_node = if unsafe { node_is_leaf(old_root) } {
                 BTreeNode::new_leaf()
             } else {
@@ -1270,24 +1299,31 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 slot.into_raw()
             } else {
                 self.root = old_root;
+                // SAFETY: new_root was obtained from Slot::into_raw() above.
                 let slot = unsafe { Slot::from_raw(new_root) };
                 slab.free(slot);
                 return Err(Full((key, value)));
             };
+            // SAFETY: new_root is a valid internal node with 1 child. old_root
+            // (child 0) is full. right is freshly allocated empty node.
             unsafe { split_child_core(new_root, 0, right) };
             self.depth += 1;
         }
 
         let mut current = self.root;
         loop {
+            // SAFETY: current is non-null and a valid tree node.
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, &key) };
             if found {
+                // SAFETY: idx < node.len (found), current is valid; &mut self exclusivity.
                 let existing = unsafe { value_at_mut(current, idx) };
                 let old = std::mem::replace(existing, value);
                 let val_ptr = existing as *mut V;
                 return Ok((val_ptr, Some(old)));
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf with room (root was split if full).
                 unsafe { shift_right(current, idx) };
                 let node = unsafe { &mut *node_deref_mut(current) };
                 node.keys[idx] = MaybeUninit::new(key);
@@ -1299,8 +1335,11 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             }
 
             let mut child_idx = idx;
+            // SAFETY: current is a valid internal node, child_idx <= node.len.
             let child = unsafe { child_at(current, child_idx) };
+            // SAFETY: child is a valid node.
             if unsafe { node_len(child) } == B - 1 {
+                // SAFETY: child is a valid node.
                 let right = match slab.try_alloc(if unsafe { node_is_leaf(child) } {
                     BTreeNode::new_leaf()
                 } else {
@@ -1309,10 +1348,14 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     Ok(slot) => slot.into_raw(),
                     Err(_) => return Err(Full((key, value))),
                 };
+                // SAFETY: current is non-full (proactive split ensures room),
+                // child at child_idx is full, right is freshly allocated.
                 unsafe { split_child_core(current, child_idx, right) };
+                // SAFETY: child_idx < current.len after split promoted the median.
                 let median = unsafe { key_at(current, child_idx) };
                 match C::cmp(&key, median) {
                     Ordering::Equal => {
+                        // SAFETY: child_idx < node.len; current is valid.
                         let existing = unsafe { value_at_mut(current, child_idx) };
                         let old = std::mem::replace(existing, value);
                         let val_ptr = existing as *mut V;
@@ -1322,6 +1365,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     Ordering::Less => {}
                 }
             }
+            // SAFETY: current is a valid internal node, child_idx <= node.len.
             current = unsafe { child_at(current, child_idx) };
         }
     }
@@ -1342,15 +1386,19 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             self.root = ptr;
             self.len += 1;
             self.depth = 0;
+            // SAFETY: ptr is freshly allocated with len=1, so values[0] is initialized.
             let val_ptr = unsafe { (*node_deref_mut(ptr)).values[0].as_mut_ptr() };
             return (val_ptr, None);
         }
 
+        // SAFETY: self.root is non-null (checked above). node_len reads the len field.
         if unsafe { node_len(self.root) } == B - 1 {
             let new_root = slab.alloc(BTreeNode::new_internal()).into_raw();
+            // SAFETY: new_root is freshly allocated. Set its first child to old root.
             unsafe { (*node_deref_mut(new_root)).children[0] = self.root };
             let old_root = self.root;
             self.root = new_root;
+            // SAFETY: old_root is a valid node.
             let right = slab
                 .alloc(if unsafe { node_is_leaf(old_root) } {
                     BTreeNode::new_leaf()
@@ -1358,20 +1406,26 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     BTreeNode::new_internal()
                 })
                 .into_raw();
+            // SAFETY: new_root has 1 child (old_root, which is full), right is
+            // freshly allocated empty node.
             unsafe { split_child_core(new_root, 0, right) };
             self.depth += 1;
         }
 
         let mut current = self.root;
         loop {
+            // SAFETY: current is non-null and a valid tree node.
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, &key) };
             if found {
+                // SAFETY: idx < node.len (found), current is valid; &mut self exclusivity.
                 let existing = unsafe { value_at_mut(current, idx) };
                 let old = std::mem::replace(existing, value);
                 let val_ptr = existing as *mut V;
                 return (val_ptr, Some(old));
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf with room (proactive split).
                 unsafe { shift_right(current, idx) };
                 let node = unsafe { &mut *node_deref_mut(current) };
                 node.keys[idx] = MaybeUninit::new(key);
@@ -1383,8 +1437,11 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             }
 
             let mut child_idx = idx;
+            // SAFETY: current is a valid internal node, child_idx <= node.len.
             let child = unsafe { child_at(current, child_idx) };
+            // SAFETY: child is a valid node.
             if unsafe { node_len(child) } == B - 1 {
+                // SAFETY: child is a valid node.
                 let right = slab
                     .alloc(if unsafe { node_is_leaf(child) } {
                         BTreeNode::new_leaf()
@@ -1392,10 +1449,14 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                         BTreeNode::new_internal()
                     })
                     .into_raw();
+                // SAFETY: current is non-full, child at child_idx is full,
+                // right is freshly allocated.
                 unsafe { split_child_core(current, child_idx, right) };
+                // SAFETY: child_idx < current.len after split promoted the median.
                 let median = unsafe { key_at(current, child_idx) };
                 match C::cmp(&key, median) {
                     Ordering::Equal => {
+                        // SAFETY: child_idx < node.len; current is valid.
                         let existing = unsafe { value_at_mut(current, child_idx) };
                         let old = std::mem::replace(existing, value);
                         let val_ptr = existing as *mut V;
@@ -1405,6 +1466,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     Ordering::Less => {}
                 }
             }
+            // SAFETY: current is a valid internal node, child_idx <= node.len.
             current = unsafe { child_at(current, child_idx) };
         }
     }
@@ -1417,10 +1479,12 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let mut result: (NodePtr<K, V, B>, u16) = (ptr::null_mut(), 0);
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
             if found {
                 return (current, idx as u16);
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 if idx < unsafe { node_len(current) } {
                     return (current, idx as u16);
@@ -1430,6 +1494,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             if idx < unsafe { node_len(current) } {
                 result = (current, idx as u16);
             }
+            // SAFETY: current is a valid internal node, idx <= node.len.
             current = unsafe { child_at(current, idx) };
         }
         result
@@ -1439,20 +1504,25 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let mut result: (NodePtr<K, V, B>, u16) = (ptr::null_mut(), 0);
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
             if found {
+                // SAFETY: current is a valid node.
                 if unsafe { node_is_leaf(current) } {
                     if idx + 1 < unsafe { node_len(current) } {
                         return (current, (idx + 1) as u16);
                     }
                     return result;
                 }
+                // SAFETY: current is internal, idx+1 <= node.len (found at idx).
                 let mut c = unsafe { child_at(current, idx + 1) };
+                // SAFETY: c is a valid child node; loop descends leftmost children.
                 while !unsafe { node_is_leaf(c) } {
                     c = unsafe { child_at(c, 0) };
                 }
                 return (c, 0);
             }
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 if idx < unsafe { node_len(current) } {
                     return (current, idx as u16);
@@ -1462,6 +1532,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             if idx < unsafe { node_len(current) } {
                 result = (current, idx as u16);
             }
+            // SAFETY: current is a valid internal node, idx <= node.len.
             current = unsafe { child_at(current, idx) };
         }
         result
@@ -1509,6 +1580,8 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         lower: Option<&K>,
         upper: Option<&K>,
     ) {
+        // SAFETY: ptr is non-null — root (verified non-null in verify_invariants)
+        // or a child pointer from a valid parent node (checked non-null above).
         let node = unsafe { &*node_deref(ptr) };
         let len = node.len as usize;
         assert!(len < B);
@@ -1518,15 +1591,18 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         assert!(!(is_root && !node.leaf && len == 0));
 
         for i in 1..len {
+            // SAFETY: keys[i-1] and keys[i] are initialized for i < len.
             let prev = unsafe { node.keys[i - 1].assume_init_ref() };
             let curr = unsafe { node.keys[i].assume_init_ref() };
             assert!(C::cmp(prev, curr) == Ordering::Less);
         }
         if let Some(lo) = lower {
+            // SAFETY: keys[0] is initialized (len > 0, checked via min occupancy).
             let first = unsafe { node.keys[0].assume_init_ref() };
             assert!(C::cmp(first, lo) == Ordering::Greater);
         }
         if let Some(hi) = upper {
+            // SAFETY: keys[len-1] is initialized for len > 0.
             let last = unsafe { node.keys[len - 1].assume_init_ref() };
             assert!(C::cmp(last, hi) == Ordering::Less);
         }
@@ -1544,11 +1620,13 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             }
             for i in 0..=len {
                 let lo = if i > 0 {
+                    // SAFETY: keys[i-1] is initialized for i <= len.
                     Some(unsafe { node.keys[i - 1].assume_init_ref() })
                 } else {
                     lower
                 };
                 let hi = if i < len {
+                    // SAFETY: keys[i] is initialized for i < len.
                     Some(unsafe { node.keys[i].assume_init_ref() })
                 } else {
                     upper
@@ -1650,9 +1728,12 @@ impl<K, V, const B: usize, C> BTree<K, V, B, C> {
         }
         let mut current = self.root;
         loop {
+            // SAFETY: current is non-null (root checked above, then valid children).
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf with at least 1 key.
                 return Some(unsafe { (key_at(current, 0), value_at(current, 0)) });
             }
+            // SAFETY: current is a valid internal node, child 0 exists.
             current = unsafe { child_at(current, 0) };
         }
     }
@@ -1664,10 +1745,13 @@ impl<K, V, const B: usize, C> BTree<K, V, B, C> {
         }
         let mut current = self.root;
         loop {
+            // SAFETY: current is non-null (root checked above, then valid children).
             let len = unsafe { node_len(current) };
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf with at least 1 key; len-1 is valid.
                 return Some(unsafe { (key_at(current, len - 1), value_at(current, len - 1)) });
             }
+            // SAFETY: current is a valid internal node, child at index len exists.
             current = unsafe { child_at(current, len) };
         }
     }
@@ -1675,6 +1759,7 @@ impl<K, V, const B: usize, C> BTree<K, V, B, C> {
     /// Removes all nodes.
     pub fn clear(&mut self, slab: &impl SlabOps<BTreeNode<K, V, B>>) {
         if !self.root.is_null() {
+            // SAFETY: self.root is non-null and a valid tree root.
             unsafe { Self::clear_subtree(self.root, slab) };
         }
         self.root = ptr::null_mut();
@@ -1737,9 +1822,11 @@ fn push_leftmost_path<K, V, const B: usize>(
         debug_assert!(*stack_len < MAX_DEPTH);
         stack[*stack_len] = (node, 0);
         *stack_len += 1;
+        // SAFETY: node is non-null (initially from caller, then valid children).
         if unsafe { node_is_leaf(node) } {
             return;
         }
+        // SAFETY: node is a valid internal node, child 0 exists.
         node = unsafe { child_at(node, 0) };
     }
 }
@@ -1752,12 +1839,14 @@ fn init_lower_bound_stack<K, V, const B: usize, C: Compare<K>>(
 ) {
     let mut current = root;
     while !current.is_null() {
+        // SAFETY: current is non-null and a valid tree node (root or child).
         let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
         if found {
             stack[*stack_len] = (current, idx as u16);
             *stack_len += 1;
             return;
         }
+        // SAFETY: current is a valid node.
         if unsafe { node_is_leaf(current) } {
             if idx < unsafe { node_len(current) } {
                 stack[*stack_len] = (current, idx as u16);
@@ -1769,6 +1858,7 @@ fn init_lower_bound_stack<K, V, const B: usize, C: Compare<K>>(
             stack[*stack_len] = (current, idx as u16);
             *stack_len += 1;
         }
+        // SAFETY: current is a valid internal node, idx <= node.len.
         current = unsafe { child_at(current, idx) };
     }
 }
@@ -1781,8 +1871,10 @@ fn init_upper_bound_stack<K, V, const B: usize, C: Compare<K>>(
 ) {
     let mut current = root;
     while !current.is_null() {
+        // SAFETY: current is non-null and a valid tree node (root or child).
         let (idx, found) = unsafe { search_in_node::<K, V, B, C>(current, key) };
         if found {
+            // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
                 if idx + 1 < unsafe { node_len(current) } {
                     stack[*stack_len] = (current, (idx + 1) as u16);
@@ -1791,11 +1883,13 @@ fn init_upper_bound_stack<K, V, const B: usize, C: Compare<K>>(
             } else {
                 stack[*stack_len] = (current, (idx + 1) as u16);
                 *stack_len += 1;
+                // SAFETY: current is internal, idx+1 <= node.len.
                 let child = unsafe { child_at(current, idx + 1) };
                 push_leftmost_path(child, stack, stack_len);
             }
             return;
         }
+        // SAFETY: current is a valid node.
         if unsafe { node_is_leaf(current) } {
             if idx < unsafe { node_len(current) } {
                 stack[*stack_len] = (current, idx as u16);
@@ -1807,6 +1901,7 @@ fn init_upper_bound_stack<K, V, const B: usize, C: Compare<K>>(
             stack[*stack_len] = (current, idx as u16);
             *stack_len += 1;
         }
+        // SAFETY: current is a valid internal node, idx <= node.len.
         current = unsafe { child_at(current, idx) };
     }
 }
@@ -1817,6 +1912,7 @@ fn advance_stack<K, V, const B: usize>(
 ) -> Option<(NodePtr<K, V, B>, usize)> {
     while *stack_len > 0 {
         let (node, idx) = stack[*stack_len - 1];
+        // SAFETY: node is a valid tree node pushed during traversal.
         if (idx as usize) < unsafe { node_len(node) } {
             break;
         }
@@ -1828,7 +1924,9 @@ fn advance_stack<K, V, const B: usize>(
     let (node, idx) = stack[*stack_len - 1];
     let i = idx as usize;
     stack[*stack_len - 1].1 = (i + 1) as u16;
+    // SAFETY: node is a valid tree node from the traversal stack.
     if !unsafe { node_is_leaf(node) } {
+        // SAFETY: node is internal, i+1 <= node.len (we just yielded key at i).
         let child = unsafe { child_at(node, i + 1) };
         push_leftmost_path(child, stack, stack_len);
     }
@@ -1843,6 +1941,7 @@ fn advance_stack_range<K, V, const B: usize>(
 ) -> Option<(NodePtr<K, V, B>, usize)> {
     while *stack_len > 0 {
         let (node, idx) = stack[*stack_len - 1];
+        // SAFETY: node is a valid tree node pushed during traversal.
         if (idx as usize) < unsafe { node_len(node) } {
             break;
         }
@@ -1858,7 +1957,9 @@ fn advance_stack_range<K, V, const B: usize>(
     }
     let i = idx as usize;
     stack[*stack_len - 1].1 = (i + 1) as u16;
+    // SAFETY: node is a valid tree node from the traversal stack.
     if !unsafe { node_is_leaf(node) } {
+        // SAFETY: node is internal, i+1 <= node.len.
         let child = unsafe { child_at(node, i + 1) };
         push_leftmost_path(child, stack, stack_len);
     }
@@ -1882,6 +1983,7 @@ impl<'a, K: 'a, V: 'a, const B: usize> Iterator for Iter<'a, K, V, B> {
     fn next(&mut self) -> Option<Self::Item> {
         let (node, idx) = advance_stack(&mut self.stack, &mut self.stack_len)?;
         self.remaining -= 1;
+        // SAFETY: advance_stack returns a valid (node, idx) where idx < node.len.
         Some(unsafe { (key_at(node, idx), value_at(node, idx)) })
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1948,6 +2050,8 @@ impl<'a, K: 'a, V: 'a, const B: usize> Iterator for IterMut<'a, K, V, B> {
     fn next(&mut self) -> Option<Self::Item> {
         let (node, idx) = advance_stack(&mut self.stack, &mut self.stack_len)?;
         self.remaining -= 1;
+        // SAFETY: advance_stack returns a valid (node, idx) where idx < node.len.
+        // &mut self ensures no other mutable references exist.
         Some(unsafe { (key_at(node, idx), value_at_mut(node, idx)) })
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1988,6 +2092,7 @@ impl<'a, K: 'a, V: 'a, const B: usize> Iterator for Range<'a, K, V, B> {
             self.end_node,
             self.end_idx,
         )?;
+        // SAFETY: advance_stack_range returns a valid (node, idx) where idx < node.len.
         Some(unsafe { (key_at(node, idx), value_at(node, idx)) })
     }
 }
@@ -2009,6 +2114,8 @@ impl<'a, K: 'a, V: 'a, const B: usize> Iterator for RangeMut<'a, K, V, B> {
             self.end_node,
             self.end_idx,
         )?;
+        // SAFETY: advance_stack_range returns a valid (node, idx) where idx < node.len.
+        // &mut self ensures no other mutable references exist.
         Some(unsafe { (key_at(node, idx), value_at_mut(node, idx)) })
     }
 }
@@ -2123,6 +2230,7 @@ impl<'a, K, V, const B: usize, C: Compare<K>>
     pub fn try_insert(self, value: V) -> Result<&'a mut V, Full<(K, V)>> {
         let VacantEntry { tree, slab, key } = self;
         let (val_ptr, _) = tree.try_insert_inner(slab, key, value)?;
+        // SAFETY: val_ptr points to an initialized value in a valid slab-allocated node.
         Ok(unsafe { &mut *val_ptr })
     }
     /// Insert (panics if full).
@@ -2131,6 +2239,7 @@ impl<'a, K, V, const B: usize, C: Compare<K>>
         let (val_ptr, _) = tree
             .try_insert_inner(slab, key, value)
             .expect("slab is full");
+        // SAFETY: val_ptr points to an initialized value in a valid slab-allocated node.
         unsafe { &mut *val_ptr }
     }
 }
@@ -2144,6 +2253,7 @@ impl<'a, K, V, const B: usize, C: Compare<K>>
     pub fn insert(self, value: V) -> &'a mut V {
         let VacantEntry { tree, slab, key } = self;
         let (val_ptr, _) = tree.insert_inner(slab, key, value);
+        // SAFETY: val_ptr points to an initialized value in a valid slab-allocated node.
         unsafe { &mut *val_ptr }
     }
 }

--- a/nexus-collections/src/rbtree.rs
+++ b/nexus-collections/src/rbtree.rs
@@ -466,6 +466,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
 
         while !current.is_null() {
             parent = current;
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let node = unsafe { &*node_deref(current) };
             match C::cmp(&key, &node.key) {
                 Ordering::Equal => {
@@ -618,6 +619,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let mut result: NodePtr<K, V> = ptr::null_mut();
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let node = unsafe { &*node_deref(current) };
             if C::cmp(key, &node.key) == Ordering::Greater {
                 current = node.right.get();
@@ -633,6 +635,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let mut result: NodePtr<K, V> = ptr::null_mut();
         let mut current = self.root;
         while !current.is_null() {
+            // SAFETY: current is non-null and a valid tree node (root or child).
             let node = unsafe { &*node_deref(current) };
             if C::cmp(key, &node.key) == Ordering::Less {
                 result = current;
@@ -667,6 +670,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         }
 
         if !end.is_null() {
+            // SAFETY: front and end are non-null valid tree nodes from lower/upper_bound.
             let front_key = unsafe { &(*node_deref(front)).key };
             let end_key = unsafe { &(*node_deref(end)).key };
             if C::cmp(front_key, end_key) != Ordering::Less {
@@ -1042,6 +1046,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let mut count = 0usize;
         Self::verify_subtree(self.root, &mut black_height, 0, &mut count);
 
+        // SAFETY: root is non-null (checked above) and a valid tree node.
         let actual_min = unsafe { tree_minimum(self.root) };
         let actual_max = unsafe { tree_maximum(self.root) };
         assert_eq!(self.leftmost, actual_min, "leftmost cache mismatch");
@@ -1069,6 +1074,8 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         }
 
         *count += 1;
+        // SAFETY: ptr is non-null (checked above) and a valid tree node
+        // reached by recursive traversal from the root.
         let node = unsafe { &*node_deref(ptr) };
 
         if is_red(ptr) {
@@ -1080,11 +1087,13 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         let right = node.right.get();
 
         if !left.is_null() {
+            // SAFETY: left is non-null and a valid child of the current node.
             let left_key = unsafe { &(*node_deref(left)).key };
             assert!(C::cmp(left_key, &node.key) == Ordering::Less);
             assert_eq!(get_parent(left), ptr);
         }
         if !right.is_null() {
+            // SAFETY: right is non-null and a valid child of the current node.
             let right_key = unsafe { &(*node_deref(right)).key };
             assert!(C::cmp(right_key, &node.key) == Ordering::Greater);
             assert_eq!(get_parent(right), ptr);

--- a/nexus-id/src/simd/sse2.rs
+++ b/nexus-id/src/simd/sse2.rs
@@ -22,6 +22,10 @@ pub fn hex_decode_16(bytes: &[u8; 16]) -> Result<u64, usize> {
 #[inline]
 pub fn hex_decode_32(bytes: &[u8; 32]) -> Result<(u64, u64), usize> {
     // Process each half with SSE2
+    // SAFETY: `bytes` is &[u8; 32], so bytes[0..16] and bytes[16..32] are both
+    // valid. The pointer casts reinterpret contiguous sub-slices as &[u8; 16]
+    // references with the same lifetime as `bytes`. Alignment is irrelevant
+    // because [u8; 16] has align 1.
     let hi_bytes: &[u8; 16] = unsafe { &*(bytes.as_ptr().cast::<[u8; 16]>()) };
     let lo_bytes: &[u8; 16] = unsafe { &*(bytes.as_ptr().add(16).cast::<[u8; 16]>()) };
 

--- a/nexus-id/src/simd/ssse3.rs
+++ b/nexus-id/src/simd/ssse3.rs
@@ -36,6 +36,10 @@ pub fn hex_encode_u64(value: u64) -> [u8; 16] {
     let bytes = value.to_be_bytes();
     let lut = hex_lut();
 
+    // SAFETY: All intrinsics are SSSE3 or below, guaranteed available by the
+    // module-level `cfg(target_feature = "ssse3")` gate. `bytes` is a stack
+    // [u8; 8]; `_mm_loadl_epi64` reads 8 bytes (unaligned-safe). `buf` is a
+    // stack [u8; 16]; `_mm_storeu_si128` writes 16 bytes (unaligned-safe).
     unsafe {
         let mask_0f = _mm_set1_epi8(0x0F);
         // Load 8 bytes into low 64 bits of XMM register
@@ -67,6 +71,11 @@ pub fn hex_encode_u64(value: u64) -> [u8; 16] {
 pub fn hex_encode_u128(hi: u64, lo: u64) -> [u8; 32] {
     let lut = hex_lut();
 
+    // SAFETY: All intrinsics are SSSE3 or below, guaranteed available by the
+    // module-level `cfg(target_feature = "ssse3")` gate. `hi_bytes`/`lo_bytes`
+    // are stack [u8; 8]; `_mm_loadl_epi64` reads 8 bytes (unaligned-safe).
+    // `buf` is a stack [u8; 32]; both `_mm_storeu_si128` writes are within bounds
+    // (offsets 0 and 16 into a 32-byte buffer).
     unsafe {
         let mask_0f = _mm_set1_epi8(0x0F);
         let mut buf = [0u8; 32];
@@ -105,11 +114,15 @@ pub fn hex_encode_u128(hi: u64, lo: u64) -> [u8; 32] {
 /// Returns `Err(position)` in the compacted 32-char hex space.
 #[inline]
 pub fn uuid_decode_dashed(bytes: &[u8; 36]) -> Result<(u64, u64), usize> {
+    // SAFETY: All intrinsics are SSSE3 or below, guaranteed available by the
+    // module-level `cfg(target_feature = "ssse3")` gate. `bytes` is &[u8; 36]:
+    // `_mm_loadu_si128` at offset 0 reads [0..16], at offset 16 reads [16..32]
+    // (both within bounds, unaligned-safe). `read_unaligned` at offset 32 reads
+    // [32..36] (4 bytes, within the 36-byte array).
     unsafe {
         // Load input: 16 + 16 + 4 bytes
         let reg_a = _mm_loadu_si128(bytes.as_ptr().cast()); // input[0..16]
         let reg_b = _mm_loadu_si128(bytes.as_ptr().add(16).cast()); // input[16..32]
-        // SAFETY: We've verified 36 bytes. Read 4 bytes at offset 32.
         let tail = core::ptr::read_unaligned(bytes.as_ptr().add(32).cast::<u32>());
         let reg_c = _mm_cvtsi32_si128(tail as i32); // input[32..36]
 

--- a/nexus-logbuf/src/channel/mpsc.rs
+++ b/nexus-logbuf/src/channel/mpsc.rs
@@ -209,6 +209,9 @@ impl Sender {
             // original `&mut self.inner` borrow is dead before the
             // returned claim is used, and the loop only re-borrows after
             // the previous iteration's borrow has fully expired.
+            // SAFETY: Polonius workaround — transmute is between identical types
+            // with identical lifetimes. Early return guarantees the original
+            // &mut self.inner borrow is dead before the claim is used.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
                 if let Ok(claim) = (*inner_ptr).try_claim(len) {
@@ -352,6 +355,8 @@ impl Receiver {
             // SAFETY: see Polonius pattern at the top of `Sender::send` in
             // this file. Same shape: early return frees the borrow before
             // any reuse.
+            // SAFETY: Polonius workaround — same-type transmute, early return
+            // ensures borrow is dead before the claim is used.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -374,6 +379,8 @@ impl Receiver {
             // SAFETY: see Polonius pattern at the top of `Sender::send` in
             // this file. Same shape: early return frees the borrow before
             // the next loop iteration reuses it.
+            // SAFETY: Polonius workaround — same-type transmute, early return
+            // ensures borrow is dead before the next iteration reborrows.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -405,6 +412,8 @@ impl Receiver {
                 // Final try after park.
                 // SAFETY: see Polonius pattern at the top of
                 // `Sender::send` in this file.
+                // SAFETY: Polonius workaround — same-type transmute, early
+                // return ensures borrow is dead before the claim is used.
                 unsafe {
                     let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                     if let Some(claim) = (*inner_ptr).try_claim() {

--- a/nexus-logbuf/src/channel/spsc.rs
+++ b/nexus-logbuf/src/channel/spsc.rs
@@ -190,6 +190,9 @@ impl Sender {
             // original `&mut self.inner` borrow is dead before the
             // returned claim is used, and the loop only re-borrows after
             // the previous iteration's borrow has fully expired.
+            // SAFETY: Polonius workaround — transmute is between identical types
+            // with identical lifetimes. Early return guarantees the original
+            // &mut self.inner borrow is dead before the claim is used.
             unsafe {
                 let inner_ptr: *mut queue::Producer = &raw mut self.inner;
                 if let Ok(claim) = (*inner_ptr).try_claim(len) {
@@ -333,6 +336,8 @@ impl Receiver {
             // SAFETY: see Polonius pattern at the top of `Sender::send` in
             // this file. Same shape: early return frees the borrow before
             // any reuse.
+            // SAFETY: Polonius workaround — same-type transmute, early return
+            // ensures borrow is dead before the claim is used.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -355,6 +360,8 @@ impl Receiver {
             // SAFETY: see Polonius pattern at the top of `Sender::send` in
             // this file. Same shape: early return frees the borrow before
             // the next loop iteration reuses it.
+            // SAFETY: Polonius workaround — same-type transmute, early return
+            // ensures borrow is dead before the next iteration reborrows.
             unsafe {
                 let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                 if let Some(claim) = (*inner_ptr).try_claim() {
@@ -386,6 +393,8 @@ impl Receiver {
                 // Final try after park.
                 // SAFETY: see Polonius pattern at the top of
                 // `Sender::send` in this file.
+                // SAFETY: Polonius workaround — same-type transmute, early
+                // return ensures borrow is dead before the claim is used.
                 unsafe {
                     let inner_ptr: *mut queue::Consumer = &raw mut self.inner;
                     if let Some(claim) = (*inner_ptr).try_claim() {

--- a/nexus-logbuf/src/queue/mpsc.rs
+++ b/nexus-logbuf/src/queue/mpsc.rs
@@ -101,10 +101,12 @@ struct Shared {
     mask: usize,
 }
 
-// Safety: Buffer access is synchronized through atomic head/tail.
+// SAFETY: Buffer access is synchronized through atomic head/tail.
 // Multiple producers coordinate via CAS on tail.
 // Single consumer is enforced by API (Consumer is not Clone).
 unsafe impl Send for Shared {}
+// SAFETY: Producers access disjoint CAS-claimed regions; consumer
+// accesses only committed regions released by the atomic len store.
 unsafe impl Sync for Shared {}
 
 impl Drop for Shared {
@@ -133,7 +135,8 @@ pub struct Producer {
     shared: Arc<Shared>,
 }
 
-// Safety: Producer coordinates with other producers via atomic CAS.
+// SAFETY: Producer coordinates with other producers via atomic CAS on
+// tail. Each producer's claimed region is disjoint after successful CAS.
 unsafe impl Send for Producer {}
 
 impl Producer {
@@ -410,7 +413,8 @@ pub struct Consumer {
     shared: Arc<Shared>,
 }
 
-// Safety: Consumer is only used from one thread.
+// SAFETY: Consumer is only used from one thread (not Clone, &mut self API).
+// Sending it to another thread is safe; using from multiple threads is not.
 unsafe impl Send for Consumer {}
 
 impl Consumer {

--- a/nexus-logbuf/src/queue/spsc.rs
+++ b/nexus-logbuf/src/queue/spsc.rs
@@ -109,9 +109,11 @@ struct Shared {
     mask: usize,
 }
 
-// Safety: Buffer is only accessed by one producer and one consumer.
-// The atomic head provides synchronization.
+// SAFETY: Buffer is only accessed by one producer and one consumer.
+// The atomic head provides synchronization between them.
 unsafe impl Send for Shared {}
+// SAFETY: All mutable access to the buffer is partitioned between
+// producer (tail region) and consumer (head region) via atomic offsets.
 unsafe impl Sync for Shared {}
 
 impl Drop for Shared {
@@ -140,7 +142,8 @@ pub struct Producer {
     shared: Arc<Shared>,
 }
 
-// Safety: Producer is only used from one thread.
+// SAFETY: Producer is only used from one thread (not Clone, &mut self API).
+// Sending it to another thread is safe; using from multiple threads is not.
 unsafe impl Send for Producer {}
 
 impl Producer {
@@ -402,7 +405,8 @@ pub struct Consumer {
     shared: Arc<Shared>,
 }
 
-// Safety: Consumer is only used from one thread.
+// SAFETY: Consumer is only used from one thread (not Clone, &mut self API).
+// Sending it to another thread is safe; using from multiple threads is not.
 unsafe impl Send for Consumer {}
 
 impl Consumer {

--- a/nexus-net/src/http/request.rs
+++ b/nexus-net/src/http/request.rs
@@ -251,6 +251,7 @@ impl RequestReader {
                     // SAFETY: header name/value pointers are within data (same allocation).
                     let ns = unsafe { h.name.as_ptr().offset_from(data_ptr) } as usize;
                     let nl = h.name.len();
+                    // SAFETY: header value pointer is within data (same allocation as data_ptr).
                     let vs = unsafe { h.value.as_ptr().offset_from(data_ptr) } as usize;
                     let vl = h.value.len();
                     self.header_offsets.push((ns, nl, vs, vl));

--- a/nexus-net/src/http/response.rs
+++ b/nexus-net/src/http/response.rs
@@ -371,6 +371,7 @@ impl ResponseReader {
                     // SAFETY: header name/value pointers are within data (same allocation).
                     let ns = unsafe { h.name.as_ptr().offset_from(data_ptr) } as usize;
                     let nl = h.name.len();
+                    // SAFETY: header value pointer is within data (same allocation as data_ptr).
                     let vs = unsafe { h.value.as_ptr().offset_from(data_ptr) } as usize;
                     let vl = h.value.len();
                     debug_assert!(ns + nl <= data.len(), "header name offset out of bounds");

--- a/nexus-notify/examples/perf_local_notify.rs
+++ b/nexus-notify/examples/perf_local_notify.rs
@@ -21,6 +21,8 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics for serialized timestamp counter read.
+    // lfence ensures all prior instructions complete before reading rdtsc.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -30,6 +32,8 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: rdtscp serializes on the read side (waits for prior instructions).
+    // Trailing lfence prevents subsequent instructions from reordering before the read.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-queue/src/mpsc.rs
+++ b/nexus-queue/src/mpsc.rs
@@ -175,6 +175,8 @@ impl<T> Drop for Shared<T> {
         // Drop any remaining elements in the queue
         let mut i = head;
         while i != tail {
+            // SAFETY: slots pointer is valid (allocated in ring_buffer, freed below).
+            // i & mask is in bounds. We have exclusive access (drop requires &mut self).
             let slot = unsafe { &*self.slots.add(i & self.mask) };
             let turn = i >> self.shift;
 

--- a/nexus-queue/src/spmc.rs
+++ b/nexus-queue/src/spmc.rs
@@ -201,6 +201,8 @@ impl<T> Drop for Shared<T> {
         // Drop any remaining elements in the queue
         let mut i = head;
         while i != tail {
+            // SAFETY: slots pointer is valid (allocated in ring_buffer, freed below).
+            // i & mask is in bounds. We have exclusive access (drop requires &mut self).
             let slot = unsafe { &*self.slots.add(i & self.mask) };
             let turn = i >> self.shift;
 

--- a/nexus-queue/src/spsc.rs
+++ b/nexus-queue/src/spsc.rs
@@ -191,6 +191,8 @@ impl<T> Drop for Shared<T> {
 
         let mut i = head;
         while i != tail {
+            // SAFETY: Slots in [head, tail) contain initialized values. We have
+            // exclusive access (drop requires &mut self, both endpoints dropped).
             self.buffer[i & self.mask].with_mut(|ptr| unsafe { (*ptr).assume_init_drop() });
             i = i.wrapping_add(1);
         }
@@ -252,6 +254,8 @@ impl<T> Producer<T> {
         unsafe {
             self.buffer.add(tail & self.mask).write(value);
         }
+        // SAFETY: Same invariant as above — slot is unoccupied. Loom UnsafeCell
+        // requires with_mut for access; the MaybeUninit write is valid on uninit memory.
         #[cfg(loom)]
         self.shared.buffer[tail & self.mask].with_mut(|ptr| unsafe { (*ptr).write(value) });
 
@@ -336,6 +340,9 @@ impl<T> Consumer<T> {
         // written by the producer. head & mask gives a valid index within the buffer.
         #[cfg(not(loom))]
         let value = unsafe { self.buffer.add(head & self.mask).read() };
+        // SAFETY: Same invariant as above — slot contains valid data written by
+        // the producer. Loom UnsafeCell requires with_mut; assume_init_read moves
+        // the value out, and the slot will not be read again until re-written.
         #[cfg(loom)]
         let value = self.shared.buffer[head & self.mask]
             .with_mut(|ptr| unsafe { (*ptr).assume_init_read() });

--- a/nexus-rate/benches/perf_rate.rs
+++ b/nexus-rate/benches/perf_rate.rs
@@ -15,6 +15,8 @@ use nexus_rate::{local, sync};
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics for serialized timestamp counter read.
+    // lfence ensures all prior instructions complete before reading rdtsc.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -23,6 +25,8 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: rdtscp serializes on the read side (waits for prior instructions).
+    // Trailing lfence prevents subsequent instructions from reordering before the read.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-slab/src/bounded.rs
+++ b/nexus-slab/src/bounded.rs
@@ -154,6 +154,7 @@ impl<T> Slab<T> {
         // pointers from the owned Vec and then moving into UnsafeCell gives
         // them stale (read-only) provenance under stacked borrows.
         let slots = core::cell::UnsafeCell::new(slots);
+        // SAFETY: UnsafeCell::get provides write-provenance pointer to the Vec.
         let base = unsafe { (*slots.get()).as_mut_ptr() };
 
         // Wire up the freelist: each slot's next_free points to the next slot
@@ -181,9 +182,8 @@ impl<T> Slab<T> {
     /// Returns the base pointer to the slots array.
     #[inline]
     pub(crate) fn slots_ptr(&self) -> *mut SlotCell<T> {
-        // Derive from *mut Vec (via UnsafeCell::get) to preserve write provenance.
-        // Creating &Vec first would give read-only provenance — writes through
-        // the returned pointer would be UB under stacked/tree borrows.
+        // SAFETY: Derive from *mut Vec (via UnsafeCell::get) to preserve write
+        // provenance. Creating &Vec first would give read-only provenance.
         unsafe { (*self.slots.get()).as_mut_ptr() }
     }
 

--- a/nexus-slab/src/byte/bounded.rs
+++ b/nexus-slab/src/byte/bounded.rs
@@ -119,6 +119,7 @@ impl<const N: usize> Slab<N> {
     /// `ptr` must point to a slot in this slab (claimed or allocated).
     #[inline]
     pub unsafe fn free_raw(&self, ptr: *mut u8) {
+        // SAFETY: Caller guarantees ptr is a valid slot in this slab.
         unsafe {
             self.inner.free_ptr(ptr.cast());
         }
@@ -143,7 +144,7 @@ impl<const N: usize> Slab<N> {
             .claim_ptr()
             .unwrap_or_else(|| panic!("byte slab full"));
         let dst = slot_ptr.cast::<u8>();
-        // SAFETY: caller guarantees src has `size` valid bytes.
+        // SAFETY: dst is a valid vacant slot. Caller guarantees src has `size` valid bytes.
         unsafe { core::ptr::copy_nonoverlapping(src, dst, size) };
         dst
     }
@@ -160,6 +161,9 @@ impl<const N: usize> Slab<N> {
         );
         mem::forget(ptr);
 
+        // SAFETY: Slot handle guarantees data_ptr is valid and occupied with a T.
+        // forget(ptr) disarms the debug leak detector. free_ptr returns the slot
+        // to the freelist after the value is dropped.
         unsafe {
             core::ptr::drop_in_place(data_ptr.cast::<T>());
             self.inner
@@ -179,6 +183,8 @@ impl<const N: usize> Slab<N> {
         );
         mem::forget(ptr);
 
+        // SAFETY: Slot handle guarantees data_ptr is valid and occupied with a T.
+        // read moves the value out, then free_ptr returns the slot to the freelist.
         unsafe {
             let value = core::ptr::read(data_ptr.cast::<T>());
             self.inner
@@ -205,6 +211,7 @@ impl<const N: usize> Slab<N> {
 /// - `slab_ptr` must point to a live `crate::bounded::Slab<AlignedBytes<N>>`.
 /// - `slot_ptr` must point to a slot within that slab.
 unsafe fn free_raw_impl<const N: usize>(slab_ptr: *const u8, slot_ptr: *mut u8, _chunk_idx: usize) {
+    // SAFETY: Caller guarantees slab_ptr points to a live bounded Slab<AlignedBytes<N>>.
     let slab = unsafe { &*(slab_ptr as *const crate::bounded::Slab<super::AlignedBytes<N>>) };
     // SAFETY: Bounded slab has one chunk — chunk_idx is ignored.
     // free_ptr returns the slot to the freelist. For vacant slots

--- a/nexus-slab/src/byte/mod.rs
+++ b/nexus-slab/src/byte/mod.rs
@@ -118,12 +118,14 @@ impl<T> Slot<T> {
     /// Byte slab memory never moves, so `Pin` is sound without `T: Unpin`.
     #[inline]
     pub fn pin(&self) -> core::pin::Pin<&T> {
+        // SAFETY: Byte slab memory never moves after init — Pin is sound.
         unsafe { core::pin::Pin::new_unchecked(&**self) }
     }
 
     /// Returns a pinned mutable reference to the value.
     #[inline]
     pub fn pin_mut(&mut self) -> core::pin::Pin<&mut T> {
+        // SAFETY: Byte slab memory never moves. &mut self guarantees exclusive access.
         unsafe { core::pin::Pin::new_unchecked(&mut **self) }
     }
 }
@@ -252,7 +254,7 @@ impl ByteClaim<'_> {
     pub fn write<T>(self, value: T) -> Slot<T> {
         validate_type_dynamic::<T>(self.slot_size);
 
-        // SAFETY: ptr points to a valid, vacant slot of at least slot_size bytes.
+        // SAFETY: ptr is a valid, vacant slot with slot_size >= size_of::<T>().
         // AlignedBytes guarantees 8-byte alignment. validate_type checked fit.
         unsafe { core::ptr::write(self.ptr.cast::<T>(), value) };
 
@@ -285,7 +287,7 @@ impl ByteClaim<'_> {
             self.slot_size
         );
 
-        // SAFETY: ptr is valid and vacant, caller guarantees src validity.
+        // SAFETY: ptr is valid and vacant with slot_size >= size. Caller guarantees src validity.
         unsafe { core::ptr::copy_nonoverlapping(src, self.ptr, size) };
 
         let ptr = self.ptr;

--- a/nexus-slab/src/byte/unbounded.rs
+++ b/nexus-slab/src/byte/unbounded.rs
@@ -65,8 +65,8 @@ impl<const N: usize> Slab<N> {
 
         let (slot_ptr, _chunk_idx) = self.inner.claim_ptr();
 
-        // SAFETY: slot_ptr is valid and vacant. AlignedBytes<N> is
-        // repr(C, align(8)), suitable for T (asserted above).
+        // SAFETY: slot_ptr is a valid, vacant SlotCell<AlignedBytes<N>>.
+        // AlignedBytes<N> is repr(C, align(8)), suitable for T (asserted above).
         unsafe {
             let data_ptr = slot_ptr.cast::<T>();
             core::ptr::write(data_ptr, value);
@@ -88,7 +88,8 @@ impl<const N: usize> Slab<N> {
         let claim = self.inner.claim();
         let (ptr, chunk_idx) = claim.into_ptr();
         let slab_ptr = core::ptr::from_ref(&self.inner).cast::<u8>();
-        // SAFETY: ptr is a valid vacant slot. chunk_idx identifies the owning chunk.
+        // SAFETY: ptr is a valid, vacant slot. chunk_idx identifies the owning chunk.
+        // free_raw_impl will return it to the correct chunk's freelist on drop.
         unsafe {
             super::ByteClaim::from_raw_parts(
                 ptr.cast::<u8>(),
@@ -107,6 +108,7 @@ impl<const N: usize> Slab<N> {
     /// `ptr` must point to a slot in this slab.
     #[inline]
     pub unsafe fn free_raw(&self, ptr: *mut u8) {
+        // SAFETY: Caller guarantees ptr is a valid slot in this slab.
         unsafe {
             self.inner.free_ptr(ptr.cast());
         }
@@ -119,6 +121,7 @@ impl<const N: usize> Slab<N> {
     /// - `ptr` must point to a slot in chunk `chunk_idx` of this slab.
     #[inline]
     pub unsafe fn free_raw_in_chunk(&self, ptr: *mut u8, chunk_idx: usize) {
+        // SAFETY: Caller guarantees ptr is in chunk chunk_idx of this slab.
         unsafe {
             self.inner.free_ptr_in_chunk(ptr.cast(), chunk_idx);
         }
@@ -139,6 +142,7 @@ impl<const N: usize> Slab<N> {
         assert!(size <= N, "raw alloc size {size} exceeds slot size {N}");
         let (slot_ptr, _chunk_idx) = self.inner.claim_ptr();
         let dst = slot_ptr.cast::<u8>();
+        // SAFETY: dst is a valid vacant slot. Caller guarantees src has `size` valid bytes.
         unsafe { core::ptr::copy_nonoverlapping(src, dst, size) };
         dst
     }
@@ -155,6 +159,9 @@ impl<const N: usize> Slab<N> {
         );
         mem::forget(ptr);
 
+        // SAFETY: Slot handle guarantees data_ptr is valid and occupied with a T.
+        // forget(ptr) disarms the debug leak detector. free_ptr returns the slot
+        // to the freelist after the value is dropped.
         unsafe {
             core::ptr::drop_in_place(data_ptr.cast::<T>());
             self.inner
@@ -174,6 +181,8 @@ impl<const N: usize> Slab<N> {
         );
         mem::forget(ptr);
 
+        // SAFETY: Slot handle guarantees data_ptr is valid and occupied with a T.
+        // read moves the value out, then free_ptr returns the slot to the freelist.
         unsafe {
             let value = core::ptr::read(data_ptr.cast::<T>());
             self.inner
@@ -257,7 +266,7 @@ impl Builder {
     /// Panics if `chunk_capacity` is zero.
     #[inline]
     pub unsafe fn build<const N: usize>(self) -> Slab<N> {
-        // SAFETY: caller upholds the slab contract.
+        // SAFETY: Caller upholds the slab contract.
         let inner = unsafe {
             crate::unbounded::Builder::new()
                 .chunk_capacity(self.chunk_capacity)
@@ -287,7 +296,9 @@ impl core::fmt::Debug for Builder {
 ///
 /// Uses `free_ptr_in_chunk` for O(1) freelist return — no linear scan.
 unsafe fn free_raw_impl<const N: usize>(slab_ptr: *const u8, slot_ptr: *mut u8, chunk_idx: usize) {
+    // SAFETY: Caller guarantees slab_ptr points to a live unbounded Slab<AlignedBytes<N>>.
     let slab = unsafe { &*(slab_ptr as *const crate::unbounded::Slab<super::AlignedBytes<N>>) };
+    // SAFETY: slot_ptr is within chunk chunk_idx. free_ptr_in_chunk returns it to the freelist.
     unsafe {
         slab.free_ptr_in_chunk(slot_ptr.cast(), chunk_idx);
     }

--- a/nexus-slab/src/rc/bounded.rs
+++ b/nexus-slab/src/rc/bounded.rs
@@ -27,6 +27,7 @@ impl<T> Slab<T> {
     #[inline]
     pub unsafe fn with_capacity(capacity: usize) -> Self {
         Self {
+            // SAFETY: Caller upholds the slab contract.
             inner: unsafe { crate::bounded::Slab::with_capacity(capacity) },
         }
     }
@@ -39,6 +40,9 @@ impl<T> Slab<T> {
     #[inline]
     pub fn alloc(&self, value: T) -> RcSlot<T> {
         let slot = self.inner.alloc(RcCell::new(value));
+        // SAFETY: slot is valid and occupied with RcCell<T>. into_raw disarms
+        // the Slot leak detector. The cast is sound because SlotCell value is
+        // at offset 0 (repr(C) union), so *mut SlotCell<RcCell<T>> == *mut RcCell<T>.
         unsafe { RcSlot::from_ptr(slot.into_raw().cast()) }
     }
 
@@ -46,6 +50,7 @@ impl<T> Slab<T> {
     #[inline]
     pub fn try_alloc(&self, value: T) -> Result<RcSlot<T>, Full<T>> {
         match self.inner.try_alloc(RcCell::new(value)) {
+            // SAFETY: Same as alloc — slot is valid, occupied, cast is sound.
             Ok(slot) => Ok(unsafe { RcSlot::from_ptr(slot.into_raw().cast()) }),
             Err(Full(rc_cell)) => Err(Full(rc_cell.into_inner())),
         }
@@ -61,9 +66,12 @@ impl<T> Slab<T> {
     pub fn free(&self, handle: RcSlot<T>) {
         let count = handle.dec_ref();
         if count == 0 {
+            // SAFETY: Refcount is 0 — no other handles exist. Drop the value
+            // and return the slot to the freelist.
             unsafe { handle.drop_value() };
             let cell_ptr = handle.slot_cell_ptr();
             core::mem::forget(handle);
+            // SAFETY: cell_ptr is within this slab. Value already dropped above.
             unsafe { self.inner.free_ptr(cell_ptr) };
         } else {
             core::mem::forget(handle);

--- a/nexus-slab/src/rc/mod.rs
+++ b/nexus-slab/src/rc/mod.rs
@@ -282,7 +282,7 @@ impl<T> RcSlot<T> {
     /// and vice versa.
     #[inline]
     pub unsafe fn value_ptr(&self) -> *const T {
-        // SAFETY: ptr is valid while any RcSlot exists.
+        // SAFETY: ptr is valid while any RcSlot exists (refcount > 0).
         unsafe { (*self.ptr).value_ptr().cast_const() }
     }
 
@@ -294,14 +294,14 @@ impl<T> RcSlot<T> {
     /// (no other pointers or guards are reading/writing the value).
     #[inline]
     pub unsafe fn value_ptr_mut(&self) -> *mut T {
-        // SAFETY: ptr is valid while any RcSlot exists.
+        // SAFETY: ptr is valid while any RcSlot exists (refcount > 0).
         unsafe { (*self.ptr).value_ptr() }
     }
 
     /// Returns the current reference count.
     #[inline]
     pub fn refcount(&self) -> usize {
-        // SAFETY: ptr is valid while any RcSlot exists.
+        // SAFETY: ptr is valid while any RcSlot exists (refcount > 0).
         unsafe { (*self.ptr).refcount() }
     }
 
@@ -312,7 +312,7 @@ impl<T> RcSlot<T> {
     /// Panics if the slot is already borrowed (by any handle, shared or exclusive).
     #[inline]
     pub fn borrow(&self) -> Ref<'_, T> {
-        // SAFETY: ptr is valid.
+        // SAFETY: ptr is valid (refcount > 0). acquire_borrow panics if already borrowed.
         unsafe { (*self.ptr).acquire_borrow() };
         Ref {
             cell: self.ptr,
@@ -327,7 +327,7 @@ impl<T> RcSlot<T> {
     /// Panics if the slot is already borrowed (by any handle, shared or exclusive).
     #[inline]
     pub fn borrow_mut(&self) -> RefMut<'_, T> {
-        // SAFETY: ptr is valid.
+        // SAFETY: ptr is valid (refcount > 0). acquire_borrow panics if already borrowed.
         unsafe { (*self.ptr).acquire_borrow() };
         RefMut {
             cell: self.ptr,
@@ -340,20 +340,21 @@ impl<T> RcSlot<T> {
     /// Slab memory never moves, so Pin is sound without `T: Unpin`.
     #[inline]
     pub fn pin(&self) -> core::pin::Pin<Ref<'_, T>> {
-        // SAFETY: slab memory is stable.
+        // SAFETY: Slab memory never moves after init — Pin is sound.
         unsafe { core::pin::Pin::new_unchecked(self.borrow()) }
     }
 
     /// Returns a pinned mutable reference guard.
     #[inline]
     pub fn pin_mut(&self) -> core::pin::Pin<RefMut<'_, T>> {
+        // SAFETY: Slab memory never moves after init — Pin is sound.
         unsafe { core::pin::Pin::new_unchecked(self.borrow_mut()) }
     }
 
     /// Increments the refcount (used by Clone).
     #[inline]
     fn inc_ref(&self) {
-        // SAFETY: ptr is valid while any RcSlot exists.
+        // SAFETY: ptr is valid while any RcSlot exists (refcount > 0).
         unsafe { (*self.ptr).inc_ref() };
     }
 
@@ -361,6 +362,7 @@ impl<T> RcSlot<T> {
     /// If 0, the caller must free the slot.
     #[inline]
     pub(crate) fn dec_ref(&self) -> usize {
+        // SAFETY: ptr is valid while any RcSlot exists (refcount > 0).
         unsafe { (*self.ptr).dec_ref() }
     }
 
@@ -371,6 +373,7 @@ impl<T> RcSlot<T> {
     /// Must only be called once, when refcount is 0.
     #[inline]
     pub(crate) unsafe fn drop_value(&self) {
+        // SAFETY: Caller guarantees refcount is 0 and this is the only call.
         unsafe { (*self.ptr).drop_value() };
     }
 
@@ -439,7 +442,7 @@ impl<T> Deref for Ref<'_, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY: Borrow bit is set, guaranteeing no other active borrows.
+        // SAFETY: Borrow bit is set — no concurrent mutation. Cell pointer is valid.
         unsafe { (*self.cell).value_ref() }
     }
 }
@@ -447,7 +450,7 @@ impl<T> Deref for Ref<'_, T> {
 impl<T> Drop for Ref<'_, T> {
     #[inline]
     fn drop(&mut self) {
-        // SAFETY: We set the borrow bit in acquire_borrow.
+        // SAFETY: Borrow bit was set by acquire_borrow when this guard was created.
         unsafe { (*self.cell).release_borrow() };
     }
 }
@@ -475,6 +478,7 @@ impl<T> Deref for RefMut<'_, T> {
 
     #[inline]
     fn deref(&self) -> &T {
+        // SAFETY: Borrow bit is set — no concurrent mutation. Cell pointer is valid.
         unsafe { (*self.cell).value_ref() }
     }
 }
@@ -482,7 +486,7 @@ impl<T> Deref for RefMut<'_, T> {
 impl<T> DerefMut for RefMut<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: Borrow bit guarantees exclusive access.
+        // SAFETY: Borrow bit guarantees exclusive access. Cell pointer is valid.
         unsafe { (*self.cell).value_mut() }
     }
 }
@@ -490,6 +494,7 @@ impl<T> DerefMut for RefMut<'_, T> {
 impl<T> Drop for RefMut<'_, T> {
     #[inline]
     fn drop(&mut self) {
+        // SAFETY: Borrow bit was set by acquire_borrow when this guard was created.
         unsafe { (*self.cell).release_borrow() };
     }
 }

--- a/nexus-slab/src/rc/unbounded.rs
+++ b/nexus-slab/src/rc/unbounded.rs
@@ -19,6 +19,7 @@ impl<T> Slab<T> {
     #[inline]
     pub unsafe fn with_chunk_capacity(chunk_capacity: usize) -> Self {
         Self {
+            // SAFETY: Caller upholds the slab contract.
             inner: unsafe { crate::unbounded::Slab::with_chunk_capacity(chunk_capacity) },
         }
     }
@@ -27,6 +28,8 @@ impl<T> Slab<T> {
     #[inline]
     pub fn alloc(&self, value: T) -> RcSlot<T> {
         let slot = self.inner.alloc(RcCell::new(value));
+        // SAFETY: slot is valid and occupied with RcCell<T>. Cast is sound
+        // because SlotCell value is at offset 0 (repr(C) union).
         unsafe { RcSlot::from_ptr(slot.into_raw().cast()) }
     }
 
@@ -38,9 +41,12 @@ impl<T> Slab<T> {
     pub fn free(&self, handle: RcSlot<T>) {
         let count = handle.dec_ref();
         if count == 0 {
+            // SAFETY: Refcount is 0 — no other handles exist. Drop the value
+            // and return the slot to the freelist.
             unsafe { handle.drop_value() };
             let cell_ptr = handle.slot_cell_ptr();
             core::mem::forget(handle);
+            // SAFETY: cell_ptr is within this slab. Value already dropped above.
             unsafe { self.inner.free_ptr(cell_ptr) };
         } else {
             core::mem::forget(handle);

--- a/nexus-slab/src/unbounded.rs
+++ b/nexus-slab/src/unbounded.rs
@@ -87,14 +87,14 @@ impl<T> fmt::Debug for Claim<'_, T> {
 
 impl<T> Drop for Claim<'_, T> {
     fn drop(&mut self) {
-        // Abandoned claim - return slot to the correct chunk's freelist
+        // Abandoned claim — return slot to the correct chunk's freelist
         let chunk = self.slab.chunk(self.chunk_idx);
         let chunk_slab = &*chunk.inner;
 
         let free_head = chunk_slab.free_head.get();
         let was_full = free_head.is_null();
 
-        // SAFETY: slot_ptr is valid and still vacant (never written to)
+        // SAFETY: slot_ptr is valid and vacant (claim was never written to).
         unsafe {
             (*self.slot_ptr).set_next_free(free_head);
         }
@@ -207,6 +207,8 @@ impl<T> Slab<T> {
     fn chunk(&self, chunk_idx: usize) -> &ChunkEntry<T> {
         let chunks = self.chunks();
         debug_assert!(chunk_idx < chunks.len());
+        // SAFETY: chunk_idx is validated by debug_assert above. In release,
+        // callers guarantee validity (from claim_ptr or freelist bookkeeping).
         unsafe { chunks.get_unchecked(chunk_idx) }
     }
 
@@ -407,6 +409,7 @@ impl<T> Slab<T> {
         let free_head = chunk_slab.free_head.get();
         let was_full = free_head.is_null();
 
+        // SAFETY: Caller guarantees slot_ptr is in chunk chunk_idx, transitioning to vacant.
         unsafe {
             (*slot_ptr).set_next_free(free_head);
         }

--- a/nexus-slot/src/lib.rs
+++ b/nexus-slot/src/lib.rs
@@ -103,7 +103,8 @@ pub unsafe trait Pod: Sized {
     };
 }
 
-// Any Copy type is Pod
+// SAFETY: Copy types are byte-copyable, have no drop glue, and own no resources.
+// This is the canonical set of Pod guarantees.
 unsafe impl<T: Copy> Pod for T {}
 
 /// Atomically stores `size_of::<T>()` bytes into shared memory.
@@ -119,6 +120,8 @@ unsafe impl<T: Copy> Pod for T {}
 /// - `dst` must be derived from `UnsafeCell` (shared-mutable provenance)
 #[inline]
 pub(crate) unsafe fn atomic_store<T: Pod>(dst: *mut T, src: &T) {
+    // SAFETY: Caller guarantees dst is valid, aligned, and from UnsafeCell.
+    // Pod bound ensures T is byte-copyable with no drop glue.
     unsafe {
         let dst = dst.cast::<u8>();
         let src = (src as *const T).cast::<u8>();
@@ -161,6 +164,9 @@ pub(crate) unsafe fn atomic_store<T: Pod>(dst: *mut T, src: &T) {
 /// - `src` must be derived from `UnsafeCell` (shared-mutable provenance)
 #[inline]
 pub(crate) unsafe fn atomic_load<T: Pod>(src: *const T) -> T {
+    // SAFETY: Caller guarantees src is valid, aligned, and from UnsafeCell.
+    // Pod bound ensures T is byte-copyable; assume_init is sound because all
+    // bytes are written by the atomic loads before we return.
     unsafe {
         let mut buf = MaybeUninit::<T>::uninit();
         let dst = buf.as_mut_ptr().cast::<u8>();

--- a/nexus-slot/src/spmc.rs
+++ b/nexus-slot/src/spmc.rs
@@ -43,6 +43,10 @@ struct Inner<T> {
     data: UnsafeCell<MaybeUninit<T>>,
 }
 
+// SAFETY: Inner is shared via Arc between one Writer and multiple SharedReaders.
+// All access to `data` goes through word-at-a-time atomics (atomic_store/atomic_load),
+// and the seqlock protocol ensures no torn reads. T: Send is required because
+// values cross thread boundaries. writer_alive uses atomic ordering for visibility.
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Send> Sync for Inner<T> {}
 
@@ -52,6 +56,9 @@ pub struct Writer<T> {
     inner: Arc<Inner<T>>,
 }
 
+// SAFETY: Writer holds an Arc<Inner<T>> and is the sole writer. Sending it to
+// another thread is safe because T: Send and the seqlock protocol coordinates
+// all shared access to Inner's data.
 unsafe impl<T: Send> Send for Writer<T> {}
 
 /// The reading half of a shared conflated slot.
@@ -64,6 +71,9 @@ pub struct SharedReader<T> {
     inner: Arc<Inner<T>>,
 }
 
+// SAFETY: SharedReader holds an Arc<Inner<T>> and only reads via the seqlock
+// protocol. Each reader's cached_seq is private (not shared). Sending to
+// another thread is safe because T: Send and all data access is atomic.
 unsafe impl<T: Send> Send for SharedReader<T> {}
 
 impl<T> Clone for SharedReader<T> {

--- a/nexus-slot/src/spsc.rs
+++ b/nexus-slot/src/spsc.rs
@@ -36,6 +36,10 @@ struct Inner<T> {
     data: UnsafeCell<MaybeUninit<T>>,
 }
 
+// SAFETY: Inner is shared via Arc between exactly one Writer and one Reader,
+// each on potentially different threads. All access to `data` goes through
+// word-at-a-time atomics (atomic_store/atomic_load), and the seqlock protocol
+// ensures no torn reads. T: Send is required because values cross thread boundaries.
 unsafe impl<T: Send> Send for Inner<T> {}
 unsafe impl<T: Send> Sync for Inner<T> {}
 
@@ -45,6 +49,9 @@ pub struct Writer<T> {
     inner: Arc<Inner<T>>,
 }
 
+// SAFETY: Writer holds an Arc<Inner<T>> and is the sole writer. Sending it to
+// another thread is safe because T: Send and the seqlock protocol coordinates
+// all shared access to Inner's data.
 unsafe impl<T: Send> Send for Writer<T> {}
 
 /// The reading half of a conflated slot.
@@ -53,6 +60,9 @@ pub struct Reader<T> {
     inner: Arc<Inner<T>>,
 }
 
+// SAFETY: Reader holds an Arc<Inner<T>> and is the sole reader. Sending it to
+// another thread is safe because T: Send and the seqlock protocol coordinates
+// all shared access to Inner's data.
 unsafe impl<T: Send> Send for Reader<T> {}
 
 /// Creates a new SPSC conflated slot.

--- a/nexus-stats/examples/perf_stats.rs
+++ b/nexus-stats/examples/perf_stats.rs
@@ -30,6 +30,8 @@ use nexus_stats::{
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics for serialized timestamp counter read.
+    // lfence ensures all prior instructions complete before reading rdtsc.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -38,6 +40,8 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: rdtscp serializes on the read side (waits for prior instructions).
+    // Trailing lfence prevents subsequent instructions from reordering before the read.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -396,8 +396,9 @@ impl<T: 'static, S: BoundedStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             }
             Err(full) => {
                 // Extract the user's T from the WheelEntry wrapper
-                // SAFETY: we just constructed this entry, take_value is valid
                 let wheel_entry = full.into_inner();
+                // SAFETY: entry was just constructed with Some(value) and never inserted
+                // into the wheel — no other code has accessed it. Single-threaded.
                 let value = unsafe { wheel_entry.take_value() }
                     .expect("entry was just constructed with Some(value)");
                 Err(Full(value))
@@ -422,6 +423,8 @@ impl<T: 'static, S: BoundedStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             }
             Err(full) => {
                 let wheel_entry = full.into_inner();
+                // SAFETY: entry was just constructed with Some(value) and never inserted
+                // into the wheel — no other code has accessed it. Single-threaded.
                 let value = unsafe { wheel_entry.take_value() }
                     .expect("entry was just constructed with Some(value)");
                 Err(Full(value))
@@ -454,6 +457,8 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
 
         if refs == 2 {
             // Active timer with handle — unlink, extract, free
+            // SAFETY: single-threaded access; entry is still in the wheel (refs==2),
+            // so the value has not been taken by fire_entry.
             let value = unsafe { entry.take_value() };
             let cancelled_deadline = entry.deadline_ticks();
             self.remove_entry(ptr);
@@ -807,6 +812,8 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
                 let next_entry = entry.next();
 
                 if entry.deadline_ticks() <= now_ticks {
+                    // SAFETY: entry_ptr is in this slot's DLL (obtained from entry_head
+                    // and walked via next pointers within the same slot).
                     unsafe { slot.remove_entry(entry_ptr) };
 
                     if let Some(value) = self.fire_entry(entry_ptr) {


### PR DESCRIPTION
## Summary

Adds `// SAFETY:` comments to every `unsafe` block across the workspace that was missing one. Two phases:

**Phase 1 — small crates (14 crates, 26 files)**
- nexus-slot: 11 comments (Pod blanket impl, Send/Sync for SPSC/SPMC)
- nexus-logbuf: 14 comments (Send/Sync case normalization, Polonius workaround annotations)
- nexus-queue: 5 comments (loom code paths, drop impls for MPSC/SPMC)
- nexus-timer: 4 comments (wheel.rs entry operations)
- nexus-id: 5 comments (SIMD intrinsics — SSE2/SSSE3)
- nexus-async-net: 4 comments (no-op Waker in test helpers)
- nexus-net: 2 comments (HTTP header offset_from)
- nexus-channel, nexus-notify, nexus-stats, nexus-rate: rdtsc intrinsics in benches/examples
- nexus-pool, nexus-stats-core, nexus-stats-smoothing: already compliant

**Phase 2 — big three (3 crates, 30 files)**
- nexus-collections: 109 comments (101 in btree.rs, 8 in rbtree.rs; list.rs and heap.rs already complete)
- nexus-async-rt: ~100+ comments across 20 files (RawWaker vtable, task state machine, cross-thread wake queue, UnsafeCell access, Send/Sync impls, test harness)
- nexus-slab: ~30 comments across 9 files (SlotCell union access, freelist manipulation, Pin soundness, borrow guards, rc subsystem)

## Approach

- Each comment describes the specific invariant that makes the unsafe sound — no boilerplate
- For repetitive patterns (slab `get_unchecked`, btree node access), concise one-liners
- `unsafe fn` with existing `# Safety` doc sections left as-is
- Send/Sync impls document the threading model that justifies them
- No functional changes — comments only

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] All agents verified crate-level tests pass
- [x] No functional code changes — zero risk of behavioral regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)