### PR TITLE
nexus-stats-detection: PageHinkley, ADWIN, PredictiveInfoBound (#286, #287)

### DIFF
--- a/nexus-stats-core/CHANGELOG.md
+++ b/nexus-stats-core/CHANGELOG.md
@@ -10,6 +10,31 @@ contained.
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-05-18
+
+Clock trait and Instant type removal.
+
+### Added
+
+- **`clock` module.** `Clock` trait (`stamp() -> u64`), `WallClock` (std,
+  wraps `Instant`, returns elapsed nanos), `EpochClock` (manual/test clock
+  with `set()`/`advance()`). Stats types accept `u64` timestamps; the caller
+  owns the clock.
+- **`elapsed(from, to)` helper** — saturating u64 subtraction.
+
+### Removed
+
+- **All `Instant`-based stats types.** `WindowedMax/MinF64/F32/I64/I32/I128`,
+  `CoDelF64/F32/I64/I32/I128` (Instant variants), `LivenessInstant`,
+  `EventRateInstant`, and `BucketAccumulator::update_instant()`. Epoch
+  management belongs in the Clock, not the stats type.
+
+### Changed
+
+- **Renamed Raw variants to canonical.** `WindowedMaxF64Raw` → `WindowedMaxF64`,
+  `CoDelF64Raw` → `CoDelF64`, etc. The `Raw` suffix was disambiguation for
+  the now-removed Instant variants.
+
 ## [1.2.1] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-stats-core/README.md
+++ b/nexus-stats-core/README.md
@@ -3,10 +3,10 @@
 Core types shared across the nexus-stats ecosystem.
 
 This crate provides the fundamental streaming statistics types: error enums,
-math utilities, core smoothing (EMA, AsymEma, Slew), statistics (Welford,
-Moments, EwmaVar, Covariance, HarmonicMean, Percentile), monitoring, core
-detection (CUSUM), and core control types (DeadBand, Hysteresis, Debounce,
-LevelCrossing, Diff).
+math utilities, clock trait (`Clock`, `WallClock`, `EpochClock`), core smoothing
+(EMA, AsymEma, Slew), statistics (Welford, Moments, EwmaVar, Covariance,
+HarmonicMean, Percentile), monitoring, core detection (CUSUM), and core
+control types (DeadBand, Hysteresis, Debounce, LevelCrossing, Diff).
 
 **Not intended for direct use** — import from
 [`nexus-stats`](https://crates.io/crates/nexus-stats) instead.

--- a/nexus-stats-detection/CHANGELOG.md
+++ b/nexus-stats-detection/CHANGELOG.md
@@ -10,6 +10,19 @@ contained.
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-05-18
+
+### Added
+
+- **`PageHinkleyF64` / `PageHinkleyF32`** — sequential test for mean drift.
+  O(1) per update, two-sided (detects upward and downward shifts).
+- **`AdwinF64` / `AdwinF32`** — adaptive windowing for distribution change
+  detection (Bifet & Gavalda, 2007). O(log n) per update, O(log n) memory.
+  Requires `alloc` + (`std` or `libm`).
+- **`PredictiveInfoBoundF64` / `PredictiveInfoBoundF32`** — streaming binned
+  mutual information I(X;Y) with Miller-Madow bias correction. Equi-width
+  bins on user-specified ranges. Requires `alloc` + (`std` or `libm`).
+
 ## [1.0.1] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-stats-detection/Cargo.toml
+++ b/nexus-stats-detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-stats-detection"
-version = "1.0.1"
+version = "1.1.0"
 description = "Advanced change detection and signal analysis for nexus-stats"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-stats-detection/README.md
+++ b/nexus-stats-detection/README.md
@@ -10,6 +10,8 @@ Advanced change detection and signal analysis for [nexus-stats](https://crates.i
 - **RobustZScoreF64** — Median-based robust Z-score anomaly detection
 - **TrendAlertF64** — Holt-based trend alerting
 - **MultiGateF64** — Multi-threshold gating
+- **PageHinkleyF64** — Sequential mean drift detection (Page-Hinkley test)
+- **AdwinF64** — Adaptive window distribution change detection (requires `alloc` + (`std` or `libm`))
 
 ## Signal Types
 
@@ -17,6 +19,7 @@ Advanced change detection and signal analysis for [nexus-stats](https://crates.i
 - **CrossCorrelationF64** — Lagged cross-correlation (requires `alloc`)
 - **EntropyF64** — Shannon entropy estimation (requires `alloc` + (`std` or `libm`))
 - **TransferEntropyF64** — Transfer entropy between series (requires `alloc` + (`std` or `libm`))
+- **PredictiveInfoBoundF64** — Binned mutual information estimation (requires `alloc` + (`std` or `libm`))
 
 ## Estimation Types
 

--- a/nexus-stats-detection/src/adwin.rs
+++ b/nexus-stats-detection/src/adwin.rs
@@ -1,0 +1,542 @@
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::Vec;
+use nexus_stats_core::DataError;
+
+#[derive(Debug, Clone, Copy)]
+struct Bucket {
+    total: f64,
+    variance: f64,
+    count: u64,
+}
+
+#[derive(Debug, Clone)]
+struct BucketList {
+    levels: Vec<Vec<Bucket>>,
+    max_buckets: usize,
+}
+
+impl BucketList {
+    fn new(max_buckets: usize) -> Self {
+        Self {
+            levels: vec![Vec::new()],
+            max_buckets,
+        }
+    }
+
+    fn insert(&mut self, value: f64) {
+        self.levels[0].push(Bucket {
+            total: value,
+            variance: 0.0,
+            count: 1,
+        });
+        self.compress();
+    }
+
+    fn compress(&mut self) {
+        for level in 0.. {
+            if level >= self.levels.len() {
+                break;
+            }
+            if self.levels[level].len() <= self.max_buckets {
+                break;
+            }
+
+            if level + 1 >= self.levels.len() {
+                self.levels.push(Vec::new());
+            }
+
+            let b2 = self.levels[level].remove(0);
+            let b1 = self.levels[level].remove(0);
+            let merged = Self::merge_buckets(b1, b2);
+            self.levels[level + 1].push(merged);
+        }
+    }
+
+    fn merge_buckets(a: Bucket, b: Bucket) -> Bucket {
+        let count = a.count + b.count;
+        let total = a.total + b.total;
+        let mean_a = a.total / a.count as f64;
+        let mean_b = b.total / b.count as f64;
+        let delta = mean_b - mean_a;
+        let variance = a.variance
+            + b.variance
+            + delta * delta * a.count as f64 * b.count as f64 / count as f64;
+        Bucket {
+            total,
+            variance,
+            count,
+        }
+    }
+
+    fn drop_oldest(&mut self) -> u64 {
+        for level in (0..self.levels.len()).rev() {
+            if !self.levels[level].is_empty() {
+                let removed = self.levels[level].remove(0);
+                return removed.count;
+            }
+        }
+        0
+    }
+
+    fn reset(&mut self) {
+        self.levels.clear();
+        self.levels.push(Vec::new());
+    }
+}
+
+macro_rules! impl_adwin {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// ADWIN — Adaptive Windowing for distribution change detection.
+        ///
+        /// Maintains a variable-length window using an exponential histogram.
+        /// Detects distribution changes by testing all possible splits via
+        /// Hoeffding bound. Automatically shrinks the window on detection.
+        ///
+        /// O(log n) amortized per update, O(log n) memory.
+        ///
+        /// Bifet & Gavalda, 2007.
+        ///
+        /// # Parameters
+        ///
+        /// - `delta` (δ) — confidence parameter. Smaller values reduce false
+        ///   positives but increase detection delay. Typical: 0.002.
+        /// - `max_buckets` — buckets per level (default 5). Higher values
+        ///   increase precision but use more memory.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_detection::detection::AdwinF64;
+        ///
+        /// let mut ad = AdwinF64::builder()
+        ///     .delta(0.01)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// // Stable signal — no detection
+        /// for _ in 0..100 {
+        ///     assert!(!ad.update(5.0).unwrap());
+        /// }
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            delta: $ty,
+            buckets: BucketList,
+            total: $ty,
+            variance: $ty,
+            width: u64,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            delta: Option<$ty>,
+            max_buckets: usize,
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    delta: Option::None,
+                    max_buckets: 5,
+                    min_samples: 30,
+                }
+            }
+
+            /// Feeds a sample. Returns `Ok(true)` if distribution change detected.
+            ///
+            /// On detection, the window shrinks to exclude the stale portion.
+            /// `count()` reflects total samples seen; `width()` reflects the
+            /// current (post-shrink) window size.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the sample is NaN, or
+            /// `DataError::Infinite` if the sample is infinite.
+            pub fn update(&mut self, sample: $ty) -> Result<bool, DataError> {
+                check_finite!(sample);
+                self.count += 1;
+                self.width += 1;
+
+                self.buckets.insert(sample as f64);
+                self.total += sample;
+
+                if self.width > 1 {
+                    let mean = self.total / self.width as $ty;
+                    let delta_val = sample - mean;
+                    self.variance += delta_val * (sample - self.total / self.width as $ty);
+                }
+
+                if !self.is_primed() {
+                    return Ok(false);
+                }
+
+                Ok(self.check_and_shrink())
+            }
+
+            fn check_and_shrink(&mut self) -> bool {
+                let mut changed = false;
+
+                while self.width > 2 {
+                    let mut n0: u64 = 0;
+                    let mut sum0: f64 = 0.0;
+                    let mut found_cut = false;
+
+                    'outer: for level in (0..self.buckets.levels.len()).rev() {
+                        for bi in 0..self.buckets.levels[level].len() {
+                            let b = &self.buckets.levels[level][bi];
+                            n0 += b.count;
+                            sum0 += b.total;
+
+                            let n1 = self.width - n0;
+                            if n0 == 0 || n1 == 0 {
+                                continue;
+                            }
+
+                            let sum1 = self.total as f64 - sum0;
+                            let mean0 = sum0 / n0 as f64;
+                            let mean1 = sum1 / n1 as f64;
+                            let diff = (mean0 - mean1).abs();
+
+                            let m = 1.0 / n0 as f64 + 1.0 / n1 as f64;
+                            let dd = self.delta as f64;
+                            let eps = nexus_stats_core::math::sqrt(
+                                0.5 * m * nexus_stats_core::math::ln(4.0 / dd),
+                            );
+
+                            if diff >= eps {
+                                found_cut = true;
+                                break 'outer;
+                            }
+                        }
+                    }
+
+                    if !found_cut {
+                        break;
+                    }
+
+                    let removed = self.buckets.drop_oldest();
+                    if removed == 0 {
+                        break;
+                    }
+
+                    let old_width = self.width;
+                    self.width -= removed;
+
+                    let new_total_f64 = {
+                        let mut s = 0.0_f64;
+                        for level in &self.buckets.levels {
+                            for b in level {
+                                s += b.total;
+                            }
+                        }
+                        s
+                    };
+                    self.total = new_total_f64 as $ty;
+
+                    if self.width > 0 && old_width > 0 {
+                        let ratio = self.width as $ty / old_width as $ty;
+                        self.variance *= ratio;
+                    }
+
+                    changed = true;
+                }
+
+                changed
+            }
+
+            /// Current window size (shrinks on detection).
+            #[inline]
+            #[must_use]
+            pub fn width(&self) -> u64 {
+                self.width
+            }
+
+            /// Current window mean, or `None` if empty.
+            #[inline]
+            #[must_use]
+            pub fn mean(&self) -> Option<$ty> {
+                if self.width == 0 {
+                    Option::None
+                } else {
+                    Option::Some(self.total / self.width as $ty)
+                }
+            }
+
+            /// Total samples ever seen (does not decrease on shrink).
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether the detector has reached `min_samples`.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets to empty state. Parameters unchanged.
+            pub fn reset(&mut self) {
+                self.buckets.reset();
+                self.total = 0.0 as $ty;
+                self.variance = 0.0 as $ty;
+                self.width = 0;
+                self.count = 0;
+            }
+        }
+
+        impl $builder {
+            /// Confidence parameter (δ). Required, must be in (0, 1).
+            ///
+            /// Smaller values reduce false positives but increase detection delay.
+            /// Typical: 0.002.
+            #[inline]
+            #[must_use]
+            pub fn delta(mut self, delta: $ty) -> Self {
+                self.delta = Option::Some(delta);
+                self
+            }
+
+            /// Buckets per level (default 5, must be >= 2).
+            ///
+            /// Higher values increase precision but use more memory.
+            #[inline]
+            #[must_use]
+            pub fn max_buckets(mut self, max_buckets: usize) -> Self {
+                self.max_buckets = max_buckets;
+                self
+            }
+
+            /// Minimum samples before detection activates. Default: 30.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = min;
+                self
+            }
+
+            /// Builds the ADWIN detector.
+            ///
+            /// # Errors
+            ///
+            /// - Delta must have been set and be in (0, 1).
+            /// - `max_buckets` must be >= 2.
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let delta = self
+                    .delta
+                    .ok_or(nexus_stats_core::ConfigError::Missing("delta"))?;
+                if delta <= 0.0 as $ty || delta >= 1.0 as $ty || delta.is_nan() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "ADWIN delta must be in (0, 1)",
+                    ));
+                }
+                if self.max_buckets < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "ADWIN max_buckets must be >= 2",
+                    ));
+                }
+
+                Ok($name {
+                    delta,
+                    buckets: BucketList::new(self.max_buckets),
+                    total: 0.0 as $ty,
+                    variance: 0.0 as $ty,
+                    width: 0,
+                    count: 0,
+                    min_samples: self.min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_adwin!(AdwinF64, AdwinF64Builder, f64);
+impl_adwin!(AdwinF32, AdwinF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_drift_stable() {
+        let mut ad = AdwinF64::builder()
+            .delta(0.01)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        for _ in 0..500 {
+            assert!(!ad.update(10.0).unwrap());
+        }
+    }
+
+    #[test]
+    fn mean_shift_detected() {
+        let mut ad = AdwinF64::builder()
+            .delta(0.002)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for _ in 0..500 {
+            let _ = ad.update(0.0);
+        }
+
+        let mut detected = false;
+        for _ in 0..500 {
+            if ad.update(5.0).unwrap() {
+                detected = true;
+                break;
+            }
+        }
+        assert!(detected, "should detect mean shift from 0 to 5");
+    }
+
+    #[test]
+    fn window_shrinks_on_detection() {
+        let mut ad = AdwinF64::builder()
+            .delta(0.002)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for _ in 0..500 {
+            let _ = ad.update(0.0);
+        }
+        let width_before = ad.width();
+
+        for _ in 0..500 {
+            if ad.update(10.0).unwrap() {
+                break;
+            }
+        }
+
+        assert!(
+            ad.width() < width_before + 500,
+            "window should have shrunk after detection"
+        );
+    }
+
+    #[test]
+    fn mean_tracks_recent() {
+        let mut ad = AdwinF64::builder()
+            .delta(0.002)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for _ in 0..500 {
+            let _ = ad.update(0.0);
+        }
+
+        for _ in 0..500 {
+            let _ = ad.update(10.0);
+        }
+
+        let mean = ad.mean().unwrap();
+        assert!(
+            mean > 5.0,
+            "mean should track recent distribution, got {mean}"
+        );
+    }
+
+    #[test]
+    fn sensitivity_vs_delta() {
+        let mut sensitive = AdwinF64::builder()
+            .delta(0.5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        let mut conservative = AdwinF64::builder()
+            .delta(0.001)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for _ in 0..200 {
+            let _ = sensitive.update(0.0);
+            let _ = conservative.update(0.0);
+        }
+
+        let mut sensitive_fired = 0u64;
+        let mut conservative_fired = 0u64;
+        for _ in 0..200 {
+            if sensitive.update(2.0).unwrap() && sensitive_fired == 0 {
+                sensitive_fired = sensitive.count();
+            }
+            if conservative.update(2.0).unwrap() && conservative_fired == 0 {
+                conservative_fired = conservative.count();
+            }
+        }
+
+        if sensitive_fired > 0 && conservative_fired > 0 {
+            assert!(
+                sensitive_fired <= conservative_fired,
+                "larger delta should detect sooner: sensitive={sensitive_fired}, conservative={conservative_fired}"
+            );
+        }
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut ad = AdwinF64::builder()
+            .delta(0.01)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for _ in 0..100 {
+            let _ = ad.update(5.0);
+        }
+
+        ad.reset();
+        assert_eq!(ad.count(), 0);
+        assert_eq!(ad.width(), 0);
+        assert!(ad.mean().is_none());
+        assert!(!ad.is_primed());
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut ad = AdwinF64::builder().delta(0.01).build().unwrap();
+        assert!(matches!(ad.update(f64::NAN), Err(DataError::NotANumber)));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut ad = AdwinF64::builder().delta(0.01).build().unwrap();
+        assert!(matches!(ad.update(f64::INFINITY), Err(DataError::Infinite)));
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(matches!(
+            AdwinF64::builder().build(),
+            Err(nexus_stats_core::ConfigError::Missing("delta"))
+        ));
+        assert!(matches!(
+            AdwinF64::builder().delta(0.0).build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+        assert!(matches!(
+            AdwinF64::builder().delta(1.0).build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+        assert!(matches!(
+            AdwinF64::builder().delta(0.01).max_buckets(1).build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+    }
+}

--- a/nexus-stats-detection/src/adwin.rs
+++ b/nexus-stats-detection/src/adwin.rs
@@ -6,7 +6,6 @@ use nexus_stats_core::DataError;
 #[derive(Debug, Clone, Copy)]
 struct Bucket {
     total: f64,
-    variance: f64,
     count: u64,
 }
 
@@ -27,7 +26,6 @@ impl BucketList {
     fn insert(&mut self, value: f64) {
         self.levels[0].push(Bucket {
             total: value,
-            variance: 0.0,
             count: 1,
         });
         self.compress();
@@ -54,18 +52,9 @@ impl BucketList {
     }
 
     fn merge_buckets(a: Bucket, b: Bucket) -> Bucket {
-        let count = a.count + b.count;
-        let total = a.total + b.total;
-        let mean_a = a.total / a.count as f64;
-        let mean_b = b.total / b.count as f64;
-        let delta = mean_b - mean_a;
-        let variance = a.variance
-            + b.variance
-            + delta * delta * a.count as f64 * b.count as f64 / count as f64;
         Bucket {
-            total,
-            variance,
-            count,
+            total: a.total + b.total,
+            count: a.count + b.count,
         }
     }
 
@@ -97,6 +86,11 @@ macro_rules! impl_adwin {
         ///
         /// Bifet & Gavalda, 2007.
         ///
+        /// **Note:** The Hoeffding bound assumes bounded support. For best
+        /// results, normalize inputs to a known range (e.g. \[0, 1\]).
+        /// Detection still works on raw values but `delta` loses its
+        /// strict confidence interpretation.
+        ///
         /// # Parameters
         ///
         /// - `delta` (δ) — confidence parameter. Smaller values reduce false
@@ -124,7 +118,6 @@ macro_rules! impl_adwin {
             delta: $ty,
             buckets: BucketList,
             total: $ty,
-            variance: $ty,
             width: u64,
             count: u64,
             min_samples: u64,
@@ -169,12 +162,6 @@ macro_rules! impl_adwin {
 
                 self.buckets.insert(sample as f64);
                 self.total += sample;
-
-                if self.width > 1 {
-                    let mean = self.total / self.width as $ty;
-                    let delta_val = sample - mean;
-                    self.variance += delta_val * (sample - self.total / self.width as $ty);
-                }
 
                 if !self.is_primed() {
                     return Ok(false);
@@ -229,7 +216,6 @@ macro_rules! impl_adwin {
                         break;
                     }
 
-                    let old_width = self.width;
                     self.width -= removed;
 
                     let new_total_f64 = {
@@ -242,11 +228,6 @@ macro_rules! impl_adwin {
                         s
                     };
                     self.total = new_total_f64 as $ty;
-
-                    if self.width > 0 && old_width > 0 {
-                        let ratio = self.width as $ty / old_width as $ty;
-                        self.variance *= ratio;
-                    }
 
                     changed = true;
                 }
@@ -290,7 +271,6 @@ macro_rules! impl_adwin {
             pub fn reset(&mut self) {
                 self.buckets.reset();
                 self.total = 0.0 as $ty;
-                self.variance = 0.0 as $ty;
                 self.width = 0;
                 self.count = 0;
             }
@@ -351,7 +331,6 @@ macro_rules! impl_adwin {
                     delta,
                     buckets: BucketList::new(self.max_buckets),
                     total: 0.0 as $ty,
-                    variance: 0.0 as $ty,
                     width: 0,
                     count: 0,
                     min_samples: self.min_samples,

--- a/nexus-stats-detection/src/lib.rs
+++ b/nexus-stats-detection/src/lib.rs
@@ -7,8 +7,8 @@
 //! and hypothesis testing types separated from the core `nexus-stats` crate.
 //!
 //! Types are organized into submodules:
-//! - [`detection`] — MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate
-//! - [`signal`] — Autocorrelation, CrossCorrelation, Entropy, TransferEntropy
+//! - [`detection`] — MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate, PageHinkley, ADWIN
+//! - [`signal`] — Autocorrelation, CrossCorrelation, Entropy, TransferEntropy, PredictiveInfoBound
 //! - [`estimation`] — SPRT (Bernoulli, Gaussian)
 
 #[cfg(feature = "alloc")]
@@ -29,11 +29,14 @@ macro_rules! check_finite {
 
 // Internal modules
 mod multi_gate;
+mod page_hinkley;
 mod robust_z;
 mod trend_alert;
 
 #[cfg(any(feature = "std", feature = "libm"))]
 mod adaptive_threshold;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod adwin;
 #[cfg(feature = "alloc")]
 mod mosum;
 #[cfg(any(feature = "std", feature = "libm"))]
@@ -44,11 +47,14 @@ mod sprt;
 /// Advanced change detection types.
 pub mod detection {
     pub use super::multi_gate::*;
+    pub use super::page_hinkley::*;
     pub use super::robust_z::*;
     pub use super::trend_alert::*;
 
     #[cfg(any(feature = "std", feature = "libm"))]
     pub use super::adaptive_threshold::*;
+    #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+    pub use super::adwin::*;
     #[cfg(feature = "alloc")]
     pub use super::mosum::*;
     #[cfg(any(feature = "std", feature = "libm"))]

--- a/nexus-stats-detection/src/page_hinkley.rs
+++ b/nexus-stats-detection/src/page_hinkley.rs
@@ -1,0 +1,373 @@
+use nexus_stats_core::DataError;
+
+macro_rules! impl_page_hinkley {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// Page-Hinkley — sequential test for mean drift.
+        ///
+        /// Accumulates deviations from the running mean. Fires when the
+        /// difference between the cumulative sum and its running minimum
+        /// (or maximum) exceeds the threshold. O(1) per update.
+        ///
+        /// Two-sided: detects both upward and downward mean shifts.
+        ///
+        /// # Parameters
+        ///
+        /// - `threshold` (λ) — detection sensitivity. Larger values
+        ///   reduce false positives but increase detection delay.
+        /// - `alpha` (δ) — magnitude tolerance. The minimum shift size
+        ///   worth detecting. Deviations smaller than `alpha` are absorbed.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_detection::detection::PageHinkleyF64;
+        ///
+        /// let mut ph = PageHinkleyF64::builder()
+        ///     .threshold(50.0)
+        ///     .alpha(0.5)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// // Stable signal — no detection
+        /// for _ in 0..100 {
+        ///     assert!(!ph.update(10.0).unwrap());
+        /// }
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            threshold: $ty,
+            alpha: $ty,
+            mean: $ty,
+            sum_pos: $ty,
+            sum_neg: $ty,
+            min_pos: $ty,
+            max_neg: $ty,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            threshold: Option<$ty>,
+            alpha: Option<$ty>,
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    threshold: Option::None,
+                    alpha: Option::None,
+                    min_samples: 30,
+                }
+            }
+
+            /// Feeds a sample. Returns `Ok(true)` if mean drift detected.
+            ///
+            /// Detection is two-sided: fires on upward or downward shifts.
+            /// Returns `Ok(false)` while priming or when no drift detected.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the sample is NaN, or
+            /// `DataError::Infinite` if the sample is infinite.
+            #[inline]
+            pub fn update(&mut self, sample: $ty) -> Result<bool, DataError> {
+                check_finite!(sample);
+                self.count += 1;
+
+                self.mean += (sample - self.mean) / self.count as $ty;
+
+                self.sum_pos += sample - self.mean - self.alpha;
+                self.sum_neg += sample - self.mean + self.alpha;
+
+                if self.sum_pos < self.min_pos {
+                    self.min_pos = self.sum_pos;
+                }
+                if self.sum_neg > self.max_neg {
+                    self.max_neg = self.sum_neg;
+                }
+
+                if !self.is_primed() {
+                    return Ok(false);
+                }
+
+                Ok(self.sum_pos - self.min_pos > self.threshold
+                    || self.max_neg - self.sum_neg > self.threshold)
+            }
+
+            /// Number of samples processed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether the tracker has reached `min_samples`.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets to uninitialized state. Parameters unchanged.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.mean = 0.0 as $ty;
+                self.sum_pos = 0.0 as $ty;
+                self.sum_neg = 0.0 as $ty;
+                self.min_pos = 0.0 as $ty;
+                self.max_neg = 0.0 as $ty;
+                self.count = 0;
+            }
+        }
+
+        impl $builder {
+            /// Detection threshold (λ). Required, must be positive.
+            ///
+            /// Larger values reduce false positives but increase detection delay.
+            #[inline]
+            #[must_use]
+            pub fn threshold(mut self, threshold: $ty) -> Self {
+                self.threshold = Option::Some(threshold);
+                self
+            }
+
+            /// Magnitude tolerance (δ). Required, must be non-negative.
+            ///
+            /// The minimum shift size worth detecting. Set to 0 to detect
+            /// any shift.
+            #[inline]
+            #[must_use]
+            pub fn alpha(mut self, alpha: $ty) -> Self {
+                self.alpha = Option::Some(alpha);
+                self
+            }
+
+            /// Minimum samples before detection activates. Default: 30.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = min;
+                self
+            }
+
+            /// Builds the Page-Hinkley detector.
+            ///
+            /// # Errors
+            ///
+            /// - Threshold must have been set and be positive.
+            /// - Alpha must have been set and be non-negative.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let threshold = self
+                    .threshold
+                    .ok_or(nexus_stats_core::ConfigError::Missing("threshold"))?;
+                if threshold <= 0.0 as $ty || threshold.is_nan() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "PageHinkley threshold must be positive",
+                    ));
+                }
+
+                let alpha = self
+                    .alpha
+                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+                if alpha < 0.0 as $ty || alpha.is_nan() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "PageHinkley alpha must be non-negative",
+                    ));
+                }
+
+                Ok($name {
+                    threshold,
+                    alpha,
+                    mean: 0.0 as $ty,
+                    sum_pos: 0.0 as $ty,
+                    sum_neg: 0.0 as $ty,
+                    min_pos: 0.0 as $ty,
+                    max_neg: 0.0 as $ty,
+                    count: 0,
+                    min_samples: self.min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_page_hinkley!(PageHinkleyF64, PageHinkleyF64Builder, f64);
+impl_page_hinkley!(PageHinkleyF32, PageHinkleyF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_drift() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .build()
+            .unwrap();
+
+        for _ in 0..200 {
+            assert!(!ph.update(10.0).unwrap());
+        }
+    }
+
+    #[test]
+    fn upward_drift() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        for _ in 0..50 {
+            let _ = ph.update(10.0);
+        }
+
+        let mut detected = false;
+        for _ in 0..200 {
+            if ph.update(20.0).unwrap() {
+                detected = true;
+                break;
+            }
+        }
+        assert!(detected, "should detect upward mean shift");
+    }
+
+    #[test]
+    fn downward_drift() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        for _ in 0..50 {
+            let _ = ph.update(20.0);
+        }
+
+        let mut detected = false;
+        for _ in 0..200 {
+            if ph.update(10.0).unwrap() {
+                detected = true;
+                break;
+            }
+        }
+        assert!(detected, "should detect downward mean shift");
+    }
+
+    #[test]
+    fn sensitivity_vs_alpha() {
+        let mut sensitive = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.0)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        let mut tolerant = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(5.0)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        for _ in 0..50 {
+            let _ = sensitive.update(10.0);
+            let _ = tolerant.update(10.0);
+        }
+
+        let mut sensitive_count = 0u64;
+        let mut tolerant_count = 0u64;
+        for _ in 0..100 {
+            if sensitive.update(12.0).unwrap() && sensitive_count == 0 {
+                sensitive_count = sensitive.count();
+            }
+            if tolerant.update(12.0).unwrap() && tolerant_count == 0 {
+                tolerant_count = tolerant.count();
+            }
+        }
+
+        assert!(
+            sensitive_count > 0,
+            "sensitive detector should fire on small shift"
+        );
+        assert_eq!(
+            tolerant_count, 0,
+            "tolerant detector should not fire on shift smaller than alpha"
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .min_samples(20)
+            .build()
+            .unwrap();
+
+        for _ in 0..50 {
+            let _ = ph.update(10.0);
+        }
+        for _ in 0..200 {
+            let _ = ph.update(20.0);
+        }
+
+        ph.reset();
+        assert_eq!(ph.count(), 0);
+        assert!(!ph.is_primed());
+
+        for _ in 0..19 {
+            assert!(!ph.update(10.0).unwrap());
+        }
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .build()
+            .unwrap();
+        assert!(matches!(ph.update(f64::NAN), Err(DataError::NotANumber)));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut ph = PageHinkleyF64::builder()
+            .threshold(50.0)
+            .alpha(0.5)
+            .build()
+            .unwrap();
+        assert!(matches!(ph.update(f64::INFINITY), Err(DataError::Infinite)));
+    }
+
+    #[test]
+    fn builder_missing_threshold() {
+        let result = PageHinkleyF64::builder().alpha(0.5).build();
+        assert!(matches!(
+            result,
+            Err(nexus_stats_core::ConfigError::Missing("threshold"))
+        ));
+    }
+
+    #[test]
+    fn builder_negative_threshold() {
+        let result = PageHinkleyF64::builder().threshold(-1.0).alpha(0.5).build();
+        assert!(matches!(
+            result,
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+    }
+}

--- a/nexus-stats-detection/src/page_hinkley.rs
+++ b/nexus-stats-detection/src/page_hinkley.rs
@@ -169,18 +169,18 @@ macro_rules! impl_page_hinkley {
                 let threshold = self
                     .threshold
                     .ok_or(nexus_stats_core::ConfigError::Missing("threshold"))?;
-                if threshold <= 0.0 as $ty || threshold.is_nan() {
+                if !threshold.is_finite() || threshold <= 0.0 as $ty {
                     return Err(nexus_stats_core::ConfigError::Invalid(
-                        "PageHinkley threshold must be positive",
+                        "PageHinkley threshold must be finite and positive",
                     ));
                 }
 
                 let alpha = self
                     .alpha
                     .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                if alpha < 0.0 as $ty || alpha.is_nan() {
+                if !alpha.is_finite() || alpha < 0.0 as $ty {
                     return Err(nexus_stats_core::ConfigError::Invalid(
-                        "PageHinkley alpha must be non-negative",
+                        "PageHinkley alpha must be finite and non-negative",
                     ));
                 }
 

--- a/nexus-stats-detection/src/signal/mod.rs
+++ b/nexus-stats-detection/src/signal/mod.rs
@@ -7,6 +7,8 @@ mod cross_correlation;
 #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
 mod entropy;
 #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod predictive_info;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
 mod transfer_entropy;
 
 #[cfg(feature = "alloc")]
@@ -15,5 +17,7 @@ pub use autocorrelation::*;
 pub use cross_correlation::*;
 #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
 pub use entropy::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use predictive_info::*;
 #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
 pub use transfer_entropy::*;

--- a/nexus-stats-detection/src/signal/predictive_info.rs
+++ b/nexus-stats-detection/src/signal/predictive_info.rs
@@ -1,0 +1,621 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+use nexus_stats_core::DataError;
+
+macro_rules! impl_predictive_info {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// Streaming mutual information estimator via binned MI.
+        ///
+        /// Estimates I(X; Y) from joint and marginal frequency counts
+        /// over equi-width bins. Miller-Madow bias correction adjusts
+        /// for finite-sample underestimation.
+        ///
+        /// O(K²) per query (K = bin count). O(1) per update.
+        ///
+        /// # Parameters
+        ///
+        /// - `bins` — number of bins per dimension (total cells = bins²)
+        /// - `x_range` — `(min, max)` for the X variable
+        /// - `y_range` — `(min, max)` for the Y variable
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_detection::signal::PredictiveInfoBoundF64;
+        ///
+        /// let mut pib = PredictiveInfoBoundF64::builder()
+        ///     .bins(10)
+        ///     .x_range(0.0, 100.0)
+        ///     .y_range(0.0, 100.0)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// // Feed identical values → high MI
+        /// for i in 0..1000 {
+        ///     let x = (i % 100) as f64;
+        ///     pib.update(x, x).unwrap();
+        /// }
+        /// assert!(pib.mutual_information().unwrap() > 0.0);
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            bins: usize,
+            x_min: $ty,
+            x_max: $ty,
+            y_min: $ty,
+            y_max: $ty,
+            x_width: $ty,
+            y_width: $ty,
+            joint: Box<[u64]>,
+            marginal_x: Box<[u64]>,
+            marginal_y: Box<[u64]>,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            bins: Option<usize>,
+            x_range: Option<($ty, $ty)>,
+            y_range: Option<($ty, $ty)>,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    bins: Option::None,
+                    x_range: Option::None,
+                    y_range: Option::None,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Feeds an (x, y) observation.
+            ///
+            /// Values outside the configured range are clamped to the
+            /// nearest bin (first or last).
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if either value is NaN, or
+            /// `DataError::Infinite` if either value is infinite.
+            #[inline]
+            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), DataError> {
+                check_finite!(x);
+                check_finite!(y);
+
+                let xi = self.bin_x(x);
+                let yi = self.bin_y(y);
+
+                self.joint[xi * self.bins + yi] += 1;
+                self.marginal_x[xi] += 1;
+                self.marginal_y[yi] += 1;
+                self.count += 1;
+                Ok(())
+            }
+
+            /// Mutual information I(X; Y) in nats, with Miller-Madow correction.
+            ///
+            /// Returns `None` if not primed.
+            #[must_use]
+            pub fn mutual_information(&self) -> Option<$ty> {
+                if !self.is_primed() {
+                    return Option::None;
+                }
+                let n = self.count as $ty;
+
+                let mut mi = 0.0 as $ty;
+                for xi in 0..self.bins {
+                    let nx = self.marginal_x[xi];
+                    if nx == 0 {
+                        continue;
+                    }
+                    for yi in 0..self.bins {
+                        let ny = self.marginal_y[yi];
+                        let nxy = self.joint[xi * self.bins + yi];
+                        if nxy == 0 || ny == 0 {
+                            continue;
+                        }
+                        let p_xy = nxy as $ty / n;
+                        let p_x = nx as $ty / n;
+                        let p_y = ny as $ty / n;
+                        #[allow(clippy::cast_possible_truncation)]
+                        {
+                            mi += p_xy
+                                * nexus_stats_core::math::ln((p_xy / (p_x * p_y)) as f64) as $ty;
+                        }
+                    }
+                }
+
+                let occupied = self.count_occupied_cells() as $ty;
+                let correction = (occupied - 1.0 as $ty) / (2.0 as $ty * n);
+                Option::Some(mi + correction)
+            }
+
+            /// Mutual information in bits (log base 2).
+            ///
+            /// Returns `None` if not primed.
+            #[inline]
+            #[must_use]
+            pub fn mutual_information_bits(&self) -> Option<$ty> {
+                #[allow(clippy::cast_possible_truncation)]
+                self.mutual_information()
+                    .map(|mi| mi / nexus_stats_core::math::ln(2.0) as $ty)
+            }
+
+            /// Normalized MI: I(X;Y) / min(H(X), H(Y)). Range [0, 1].
+            ///
+            /// Returns `None` if not primed or if either marginal entropy is zero.
+            #[must_use]
+            pub fn normalized_mi(&self) -> Option<$ty> {
+                let mi = self.mutual_information()?;
+                let hx = self.marginal_entropy_x()?;
+                let hy = self.marginal_entropy_y()?;
+                let min_h = if hx < hy { hx } else { hy };
+                if min_h <= 0.0 as $ty {
+                    return Option::None;
+                }
+                let nmi = mi / min_h;
+                let clamped = if nmi < 0.0 as $ty {
+                    0.0 as $ty
+                } else if nmi > 1.0 as $ty {
+                    1.0 as $ty
+                } else {
+                    nmi
+                };
+                Option::Some(clamped)
+            }
+
+            fn marginal_entropy_x(&self) -> Option<$ty> {
+                if self.count == 0 {
+                    return Option::None;
+                }
+                let n = self.count as $ty;
+                let mut h = 0.0 as $ty;
+                for xi in 0..self.bins {
+                    let c = self.marginal_x[xi];
+                    if c > 0 {
+                        let p = c as $ty / n;
+                        #[allow(clippy::cast_possible_truncation)]
+                        {
+                            h -= p * nexus_stats_core::math::ln(p as f64) as $ty;
+                        }
+                    }
+                }
+                Option::Some(h)
+            }
+
+            fn marginal_entropy_y(&self) -> Option<$ty> {
+                if self.count == 0 {
+                    return Option::None;
+                }
+                let n = self.count as $ty;
+                let mut h = 0.0 as $ty;
+                for yi in 0..self.bins {
+                    let c = self.marginal_y[yi];
+                    if c > 0 {
+                        let p = c as $ty / n;
+                        #[allow(clippy::cast_possible_truncation)]
+                        {
+                            h -= p * nexus_stats_core::math::ln(p as f64) as $ty;
+                        }
+                    }
+                }
+                Option::Some(h)
+            }
+
+            fn count_occupied_cells(&self) -> u64 {
+                self.joint.iter().filter(|&&c| c > 0).count() as u64
+            }
+
+            fn bin_x(&self, x: $ty) -> usize {
+                let clamped = if x < self.x_min {
+                    self.x_min
+                } else if x > self.x_max {
+                    self.x_max
+                } else {
+                    x
+                };
+                let idx = ((clamped - self.x_min) / self.x_width) as usize;
+                if idx >= self.bins { self.bins - 1 } else { idx }
+            }
+
+            fn bin_y(&self, y: $ty) -> usize {
+                let clamped = if y < self.y_min {
+                    self.y_min
+                } else if y > self.y_max {
+                    self.y_max
+                } else {
+                    y
+                };
+                let idx = ((clamped - self.y_min) / self.y_width) as usize;
+                if idx >= self.bins { self.bins - 1 } else { idx }
+            }
+
+            /// Total observations.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether enough samples have been observed.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets counts. Configuration and allocation preserved.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.joint.fill(0);
+                self.marginal_x.fill(0);
+                self.marginal_y.fill(0);
+                self.count = 0;
+            }
+        }
+
+        impl $builder {
+            /// Number of bins per dimension (required, 2..=256).
+            #[inline]
+            #[must_use]
+            pub fn bins(mut self, bins: usize) -> Self {
+                self.bins = Option::Some(bins);
+                self
+            }
+
+            /// Range for the X variable (required, max > min).
+            #[inline]
+            #[must_use]
+            pub fn x_range(mut self, min: $ty, max: $ty) -> Self {
+                self.x_range = Option::Some((min, max));
+                self
+            }
+
+            /// Range for the Y variable (required, max > min).
+            #[inline]
+            #[must_use]
+            pub fn y_range(mut self, min: $ty, max: $ty) -> Self {
+                self.y_range = Option::Some((min, max));
+                self
+            }
+
+            /// Minimum samples before MI is valid. Default: bins².
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = Option::Some(min);
+                self
+            }
+
+            /// Builds the mutual information estimator.
+            ///
+            /// # Errors
+            ///
+            /// - `bins` must be in [2, 256].
+            /// - `x_range` and `y_range` must have `max > min`, both finite.
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let bins = self
+                    .bins
+                    .ok_or(nexus_stats_core::ConfigError::Missing("bins"))?;
+                if bins < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "PredictiveInfoBound bins must be >= 2",
+                    ));
+                }
+                if bins > 256 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "PredictiveInfoBound bins must be <= 256",
+                    ));
+                }
+
+                let (x_min, x_max) = self
+                    .x_range
+                    .ok_or(nexus_stats_core::ConfigError::Missing("x_range"))?;
+                if x_max <= x_min || !x_min.is_finite() || !x_max.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "x_range must have max > min, both finite",
+                    ));
+                }
+
+                let (y_min, y_max) = self
+                    .y_range
+                    .ok_or(nexus_stats_core::ConfigError::Missing("y_range"))?;
+                if y_max <= y_min || !y_min.is_finite() || !y_max.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "y_range must have max > min, both finite",
+                    ));
+                }
+
+                let x_width = (x_max - x_min) / bins as $ty;
+                let y_width = (y_max - y_min) / bins as $ty;
+                let min_samples = self.min_samples.unwrap_or((bins * bins) as u64);
+
+                Ok($name {
+                    bins,
+                    x_min,
+                    x_max,
+                    y_min,
+                    y_max,
+                    x_width,
+                    y_width,
+                    joint: vec![0u64; bins * bins].into_boxed_slice(),
+                    marginal_x: vec![0u64; bins].into_boxed_slice(),
+                    marginal_y: vec![0u64; bins].into_boxed_slice(),
+                    count: 0,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_predictive_info!(PredictiveInfoBoundF64, PredictiveInfoBoundF64Builder, f64);
+impl_predictive_info!(PredictiveInfoBoundF32, PredictiveInfoBoundF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn independent_variables() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(10)
+            .x_range(0.0, 10.0)
+            .y_range(0.0, 10.0)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        // X cycles 0..10 sequentially, Y uses a co-prime stride that
+        // produces a uniform marginal over bins, independent of X.
+        // With 10 bins and stride 7 (coprime to 10), every (x,y) cell
+        // is hit equally over a full 100-step cycle.
+        for i in 0..10_000u64 {
+            let x = (i % 10) as f64 + 0.5;
+            let y = ((i / 10) % 10) as f64 + 0.5;
+            pib.update(x, y).unwrap();
+        }
+
+        let mi = pib.mutual_information().unwrap();
+        assert!(
+            mi.abs() < 0.1,
+            "independent variables should have MI ≈ 0, got {mi}"
+        );
+    }
+
+    #[test]
+    fn identical_variables() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(10)
+            .x_range(0.0, 10.0)
+            .y_range(0.0, 10.0)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..1000 {
+            let x = (i % 10) as f64 + 0.5;
+            pib.update(x, x).unwrap();
+        }
+
+        let mi = pib.mutual_information().unwrap();
+        let hx = pib.marginal_entropy_x().unwrap();
+        assert!(
+            (mi - hx).abs() < 0.2,
+            "identical variables: MI ({mi}) should ≈ H(X) ({hx})"
+        );
+    }
+
+    #[test]
+    fn linear_relationship() {
+        let mut pib_tight = PredictiveInfoBoundF64::builder()
+            .bins(10)
+            .x_range(0.0, 10.0)
+            .y_range(0.0, 20.0)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..1000 {
+            let x = (i % 10) as f64 + 0.5;
+            let y = 2.0 * x;
+            pib_tight.update(x, y).unwrap();
+        }
+
+        let mi_tight = pib_tight.mutual_information().unwrap();
+        assert!(
+            mi_tight > 0.5,
+            "tight linear relationship should have high MI, got {mi_tight}"
+        );
+    }
+
+    #[test]
+    fn clamping() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 10.0)
+            .y_range(0.0, 10.0)
+            .min_samples(2)
+            .build()
+            .unwrap();
+
+        pib.update(-5.0, 15.0).unwrap();
+        pib.update(100.0, -100.0).unwrap();
+        assert_eq!(pib.count(), 2);
+    }
+
+    #[test]
+    fn miller_madow_correction() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(4)
+            .x_range(0.0, 4.0)
+            .y_range(0.0, 4.0)
+            .min_samples(2)
+            .build()
+            .unwrap();
+
+        for i in 0..20 {
+            let x = (i % 4) as f64 + 0.5;
+            pib.update(x, x).unwrap();
+        }
+
+        let mi = pib.mutual_information().unwrap();
+        assert!(mi > 0.0, "MI with correction should be positive, got {mi}");
+    }
+
+    #[test]
+    fn bits_vs_nats() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 5.0)
+            .y_range(0.0, 5.0)
+            .min_samples(5)
+            .build()
+            .unwrap();
+
+        for i in 0..500 {
+            let x = (i % 5) as f64 + 0.5;
+            pib.update(x, x).unwrap();
+        }
+
+        let nats = pib.mutual_information().unwrap();
+        let bits = pib.mutual_information_bits().unwrap();
+        let ratio = bits / nats;
+        let expected_ratio = 1.0 / (2.0_f64).ln();
+        assert!(
+            (ratio - expected_ratio).abs() < 0.01,
+            "bits/nats ratio should be 1/ln(2), got {ratio}"
+        );
+    }
+
+    #[test]
+    fn normalized_mi_range() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 5.0)
+            .y_range(0.0, 5.0)
+            .min_samples(5)
+            .build()
+            .unwrap();
+
+        for i in 0..500 {
+            let x = (i % 5) as f64 + 0.5;
+            pib.update(x, x).unwrap();
+        }
+
+        let nmi = pib.normalized_mi().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&nmi),
+            "normalized MI should be in [0, 1], got {nmi}"
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 5.0)
+            .y_range(0.0, 5.0)
+            .min_samples(5)
+            .build()
+            .unwrap();
+
+        for i in 0..100 {
+            let x = (i % 5) as f64 + 0.5;
+            pib.update(x, x).unwrap();
+        }
+
+        pib.reset();
+        assert_eq!(pib.count(), 0);
+        assert!(pib.mutual_information().is_none());
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 5.0)
+            .y_range(0.0, 5.0)
+            .build()
+            .unwrap();
+        assert!(matches!(
+            pib.update(f64::NAN, 1.0),
+            Err(DataError::NotANumber)
+        ));
+        assert!(matches!(
+            pib.update(1.0, f64::NAN),
+            Err(DataError::NotANumber)
+        ));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut pib = PredictiveInfoBoundF64::builder()
+            .bins(5)
+            .x_range(0.0, 5.0)
+            .y_range(0.0, 5.0)
+            .build()
+            .unwrap();
+        assert!(matches!(
+            pib.update(f64::INFINITY, 1.0),
+            Err(DataError::Infinite)
+        ));
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(matches!(
+            PredictiveInfoBoundF64::builder()
+                .x_range(0.0, 10.0)
+                .y_range(0.0, 10.0)
+                .build(),
+            Err(nexus_stats_core::ConfigError::Missing("bins"))
+        ));
+
+        assert!(matches!(
+            PredictiveInfoBoundF64::builder()
+                .bins(1)
+                .x_range(0.0, 10.0)
+                .y_range(0.0, 10.0)
+                .build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+
+        assert!(matches!(
+            PredictiveInfoBoundF64::builder()
+                .bins(257)
+                .x_range(0.0, 10.0)
+                .y_range(0.0, 10.0)
+                .build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+
+        assert!(matches!(
+            PredictiveInfoBoundF64::builder()
+                .bins(10)
+                .x_range(10.0, 0.0)
+                .y_range(0.0, 10.0)
+                .build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+
+        assert!(matches!(
+            PredictiveInfoBoundF64::builder()
+                .bins(10)
+                .x_range(0.0, 10.0)
+                .y_range(10.0, 0.0)
+                .build(),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+    }
+}

--- a/nexus-stats-detection/src/signal/predictive_info.rs
+++ b/nexus-stats-detection/src/signal/predictive_info.rs
@@ -339,6 +339,11 @@ macro_rules! impl_predictive_info {
                 let x_width = (x_max - x_min) / bins as $ty;
                 let y_width = (y_max - y_min) / bins as $ty;
                 let min_samples = self.min_samples.unwrap_or((bins * bins) as u64);
+                if min_samples < 1 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "PredictiveInfoBound min_samples must be >= 1",
+                    ));
+                }
 
                 Ok($name {
                     bins,

--- a/nexus-stats/CHANGELOG.md
+++ b/nexus-stats/CHANGELOG.md
@@ -10,6 +10,24 @@ contained.
 
 ## [Unreleased]
 
+## [5.0.0] — 2026-05-18
+
+Breaking: tracks nexus-stats-core 2.0.0.
+
+### Added
+
+- **`clock` module** re-exported from nexus-stats-core. `Clock` trait,
+  `WallClock`, `EpochClock`.
+
+### Changed
+
+- `std` feature now also provides `WallClock`.
+
+### Removed
+
+- All `Instant`-based stats types (see nexus-stats-core 2.0.0 CHANGELOG).
+- `Raw` suffix dropped from windowed/CoDel type names.
+
 ## [4.x] — workspace re-export pattern
 
 `nexus-stats` is the umbrella crate that re-exports from the

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -46,7 +46,7 @@ if let Some(mean) = stats.mean() {
 
 ## Algorithms
 
-55+ algorithms across 10 categories. See [full documentation](docs/INDEX.md)
+58+ algorithms across 10 categories. See [full documentation](docs/INDEX.md)
 for deep-dives on each algorithm.
 
 ### Change Detection
@@ -59,6 +59,8 @@ for deep-dives on each algorithm.
 | `MultiGateF64` | Graded anomalies: Accept/Unusual/Suspect/Reject | 12 |
 | `RobustZScoreF64` | MAD-based outlier scoring with estimator freeze | 12 |
 | `AdaptiveThresholdF64` | Z-score anomalies with self-learning baseline | 15 |
+| `PageHinkleyF64` | Sequential mean drift (Page-Hinkley test) | TBD |
+| `AdwinF64` | Adaptive window distribution change (ADWIN) | TBD |
 
 ### Smoothing & Filtering
 
@@ -108,6 +110,7 @@ for deep-dives on each algorithm.
 |------|-----------------|-----|
 | `EntropyF64` | Shannon entropy over K categories | 3 |
 | `TransferEntropyF64` *(alloc, std\|libm)* | Directed information flow (Granger causality) | 14 |
+| `PredictiveInfoBoundF64` *(alloc, std\|libm)* | Binned mutual information I(X;Y) with Miller-Madow | TBD |
 
 ### Monitoring
 
@@ -168,6 +171,9 @@ intrinsics; integer types use bit-shift arithmetic.
 | TransferEntropy | | ✓ | | | |
 | Holt, KAMA, Kalman1D, Spring | ✓ | ✓ | | | |
 | MultiGate, RobustZScore, AdaptiveThreshold | ✓ | ✓ | | | |
+| PageHinkley | ✓ | ✓ | | | |
+| ADWIN | ✓ | ✓ | | | |
+| PredictiveInfoBound | ✓ | ✓ | | | |
 | Saturation, ErrorRate, TrendAlert | ✓ | ✓ | | | |
 | ShiryaevRoberts | | ✓ | | | |
 
@@ -228,7 +234,7 @@ stats.update(sample).unwrap();
 
 | Feature | Default | What |
 |---------|---------|------|
-| `std` | yes | Hardware intrinsics for `sqrt`/`exp` |
+| `std` | yes | `WallClock`, hardware intrinsics for `sqrt`/`exp` |
 | `libm` | no | Pure Rust math fallback for `no_std` |
 | `alloc` | no | Runtime-sized windows (MOSUM, WindowedMedian, KAMA, BoolWindow) |
 
@@ -240,7 +246,7 @@ and construction (`halflife()`).
 
 nexus-stats is split into five workspace crates for independent compilation and feature gating:
 
-- **nexus-stats-core** — shared traits, error types, and builder infrastructure
+- **nexus-stats-core** — shared traits, error types, clock (`Clock`, `WallClock`, `EpochClock`), and builder infrastructure
 - **nexus-stats-smoothing** — EMA, KAMA, Kalman, Holt, Spring, Slew, WindowedMedian
 - **nexus-stats-detection** — CUSUM, MOSUM, Shiryaev-Roberts, MultiGate, RobustZScore, AdaptiveThreshold
 - **nexus-stats-regression** — Linear, polynomial, exponential, logarithmic, power regression

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -46,7 +46,7 @@ if let Some(mean) = stats.mean() {
 
 ## Algorithms
 
-58+ algorithms across 10 categories. See [full documentation](docs/INDEX.md)
+60+ algorithms across 10 categories. See [full documentation](docs/INDEX.md)
 for deep-dives on each algorithm.
 
 ### Change Detection

--- a/nexus-stats/src/lib.rs
+++ b/nexus-stats/src/lib.rs
@@ -76,8 +76,8 @@
 //! | Feature | Module | Contents |
 //! |---------|--------|----------|
 //! | `smoothing` | `smoothing` | + Holt, KAMA, Spring, Kalman1d, WindowedMedian |
-//! | `detection` | `detection` | + MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate |
-//! | `detection` | `signal` | Autocorrelation, CrossCorrelation, Entropy, TransferEntropy |
+//! | `detection` | `detection` | + MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate, PageHinkley, ADWIN |
+//! | `detection` | `signal` | Autocorrelation, CrossCorrelation, Entropy, TransferEntropy, PredictiveInfoBound |
 //! | `detection` | `estimation` | + SPRT |
 //! | `regression` | `regression` | Linear, Polynomial, EW variants, Transformed, LogisticRegression |
 //! | `regression` | `learning` | LMS, NLMS, RLS, OnlineKMeans, GD, AdaGrad, Adam |

--- a/nexus-stats/src/lib.rs
+++ b/nexus-stats/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Fixed-memory, zero-allocation streaming statistics for real-time systems.
 //!
-//! 65+ algorithms, all O(1) per update (or O(d) for d-dimensional filters), fixed memory.
+//! 60+ algorithms, all O(1) per update (or O(d) for d-dimensional filters), fixed memory.
 //! Core types are `no_std` compatible; types marked *(std)* require the `std` feature,
 //! *(alloc)* require `alloc`, and *(std|libm)* require either `std` or `libm`.
 //!


### PR DESCRIPTION
## Summary

Adds three new streaming algorithms to `nexus-stats-detection`, closing #286 and #287:

- **PageHinkleyF64/F32** — Sequential mean drift test. Two-sided (upward + downward shifts). O(1) per update. Accumulates deviations from running mean, fires when cumulative sum exceeds threshold. No feature gate needed.
- **AdwinF64/F32** — Adaptive Windowing (Bifet & Gavalda, 2007). Exponential histogram with Hoeffding bound for distribution change detection. Automatically shrinks window on detection. O(log n) amortized per update. Requires `alloc` + (`std` or `libm`).
- **PredictiveInfoBoundF64/F32** — Streaming binned mutual information I(X;Y). Equi-width bins on user-specified ranges. Miller-Madow bias correction. O(K²) per query, O(1) per update. Requires `alloc` + (`std` or `libm`).

Also catches up documentation for the Clock trait work from #336:
- `nexus-stats-core` CHANGELOG: 2.0.0 entry (Clock trait, WallClock, EpochClock, Instant removal)
- `nexus-stats` CHANGELOG: 5.0.0 entry (clock re-export, std feature change)
- README updates for both crates

### Files changed (13)

**New (3):**
- `nexus-stats-detection/src/page_hinkley.rs` — 9 tests
- `nexus-stats-detection/src/adwin.rs` — 8 tests
- `nexus-stats-detection/src/signal/predictive_info.rs` — 10 tests

**Modified (10):**
- Module wiring (`lib.rs`, `signal/mod.rs`), version bump (1.0.1 → 1.1.0)
- 3 CHANGELOGs, 3 READMEs, 1 `lib.rs` doc comment

## Test plan

- [x] `cargo test -p nexus-stats-detection --all-features` — 156 tests + 15 doctests pass
- [x] `cargo test -p nexus-stats-detection --no-default-features` — 37 tests + 2 doctests pass
- [x] `cargo clippy -p nexus-stats-detection --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Verify ADWIN detects mean shift and window shrinks post-detection
- [ ] Verify PageHinkley detects both upward and downward drift
- [ ] Verify PIB returns MI ≈ 0 for independent variables, MI ≈ H(X) for identical

Closes #286, closes #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)