### PR TITLE
nexus-stats-core: RollSpread, BipowerVariation, TwoScaleRv, HawkesIntensity (#290, #294, #295)

### DIFF
--- a/nexus-stats-core/CHANGELOG.md
+++ b/nexus-stats-core/CHANGELOG.md
@@ -10,6 +10,21 @@ contained.
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-05-18
+
+### Added
+
+- **`BipowerVariationF64/F32`** — jump-robust volatility estimator using
+  products of consecutive absolute returns. Barndorff-Nielsen & Shephard (2004).
+- **`RollSpreadF64/F32`** — Roll's implicit spread estimator from
+  autocovariance of consecutive price changes, with Hasbrouck (2009) adjustment.
+  Requires `std` or `libm`.
+- **`TwoScaleRvF64`** — two-scale realized variance, noise-corrected volatility
+  estimator. Zhang, Mykland, Ait-Sahalia (2005). Requires `alloc` + `std`/`libm`.
+- **`HawkesIntensityF64/F32`** — self-exciting point process intensity
+  estimator. Models bursty event arrivals with exponential decay. Requires
+  `std` or `libm`.
+
 ## [2.0.0] — 2026-05-18
 
 Clock trait and Instant type removal.

--- a/nexus-stats-core/Cargo.toml
+++ b/nexus-stats-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-stats-core"
-version = "2.0.0"
+version = "2.1.0"
 description = "Core types and utilities shared across nexus-stats subcrates"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-stats-core/README.md
+++ b/nexus-stats-core/README.md
@@ -5,8 +5,9 @@ Core types shared across the nexus-stats ecosystem.
 This crate provides the fundamental streaming statistics types: error enums,
 math utilities, clock trait (`Clock`, `WallClock`, `EpochClock`), core smoothing
 (EMA, AsymEma, Slew), statistics (Welford, Moments, EwmaVar, Covariance,
-HarmonicMean, Percentile), monitoring, core detection (CUSUM), and core
-control types (DeadBand, Hysteresis, Debounce, LevelCrossing, Diff).
+HarmonicMean, Percentile, BipowerVariation, RollSpread, TwoScaleRv),
+monitoring (Hawkes intensity), core detection (CUSUM), and core control types
+(DeadBand, Hysteresis, Debounce, LevelCrossing, Diff).
 
 **Not intended for direct use** — import from
 [`nexus-stats`](https://crates.io/crates/nexus-stats) instead.

--- a/nexus-stats-core/README.md
+++ b/nexus-stats-core/README.md
@@ -5,8 +5,9 @@ Core types shared across the nexus-stats ecosystem.
 This crate provides the fundamental streaming statistics types: error enums,
 math utilities, clock trait (`Clock`, `WallClock`, `EpochClock`), core smoothing
 (EMA, AsymEma, Slew), statistics (Welford, Moments, EwmaVar, Covariance,
-HarmonicMean, Percentile, BipowerVariation, RollSpread, TwoScaleRv),
-monitoring (Hawkes intensity), core detection (CUSUM), and core control types
+HarmonicMean, Percentile, BipowerVariation, RollSpread *(std/libm)*,
+TwoScaleRv *(alloc+std/libm)*), monitoring (HawkesIntensity *(std/libm)*),
+core detection (CUSUM), and core control types
 (DeadBand, Hysteresis, Debounce, LevelCrossing, Diff).
 
 **Not intended for direct use** — import from

--- a/nexus-stats-core/src/monitoring/hawkes.rs
+++ b/nexus-stats-core/src/monitoring/hawkes.rs
@@ -103,7 +103,9 @@ macro_rules! impl_hawkes {
 
             /// Intensity at an arbitrary time (without recording an event).
             ///
-            /// Decays excitation from last event time to `time`.
+            /// Decays excitation from last event time to `time`. Assumes
+            /// monotonic timestamps; times before `last_time` are clamped
+            /// to zero delta, returning the current intensity.
             #[inline]
             #[must_use]
             pub fn intensity_at(&self, time: u64) -> $ty {

--- a/nexus-stats-core/src/monitoring/hawkes.rs
+++ b/nexus-stats-core/src/monitoring/hawkes.rs
@@ -1,0 +1,383 @@
+macro_rules! impl_hawkes {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// Hawkes process intensity estimator.
+        ///
+        /// Self-exciting point process: each event increases the intensity,
+        /// which then decays exponentially. Models bursty arrivals where
+        /// events cluster (trade arrivals, order bursts, alert cascades).
+        ///
+        /// λ(t) = μ + α · Σ exp(-β · (t - t_i))
+        ///
+        /// Recursive form: O(1) per event.
+        ///
+        /// # Parameters
+        ///
+        /// - `mu` (μ) — baseline intensity (events per unit time)
+        /// - `alpha` (α) — excitation per event
+        /// - `beta` (β) — decay rate (higher = faster decay)
+        ///
+        /// Stability requires α < β (branching ratio α/β < 1).
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_core::monitoring::HawkesIntensityF64;
+        ///
+        /// let mut h = HawkesIntensityF64::builder()
+        ///     .mu(1.0)
+        ///     .alpha(0.5)
+        ///     .beta(1.0)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// h.update(0);
+        /// h.update(100);
+        /// assert!(h.intensity() > 1.0); // above baseline after event
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            mu: $ty,
+            alpha: $ty,
+            beta: $ty,
+            excitation: $ty,
+            last_time: u64,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            mu: Option<$ty>,
+            alpha: Option<$ty>,
+            beta: Option<$ty>,
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    mu: Option::None,
+                    alpha: Option::None,
+                    beta: Option::None,
+                    min_samples: 2,
+                }
+            }
+
+            /// Records an event at the given timestamp.
+            ///
+            /// Timestamps are u64 (matching `Clock::stamp()`). The delta
+            /// between timestamps is computed with saturating subtraction.
+            #[inline]
+            pub fn update(&mut self, time: u64) {
+                self.count += 1;
+
+                if self.count == 1 {
+                    self.excitation = self.alpha;
+                    self.last_time = time;
+                    return;
+                }
+
+                let dt = time.saturating_sub(self.last_time);
+                #[allow(clippy::cast_possible_truncation)]
+                let decay = crate::math::exp(-(self.beta * dt as $ty) as f64) as $ty;
+                self.excitation = crate::math::MulAdd::fma(decay, self.excitation, self.alpha);
+                self.last_time = time;
+            }
+
+            /// Current intensity λ at last event time: `μ + excitation`.
+            #[inline]
+            #[must_use]
+            pub fn intensity(&self) -> $ty {
+                if self.count == 0 {
+                    self.mu
+                } else {
+                    self.mu + self.excitation
+                }
+            }
+
+            /// Intensity at an arbitrary time (without recording an event).
+            ///
+            /// Decays excitation from last event time to `time`.
+            #[inline]
+            #[must_use]
+            pub fn intensity_at(&self, time: u64) -> $ty {
+                if self.count == 0 {
+                    return self.mu;
+                }
+                let dt = time.saturating_sub(self.last_time);
+                #[allow(clippy::cast_possible_truncation)]
+                let decay = crate::math::exp(-(self.beta * dt as $ty) as f64) as $ty;
+                crate::math::MulAdd::fma(decay, self.excitation, self.mu)
+            }
+
+            /// Baseline intensity μ.
+            #[inline]
+            #[must_use]
+            pub fn baseline(&self) -> $ty {
+                self.mu
+            }
+
+            /// Branching ratio α/β. Must be < 1 for stability.
+            #[inline]
+            #[must_use]
+            pub fn branching_ratio(&self) -> $ty {
+                self.alpha / self.beta
+            }
+
+            /// Number of events recorded.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether enough events have been observed.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets to empty state. Parameters unchanged.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.excitation = 0.0 as $ty;
+                self.last_time = 0;
+                self.count = 0;
+            }
+        }
+
+        impl $builder {
+            /// Baseline intensity μ (required, > 0).
+            #[inline]
+            #[must_use]
+            pub fn mu(mut self, mu: $ty) -> Self {
+                self.mu = Option::Some(mu);
+                self
+            }
+
+            /// Excitation per event α (required, >= 0).
+            #[inline]
+            #[must_use]
+            pub fn alpha(mut self, alpha: $ty) -> Self {
+                self.alpha = Option::Some(alpha);
+                self
+            }
+
+            /// Decay rate β (required, > 0, must be > α for stability).
+            #[inline]
+            #[must_use]
+            pub fn beta(mut self, beta: $ty) -> Self {
+                self.beta = Option::Some(beta);
+                self
+            }
+
+            /// Minimum events before is_primed. Default: 2.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = min;
+                self
+            }
+
+            /// Builds the Hawkes intensity estimator.
+            ///
+            /// # Errors
+            ///
+            /// - `mu` must be positive and finite.
+            /// - `alpha` must be non-negative and finite.
+            /// - `beta` must be positive and finite.
+            /// - `alpha` must be < `beta` (branching ratio < 1).
+            #[inline]
+            pub fn build(self) -> Result<$name, crate::ConfigError> {
+                let mu = self.mu.ok_or(crate::ConfigError::Missing("mu"))?;
+                if mu <= 0.0 as $ty || !mu.is_finite() {
+                    return Err(crate::ConfigError::Invalid(
+                        "Hawkes mu must be positive and finite",
+                    ));
+                }
+
+                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+                if alpha < 0.0 as $ty || !alpha.is_finite() {
+                    return Err(crate::ConfigError::Invalid(
+                        "Hawkes alpha must be non-negative and finite",
+                    ));
+                }
+
+                let beta = self.beta.ok_or(crate::ConfigError::Missing("beta"))?;
+                if beta <= 0.0 as $ty || !beta.is_finite() {
+                    return Err(crate::ConfigError::Invalid(
+                        "Hawkes beta must be positive and finite",
+                    ));
+                }
+
+                if alpha >= beta {
+                    return Err(crate::ConfigError::Invalid(
+                        "Hawkes alpha must be < beta (branching ratio < 1)",
+                    ));
+                }
+
+                Ok($name {
+                    mu,
+                    alpha,
+                    beta,
+                    excitation: 0.0 as $ty,
+                    last_time: 0,
+                    count: 0,
+                    min_samples: self.min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_hawkes!(HawkesIntensityF64, HawkesIntensityF64Builder, f64);
+impl_hawkes!(HawkesIntensityF32, HawkesIntensityF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_without_events() {
+        let h = HawkesIntensityF64::builder()
+            .mu(5.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        assert!((h.intensity() - 5.0).abs() < 1e-10);
+        assert!((h.intensity_at(1_000_000) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn excitation_spike() {
+        let mut h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        h.update(0);
+        let after_event = h.intensity();
+        assert!(
+            after_event > 1.0,
+            "intensity should spike above baseline after event, got {after_event}"
+        );
+    }
+
+    #[test]
+    fn decay_over_time() {
+        let mut h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        h.update(0);
+        let far_future = h.intensity_at(1_000_000);
+        assert!(
+            (far_future - 1.0).abs() < 0.01,
+            "intensity should decay to baseline, got {far_future}"
+        );
+    }
+
+    #[test]
+    fn burst_intensifies() {
+        let mut h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        h.update(0);
+        let after_one = h.intensity();
+
+        h.update(1);
+        let after_two = h.intensity();
+
+        h.update(2);
+        let after_three = h.intensity();
+
+        assert!(
+            after_three > after_two && after_two > after_one,
+            "rapid events should increase intensity: {after_one} < {after_two} < {after_three}"
+        );
+    }
+
+    #[test]
+    fn branching_ratio_value() {
+        let h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.3)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        assert!((h.branching_ratio() - 0.3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn stability_validation() {
+        let result = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(1.0)
+            .beta(1.0)
+            .build();
+        assert!(matches!(result, Err(crate::ConfigError::Invalid(_))));
+
+        let result = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(2.0)
+            .beta(1.0)
+            .build();
+        assert!(matches!(result, Err(crate::ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        h.update(0);
+        h.update(10);
+        h.reset();
+        assert_eq!(h.count(), 0);
+        assert!((h.intensity() - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn same_timestamp_events() {
+        let mut h = HawkesIntensityF64::builder()
+            .mu(1.0)
+            .alpha(0.5)
+            .beta(1.0)
+            .build()
+            .unwrap();
+
+        h.update(100);
+        let after_one = h.intensity();
+
+        h.update(100);
+        let after_two = h.intensity();
+
+        assert!(
+            after_two > after_one,
+            "same-time events should stack: {after_one} < {after_two}"
+        );
+    }
+}

--- a/nexus-stats-core/src/monitoring/mod.rs
+++ b/nexus-stats-core/src/monitoring/mod.rs
@@ -4,6 +4,8 @@ mod codel;
 mod drawdown;
 mod error_rate;
 mod event_rate;
+#[cfg(any(feature = "std", feature = "libm"))]
+mod hawkes;
 mod jitter;
 mod liveness;
 mod max_gauge;
@@ -16,6 +18,8 @@ pub use codel::*;
 pub use drawdown::*;
 pub use error_rate::*;
 pub use event_rate::*;
+#[cfg(any(feature = "std", feature = "libm"))]
+pub use hawkes::*;
 pub use jitter::*;
 pub use liveness::*;
 pub use max_gauge::*;

--- a/nexus-stats-core/src/statistics/bipower.rs
+++ b/nexus-stats-core/src/statistics/bipower.rs
@@ -1,0 +1,334 @@
+macro_rules! impl_bipower {
+    ($name:ident, $builder:ident, $ty:ty, $pi_over_2:expr) => {
+        /// Bipower variation — jump-robust volatility estimator.
+        ///
+        /// Estimates the continuous component of quadratic variation
+        /// using products of consecutive absolute returns. Difference
+        /// with realized variance isolates the jump component.
+        ///
+        /// Barndorff-Nielsen & Shephard (2004).
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_core::statistics::BipowerVariationF64;
+        ///
+        /// let mut bv = BipowerVariationF64::new();
+        /// for i in 0..100 {
+        ///     bv.update(100.0 + (i as f64) * 0.01).unwrap();
+        /// }
+        /// assert!(bv.bipower_variation().is_some());
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            sum_bv: $ty,
+            sum_rv: $ty,
+            prev_abs_diff: $ty,
+            prev_price: $ty,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a new bipower variation tracker with default min_samples (30).
+            #[inline]
+            #[must_use]
+            pub const fn new() -> Self {
+                Self {
+                    sum_bv: 0.0 as $ty,
+                    sum_rv: 0.0 as $ty,
+                    prev_abs_diff: 0.0 as $ty,
+                    prev_price: 0.0 as $ty,
+                    count: 0,
+                    min_samples: 30,
+                }
+            }
+
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder { min_samples: 30 }
+            }
+
+            /// Feeds a trade price.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the price is NaN, or
+            /// `DataError::Infinite` if the price is infinite.
+            #[inline]
+            pub fn update(&mut self, price: $ty) -> Result<(), crate::DataError> {
+                check_finite!(price);
+                self.count += 1;
+
+                if self.count == 1 {
+                    self.prev_price = price;
+                    return Ok(());
+                }
+
+                let diff = price - self.prev_price;
+                let abs_diff = if diff < 0.0 as $ty { -diff } else { diff };
+
+                self.sum_rv += diff * diff;
+
+                if self.count >= 3 {
+                    self.sum_bv += abs_diff * self.prev_abs_diff;
+                }
+
+                self.prev_abs_diff = abs_diff;
+                self.prev_price = price;
+                Ok(())
+            }
+
+            /// Bipower variation: `(π/2) · Σ|Δp_t|·|Δp_{t-1}| / n`.
+            ///
+            /// Returns `None` if not primed.
+            #[inline]
+            #[must_use]
+            pub fn bipower_variation(&self) -> Option<$ty> {
+                if !self.is_primed() || self.count < 3 {
+                    return Option::None;
+                }
+                let n = (self.count - 2) as $ty;
+                Option::Some($pi_over_2 * self.sum_bv / n)
+            }
+
+            /// Realized variance: `Σ(Δp_t)² / n`.
+            ///
+            /// Returns `None` if not primed.
+            #[inline]
+            #[must_use]
+            pub fn realized_variance(&self) -> Option<$ty> {
+                if !self.is_primed() || self.count < 2 {
+                    return Option::None;
+                }
+                let n = (self.count - 1) as $ty;
+                Option::Some(self.sum_rv / n)
+            }
+
+            /// Jump variation: `max(RV - BV, 0)`.
+            ///
+            /// Returns `None` if not primed.
+            #[inline]
+            #[must_use]
+            pub fn jump_variation(&self) -> Option<$ty> {
+                let rv = self.realized_variance()?;
+                let bv = self.bipower_variation()?;
+                let jv = rv - bv;
+                if jv > 0.0 as $ty {
+                    Option::Some(jv)
+                } else {
+                    Option::Some(0.0 as $ty)
+                }
+            }
+
+            /// Jump ratio: `max(RV - BV, 0) / RV`. Range [0, 1].
+            ///
+            /// Returns `None` if not primed or RV is zero.
+            #[inline]
+            #[must_use]
+            pub fn jump_ratio(&self) -> Option<$ty> {
+                let rv = self.realized_variance()?;
+                if rv <= 0.0 as $ty {
+                    return Option::None;
+                }
+                let jv = self.jump_variation()?;
+                Option::Some(jv / rv)
+            }
+
+            /// Number of prices seen.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether enough samples have been observed.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets to uninitialized state. Parameters unchanged.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.sum_bv = 0.0 as $ty;
+                self.sum_rv = 0.0 as $ty;
+                self.prev_abs_diff = 0.0 as $ty;
+                self.prev_price = 0.0 as $ty;
+                self.count = 0;
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl $builder {
+            /// Minimum prices before results are valid. Default: 30.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = min;
+                self
+            }
+
+            /// Builds the bipower variation tracker.
+            #[inline]
+            pub fn build(self) -> $name {
+                $name {
+                    sum_bv: 0.0 as $ty,
+                    sum_rv: 0.0 as $ty,
+                    prev_abs_diff: 0.0 as $ty,
+                    prev_price: 0.0 as $ty,
+                    count: 0,
+                    min_samples: self.min_samples,
+                }
+            }
+        }
+    };
+}
+
+impl_bipower!(
+    BipowerVariationF64,
+    BipowerVariationF64Builder,
+    f64,
+    core::f64::consts::FRAC_PI_2
+);
+impl_bipower!(
+    BipowerVariationF32,
+    BipowerVariationF32Builder,
+    f32,
+    core::f32::consts::FRAC_PI_2
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smooth_series() {
+        let mut bv = BipowerVariationF64::new();
+        for i in 0..100 {
+            bv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+        let bipower = bv.bipower_variation().unwrap();
+        let rv = bv.realized_variance().unwrap();
+        assert!(bipower > 0.0, "bipower should be positive for smooth trend");
+        assert!(
+            bipower < rv * 2.0,
+            "smooth series: BV should be comparable to RV, got BV={bipower}, RV={rv}"
+        );
+    }
+
+    #[test]
+    fn series_with_jump() {
+        let mut bv = BipowerVariationF64::new();
+        for i in 0..50 {
+            bv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+        bv.update(110.0).unwrap(); // jump
+        for i in 51..100 {
+            bv.update(110.0 + ((i - 51) as f64) * 0.01).unwrap();
+        }
+        let jv = bv.jump_variation().unwrap();
+        assert!(jv > 0.0, "jump variation should be positive, got {jv}");
+    }
+
+    #[test]
+    fn jump_ratio_range() {
+        let mut bv = BipowerVariationF64::new();
+        for i in 0..50 {
+            bv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+        bv.update(110.0).unwrap();
+        for i in 51..100 {
+            bv.update(110.0 + ((i - 51) as f64) * 0.01).unwrap();
+        }
+        let ratio = bv.jump_ratio().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&ratio),
+            "jump ratio should be in [0, 1], got {ratio}"
+        );
+    }
+
+    #[test]
+    fn rv_matches_manual() {
+        let mut bv = BipowerVariationF64::new();
+        let prices = [100.0, 101.0, 99.0, 102.0];
+        for &p in &prices {
+            bv.update(p).unwrap();
+        }
+        // diffs: 1, -2, 3 → sum_sq = 1+4+9 = 14, n = 3 → RV = 14/3
+        let min_bv = BipowerVariationF64::builder().min_samples(2).build();
+        let mut bv2 = min_bv;
+        for &p in &prices {
+            bv2.update(p).unwrap();
+        }
+        let rv = bv2.realized_variance().unwrap();
+        let expected = 14.0 / 3.0;
+        assert!(
+            (rv - expected).abs() < 1e-10,
+            "RV should be {expected}, got {rv}"
+        );
+    }
+
+    #[test]
+    fn bv_scaling() {
+        let mut bv = BipowerVariationF64::builder().min_samples(4).build();
+        let prices = [100.0, 101.0, 99.0, 102.0, 100.0];
+        for &p in &prices {
+            bv.update(p).unwrap();
+        }
+        let bipower = bv.bipower_variation().unwrap();
+        // sum_bv: |1|*|-2| + |-2|*|3| + |3|*|-2| = 2+6+6 = 14, n_bv = 3
+        // BV = (π/2) * 14/3
+        let expected = core::f64::consts::FRAC_PI_2 * 14.0 / 3.0;
+        assert!(
+            (bipower - expected).abs() < 1e-10,
+            "BV should be {expected}, got {bipower}"
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut bv = BipowerVariationF64::new();
+        for i in 0..50 {
+            bv.update(100.0 + (i as f64) * 0.1).unwrap();
+        }
+        bv.reset();
+        assert_eq!(bv.count(), 0);
+        assert!(bv.bipower_variation().is_none());
+        assert!(bv.realized_variance().is_none());
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut bv = BipowerVariationF64::new();
+        assert!(matches!(
+            bv.update(f64::NAN),
+            Err(crate::DataError::NotANumber)
+        ));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut bv = BipowerVariationF64::new();
+        assert!(matches!(
+            bv.update(f64::INFINITY),
+            Err(crate::DataError::Infinite)
+        ));
+    }
+}

--- a/nexus-stats-core/src/statistics/mod.rs
+++ b/nexus-stats-core/src/statistics/mod.rs
@@ -1,6 +1,7 @@
 //! Core streaming statistics.
 
 mod amihud;
+mod bipower;
 mod bucket;
 mod covariance;
 #[cfg(feature = "alloc")]
@@ -14,11 +15,16 @@ mod hit_rate;
 mod hurst;
 mod moments;
 mod percentile;
+#[cfg(any(feature = "std", feature = "libm"))]
+mod roll_spread;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod two_scale_rv;
 #[cfg(feature = "alloc")]
 mod variance_ratio;
 mod welford;
 
 pub use amihud::*;
+pub use bipower::*;
 pub use bucket::*;
 pub use covariance::*;
 #[cfg(feature = "alloc")]
@@ -32,6 +38,10 @@ pub use hit_rate::*;
 pub use hurst::*;
 pub use moments::*;
 pub use percentile::*;
+#[cfg(any(feature = "std", feature = "libm"))]
+pub use roll_spread::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use two_scale_rv::*;
 #[cfg(feature = "alloc")]
 pub use variance_ratio::*;
 pub use welford::*;

--- a/nexus-stats-core/src/statistics/roll_spread.rs
+++ b/nexus-stats-core/src/statistics/roll_spread.rs
@@ -122,7 +122,8 @@ macro_rules! impl_roll_spread {
             /// Hasbrouck's adjusted spread: `spread · √(1 + ρ)` where
             /// `ρ = cov / var` is the first-order autocorrelation.
             ///
-            /// Returns `None` if Roll spread is `None` or variance is zero.
+            /// Returns `None` if Roll spread is `None`, variance is zero,
+            /// or `1 + ρ <= 0` (extreme mean-reversion).
             #[inline]
             #[must_use]
             pub fn hasbrouck_spread(&self) -> Option<$ty> {
@@ -272,18 +273,18 @@ mod tests {
             .build()
             .unwrap();
 
+        // Trend + bounce: negative autocov but ρ > -1
         for i in 0..200 {
-            let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
-            rs.update(price).unwrap();
+            let bounce = if i % 2 == 0 { 0.2 } else { -0.2 };
+            rs.update(100.0 + (i as f64) * 0.1 + bounce).unwrap();
         }
 
         let roll = rs.spread().unwrap();
-        if let Some(hasbrouck) = rs.hasbrouck_spread() {
-            assert!(
-                hasbrouck <= roll * 1.5,
-                "Hasbrouck should be reasonable relative to Roll: H={hasbrouck}, R={roll}"
-            );
-        }
+        let hasbrouck = rs.hasbrouck_spread().unwrap();
+        assert!(
+            hasbrouck > 0.0 && hasbrouck <= roll * 1.5,
+            "Hasbrouck ({hasbrouck}) should be positive and reasonable vs Roll ({roll})"
+        );
     }
 
     #[test]

--- a/nexus-stats-core/src/statistics/roll_spread.rs
+++ b/nexus-stats-core/src/statistics/roll_spread.rs
@@ -1,0 +1,359 @@
+use crate::math::MulAdd;
+
+macro_rules! impl_roll_spread {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// Roll's implicit spread estimator.
+        ///
+        /// Estimates effective bid-ask spread from the autocovariance of
+        /// consecutive price changes: `spread = 2·√(-Cov(Δp_t, Δp_{t-1}))`.
+        ///
+        /// When autocovariance is non-negative (trending market), spread
+        /// is undefined and `spread()` returns `None`.
+        ///
+        /// Hasbrouck (2009) adjustment uses autocorrelation:
+        /// `spread_h = spread · √(1 + ρ)`.
+        ///
+        /// Roll (1984).
+        ///
+        /// # Parameters
+        ///
+        /// - `alpha` — EW decay factor for the autocovariance estimator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_core::statistics::RollSpreadF64;
+        ///
+        /// let mut rs = RollSpreadF64::builder()
+        ///     .alpha(0.05)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// // Feed alternating prices (mean-reverting → negative autocov)
+        /// for i in 0..200 {
+        ///     let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+        ///     rs.update(price).unwrap();
+        /// }
+        /// assert!(rs.spread().is_some());
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            alpha: $ty,
+            one_minus_alpha: $ty,
+            ew_cov: $ty,
+            ew_var: $ty,
+            prev_price: $ty,
+            prev_diff: $ty,
+            count: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            alpha: Option<$ty>,
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    alpha: Option::None,
+                    min_samples: 30,
+                }
+            }
+
+            /// Feeds a trade price.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the price is NaN, or
+            /// `DataError::Infinite` if the price is infinite.
+            #[inline]
+            pub fn update(&mut self, price: $ty) -> Result<(), crate::DataError> {
+                check_finite!(price);
+                self.count += 1;
+
+                if self.count == 1 {
+                    self.prev_price = price;
+                    return Ok(());
+                }
+
+                let diff = price - self.prev_price;
+                self.prev_price = price;
+
+                if self.count == 2 {
+                    self.prev_diff = diff;
+                    return Ok(());
+                }
+
+                self.ew_cov = self
+                    .alpha
+                    .fma(diff * self.prev_diff, self.one_minus_alpha * self.ew_cov);
+                self.ew_var = self
+                    .alpha
+                    .fma(diff * diff, self.one_minus_alpha * self.ew_var);
+                self.prev_diff = diff;
+                Ok(())
+            }
+
+            /// Roll's spread: `2·√(-cov)`.
+            ///
+            /// Returns `None` if not primed or autocovariance is non-negative
+            /// (trending market — spread undefined).
+            #[inline]
+            #[must_use]
+            pub fn spread(&self) -> Option<$ty> {
+                if !self.is_primed() {
+                    return Option::None;
+                }
+                if self.ew_cov >= 0.0 as $ty {
+                    return Option::None;
+                }
+                #[allow(clippy::cast_possible_truncation)]
+                Option::Some(2.0 as $ty * crate::math::sqrt((-self.ew_cov) as f64) as $ty)
+            }
+
+            /// Hasbrouck's adjusted spread: `spread · √(1 + ρ)` where
+            /// `ρ = cov / var` is the first-order autocorrelation.
+            ///
+            /// Returns `None` if Roll spread is `None` or variance is zero.
+            #[inline]
+            #[must_use]
+            pub fn hasbrouck_spread(&self) -> Option<$ty> {
+                let s = self.spread()?;
+                if self.ew_var <= 0.0 as $ty {
+                    return Option::None;
+                }
+                let rho = self.ew_cov / self.ew_var;
+                let factor = 1.0 as $ty + rho;
+                if factor <= 0.0 as $ty {
+                    return Option::None;
+                }
+                #[allow(clippy::cast_possible_truncation)]
+                Option::Some(s * crate::math::sqrt(factor as f64) as $ty)
+            }
+
+            /// Raw exponentially weighted autocovariance, or `None` if not primed.
+            #[inline]
+            #[must_use]
+            pub fn autocovariance(&self) -> Option<$ty> {
+                if self.is_primed() {
+                    Option::Some(self.ew_cov)
+                } else {
+                    Option::None
+                }
+            }
+
+            /// Number of prices seen.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.count
+            }
+
+            /// Whether enough samples have been observed.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.count >= self.min_samples
+            }
+
+            /// Resets to uninitialized state. Parameters unchanged.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.ew_cov = 0.0 as $ty;
+                self.ew_var = 0.0 as $ty;
+                self.prev_price = 0.0 as $ty;
+                self.prev_diff = 0.0 as $ty;
+                self.count = 0;
+            }
+        }
+
+        impl $builder {
+            /// EW decay factor (required, in (0, 1)).
+            #[inline]
+            #[must_use]
+            pub fn alpha(mut self, alpha: $ty) -> Self {
+                self.alpha = Option::Some(alpha);
+                self
+            }
+
+            /// Minimum prices before results are valid. Default: 30.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, min: u64) -> Self {
+                self.min_samples = min;
+                self
+            }
+
+            /// Builds the Roll spread estimator.
+            ///
+            /// # Errors
+            ///
+            /// - Alpha must have been set and be in (0, 1).
+            #[inline]
+            pub fn build(self) -> Result<$name, crate::ConfigError> {
+                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+                if alpha <= 0.0 as $ty || alpha >= 1.0 as $ty || !alpha.is_finite() {
+                    return Err(crate::ConfigError::Invalid(
+                        "RollSpread alpha must be in (0, 1)",
+                    ));
+                }
+
+                Ok($name {
+                    alpha,
+                    one_minus_alpha: 1.0 as $ty - alpha,
+                    ew_cov: 0.0 as $ty,
+                    ew_var: 0.0 as $ty,
+                    prev_price: 0.0 as $ty,
+                    prev_diff: 0.0 as $ty,
+                    count: 0,
+                    min_samples: self.min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_roll_spread!(RollSpreadF64, RollSpreadF64Builder, f64);
+impl_roll_spread!(RollSpreadF32, RollSpreadF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mean_reverting_spread() {
+        let mut rs = RollSpreadF64::builder()
+            .alpha(0.05)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+            rs.update(price).unwrap();
+        }
+
+        let spread = rs.spread();
+        assert!(spread.is_some(), "mean-reverting should produce a spread");
+        assert!(spread.unwrap() > 0.0, "spread should be positive");
+    }
+
+    #[test]
+    fn trending_no_spread() {
+        let mut rs = RollSpreadF64::builder()
+            .alpha(0.05)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            rs.update(100.0 + i as f64 * 0.1).unwrap();
+        }
+
+        assert!(
+            rs.spread().is_none(),
+            "trending series should have no spread (positive autocov)"
+        );
+    }
+
+    #[test]
+    fn hasbrouck_vs_roll() {
+        let mut rs = RollSpreadF64::builder()
+            .alpha(0.05)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+            rs.update(price).unwrap();
+        }
+
+        let roll = rs.spread().unwrap();
+        if let Some(hasbrouck) = rs.hasbrouck_spread() {
+            assert!(
+                hasbrouck <= roll * 1.5,
+                "Hasbrouck should be reasonable relative to Roll: H={hasbrouck}, R={roll}"
+            );
+        }
+    }
+
+    #[test]
+    fn autocovariance_negative() {
+        let mut rs = RollSpreadF64::builder()
+            .alpha(0.05)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+            rs.update(price).unwrap();
+        }
+
+        let cov = rs.autocovariance().unwrap();
+        assert!(
+            cov < 0.0,
+            "mean-reverting should have negative autocov, got {cov}"
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut rs = RollSpreadF64::builder()
+            .alpha(0.05)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..50 {
+            let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+            rs.update(price).unwrap();
+        }
+        rs.reset();
+        assert_eq!(rs.count(), 0);
+        assert!(rs.spread().is_none());
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut rs = RollSpreadF64::builder().alpha(0.05).build().unwrap();
+        assert!(matches!(
+            rs.update(f64::NAN),
+            Err(crate::DataError::NotANumber)
+        ));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut rs = RollSpreadF64::builder().alpha(0.05).build().unwrap();
+        assert!(matches!(
+            rs.update(f64::INFINITY),
+            Err(crate::DataError::Infinite)
+        ));
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(matches!(
+            RollSpreadF64::builder().build(),
+            Err(crate::ConfigError::Missing("alpha"))
+        ));
+        assert!(matches!(
+            RollSpreadF64::builder().alpha(0.0).build(),
+            Err(crate::ConfigError::Invalid(_))
+        ));
+        assert!(matches!(
+            RollSpreadF64::builder().alpha(1.0).build(),
+            Err(crate::ConfigError::Invalid(_))
+        ));
+    }
+}

--- a/nexus-stats-core/src/statistics/two_scale_rv.rs
+++ b/nexus-stats-core/src/statistics/two_scale_rv.rs
@@ -1,0 +1,397 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+/// Two-scale realized variance — noise-corrected volatility estimator.
+///
+/// Combines high-frequency (all-tick) and subsampled (every K ticks)
+/// realized variance to cancel microstructure noise bias.
+///
+/// TSRV = RV_slow - (n_bar / n) · RV_fast
+///
+/// where n_bar = n_fast / K is the effective slow-scale sample count.
+///
+/// Zhang, Mykland, Aït-Sahalia (2005).
+///
+/// # Parameters
+///
+/// - `k` — subsampling frequency (typically 5–20)
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::TwoScaleRvF64;
+///
+/// let mut tsrv = TwoScaleRvF64::builder()
+///     .k(5)
+///     .min_samples(20)
+///     .build()
+///     .unwrap();
+///
+/// for i in 0..100 {
+///     tsrv.update(100.0 + (i as f64) * 0.01).unwrap();
+/// }
+/// assert!(tsrv.realized_variance().is_some());
+/// ```
+#[derive(Debug, Clone)]
+pub struct TwoScaleRvF64 {
+    fast_sum_sq: f64,
+    slow_sum_sq: f64,
+    buffer: Box<[f64]>,
+    write_idx: usize,
+    filled: bool,
+    prev_price: f64,
+    k: usize,
+    n_slow: u64,
+    count: u64,
+    min_samples: u64,
+}
+
+/// Builder for [`TwoScaleRvF64`].
+#[derive(Debug, Clone)]
+pub struct TwoScaleRvF64Builder {
+    k: Option<usize>,
+    min_samples: Option<u64>,
+}
+
+impl TwoScaleRvF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> TwoScaleRvF64Builder {
+        TwoScaleRvF64Builder {
+            k: Option::None,
+            min_samples: Option::None,
+        }
+    }
+
+    /// Feeds a trade price.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the price is NaN, or
+    /// `DataError::Infinite` if the price is infinite.
+    #[inline]
+    pub fn update(&mut self, price: f64) -> Result<(), crate::DataError> {
+        check_finite!(price);
+        self.count += 1;
+
+        if self.count >= 2 {
+            let fast_diff = price - self.prev_price;
+            self.fast_sum_sq += fast_diff * fast_diff;
+        }
+
+        let old_idx = (self.write_idx + 1) % self.k;
+        self.buffer[self.write_idx] = price;
+
+        if self.filled {
+            let old_price = self.buffer[old_idx];
+            let slow_diff = price - old_price;
+            self.slow_sum_sq += slow_diff * slow_diff;
+            self.n_slow += 1;
+        }
+
+        self.write_idx = (self.write_idx + 1) % self.k;
+        if self.write_idx == 0 {
+            self.filled = true;
+        }
+
+        self.prev_price = price;
+        Ok(())
+    }
+
+    /// Noise-corrected two-scale realized variance.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn realized_variance(&self) -> Option<f64> {
+        if !self.is_primed() {
+            return Option::None;
+        }
+        let n_fast = self.count - 1;
+        if n_fast == 0 || self.n_slow == 0 {
+            return Option::None;
+        }
+
+        let rv_slow = self.slow_sum_sq / self.n_slow as f64;
+        let n_bar = n_fast as f64 / self.k as f64;
+        let tsrv = rv_slow - (n_bar / n_fast as f64) * self.fast_sum_sq / n_fast as f64;
+
+        Option::Some(if tsrv > 0.0 { tsrv } else { 0.0 })
+    }
+
+    /// Noise-corrected realized volatility: `√(TSRV)`.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn realized_volatility(&self) -> Option<f64> {
+        self.realized_variance().map(crate::math::sqrt)
+    }
+
+    /// Raw all-tick realized variance (noisy).
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn fast_rv(&self) -> Option<f64> {
+        if !self.is_primed() || self.count < 2 {
+            return Option::None;
+        }
+        Option::Some(self.fast_sum_sq / (self.count - 1) as f64)
+    }
+
+    /// Estimated noise variance: `(RV_fast - TSRV) / 2`.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn noise_variance(&self) -> Option<f64> {
+        let fast = self.fast_rv()?;
+        let tsrv = self.realized_variance()?;
+        let noise = (fast - tsrv) / 2.0;
+        Option::Some(if noise > 0.0 { noise } else { 0.0 })
+    }
+
+    /// Number of prices seen.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough samples have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters and allocation preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.fast_sum_sq = 0.0;
+        self.slow_sum_sq = 0.0;
+        self.buffer.fill(0.0);
+        self.write_idx = 0;
+        self.filled = false;
+        self.prev_price = 0.0;
+        self.n_slow = 0;
+        self.count = 0;
+    }
+}
+
+impl TwoScaleRvF64Builder {
+    /// Subsampling frequency (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn k(mut self, k: usize) -> Self {
+        self.k = Option::Some(k);
+        self
+    }
+
+    /// Minimum prices before results are valid. Default: `k * 10`.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = Option::Some(min);
+        self
+    }
+
+    /// Builds the two-scale RV estimator.
+    ///
+    /// # Errors
+    ///
+    /// - `k` must have been set and be >= 2.
+    #[inline]
+    pub fn build(self) -> Result<TwoScaleRvF64, crate::ConfigError> {
+        let k = self.k.ok_or(crate::ConfigError::Missing("k"))?;
+        if k < 2 {
+            return Err(crate::ConfigError::Invalid("TwoScaleRv k must be >= 2"));
+        }
+
+        let min_samples = self.min_samples.unwrap_or((k * 10) as u64);
+
+        Ok(TwoScaleRvF64 {
+            fast_sum_sq: 0.0,
+            slow_sum_sq: 0.0,
+            buffer: vec![0.0; k].into_boxed_slice(),
+            write_idx: 0,
+            filled: false,
+            prev_price: 0.0,
+            k,
+            n_slow: 0,
+            count: 0,
+            min_samples,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn white_noise_correction() {
+        let mut tsrv = TwoScaleRvF64::builder()
+            .k(5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        // Noisy prices: smooth trend + noise
+        for i in 0..500 {
+            let noise = if i % 3 == 0 {
+                0.1
+            } else if i % 3 == 1 {
+                -0.1
+            } else {
+                0.0
+            };
+            tsrv.update(100.0 + (i as f64) * 0.001 + noise).unwrap();
+        }
+
+        let fast = tsrv.fast_rv().unwrap();
+        let corrected = tsrv.realized_variance().unwrap();
+        assert!(
+            corrected < fast,
+            "TSRV ({corrected}) should be less than fast RV ({fast}) for noisy data"
+        );
+    }
+
+    #[test]
+    fn clean_signal_produces_valid_result() {
+        let mut tsrv = TwoScaleRvF64::builder()
+            .k(5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            tsrv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+
+        let corrected = tsrv.realized_variance().unwrap();
+        assert!(
+            corrected >= 0.0,
+            "TSRV should be non-negative for clean data, got {corrected}"
+        );
+        let vol = tsrv.realized_volatility().unwrap();
+        assert!(vol >= 0.0, "volatility should be non-negative, got {vol}");
+    }
+
+    #[test]
+    fn noise_variance_positive() {
+        let mut tsrv = TwoScaleRvF64::builder()
+            .k(5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..500 {
+            let noise = if i % 2 == 0 { 0.1 } else { -0.1 };
+            tsrv.update(100.0 + noise).unwrap();
+        }
+
+        let nv = tsrv.noise_variance().unwrap();
+        assert!(nv >= 0.0, "noise variance should be non-negative, got {nv}");
+    }
+
+    #[test]
+    fn volatility_is_sqrt() {
+        let mut tsrv = TwoScaleRvF64::builder()
+            .k(5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..200 {
+            tsrv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+
+        let var = tsrv.realized_variance().unwrap();
+        let vol = tsrv.realized_volatility().unwrap();
+        assert!(
+            (vol * vol - var).abs() < 1e-10,
+            "vol² ({}) should equal var ({var})",
+            vol * vol
+        );
+    }
+
+    #[test]
+    fn k_sensitivity() {
+        let prices: alloc::vec::Vec<f64> = (0..500)
+            .map(|i| {
+                let noise = if i % 2 == 0 { 0.1 } else { -0.1 };
+                100.0 + (i as f64) * 0.001 + noise
+            })
+            .collect();
+
+        let mut tsrv_small = TwoScaleRvF64::builder()
+            .k(3)
+            .min_samples(10)
+            .build()
+            .unwrap();
+        let mut tsrv_large = TwoScaleRvF64::builder()
+            .k(10)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for &p in &prices {
+            tsrv_small.update(p).unwrap();
+            tsrv_large.update(p).unwrap();
+        }
+
+        // Both should produce valid results
+        assert!(tsrv_small.realized_variance().is_some());
+        assert!(tsrv_large.realized_variance().is_some());
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut tsrv = TwoScaleRvF64::builder()
+            .k(5)
+            .min_samples(10)
+            .build()
+            .unwrap();
+
+        for i in 0..50 {
+            tsrv.update(100.0 + (i as f64) * 0.01).unwrap();
+        }
+        tsrv.reset();
+        assert_eq!(tsrv.count(), 0);
+        assert!(tsrv.realized_variance().is_none());
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut tsrv = TwoScaleRvF64::builder().k(5).build().unwrap();
+        assert!(matches!(
+            tsrv.update(f64::NAN),
+            Err(crate::DataError::NotANumber)
+        ));
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut tsrv = TwoScaleRvF64::builder().k(5).build().unwrap();
+        assert!(matches!(
+            tsrv.update(f64::INFINITY),
+            Err(crate::DataError::Infinite)
+        ));
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(matches!(
+            TwoScaleRvF64::builder().build(),
+            Err(crate::ConfigError::Missing("k"))
+        ));
+        assert!(matches!(
+            TwoScaleRvF64::builder().k(1).build(),
+            Err(crate::ConfigError::Invalid(_))
+        ));
+    }
+}

--- a/nexus-stats-core/src/statistics/two_scale_rv.rs
+++ b/nexus-stats-core/src/statistics/two_scale_rv.rs
@@ -7,9 +7,9 @@ use alloc::vec;
 /// Combines high-frequency (all-tick) and subsampled (every K ticks)
 /// realized variance to cancel microstructure noise bias.
 ///
-/// TSRV = RV_slow - (n_bar / n) · RV_fast
+/// TSRV = [Y,Y]^{(avg)} - (n̄ / n) · [Y,Y]^{(all)}
 ///
-/// where n_bar = n_fast / K is the effective slow-scale sample count.
+/// where [Y,Y]^{(avg)} = Σ(K-tick returns²) / K and n̄ = n_slow / K.
 ///
 /// Zhang, Mykland, Aït-Sahalia (2005).
 ///
@@ -81,11 +81,10 @@ impl TwoScaleRvF64 {
             self.fast_sum_sq += fast_diff * fast_diff;
         }
 
-        let old_idx = (self.write_idx + 1) % self.k;
+        let oldest = if self.filled { Some(self.buffer[self.write_idx]) } else { None };
         self.buffer[self.write_idx] = price;
 
-        if self.filled {
-            let old_price = self.buffer[old_idx];
+        if let Some(old_price) = oldest {
             let slow_diff = price - old_price;
             self.slow_sum_sq += slow_diff * slow_diff;
             self.n_slow += 1;
@@ -114,9 +113,11 @@ impl TwoScaleRvF64 {
             return Option::None;
         }
 
-        let rv_slow = self.slow_sum_sq / self.n_slow as f64;
-        let n_bar = n_fast as f64 / self.k as f64;
-        let tsrv = rv_slow - (n_bar / n_fast as f64) * self.fast_sum_sq / n_fast as f64;
+        let n_bar = self.n_slow as f64 / self.k as f64;
+        let correction = n_bar / n_fast as f64;
+        let tsrv = crate::math::MulAdd::fma(
+            -correction, self.fast_sum_sq, self.slow_sum_sq / self.k as f64,
+        );
 
         Option::Some(if tsrv > 0.0 { tsrv } else { 0.0 })
     }
@@ -130,8 +131,9 @@ impl TwoScaleRvF64 {
         self.realized_variance().map(crate::math::sqrt)
     }
 
-    /// Raw all-tick realized variance (noisy).
+    /// Raw all-tick realized variance (noisy, unnormalized).
     ///
+    /// Returns the sum of squared one-tick returns: `[Y,Y]^{(all)}`.
     /// Returns `None` if not primed.
     #[inline]
     #[must_use]
@@ -139,10 +141,10 @@ impl TwoScaleRvF64 {
         if !self.is_primed() || self.count < 2 {
             return Option::None;
         }
-        Option::Some(self.fast_sum_sq / (self.count - 1) as f64)
+        Option::Some(self.fast_sum_sq)
     }
 
-    /// Estimated noise variance: `(RV_fast - TSRV) / 2`.
+    /// Estimated noise variance per observation: `([Y,Y]^{(all)} - TSRV) / 2n`.
     ///
     /// Returns `None` if not primed.
     #[inline]
@@ -150,7 +152,8 @@ impl TwoScaleRvF64 {
     pub fn noise_variance(&self) -> Option<f64> {
         let fast = self.fast_rv()?;
         let tsrv = self.realized_variance()?;
-        let noise = (fast - tsrv) / 2.0;
+        let n_fast = (self.count - 1) as f64;
+        let noise = (fast - tsrv) / (2.0 * n_fast);
         Option::Some(if noise > 0.0 { noise } else { 0.0 })
     }
 

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -84,6 +84,9 @@ for deep-dives on each algorithm.
 | `EwmaVarF64` | Exponentially weighted variance | 12 |
 | `CovarianceF64` | Online covariance + Pearson correlation | 12 |
 | `HarmonicMeanF64` | Correct average for rates/throughputs | 5 |
+| `BipowerVariationF64` | Jump-robust volatility (BV vs RV) | TBD |
+| `RollSpreadF64` *(std\|libm)* | Implicit bid-ask spread from autocovariance | TBD |
+| `TwoScaleRvF64` *(alloc, std\|libm)* | Noise-corrected realized variance | TBD |
 
 ### Regression
 
@@ -128,6 +131,7 @@ for deep-dives on each algorithm.
 | `ErrorRateF64` | Failure rate with weighted severity | 6 |
 | `TrendAlertF64` | Trend direction (Stable/Rising/Falling) | 12 |
 | `JitterF64` | Signal variability measurement | 6 |
+| `HawkesIntensityF64` *(std\|libm)* | Self-exciting point process intensity | TBD |
 
 ### Frequency & Scoring
 
@@ -174,6 +178,10 @@ intrinsics; integer types use bit-shift arithmetic.
 | PageHinkley | ✓ | ✓ | | | |
 | ADWIN | ✓ | ✓ | | | |
 | PredictiveInfoBound | ✓ | ✓ | | | |
+| BipowerVariation | ✓ | ✓ | | | |
+| RollSpread | ✓ | ✓ | | | |
+| TwoScaleRv | | ✓ | | | |
+| HawkesIntensity | ✓ | ✓ | | | |
 | Saturation, ErrorRate, TrendAlert | ✓ | ✓ | | | |
 | ShiryaevRoberts | | ✓ | | | |
 
@@ -271,6 +279,10 @@ See [`docs/use-cases/trading.md`](docs/use-cases/trading.md) for full guide with
 | Random walk test | `VarianceRatioF64` | core |
 | Distribution change | `DistributionShiftF64` | core |
 | Win rate | `HitRateF64` | core |
+| Jump-robust volatility | `BipowerVariationF64` | core |
+| Implicit spread estimation | `RollSpreadF64` | core |
+| Noise-corrected realized vol | `TwoScaleRvF64` | core |
+| Bursty event intensity | `HawkesIntensityF64` | core |
 | Conditional smoothing | `ConditionalEmaF64` | smoothing |
 
 ## License

--- a/nexus-stats/src/lib.rs
+++ b/nexus-stats/src/lib.rs
@@ -67,8 +67,8 @@
 //! |--------|----------|
 //! | [`smoothing`] | EMA, AsymEma, Slew |
 //! | [`detection`] | CUSUM |
-//! | [`statistics`] | Welford, Moments, EwmaVar, Covariance, HarmonicMean, Percentile, BipowerVariation, RollSpread, TwoScaleRv |
-//! | [`monitoring`] | Drawdown, Windowed Min/Max, CoDel, Liveness, EventRate, Jitter, ErrorRate, Saturation, HawkesIntensity |
+//! | [`statistics`] | Welford, Moments, EwmaVar, Covariance, HarmonicMean, Percentile, BipowerVariation, RollSpread *(std\|libm)*, TwoScaleRv *(alloc, std\|libm)* |
+//! | [`monitoring`] | Drawdown, Windowed Min/Max, CoDel, Liveness, EventRate, Jitter, ErrorRate, Saturation, HawkesIntensity *(std\|libm)* |
 //! | [`control`] | DeadBand, Hysteresis, Debounce, LevelCrossing, Diff |
 //!
 //! ## Advanced (feature-gated, re-exported from subcrates)

--- a/nexus-stats/src/lib.rs
+++ b/nexus-stats/src/lib.rs
@@ -67,8 +67,8 @@
 //! |--------|----------|
 //! | [`smoothing`] | EMA, AsymEma, Slew |
 //! | [`detection`] | CUSUM |
-//! | [`statistics`] | Welford, Moments, EwmaVar, Covariance, HarmonicMean, Percentile |
-//! | [`monitoring`] | Drawdown, Windowed Min/Max, CoDel, Liveness, EventRate, Jitter, ErrorRate, Saturation |
+//! | [`statistics`] | Welford, Moments, EwmaVar, Covariance, HarmonicMean, Percentile, BipowerVariation, RollSpread, TwoScaleRv |
+//! | [`monitoring`] | Drawdown, Windowed Min/Max, CoDel, Liveness, EventRate, Jitter, ErrorRate, Saturation, HawkesIntensity |
 //! | [`control`] | DeadBand, Hysteresis, Debounce, LevelCrossing, Diff |
 //!
 //! ## Advanced (feature-gated, re-exported from subcrates)


### PR DESCRIPTION
## Summary

Adds four streaming algorithms to `nexus-stats-core`, closing #290, #294, and #295:

- **RollSpreadF64/F32** (`statistics`) — Roll's implicit spread estimator from autocovariance of consecutive price changes. Includes Hasbrouck adjustment. EW decay, O(1) per update. Requires `std` or `libm`.
- **BipowerVariationF64/F32** (`statistics`) — Jump-robust volatility estimator (Barndorff-Nielsen & Shephard, 2004). Separates continuous variation from jumps via products of consecutive absolute returns. Fully `no_std`. O(1) per update.
- **TwoScaleRvF64** (`statistics`) — Noise-corrected realized variance (Zhang, Mykland, Aït-Sahalia, 2005). Ring-buffer subsampling at frequency K cancels microstructure noise bias. Requires `alloc` + (`std` or `libm`).
- **HawkesIntensityF64/F32** (`monitoring`) — Self-exciting point process with exponential decay kernel. Recursive O(1) update on u64 timestamps. Models bursty event arrivals. Requires `std` or `libm`.

Originally filed under a proposed `nexus-stats-trading` crate — all four are general-purpose streaming accumulators that belong in `nexus-stats-core`.

### Files changed (11)

**New (4):**
- `nexus-stats-core/src/statistics/roll_spread.rs`
- `nexus-stats-core/src/statistics/bipower.rs`
- `nexus-stats-core/src/statistics/two_scale_rv.rs`
- `nexus-stats-core/src/monitoring/hawkes.rs`

**Modified (7):**
- Module wiring (`statistics/mod.rs`, `monitoring/mod.rs`)
- Version bump 2.0.0 → 2.1.0 (`Cargo.toml`)
- `nexus-stats-core/CHANGELOG.md`, `nexus-stats-core/README.md`
- `nexus-stats/README.md`, `nexus-stats/src/lib.rs`

## Test plan

- [x] `cargo test -p nexus-stats-core --all-features`
- [x] `cargo test -p nexus-stats-core --no-default-features`
- [x] `cargo test -p nexus-stats --all-features`
- [x] `cargo clippy -p nexus-stats-core --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Verify Roll's spread returns None for trending data, positive for mean-reverting
- [ ] Verify Bipower jump_variation > 0 when series has a spike
- [ ] Verify TwoScaleRv corrects noisy fast-scale RV downward
- [ ] Verify Hawkes intensity spikes on event bursts, decays toward baseline

Closes #290, closes #294, closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)