### PR TITLE
multi-armed bandit algorithms for nexus-stats-regression

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,6 +46,12 @@ gotchas called out.
   reading p50/p99/p999/p9999, A/B comparison, common pitfalls.
   **Read this before running your first benchmark.**
 
+## Guides
+
+- [**bandits.md**](./bandits.md) — Multi-armed bandits: when to use
+  UCB1, Thompson, EpsilonGreedy, or EXP3. Discounting, reward
+  normalization, trading examples.
+
 ## Per-crate documentation
 
 Each crate owns its own deep-dive docs. When you need the internals of

--- a/docs/bandits.md
+++ b/docs/bandits.md
@@ -1,0 +1,272 @@
+# Multi-Armed Bandits
+
+Sequential decision algorithms that balance exploration (trying uncertain
+options) with exploitation (using the best-known option). All five types
+live in `nexus_stats::learning` (requires `regression` feature) or
+`nexus_stats_regression::learning`.
+
+Feature gate: `alloc` + (`std` or `libm`).
+
+---
+
+## What bandits solve
+
+You have K options (arms) and must choose one on each round. After
+choosing, you observe a reward. The goal: maximize cumulative reward
+over time by learning which arms are best while not spending too many
+rounds on bad arms.
+
+The core tension is explore vs exploit. Pure exploitation locks onto
+whatever looked best early and misses better options. Pure exploration
+gathers information but never uses it. Bandits formalize the tradeoff
+with provable regret bounds.
+
+Trading examples: which exchange fills fastest, which spread parameter
+yields the best P&L, which order size captures the most edge. The
+environment is often non-stationary — venue performance shifts, market
+regimes change, competitors adapt. All five types support exponential
+discounting via the `decay` builder parameter to handle this.
+
+---
+
+## When to use what
+
+| Your situation | Use | Why |
+|----------------|-----|-----|
+| Binary outcome (fill / no fill) | `ThompsonBetaF64` | Natural conjugate for Bernoulli rewards. Explores proportional to uncertainty. |
+| Positive continuous reward (latency, P&L) | `ThompsonGammaF64` | Gamma prior handles unbounded positive rewards. Posterior mean tracks sample mean. |
+| Bounded reward, want deterministic selection | `Ucb1F64` | No RNG needed. Deterministic upper confidence bound. Good for auditing. |
+| Want the simplest possible thing | `EpsilonGreedyF64` | One parameter (ε). Easy to reason about. Good baseline. |
+| Adversarial environment (competitors adapt) | `Exp3F64` | No stochastic assumption. Robust when reward distributions shift arbitrarily. |
+| Need to explain decisions to compliance | `Ucb1F64` | Deterministic: same state always selects the same arm. Auditable. |
+| Few arms (2-5), fast convergence matters | `ThompsonBetaF64` / `ThompsonGammaF64` | Thompson converges faster than UCB1 empirically, especially for few arms. |
+| Many arms (50+), concerned about cost | `EpsilonGreedyF64` | O(K) select is cheap. ε controls exploration budget directly. |
+
+### Decision tree
+
+```
+Is the reward binary (success/failure)?
+├─ Yes → ThompsonBetaF64
+└─ No → Is the reward always positive?
+    ├─ Yes → ThompsonGammaF64
+    └─ No → Can you normalize to [0, 1]?
+        ├─ Yes, and you want deterministic → Ucb1F64
+        ├─ Yes, and environment is adversarial → Exp3F64
+        └─ Yes, and you want simplicity → EpsilonGreedyF64
+```
+
+---
+
+## Discounting and non-stationarity
+
+All five types support `decay` in the builder. Default is `1.0`
+(stationary — all observations weighted equally). Set `decay < 1.0`
+to exponentially discount old observations.
+
+### Why discount
+
+A stationary bandit converges to the best arm and stays there. If
+the best arm changes (venue latency degrades, competitor enters a
+market, regime shifts), the bandit has accumulated so much evidence
+for the old best that it takes an unreasonable number of rounds to
+switch. This is the "converge fast then become wrong fast" failure
+mode.
+
+With `decay = 0.99`, each observation's effective weight halves
+every ~69 rounds (`ln(2) / ln(1/0.99) ≈ 69`). With `decay = 0.95`,
+the half-life is ~14 rounds.
+
+### Choosing a decay value
+
+| Regime change speed | Decay | Half-life |
+|---------------------|-------|-----------|
+| Slow (daily) | 0.999 | ~693 rounds |
+| Moderate (hourly) | 0.99 | ~69 rounds |
+| Fast (minutes) | 0.95 | ~14 rounds |
+| Very fast | 0.9 | ~7 rounds |
+
+Start with `0.99` and tune based on how quickly your environment
+changes. Too aggressive (low decay) and the bandit never converges.
+Too conservative (high decay) and it can't track shifts.
+
+### How it works internally
+
+Before each `update()`, all per-arm statistics are multiplied by
+`decay`. For UCB1 and EpsilonGreedy, this means counts and reward
+sums shrink. For Thompson variants, the prior parameters (α/β or
+shape/rate) shrink toward zero, widening the posterior and
+encouraging re-exploration of arms that haven't been pulled recently.
+
+---
+
+## Reward normalization
+
+The caller is responsible for normalizing rewards before feeding
+them to the bandit. Each algorithm has different requirements:
+
+| Algorithm | Valid rewards | Notes |
+|-----------|-------------|-------|
+| `Ucb1F64` | Any finite value | Regret bound assumes [0,1]. Scale `c` if using wider range. |
+| `ThompsonBetaF64` | [0, 1] | Returns `DataError` outside this range. |
+| `ThompsonGammaF64` | (0, ∞) | Returns `DataError` for zero or negative. |
+| `EpsilonGreedyF64` | Any finite value | No range assumption. |
+| `Exp3F64` | [0, 1] | Returns `DataError` outside this range. |
+
+### Normalization strategies
+
+**Z-score normalization** (for UCB1, EpsilonGreedy):
+Track a running `WelfordF64` on raw rewards. Normalize as
+`(reward - mean) / std_dev`, then shift to [0,1] if needed.
+
+**Min-max normalization** (for Exp3):
+`(reward - min) / (max - min)`. Use `RunningMinF64` /
+`RunningMaxF64` from nexus-stats monitoring, or windowed variants
+for non-stationary data.
+
+**Natural [0,1] rewards** (for ThompsonBeta):
+Fill rates, success rates, and binary outcomes are already in range.
+
+**Positive rewards** (for ThompsonGamma):
+Latency inverse (1/latency_us), P&L per unit risk, fill quality
+scores. If your reward can be zero, add a small epsilon or use
+a different algorithm.
+
+---
+
+## Code examples
+
+### Venue selection with Thompson Beta
+
+Four exchanges, binary fill/no-fill outcome. Non-stationary because
+venue performance shifts with market conditions.
+
+```rust
+use nexus_stats_regression::learning::ThompsonBetaF64;
+
+let mut venue_bandit = ThompsonBetaF64::builder()
+    .arms(4)               // 4 exchanges
+    .decay(0.99)           // half-life ~69 orders
+    .build()
+    .unwrap();
+
+// Your RNG source (any closure returning uniform [0, 1))
+let mut rng_state: u64 = 12345;
+let mut rng = || -> f64 {
+    // xorshift64 for illustration — use a proper RNG in production
+    rng_state ^= rng_state << 13;
+    rng_state ^= rng_state >> 7;
+    rng_state ^= rng_state << 17;
+    (rng_state as f64) / (u64::MAX as f64)
+};
+
+// On each order:
+let venue = venue_bandit.select(&mut rng);
+// ... send order to venue[venue] ...
+// ... observe fill (1.0) or no fill (0.0) ...
+let filled = 1.0_f64;
+venue_bandit.update(venue, filled).unwrap();
+
+// After warmup, check which venue is winning:
+for i in 0..4 {
+    let fill_rate = venue_bandit.mean_reward(i);
+    // fill_rate = alpha / (alpha + beta), the posterior mean
+}
+```
+
+### Parameter A/B with UCB1
+
+Two spread parameters, reward = normalized P&L per trade.
+Deterministic selection for auditability.
+
+```rust
+use nexus_stats_regression::learning::Ucb1F64;
+use nexus_stats::statistics::WelfordF64;
+
+let mut spread_bandit = Ucb1F64::builder()
+    .arms(2)               // 2 spread settings
+    .exploration(1.0)      // slightly less than default sqrt(2)
+    .decay(0.995)          // slow decay, spreads are stable
+    .build()
+    .unwrap();
+
+// Normalize rewards with running stats
+let mut reward_stats = WelfordF64::new();
+
+// On each trade:
+let spread_idx = spread_bandit.select();
+// ... use spread_settings[spread_idx] ...
+// ... observe P&L ...
+let pnl = 0.5_f64;
+
+// Normalize to roughly [0,1]
+reward_stats.update(pnl);
+let normalized = if let (Some(mean), Some(std)) =
+    (reward_stats.mean(), reward_stats.std_dev())
+{
+    if std > 0.0 { ((pnl - mean) / (4.0 * std) + 0.5).clamp(0.0, 1.0) }
+    else { 0.5 }
+} else { 0.5 };
+
+spread_bandit.update(spread_idx, normalized).unwrap();
+```
+
+### Adversarial setting with EXP3
+
+Market adapts to your strategy. Reward distributions shift
+unpredictably. EXP3 provides worst-case guarantees.
+
+```rust
+use nexus_stats_regression::learning::Exp3F64;
+
+let mut strategy_bandit = Exp3F64::builder()
+    .arms(3)               // 3 strategy variants
+    .gamma(0.2)            // 20% exploration mixing
+    .build()
+    .unwrap();
+
+let mut rng_state: u64 = 42;
+let mut rng = || -> f64 {
+    rng_state ^= rng_state << 13;
+    rng_state ^= rng_state >> 7;
+    rng_state ^= rng_state << 17;
+    (rng_state as f64) / (u64::MAX as f64)
+};
+
+// EXP3 returns both the arm and the selection probability
+let (strategy, prob) = strategy_bandit.select(&mut rng);
+// ... execute strategy[strategy] ...
+// ... observe reward in [0, 1] ...
+let reward = 0.7_f64;
+
+// Must pass prob back — EXP3 uses importance weighting
+strategy_bandit.update(strategy, reward, prob).unwrap();
+
+// Inspect current probability distribution
+let mut probs = vec![0.0_f64; 3];
+strategy_bandit.probabilities(&mut probs);
+// probs[i] shows how much weight each strategy has
+```
+
+---
+
+## API summary
+
+All types share a common pattern:
+
+| Method | UCB1 | ThompsonBeta | ThompsonGamma | EpsilonGreedy | EXP3 |
+|--------|------|-------------|--------------|--------------|------|
+| `select` | `-> usize` | `(rng) -> usize` | `(rng) -> usize` | `(rng) -> usize` | `(rng) -> (usize, prob)` |
+| `update` | `(arm, reward)` | `(arm, reward)` | `(arm, reward)` | `(arm, reward)` | `(arm, reward, prob)` |
+| `mean_reward` | `Option<f64>` | `f64` | `f64` | `Option<f64>` | — |
+| `is_primed` | yes | yes | yes | yes | yes |
+| `reset` | yes | yes | yes | yes | yes |
+| `num_arms` | yes | yes | yes | yes | yes |
+| `total_pulls` | yes | yes | yes | yes | yes |
+
+UCB1 is the only type that doesn't need an RNG for selection.
+
+Thompson `mean_reward` always returns a value (prior provides a
+baseline). UCB1 and EpsilonGreedy return `None` for unpulled arms.
+
+EXP3 doesn't track per-arm means — it maintains weights. Use
+`probabilities()` to see the current distribution.

--- a/docs/bandits.md
+++ b/docs/bandits.md
@@ -59,9 +59,12 @@ Is the reward binary (success/failure)?
 
 ## Discounting and non-stationarity
 
-All five types support `decay` in the builder. Default is `1.0`
-(stationary — all observations weighted equally). Set `decay < 1.0`
-to exponentially discount old observations.
+Four types (UCB1, ThompsonBeta, ThompsonGamma, EpsilonGreedy) support
+`decay` in the builder. Default is `1.0` (stationary — all observations
+weighted equally). Set `decay < 1.0` to exponentially discount old
+observations. EXP3 handles non-stationarity differently — its `gamma`
+parameter controls exploration mixing, ensuring continued exploration
+without explicit discounting.
 
 ### Why discount
 
@@ -96,6 +99,11 @@ Before each `update()`, all per-arm statistics are multiplied by
 sums shrink. For Thompson variants, the prior parameters (α/β or
 shape/rate) shrink toward zero, widening the posterior and
 encouraging re-exploration of arms that haven't been pulled recently.
+
+EXP3 does not use `decay`. Its exploration is governed by `gamma`,
+which mixes uniform exploration into every selection. This provides
+inherent adaptivity without discounting — the multiplicative weight
+updates naturally track shifting reward distributions.
 
 ---
 

--- a/docs/bandits.md
+++ b/docs/bandits.md
@@ -24,8 +24,10 @@ with provable regret bounds.
 Trading examples: which exchange fills fastest, which spread parameter
 yields the best P&L, which order size captures the most edge. The
 environment is often non-stationary — venue performance shifts, market
-regimes change, competitors adapt. All five types support exponential
-discounting via the `decay` builder parameter to handle this.
+regimes change, competitors adapt. Four types (UCB1, ThompsonBeta,
+ThompsonGamma, EpsilonGreedy) support exponential discounting via
+the `decay` builder parameter. EXP3 handles non-stationarity through
+its `gamma` exploration mixing rate.
 
 ---
 
@@ -164,7 +166,7 @@ let mut rng = || -> f64 {
     rng_state ^= rng_state << 13;
     rng_state ^= rng_state >> 7;
     rng_state ^= rng_state << 17;
-    (rng_state as f64) / (u64::MAX as f64)
+    (rng_state >> 11) as f64 / (1u64 << 53) as f64
 };
 
 // On each order:
@@ -237,7 +239,7 @@ let mut rng = || -> f64 {
     rng_state ^= rng_state << 13;
     rng_state ^= rng_state >> 7;
     rng_state ^= rng_state << 17;
-    (rng_state as f64) / (u64::MAX as f64)
+    (rng_state >> 11) as f64 / (1u64 << 53) as f64
 };
 
 // EXP3 returns both the arm and the selection probability

--- a/nexus-stats-regression/CHANGELOG.md
+++ b/nexus-stats-regression/CHANGELOG.md
@@ -23,8 +23,10 @@ contained.
 - **`EpsilonGreedyF64/F32`** — Epsilon-greedy bandit. Simplest baseline.
 - **`Exp3F64/F32`** — EXP3 adversarial bandit. Robust to non-stochastic
   rewards. Auer, Cesa-Bianchi, Freund, Schapire (2002).
-- All five types support exponential discounting via `decay` parameter
-  for non-stationary reward environments.
+- UCB1, ThompsonBeta, ThompsonGamma, and EpsilonGreedy support
+  exponential discounting via `decay` parameter for non-stationary
+  reward environments. EXP3 handles non-stationarity through its
+  `gamma` exploration mixing rate.
 - Internal sampling utilities (Marsaglia polar, Marsaglia-Tsang Gamma,
   Beta from Gamma ratio).
 

--- a/nexus-stats-regression/CHANGELOG.md
+++ b/nexus-stats-regression/CHANGELOG.md
@@ -10,6 +10,26 @@ contained.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-05-19
+
+### Added
+
+- **`Ucb1F64/F32`** — UCB1 multi-armed bandit. Deterministic selection,
+  no RNG needed. Auer, Cesa-Bianchi, Fischer (2002).
+- **`ThompsonBetaF64/F32`** — Thompson Sampling with Beta conjugate
+  prior for binary/[0,1] rewards. Thompson (1933).
+- **`ThompsonGammaF64/F32`** — Thompson Sampling with Gamma conjugate
+  prior for positive continuous rewards.
+- **`EpsilonGreedyF64/F32`** — Epsilon-greedy bandit. Simplest baseline.
+- **`Exp3F64/F32`** — EXP3 adversarial bandit. Robust to non-stochastic
+  rewards. Auer, Cesa-Bianchi, Freund, Schapire (2002).
+- All five types support exponential discounting via `decay` parameter
+  for non-stationary reward environments.
+- Internal sampling utilities (Marsaglia polar, Marsaglia-Tsang Gamma,
+  Beta from Gamma ratio).
+
+All bandit types require `alloc` + (`std` or `libm`).
+
 ## [1.2.0] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-stats-regression/Cargo.toml
+++ b/nexus-stats-regression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-stats-regression"
-version = "1.2.1"
+version = "1.3.0"
 description = "Online regression, learning, and estimation for nexus-stats"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-stats-regression/README.md
+++ b/nexus-stats-regression/README.md
@@ -18,6 +18,11 @@ Online regression, learning, and estimation for [nexus-stats](https://crates.io/
 - **OnlineGdF64** — Online gradient descent (requires `alloc`)
 - **AdaGradF64** — AdaGrad optimizer (requires `alloc` + (`std` or `libm`))
 - **AdamF64** — Adam optimizer (requires `alloc` + (`std` or `libm`))
+- **Ucb1F64** — UCB1 multi-armed bandit (requires `alloc` + (`std` or `libm`))
+- **ThompsonBetaF64** — Thompson Sampling with Beta prior (requires `alloc` + (`std` or `libm`))
+- **ThompsonGammaF64** — Thompson Sampling with Gamma prior (requires `alloc` + (`std` or `libm`))
+- **EpsilonGreedyF64** — Epsilon-greedy bandit (requires `alloc` + (`std` or `libm`))
+- **Exp3F64** — EXP3 adversarial bandit (requires `alloc` + (`std` or `libm`))
 
 ## Estimation Types
 

--- a/nexus-stats-regression/src/learning/epsilon_greedy.rs
+++ b/nexus-stats-regression/src/learning/epsilon_greedy.rs
@@ -84,8 +84,8 @@ macro_rules! impl_epsilon_greedy {
             #[allow(clippy::float_cmp)]
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
                 // Round-robin unpulled arms first
-                for i in 0..self.num_arms {
-                    if self.counts[i] == 0.0 as $ty {
+                for (i, &c) in self.counts.iter().enumerate() {
+                    if c == 0.0 as $ty {
                         return i;
                     }
                 }
@@ -104,9 +104,9 @@ macro_rules! impl_epsilon_greedy {
                 } else {
                     // Exploit: best mean reward
                     let mut best_arm = 0;
-                    let mut best_mean = self.rewards[0] / self.counts[0];
-                    for i in 1..self.num_arms {
-                        let mean = self.rewards[i] / self.counts[i];
+                    let mut best_mean = -(1.0 as $ty / 0.0 as $ty);
+                    for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
+                        let mean = r / c;
                         if mean > best_mean {
                             best_mean = mean;
                             best_arm = i;
@@ -139,9 +139,10 @@ macro_rules! impl_epsilon_greedy {
                 );
 
                 if self.decay < 1.0 as $ty {
-                    for i in 0..self.num_arms {
-                        self.counts[i] *= self.decay;
-                        self.rewards[i] *= self.decay;
+                    let decay = self.decay;
+                    for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
+                        *c *= decay;
+                        *r *= decay;
                     }
                 }
 

--- a/nexus-stats-regression/src/learning/epsilon_greedy.rs
+++ b/nexus-stats-regression/src/learning/epsilon_greedy.rs
@@ -1,0 +1,526 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+macro_rules! impl_epsilon_greedy {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// Epsilon-greedy multi-armed bandit.
+        ///
+        /// With probability `epsilon`, selects a uniformly random arm
+        /// (explore). Otherwise selects the arm with the highest mean
+        /// reward (exploit). Ties broken by lowest index.
+        ///
+        /// Arms with zero pulls are selected first (round-robin, lowest
+        /// index priority) before the epsilon-greedy rule applies.
+        ///
+        /// The simplest bandit algorithm. Useful as a baseline and when
+        /// operational simplicity matters more than convergence speed.
+        ///
+        /// # Parameters
+        ///
+        /// - `arms` — number of arms (>= 2)
+        /// - `epsilon` — exploration probability, in (0, 1)
+        /// - `decay` — exponential discount on counts/rewards (default: 1.0)
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_regression::learning::EpsilonGreedyF64;
+        ///
+        /// let mut bandit = EpsilonGreedyF64::builder()
+        ///     .arms(3)
+        ///     .epsilon(0.1)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// let mut s: u64 = 42;
+        /// let mut rng = || -> f64 {
+        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ///     (s >> 33) as f64 / (1u64 << 31) as f64
+        /// };
+        /// let arm = bandit.select(&mut rng);
+        /// bandit.update(arm, 1.0).unwrap();
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            counts: Box<[$ty]>,
+            rewards: Box<[$ty]>,
+            epsilon: $ty,
+            decay: $ty,
+            total_pulls: u64,
+            num_arms: usize,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            arms: Option<usize>,
+            epsilon: Option<$ty>,
+            decay: $ty,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    arms: Option::None,
+                    epsilon: Option::None,
+                    decay: 1.0 as $ty,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Selects an arm: random with probability epsilon, best mean otherwise.
+            ///
+            /// Unpulled arms are selected first (lowest index priority).
+            /// `rng` must return a uniform sample in [0, 1).
+            #[must_use]
+            #[allow(clippy::float_cmp)]
+            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
+                // Round-robin unpulled arms first
+                for i in 0..self.num_arms {
+                    if self.counts[i] == 0.0 as $ty {
+                        return i;
+                    }
+                }
+
+                let coin = rng();
+                if coin < self.epsilon {
+                    // Explore: uniform random arm
+                    let r = rng();
+                    let idx = (r * self.num_arms as $ty) as usize;
+                    // Clamp to valid range (r could be very close to 1.0)
+                    if idx >= self.num_arms {
+                        self.num_arms - 1
+                    } else {
+                        idx
+                    }
+                } else {
+                    // Exploit: best mean reward
+                    let mut best_arm = 0;
+                    let mut best_mean = self.rewards[0] / self.counts[0];
+                    for i in 1..self.num_arms {
+                        let mean = self.rewards[i] / self.counts[i];
+                        if mean > best_mean {
+                            best_mean = mean;
+                            best_arm = i;
+                        }
+                    }
+                    best_arm
+                }
+            }
+
+            /// Records a reward for an arm.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError` if reward is NaN or infinite.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `arm >= num_arms`.
+            #[inline]
+            pub fn update(
+                &mut self,
+                arm: usize,
+                reward: $ty,
+            ) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(reward);
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+
+                if self.decay < 1.0 as $ty {
+                    for i in 0..self.num_arms {
+                        self.counts[i] *= self.decay;
+                        self.rewards[i] *= self.decay;
+                    }
+                }
+
+                self.counts[arm] += 1.0 as $ty;
+                self.rewards[arm] += reward;
+                self.total_pulls += 1;
+                Ok(())
+            }
+
+            /// Mean reward for an arm, or `None` if never pulled.
+            #[inline]
+            #[must_use]
+            #[allow(clippy::float_cmp)]
+            pub fn mean_reward(&self, arm: usize) -> Option<$ty> {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                if self.counts[arm] == 0.0 as $ty {
+                    return Option::None;
+                }
+                Option::Some(self.rewards[arm] / self.counts[arm])
+            }
+
+            /// Effective pull count for an arm (decayed).
+            #[inline]
+            #[must_use]
+            pub fn pulls(&self, arm: usize) -> $ty {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                self.counts[arm]
+            }
+
+            /// Total pulls across all arms (un-decayed counter).
+            #[inline]
+            #[must_use]
+            pub fn total_pulls(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Number of arms.
+            #[inline]
+            #[must_use]
+            pub fn num_arms(&self) -> usize {
+                self.num_arms
+            }
+
+            /// Whether all arms have been pulled at least once
+            /// and `total_pulls >= min_samples`.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0 as $ty)
+            }
+
+            /// Returns the number of updates performed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Resets all state, keeping configuration.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.counts.fill(0.0 as $ty);
+                self.rewards.fill(0.0 as $ty);
+                self.total_pulls = 0;
+            }
+        }
+
+        impl $builder {
+            /// Sets the number of arms (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn arms(mut self, n: usize) -> Self {
+                self.arms = Option::Some(n);
+                self
+            }
+
+            /// Sets the exploration probability (required, in (0, 1)).
+            #[inline]
+            #[must_use]
+            pub fn epsilon(mut self, e: $ty) -> Self {
+                self.epsilon = Option::Some(e);
+                self
+            }
+
+            /// Sets the decay factor (default: 1.0, in (0, 1]).
+            #[inline]
+            #[must_use]
+            pub fn decay(mut self, d: $ty) -> Self {
+                self.decay = d;
+                self
+            }
+
+            /// Sets the minimum samples before `is_primed()` returns true.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = Option::Some(n);
+                self
+            }
+
+            /// Builds the bandit.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let arms = self
+                    .arms
+                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+                let epsilon = self
+                    .epsilon
+                    .ok_or(nexus_stats_core::ConfigError::Missing("epsilon"))?;
+                if arms < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+                }
+                if epsilon <= 0.0 as $ty || epsilon >= 1.0 as $ty || !epsilon.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "epsilon must be in (0, 1)",
+                    ));
+                }
+                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "decay must be in (0, 1]",
+                    ));
+                }
+                let min_samples = self.min_samples.unwrap_or(arms as u64);
+                Ok($name {
+                    counts: vec![0.0 as $ty; arms].into_boxed_slice(),
+                    rewards: vec![0.0 as $ty; arms].into_boxed_slice(),
+                    epsilon,
+                    decay: self.decay,
+                    total_pulls: 0,
+                    num_arms: arms,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_epsilon_greedy!(EpsilonGreedyF64, EpsilonGreedyF64Builder, f64);
+impl_epsilon_greedy!(EpsilonGreedyF32, EpsilonGreedyF32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng(seed: u64) -> impl FnMut() -> f64 {
+        let mut state = seed;
+        move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / (1u64 << 31) as f64
+        }
+    }
+
+    #[test]
+    fn explore_all_first() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(3)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        let mut rng = make_rng(42);
+
+        let a0 = bandit.select(&mut rng);
+        bandit.update(a0, 0.5).unwrap();
+        let a1 = bandit.select(&mut rng);
+        assert_ne!(a1, a0);
+        bandit.update(a1, 0.5).unwrap();
+        let a2 = bandit.select(&mut rng);
+        assert_ne!(a2, a0);
+        assert_ne!(a2, a1);
+    }
+
+    #[test]
+    fn pure_exploit() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(3)
+            .epsilon(0.01) // very low exploration
+            .build()
+            .unwrap();
+
+        // Seed all arms
+        bandit.update(0, 0.0).unwrap();
+        bandit.update(1, 1.0).unwrap();
+        bandit.update(2, 0.0).unwrap();
+
+        let mut rng = make_rng(42);
+        let mut best_count = 0u32;
+        let trials = 500;
+        for _ in 0..trials {
+            let arm = bandit.select(&mut rng);
+            if arm == 1 {
+                best_count += 1;
+            }
+            bandit
+                .update(arm, if arm == 1 { 1.0 } else { 0.0 })
+                .unwrap();
+        }
+
+        assert!(
+            best_count as f64 / trials as f64 > 0.9,
+            "best arm fraction = {}",
+            best_count as f64 / trials as f64
+        );
+    }
+
+    #[test]
+    fn explores_at_rate() {
+        let epsilon = 0.3;
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(epsilon)
+            .build()
+            .unwrap();
+
+        // Seed both arms — arm 0 is clearly better
+        bandit.update(0, 1.0).unwrap();
+        bandit.update(1, 0.0).unwrap();
+
+        let mut rng = make_rng(42);
+        let mut explore_count = 0u32;
+        let trials = 2000;
+        for _ in 0..trials {
+            let arm = bandit.select(&mut rng);
+            if arm == 1 {
+                explore_count += 1;
+            }
+            bandit
+                .update(arm, if arm == 0 { 1.0 } else { 0.0 })
+                .unwrap();
+        }
+
+        // Should explore ~epsilon/2 of the time (half of explores go to arm 1)
+        let explore_rate = explore_count as f64 / trials as f64;
+        assert!(
+            explore_rate > 0.05 && explore_rate < 0.4,
+            "explore_rate={explore_rate}, expected ~{}",
+            epsilon / 2.0
+        );
+    }
+
+    #[test]
+    fn decay_adapts() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(0.1)
+            .decay(0.9)
+            .build()
+            .unwrap();
+
+        // Phase 1: arm 0 best
+        for _ in 0..50 {
+            bandit.update(0, 1.0).unwrap();
+            bandit.update(1, 0.0).unwrap();
+        }
+        assert!(bandit.mean_reward(0).unwrap() > bandit.mean_reward(1).unwrap());
+
+        // Phase 2: arm 1 best
+        for _ in 0..100 {
+            bandit.update(0, 0.0).unwrap();
+            bandit.update(1, 1.0).unwrap();
+        }
+        assert!(
+            bandit.mean_reward(1).unwrap() > bandit.mean_reward(0).unwrap(),
+            "should adapt: arm0={}, arm1={}",
+            bandit.mean_reward(0).unwrap(),
+            bandit.mean_reward(1).unwrap(),
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        bandit.update(0, 1.0).unwrap();
+        bandit.reset();
+        assert_eq!(bandit.total_pulls(), 0);
+        assert_eq!(bandit.mean_reward(0), Option::None);
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        assert_eq!(
+            bandit.update(0, f64::NAN),
+            Err(nexus_stats_core::DataError::NotANumber)
+        );
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        assert_eq!(
+            bandit.update(0, f64::INFINITY),
+            Err(nexus_stats_core::DataError::Infinite)
+        );
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(
+            EpsilonGreedyF64::builder()
+                .arms(1)
+                .epsilon(0.1)
+                .build()
+                .is_err()
+        );
+        assert!(
+            EpsilonGreedyF64::builder()
+                .arms(2)
+                .epsilon(0.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            EpsilonGreedyF64::builder()
+                .arms(2)
+                .epsilon(1.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            EpsilonGreedyF64::builder()
+                .arms(2)
+                .epsilon(-0.1)
+                .build()
+                .is_err()
+        );
+        assert!(
+            EpsilonGreedyF64::builder()
+                .arms(2)
+                .epsilon(0.1)
+                .decay(0.0)
+                .build()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn mean_reward_tracks() {
+        let mut bandit = EpsilonGreedyF64::builder()
+            .arms(2)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+
+        for _ in 0..100 {
+            bandit.update(0, 0.8).unwrap();
+            bandit.update(1, 0.2).unwrap();
+        }
+
+        let m0 = bandit.mean_reward(0).unwrap();
+        let m1 = bandit.mean_reward(1).unwrap();
+        assert!(
+            (m0 - 0.8).abs() < 0.01,
+            "mean_reward(0)={m0}, expected ~0.8"
+        );
+        assert!(
+            (m1 - 0.2).abs() < 0.01,
+            "mean_reward(1)={m1}, expected ~0.2"
+        );
+    }
+}

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -89,11 +89,12 @@ macro_rules! impl_exp3 {
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> (usize, $ty) {
                 let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
+                let gamma = self.gamma;
                 let u = rng();
                 let mut cumulative = 0.0 as $ty;
 
-                for i in 0..self.num_arms {
-                    let p_i = (1.0 as $ty - self.gamma) * self.weights[i] / sum_w + self.gamma / k;
+                for (i, &w) in self.weights.iter().enumerate() {
+                    let p_i = (1.0 as $ty - gamma) * w / sum_w + gamma / k;
                     cumulative += p_i;
                     if u < cumulative {
                         return (i, p_i);
@@ -103,7 +104,7 @@ macro_rules! impl_exp3 {
                 // Numerical safety: return last arm
                 let last = self.num_arms - 1;
                 let p_last =
-                    (1.0 as $ty - self.gamma) * self.weights[last] / sum_w + self.gamma / k;
+                    (1.0 as $ty - gamma) * self.weights[last] / sum_w + gamma / k;
                 (last, p_last)
             }
 
@@ -183,8 +184,9 @@ macro_rules! impl_exp3 {
                 );
                 let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
-                for i in 0..self.num_arms {
-                    out[i] = (1.0 as $ty - self.gamma) * self.weights[i] / sum_w + self.gamma / k;
+                let gamma = self.gamma;
+                for (o, &w) in out.iter_mut().zip(self.weights.iter()) {
+                    *o = (1.0 as $ty - gamma) * w / sum_w + gamma / k;
                 }
             }
 

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -90,11 +90,13 @@ macro_rules! impl_exp3 {
                 let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
                 let gamma = self.gamma;
+                let scale = (1.0 as $ty - gamma) / sum_w;
+                let gamma_over_k = gamma / k;
                 let u = rng();
                 let mut cumulative = 0.0 as $ty;
 
                 for (i, &w) in self.weights.iter().enumerate() {
-                    let p_i = (1.0 as $ty - gamma) * w / sum_w + gamma / k;
+                    let p_i = w * scale + gamma_over_k;
                     cumulative += p_i;
                     if u < cumulative {
                         return (i, p_i);
@@ -103,8 +105,7 @@ macro_rules! impl_exp3 {
 
                 // Numerical safety: return last arm
                 let last = self.num_arms - 1;
-                let p_last =
-                    (1.0 as $ty - gamma) * self.weights[last] / sum_w + gamma / k;
+                let p_last = self.weights[last] * scale + gamma_over_k;
                 (last, p_last)
             }
 
@@ -185,8 +186,10 @@ macro_rules! impl_exp3 {
                 let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
                 let gamma = self.gamma;
+                let scale = (1.0 as $ty - gamma) / sum_w;
+                let gamma_over_k = gamma / k;
                 for (o, &w) in out.iter_mut().zip(self.weights.iter()) {
-                    *o = (1.0 as $ty - gamma) * w / sum_w + gamma / k;
+                    *o = w * scale + gamma_over_k;
                 }
             }
 

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -49,14 +49,31 @@ macro_rules! impl_exp3 {
         /// let (arm, prob) = bandit.select(&mut rng);
         /// bandit.update(arm, 0.8, prob).unwrap();
         /// ```
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $name {
             log_weights: Box<[$ty]>,
+            scratch: core::cell::UnsafeCell<Box<[$ty]>>,
             gamma: $ty,
             eta: $ty,
             total_pulls: u64,
             num_arms: usize,
             min_samples: u64,
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                Self {
+                    log_weights: self.log_weights.clone(),
+                    scratch: core::cell::UnsafeCell::new(
+                        vec![0.0 as $ty; self.num_arms].into_boxed_slice(),
+                    ),
+                    gamma: self.gamma,
+                    eta: self.eta,
+                    total_pulls: self.total_pulls,
+                    num_arms: self.num_arms,
+                    min_samples: self.min_samples,
+                }
+            }
         }
 
         /// Builder for [`
@@ -88,31 +105,35 @@ macro_rules! impl_exp3 {
             /// Returns `(arm_index, selection_probability)`. The caller
             /// must pass the probability back to `update()`.
             ///
-            /// Uses log-sum-exp internally for numerical stability.
+            /// Uses log-sum-exp with a cached scratch buffer to avoid
+            /// recomputing exp() values during CDF sampling.
             #[must_use]
             #[allow(clippy::suboptimal_flops, clippy::cast_possible_truncation)]
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> (usize, $ty) {
                 let k = self.num_arms as $ty;
                 let gamma = self.gamma;
 
-                // Log-sum-exp: find max for numerical stability
+                // SAFETY: scratch is a write-only cache derived from log_weights.
+                // No reference escapes this method and select() is not reentrant.
+                let scratch = unsafe { &mut *self.scratch.get() };
+
                 let max_lw = self.log_weights.iter().copied()
                     .fold(-(1.0 as $ty / 0.0 as $ty), |a, b| if a > b { a } else { b });
 
-                // First pass: sum of exp(lw - max_lw)
+                // Compute exp values into scratch, accumulate sum (K exp calls)
                 let mut sum_exp = 0.0 as $ty;
-                for &lw in self.log_weights.iter() {
-                    sum_exp += nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                for (s, &lw) in scratch.iter_mut().zip(self.log_weights.iter()) {
+                    *s = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                    sum_exp += *s;
                 }
 
-                // Second pass: sample from CDF
                 let scale = (1.0 as $ty - gamma) / sum_exp;
                 let gamma_over_k = gamma / k;
                 let u = rng();
                 let mut cumulative = 0.0 as $ty;
 
-                for (i, &lw) in self.log_weights.iter().enumerate() {
-                    let exp_w = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                // CDF sampling from cached exp values — no exp() calls
+                for (i, &exp_w) in scratch.iter().enumerate() {
                     let p_i = exp_w * scale + gamma_over_k;
                     cumulative += p_i;
                     if u < cumulative {
@@ -120,10 +141,8 @@ macro_rules! impl_exp3 {
                     }
                 }
 
-                // Numerical safety: return last arm
                 let last = self.num_arms - 1;
-                let exp_last = nexus_stats_core::math::exp((self.log_weights[last] - max_lw) as f64) as $ty;
-                let p_last = exp_last * scale + gamma_over_k;
+                let p_last = scratch[last] * scale + gamma_over_k;
                 (last, p_last)
             }
 
@@ -294,6 +313,9 @@ macro_rules! impl_exp3 {
                 let min_samples = self.min_samples.unwrap_or(arms as u64);
                 Ok($name {
                     log_weights: vec![0.0 as $ty; arms].into_boxed_slice(),
+                    scratch: core::cell::UnsafeCell::new(
+                        vec![0.0 as $ty; arms].into_boxed_slice(),
+                    ),
                     gamma,
                     eta,
                     total_pulls: 0,

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -13,7 +13,10 @@ macro_rules! impl_exp3 {
         ///
         /// Selection probability: `p_i = (1 - gamma) * w_i / sum(w) + gamma / K`
         ///
-        /// Weight update: `w_i *= exp(eta * reward / (K * p_i))`
+        /// Weight update (log-space): `ln(w_i) += eta * reward / (K * p_i)`
+        ///
+        /// Internally stores log-weights for numerical stability. No
+        /// overflow possible regardless of learning rate or horizon.
         ///
         /// Auer, Cesa-Bianchi, Freund, Schapire (2002).
         ///
@@ -48,7 +51,7 @@ macro_rules! impl_exp3 {
         /// ```
         #[derive(Debug, Clone)]
         pub struct $name {
-            weights: Box<[$ty]>,
+            log_weights: Box<[$ty]>,
             gamma: $ty,
             eta: $ty,
             total_pulls: u64,
@@ -84,19 +87,33 @@ macro_rules! impl_exp3 {
             ///
             /// Returns `(arm_index, selection_probability)`. The caller
             /// must pass the probability back to `update()`.
+            ///
+            /// Uses log-sum-exp internally for numerical stability.
             #[must_use]
-            #[allow(clippy::suboptimal_flops)]
+            #[allow(clippy::suboptimal_flops, clippy::cast_possible_truncation)]
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> (usize, $ty) {
-                let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
                 let gamma = self.gamma;
-                let scale = (1.0 as $ty - gamma) / sum_w;
+
+                // Log-sum-exp: find max for numerical stability
+                let max_lw = self.log_weights.iter().copied()
+                    .fold(-(1.0 as $ty / 0.0 as $ty), |a, b| if a > b { a } else { b });
+
+                // First pass: sum of exp(lw - max_lw)
+                let mut sum_exp = 0.0 as $ty;
+                for &lw in self.log_weights.iter() {
+                    sum_exp += nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                }
+
+                // Second pass: sample from CDF
+                let scale = (1.0 as $ty - gamma) / sum_exp;
                 let gamma_over_k = gamma / k;
                 let u = rng();
                 let mut cumulative = 0.0 as $ty;
 
-                for (i, &w) in self.weights.iter().enumerate() {
-                    let p_i = w * scale + gamma_over_k;
+                for (i, &lw) in self.log_weights.iter().enumerate() {
+                    let exp_w = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                    let p_i = exp_w * scale + gamma_over_k;
                     cumulative += p_i;
                     if u < cumulative {
                         return (i, p_i);
@@ -105,13 +122,15 @@ macro_rules! impl_exp3 {
 
                 // Numerical safety: return last arm
                 let last = self.num_arms - 1;
-                let p_last = self.weights[last] * scale + gamma_over_k;
+                let exp_last = nexus_stats_core::math::exp((self.log_weights[last] - max_lw) as f64) as $ty;
+                let p_last = exp_last * scale + gamma_over_k;
                 (last, p_last)
             }
 
             /// Records a reward for the selected arm.
             ///
             /// `prob` is the selection probability returned by `select()`.
+            /// Log-weight update: `ln(w_arm) += eta * reward / (K * prob)`.
             ///
             /// # Errors
             ///
@@ -122,7 +141,6 @@ macro_rules! impl_exp3 {
             ///
             /// Panics if `arm >= num_arms`.
             #[inline]
-            #[allow(clippy::cast_possible_truncation)]
             pub fn update(
                 &mut self,
                 arm: usize,
@@ -144,27 +162,7 @@ macro_rules! impl_exp3 {
                 );
 
                 let k = self.num_arms as $ty;
-                let estimated_reward = reward / prob;
-                let exponent = self.eta * estimated_reward / k;
-                self.weights[arm] *= nexus_stats_core::math::exp(exponent as f64) as $ty;
-
-                // Prevent weight overflow: normalize if max weight exceeds threshold
-                let threshold = if core::mem::size_of::<$ty>() >= 8 {
-                    1e30 as $ty
-                } else {
-                    1e15 as $ty
-                };
-                let max_w = self
-                    .weights
-                    .iter()
-                    .copied()
-                    .fold(0.0 as $ty, |a, b| if a > b { a } else { b });
-                if max_w > threshold {
-                    for w in self.weights.iter_mut() {
-                        *w /= max_w;
-                    }
-                }
-
+                self.log_weights[arm] += self.eta * reward / (k * prob);
                 self.total_pulls += 1;
                 Ok(())
             }
@@ -174,7 +172,7 @@ macro_rules! impl_exp3 {
             /// # Panics
             ///
             /// Panics if `out.len() != num_arms`.
-            #[allow(clippy::suboptimal_flops)]
+            #[allow(clippy::suboptimal_flops, clippy::cast_possible_truncation)]
             pub fn probabilities(&self, out: &mut [$ty]) {
                 assert_eq!(
                     out.len(),
@@ -183,13 +181,21 @@ macro_rules! impl_exp3 {
                     out.len(),
                     self.num_arms,
                 );
-                let sum_w: $ty = self.weights.iter().copied().sum();
                 let k = self.num_arms as $ty;
                 let gamma = self.gamma;
-                let scale = (1.0 as $ty - gamma) / sum_w;
+
+                // Log-sum-exp: use output buffer as scratch for exp values
+                let max_lw = self.log_weights.iter().copied()
+                    .fold(-(1.0 as $ty / 0.0 as $ty), |a, b| if a > b { a } else { b });
+                let mut sum_exp = 0.0 as $ty;
+                for (o, &lw) in out.iter_mut().zip(self.log_weights.iter()) {
+                    *o = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
+                    sum_exp += *o;
+                }
+                let scale = (1.0 as $ty - gamma) / sum_exp;
                 let gamma_over_k = gamma / k;
-                for (o, &w) in out.iter_mut().zip(self.weights.iter()) {
-                    *o = w * scale + gamma_over_k;
+                for o in out.iter_mut() {
+                    *o = *o * scale + gamma_over_k;
                 }
             }
 
@@ -221,10 +227,10 @@ macro_rules! impl_exp3 {
                 self.total_pulls
             }
 
-            /// Resets weights to uniform.
+            /// Resets log-weights to uniform (all zero = equal weight).
             #[inline]
             pub fn reset(&mut self) {
-                self.weights.fill(1.0 as $ty);
+                self.log_weights.fill(0.0 as $ty);
                 self.total_pulls = 0;
             }
         }
@@ -287,7 +293,7 @@ macro_rules! impl_exp3 {
                 }
                 let min_samples = self.min_samples.unwrap_or(arms as u64);
                 Ok($name {
-                    weights: vec![1.0 as $ty; arms].into_boxed_slice(),
+                    log_weights: vec![0.0 as $ty; arms].into_boxed_slice(),
                     gamma,
                     eta,
                     total_pulls: 0,
@@ -387,25 +393,29 @@ mod tests {
     }
 
     #[test]
-    fn weight_normalization() {
+    fn log_weights_no_overflow() {
         let mut bandit = Exp3F64::builder()
             .arms(2)
             .gamma(0.1)
-            .eta(1.0) // aggressive learning rate
+            .eta(10.0) // aggressive learning rate
             .build()
             .unwrap();
 
-        // Many updates with high reward to trigger normalization
-        for _ in 0..500 {
-            bandit.update(0, 1.0, 0.5).unwrap();
+        // Many updates that would overflow raw weights
+        for _ in 0..10_000 {
+            bandit.update(0, 1.0, 0.05).unwrap();
         }
 
-        // Weights should be finite after normalization
+        // Log-weights stay finite, probabilities still valid
         assert!(
-            bandit.weights.iter().all(|w| w.is_finite()),
-            "weights should be finite: {:?}",
-            &*bandit.weights,
+            bandit.log_weights.iter().all(|w| w.is_finite()),
+            "log_weights should be finite: {:?}",
+            &*bandit.log_weights,
         );
+        let mut probs = vec![0.0; 2];
+        bandit.probabilities(&mut probs);
+        let sum: f64 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-10, "prob sum={sum}");
     }
 
     #[test]

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -1,0 +1,449 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+macro_rules! impl_exp3 {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// EXP3 adversarial bandit.
+        ///
+        /// Exponential-weight algorithm for Exploration and Exploitation.
+        /// Unlike UCB1/Thompson which assume stochastic rewards, EXP3
+        /// makes no assumptions about how rewards are generated — they
+        /// can be adversarial.
+        ///
+        /// Selection probability: `p_i = (1 - gamma) * w_i / sum(w) + gamma / K`
+        ///
+        /// Weight update: `w_i *= exp(eta * reward / (K * p_i))`
+        ///
+        /// Auer, Cesa-Bianchi, Freund, Schapire (2002).
+        ///
+        /// # Parameters
+        ///
+        /// - `arms` — number of arms K (>= 2)
+        /// - `gamma` — exploration mixing rate, in (0, 1]. Higher = more uniform.
+        /// - `eta` — learning rate (default: gamma / K)
+        ///
+        /// # Reward range
+        ///
+        /// Rewards must be in [0, 1]. Normalize before feeding.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_regression::learning::Exp3F64;
+        ///
+        /// let mut bandit = Exp3F64::builder()
+        ///     .arms(3)
+        ///     .gamma(0.1)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// let mut s: u64 = 42;
+        /// let mut rng = || -> f64 {
+        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ///     (s >> 33) as f64 / (1u64 << 31) as f64
+        /// };
+        /// let (arm, prob) = bandit.select(&mut rng);
+        /// bandit.update(arm, 0.8, prob).unwrap();
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            weights: Box<[$ty]>,
+            gamma: $ty,
+            eta: $ty,
+            total_pulls: u64,
+            num_arms: usize,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            arms: Option<usize>,
+            gamma: Option<$ty>,
+            eta: Option<$ty>,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    arms: Option::None,
+                    gamma: Option::None,
+                    eta: Option::None,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Samples an arm proportional to mixed weights.
+            ///
+            /// Returns `(arm_index, selection_probability)`. The caller
+            /// must pass the probability back to `update()`.
+            #[must_use]
+            #[allow(clippy::suboptimal_flops)]
+            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> (usize, $ty) {
+                let sum_w: $ty = self.weights.iter().copied().sum();
+                let k = self.num_arms as $ty;
+                let u = rng();
+                let mut cumulative = 0.0 as $ty;
+
+                for i in 0..self.num_arms {
+                    let p_i = (1.0 as $ty - self.gamma) * self.weights[i] / sum_w + self.gamma / k;
+                    cumulative += p_i;
+                    if u < cumulative {
+                        return (i, p_i);
+                    }
+                }
+
+                // Numerical safety: return last arm
+                let last = self.num_arms - 1;
+                let p_last =
+                    (1.0 as $ty - self.gamma) * self.weights[last] / sum_w + self.gamma / k;
+                (last, p_last)
+            }
+
+            /// Records a reward for the selected arm.
+            ///
+            /// `prob` is the selection probability returned by `select()`.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1],
+            /// or if prob is NaN, infinite, or <= 0.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `arm >= num_arms`.
+            #[inline]
+            #[allow(clippy::cast_possible_truncation)]
+            pub fn update(
+                &mut self,
+                arm: usize,
+                reward: $ty,
+                prob: $ty,
+            ) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(reward);
+                if reward < 0.0 as $ty || reward > 1.0 as $ty {
+                    return Err(nexus_stats_core::DataError::Negative);
+                }
+                check_finite!(prob);
+                if prob <= 0.0 as $ty {
+                    return Err(nexus_stats_core::DataError::Negative);
+                }
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+
+                let k = self.num_arms as $ty;
+                let estimated_reward = reward / prob;
+                let exponent = self.eta * estimated_reward / k;
+                self.weights[arm] *= nexus_stats_core::math::exp(exponent as f64) as $ty;
+
+                // Prevent weight overflow: normalize if max weight exceeds threshold
+                let threshold = if core::mem::size_of::<$ty>() >= 8 {
+                    1e30 as $ty
+                } else {
+                    1e15 as $ty
+                };
+                let max_w = self
+                    .weights
+                    .iter()
+                    .copied()
+                    .fold(0.0 as $ty, |a, b| if a > b { a } else { b });
+                if max_w > threshold {
+                    for w in self.weights.iter_mut() {
+                        *w /= max_w;
+                    }
+                }
+
+                self.total_pulls += 1;
+                Ok(())
+            }
+
+            /// Writes the current probability distribution into `out`.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `out.len() != num_arms`.
+            #[allow(clippy::suboptimal_flops)]
+            pub fn probabilities(&self, out: &mut [$ty]) {
+                assert_eq!(
+                    out.len(),
+                    self.num_arms,
+                    "output length {} != num_arms {}",
+                    out.len(),
+                    self.num_arms,
+                );
+                let sum_w: $ty = self.weights.iter().copied().sum();
+                let k = self.num_arms as $ty;
+                for i in 0..self.num_arms {
+                    out[i] = (1.0 as $ty - self.gamma) * self.weights[i] / sum_w + self.gamma / k;
+                }
+            }
+
+            /// Total pulls across all arms.
+            #[inline]
+            #[must_use]
+            pub fn total_pulls(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Number of arms.
+            #[inline]
+            #[must_use]
+            pub fn num_arms(&self) -> usize {
+                self.num_arms
+            }
+
+            /// Whether total pulls >= min_samples.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.total_pulls >= self.min_samples
+            }
+
+            /// Returns the number of updates performed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Resets weights to uniform.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.weights.fill(1.0 as $ty);
+                self.total_pulls = 0;
+            }
+        }
+
+        impl $builder {
+            /// Sets the number of arms (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn arms(mut self, n: usize) -> Self {
+                self.arms = Option::Some(n);
+                self
+            }
+
+            /// Sets the exploration mixing rate (required, in (0, 1]).
+            #[inline]
+            #[must_use]
+            pub fn gamma(mut self, g: $ty) -> Self {
+                self.gamma = Option::Some(g);
+                self
+            }
+
+            /// Sets the learning rate (default: gamma / K, must be > 0).
+            #[inline]
+            #[must_use]
+            pub fn eta(mut self, e: $ty) -> Self {
+                self.eta = Option::Some(e);
+                self
+            }
+
+            /// Sets the minimum samples before `is_primed()` returns true.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = Option::Some(n);
+                self
+            }
+
+            /// Builds the bandit.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let arms = self
+                    .arms
+                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+                let gamma = self
+                    .gamma
+                    .ok_or(nexus_stats_core::ConfigError::Missing("gamma"))?;
+                if arms < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+                }
+                if gamma <= 0.0 as $ty || gamma > 1.0 as $ty || !gamma.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "gamma must be in (0, 1]",
+                    ));
+                }
+                let eta = self.eta.unwrap_or(gamma / arms as $ty);
+                if eta <= 0.0 as $ty || !eta.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "eta must be positive and finite",
+                    ));
+                }
+                let min_samples = self.min_samples.unwrap_or(arms as u64);
+                Ok($name {
+                    weights: vec![1.0 as $ty; arms].into_boxed_slice(),
+                    gamma,
+                    eta,
+                    total_pulls: 0,
+                    num_arms: arms,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_exp3!(Exp3F64, Exp3F64Builder, f64);
+impl_exp3!(Exp3F32, Exp3F32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng(seed: u64) -> impl FnMut() -> f64 {
+        let mut state = seed;
+        move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / (1u64 << 31) as f64
+        }
+    }
+
+    #[test]
+    fn uniform_start() {
+        let bandit = Exp3F64::builder().arms(3).gamma(0.1).build().unwrap();
+
+        let mut probs = vec![0.0; 3];
+        bandit.probabilities(&mut probs);
+        let expected = 1.0 / 3.0;
+        for (i, &p) in probs.iter().enumerate() {
+            assert!(
+                (p - expected).abs() < 1e-10,
+                "prob[{i}]={p}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn adapts_to_best() {
+        let mut bandit = Exp3F64::builder().arms(3).gamma(0.1).build().unwrap();
+        let mut rng = make_rng(42);
+
+        for _ in 0..500 {
+            let (arm, prob) = bandit.select(&mut rng);
+            let reward = if arm == 1 { 0.9 } else { 0.1 };
+            bandit.update(arm, reward, prob).unwrap();
+        }
+
+        let mut probs = vec![0.0; 3];
+        bandit.probabilities(&mut probs);
+        assert!(
+            probs[1] > probs[0] && probs[1] > probs[2],
+            "arm 1 should have highest prob: {probs:?}"
+        );
+    }
+
+    #[test]
+    fn adversarial_robustness() {
+        let mut bandit = Exp3F64::builder().arms(2).gamma(0.2).build().unwrap();
+        let mut rng = make_rng(42);
+
+        // Alternating which arm pays
+        for round in 0..200 {
+            let (arm, prob) = bandit.select(&mut rng);
+            let best_arm = round % 2;
+            let reward = if arm == best_arm { 1.0 } else { 0.0 };
+            bandit.update(arm, reward, prob).unwrap();
+        }
+
+        // Both arms should maintain reasonable probability
+        let mut probs = vec![0.0; 2];
+        bandit.probabilities(&mut probs);
+        assert!(probs[0] > 0.1, "arm 0 prob={}", probs[0]);
+        assert!(probs[1] > 0.1, "arm 1 prob={}", probs[1]);
+    }
+
+    #[test]
+    fn prob_sums_to_one() {
+        let mut bandit = Exp3F64::builder().arms(4).gamma(0.15).build().unwrap();
+        let mut rng = make_rng(42);
+
+        for _ in 0..50 {
+            let (arm, prob) = bandit.select(&mut rng);
+            bandit.update(arm, 0.5, prob).unwrap();
+        }
+
+        let mut probs = vec![0.0; 4];
+        bandit.probabilities(&mut probs);
+        let sum: f64 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-10, "prob sum={sum}, expected 1.0");
+    }
+
+    #[test]
+    fn weight_normalization() {
+        let mut bandit = Exp3F64::builder()
+            .arms(2)
+            .gamma(0.1)
+            .eta(1.0) // aggressive learning rate
+            .build()
+            .unwrap();
+
+        // Many updates with high reward to trigger normalization
+        for _ in 0..500 {
+            bandit.update(0, 1.0, 0.5).unwrap();
+        }
+
+        // Weights should be finite after normalization
+        assert!(
+            bandit.weights.iter().all(|w| w.is_finite()),
+            "weights should be finite: {:?}",
+            &*bandit.weights,
+        );
+    }
+
+    #[test]
+    fn reward_out_of_range() {
+        let mut bandit = Exp3F64::builder().arms(2).gamma(0.1).build().unwrap();
+        assert!(bandit.update(0, -0.1, 0.5).is_err());
+        assert!(bandit.update(0, 1.1, 0.5).is_err());
+        assert!(bandit.update(0, 0.5, 0.0).is_err());
+        assert!(bandit.update(0, 0.5, -0.1).is_err());
+        assert!(bandit.update(0, f64::NAN, 0.5).is_err());
+        assert_eq!(bandit.total_pulls(), 0);
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut bandit = Exp3F64::builder().arms(3).gamma(0.1).build().unwrap();
+
+        bandit.update(0, 0.9, 0.5).unwrap();
+        bandit.update(1, 0.1, 0.4).unwrap();
+        bandit.reset();
+
+        assert_eq!(bandit.total_pulls(), 0);
+        let mut probs = vec![0.0; 3];
+        bandit.probabilities(&mut probs);
+        let expected = 1.0 / 3.0;
+        for &p in &probs {
+            assert!((p - expected).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(Exp3F64::builder().arms(1).gamma(0.1).build().is_err());
+        assert!(Exp3F64::builder().arms(2).gamma(0.0).build().is_err());
+        assert!(Exp3F64::builder().arms(2).gamma(1.5).build().is_err());
+        assert!(
+            Exp3F64::builder()
+                .arms(2)
+                .gamma(0.1)
+                .eta(0.0)
+                .build()
+                .is_err()
+        );
+        assert!(Exp3F64::builder().arms(2).build().is_err()); // missing gamma
+    }
+}

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -21,7 +21,7 @@ macro_rules! impl_exp3 {
         ///
         /// - `arms` — number of arms K (>= 2)
         /// - `gamma` — exploration mixing rate, in (0, 1]. Higher = more uniform.
-        /// - `eta` — learning rate (default: gamma / K)
+        /// - `eta` — learning rate (default: gamma)
         ///
         /// # Reward range
         ///
@@ -241,7 +241,7 @@ macro_rules! impl_exp3 {
                 self
             }
 
-            /// Sets the learning rate (default: gamma / K, must be > 0).
+            /// Sets the learning rate (default: gamma, must be > 0).
             #[inline]
             #[must_use]
             pub fn eta(mut self, e: $ty) -> Self {
@@ -274,7 +274,7 @@ macro_rules! impl_exp3 {
                         "gamma must be in (0, 1]",
                     ));
                 }
-                let eta = self.eta.unwrap_or(gamma / arms as $ty);
+                let eta = self.eta.unwrap_or(gamma);
                 if eta <= 0.0 as $ty || !eta.is_finite() {
                     return Err(nexus_stats_core::ConfigError::Invalid(
                         "eta must be positive and finite",

--- a/nexus-stats-regression/src/learning/lms.rs
+++ b/nexus-stats-regression/src/learning/lms.rs
@@ -8,8 +8,8 @@
 
 extern crate alloc;
 use alloc::boxed::Box;
-use nexus_stats_core::math::MulAdd;
 use alloc::vec;
+use nexus_stats_core::math::MulAdd;
 
 macro_rules! impl_lms_filter {
     ($name:ident, $builder:ident, $ty:ty) => {

--- a/nexus-stats-regression/src/learning/mod.rs
+++ b/nexus-stats-regression/src/learning/mod.rs
@@ -29,3 +29,27 @@ pub use online_gd::*;
 pub use online_kmeans::*;
 #[cfg(feature = "alloc")]
 pub use rls::*;
+
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod epsilon_greedy;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod exp3;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod sampling;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod thompson_beta;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod thompson_gamma;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod ucb1;
+
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use epsilon_greedy::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use exp3::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use thompson_beta::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use thompson_gamma::*;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+pub use ucb1::*;

--- a/nexus-stats-regression/src/learning/rls.rs
+++ b/nexus-stats-regression/src/learning/rls.rs
@@ -150,9 +150,9 @@ macro_rules! impl_rls_filter {
                 let inv_lambda = 1.0 as $ty / lambda;
                 for i in 0..d {
                     for j in 0..d {
-                        self.p_matrix[i * d + j] =
-                            (-self.scratch_k[i]).fma(self.scratch_px[j], self.p_matrix[i * d + j])
-                                * inv_lambda;
+                        self.p_matrix[i * d + j] = (-self.scratch_k[i])
+                            .fma(self.scratch_px[j], self.p_matrix[i * d + j])
+                            * inv_lambda;
                     }
                 }
 

--- a/nexus-stats-regression/src/learning/sampling.rs
+++ b/nexus-stats-regression/src/learning/sampling.rs
@@ -1,0 +1,183 @@
+macro_rules! impl_sampling {
+    ($mod_name:ident, $ty:ty) => {
+        pub(super) mod $mod_name {
+            /// Marsaglia polar method. Returns one standard normal sample.
+            /// Consumes at least two calls to `rng` per sample.
+            #[allow(clippy::cast_possible_truncation, clippy::suboptimal_flops)]
+            pub fn normal_sample(rng: &mut impl FnMut() -> $ty) -> $ty {
+                loop {
+                    let u = 2.0 as $ty * rng() - 1.0 as $ty;
+                    let v = 2.0 as $ty * rng() - 1.0 as $ty;
+                    let s = u * u + v * v;
+                    if s > 0.0 as $ty && s < 1.0 as $ty {
+                        let ln_s = nexus_stats_core::math::ln(s as f64) as $ty;
+                        let factor =
+                            nexus_stats_core::math::sqrt((-(2.0 as $ty) * ln_s / s) as f64) as $ty;
+                        return u * factor;
+                    }
+                }
+            }
+
+            /// Marsaglia-Tsang method for Gamma(shape, 1). Shape must be > 0.
+            /// For shape < 1: Gamma(shape) = Gamma(shape+1) * U^(1/shape).
+            #[allow(clippy::cast_possible_truncation, clippy::suboptimal_flops)]
+            pub fn gamma_sample(shape: $ty, rng: &mut impl FnMut() -> $ty) -> $ty {
+                if shape < 1.0 as $ty {
+                    let g = gamma_sample(shape + 1.0 as $ty, rng);
+                    let u = rng();
+                    let pow = nexus_stats_core::math::exp(
+                        nexus_stats_core::math::ln(u as f64) / shape as f64,
+                    ) as $ty;
+                    return g * pow;
+                }
+
+                let d = shape - 1.0 as $ty / 3.0 as $ty;
+                let c = (1.0 / nexus_stats_core::math::sqrt((9.0 as $ty * d) as f64)) as $ty;
+
+                loop {
+                    let x = normal_sample(rng);
+                    let v_base = 1.0 as $ty + c * x;
+                    if v_base <= 0.0 as $ty {
+                        continue;
+                    }
+                    let v = v_base * v_base * v_base;
+                    let u = rng();
+                    let x2 = x * x;
+
+                    if u < 1.0 as $ty - 0.0331 as $ty * x2 * x2 {
+                        return d * v;
+                    }
+
+                    let ln_u = nexus_stats_core::math::ln(u as f64) as $ty;
+                    let ln_v = nexus_stats_core::math::ln(v as f64) as $ty;
+                    if ln_u < 0.5 as $ty * x2 + d * (1.0 as $ty - v + ln_v) {
+                        return d * v;
+                    }
+                }
+            }
+
+            /// Beta(alpha, beta) via ratio of two Gamma samples.
+            #[allow(clippy::float_cmp)]
+            pub fn beta_sample(alpha: $ty, beta: $ty, rng: &mut impl FnMut() -> $ty) -> $ty {
+                let x = gamma_sample(alpha, rng);
+                let y = gamma_sample(beta, rng);
+                let sum = x + y;
+                if sum == 0.0 as $ty {
+                    return 0.5 as $ty;
+                }
+                x / sum
+            }
+        }
+    };
+}
+
+impl_sampling!(f64_impl, f64);
+impl_sampling!(f32_impl, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng_f64(seed: u64) -> impl FnMut() -> f64 {
+        let mut state = seed;
+        move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / (1u64 << 31) as f64
+        }
+    }
+
+    #[test]
+    fn normal_sample_distribution() {
+        let mut rng = make_rng_f64(42);
+        let n = 10_000;
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        for _ in 0..n {
+            let x = f64_impl::normal_sample(&mut rng);
+            sum += x;
+            sum_sq += x * x;
+        }
+        let mean = sum / n as f64;
+        let var = sum_sq / n as f64 - mean * mean;
+        assert!(mean.abs() < 0.05, "mean={mean}, expected ~0");
+        assert!((var - 1.0).abs() < 0.1, "var={var}, expected ~1");
+    }
+
+    #[test]
+    fn gamma_sample_mean() {
+        let mut rng = make_rng_f64(123);
+        let shape = 5.0;
+        let n = 10_000;
+        let mut sum = 0.0;
+        for _ in 0..n {
+            let x = f64_impl::gamma_sample(shape, &mut rng);
+            assert!(x > 0.0, "gamma sample must be positive");
+            sum += x;
+        }
+        let mean = sum / n as f64;
+        assert!((mean - shape).abs() < 0.3, "mean={mean}, expected ~{shape}");
+    }
+
+    #[test]
+    fn gamma_sample_shape_less_than_one() {
+        let mut rng = make_rng_f64(77);
+        let shape = 0.5;
+        let n = 5_000;
+        let mut sum = 0.0;
+        for _ in 0..n {
+            let x = f64_impl::gamma_sample(shape, &mut rng);
+            assert!(x >= 0.0, "gamma sample must be non-negative");
+            sum += x;
+        }
+        let mean = sum / n as f64;
+        assert!((mean - shape).abs() < 0.1, "mean={mean}, expected ~{shape}");
+    }
+
+    #[test]
+    fn beta_sample_range() {
+        let mut rng = make_rng_f64(99);
+        for _ in 0..1_000 {
+            let x = f64_impl::beta_sample(2.0, 5.0, &mut rng);
+            assert!((0.0..=1.0).contains(&x), "beta sample {x} out of [0,1]");
+        }
+    }
+
+    #[test]
+    fn beta_sample_mean() {
+        let mut rng = make_rng_f64(55);
+        let alpha = 2.0;
+        let beta = 5.0;
+        let n = 10_000;
+        let mut sum = 0.0;
+        for _ in 0..n {
+            sum += f64_impl::beta_sample(alpha, beta, &mut rng);
+        }
+        let mean = sum / n as f64;
+        let expected = alpha / (alpha + beta);
+        assert!(
+            (mean - expected).abs() < 0.02,
+            "mean={mean}, expected ~{expected}"
+        );
+    }
+
+    #[test]
+    fn f32_normal_sample() {
+        let mut state: u64 = 42;
+        let mut rng = || -> f32 {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f32 / (1u64 << 31) as f32
+        };
+        let mut sum = 0.0_f32;
+        for _ in 0..1_000 {
+            let x = f32_impl::normal_sample(&mut rng);
+            assert!(x.is_finite());
+            sum += x;
+        }
+        let mean = sum / 1000.0;
+        assert!(mean.abs() < 0.2, "f32 mean={mean}");
+    }
+}

--- a/nexus-stats-regression/src/learning/thompson_beta.rs
+++ b/nexus-stats-regression/src/learning/thompson_beta.rs
@@ -86,9 +86,8 @@ macro_rules! impl_thompson_beta {
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
                 let mut best_arm = 0;
                 let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
-                for i in 0..self.num_arms {
-                    let sample =
-                        super::sampling::$sampling::beta_sample(self.alphas[i], self.betas[i], rng);
+                for (i, (&a, &b)) in self.alphas.iter().zip(self.betas.iter()).enumerate() {
+                    let sample = super::sampling::$sampling::beta_sample(a, b, rng);
                     if sample > best_sample {
                         best_sample = sample;
                         best_arm = i;
@@ -126,9 +125,10 @@ macro_rules! impl_thompson_beta {
                 );
 
                 if self.decay < 1.0 as $ty {
-                    for i in 0..self.num_arms {
-                        self.alphas[i] *= self.decay;
-                        self.betas[i] *= self.decay;
+                    let decay = self.decay;
+                    for (a, b) in self.alphas.iter_mut().zip(self.betas.iter_mut()) {
+                        *a *= decay;
+                        *b *= decay;
                     }
                 }
 

--- a/nexus-stats-regression/src/learning/thompson_beta.rs
+++ b/nexus-stats-regression/src/learning/thompson_beta.rs
@@ -1,0 +1,439 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+macro_rules! impl_thompson_beta {
+    ($name:ident, $builder:ident, $ty:ty, $sampling:ident) => {
+        /// Thompson Sampling with Beta prior.
+        ///
+        /// Each arm maintains Beta(alpha, beta) parameters. Selection samples
+        /// from each arm's Beta posterior and picks the highest sample.
+        /// Arms with wider posteriors (more uncertain) are explored naturally.
+        ///
+        /// For binary rewards: alpha counts successes, beta counts failures.
+        /// For continuous [0, 1] rewards: alpha += reward, beta += (1 - reward).
+        ///
+        /// Thompson (1933), Agrawal & Goyal (2012).
+        ///
+        /// # Parameters
+        ///
+        /// - `arms` — number of arms (>= 2)
+        /// - `initial_alpha` — prior alpha for all arms (default: 1.0, uniform)
+        /// - `initial_beta` — prior beta for all arms (default: 1.0, uniform)
+        /// - `decay` — multiplicative discount on alpha, beta per update (default: 1.0)
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_regression::learning::ThompsonBetaF64;
+        ///
+        /// let mut bandit = ThompsonBetaF64::builder()
+        ///     .arms(3)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// let mut s: u64 = 42;
+        /// let mut rng = || -> f64 {
+        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ///     (s >> 33) as f64 / (1u64 << 31) as f64
+        /// };
+        /// let arm = bandit.select(&mut rng);
+        /// bandit.update(arm, 1.0).unwrap();
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            alphas: Box<[$ty]>,
+            betas: Box<[$ty]>,
+            initial_alpha: $ty,
+            initial_beta: $ty,
+            decay: $ty,
+            total_pulls: u64,
+            num_arms: usize,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            arms: Option<usize>,
+            initial_alpha: $ty,
+            initial_beta: $ty,
+            decay: $ty,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    arms: Option::None,
+                    initial_alpha: 1.0 as $ty,
+                    initial_beta: 1.0 as $ty,
+                    decay: 1.0 as $ty,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Samples from each arm's Beta posterior, returns the arm
+            /// with the highest sample.
+            ///
+            /// `rng` must return independent uniform samples in [0, 1).
+            #[must_use]
+            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
+                let mut best_arm = 0;
+                let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
+                for i in 0..self.num_arms {
+                    let sample =
+                        super::sampling::$sampling::beta_sample(self.alphas[i], self.betas[i], rng);
+                    if sample > best_sample {
+                        best_sample = sample;
+                        best_arm = i;
+                    }
+                }
+                best_arm
+            }
+
+            /// Records a reward in [0, 1] for an arm.
+            ///
+            /// Updates: alpha += reward, beta += (1 - reward).
+            /// If `decay < 1.0`, all alpha/beta are discounted first.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1].
+            ///
+            /// # Panics
+            ///
+            /// Panics if `arm >= num_arms`.
+            #[inline]
+            pub fn update(
+                &mut self,
+                arm: usize,
+                reward: $ty,
+            ) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(reward);
+                if reward < 0.0 as $ty || reward > 1.0 as $ty {
+                    return Err(nexus_stats_core::DataError::Negative);
+                }
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+
+                if self.decay < 1.0 as $ty {
+                    for i in 0..self.num_arms {
+                        self.alphas[i] *= self.decay;
+                        self.betas[i] *= self.decay;
+                    }
+                }
+
+                self.alphas[arm] += reward;
+                self.betas[arm] += 1.0 as $ty - reward;
+                self.total_pulls += 1;
+                Ok(())
+            }
+
+            /// Posterior mean for an arm: alpha / (alpha + beta).
+            #[inline]
+            #[must_use]
+            pub fn mean_reward(&self, arm: usize) -> $ty {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                self.alphas[arm] / (self.alphas[arm] + self.betas[arm])
+            }
+
+            /// Total pulls across all arms.
+            #[inline]
+            #[must_use]
+            pub fn total_pulls(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Number of arms.
+            #[inline]
+            #[must_use]
+            pub fn num_arms(&self) -> usize {
+                self.num_arms
+            }
+
+            /// Whether total pulls >= min_samples.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.total_pulls >= self.min_samples
+            }
+
+            /// Returns the number of updates performed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Resets alpha/beta to initial priors.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.alphas.fill(self.initial_alpha);
+                self.betas.fill(self.initial_beta);
+                self.total_pulls = 0;
+            }
+        }
+
+        impl $builder {
+            /// Sets the number of arms (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn arms(mut self, n: usize) -> Self {
+                self.arms = Option::Some(n);
+                self
+            }
+
+            /// Sets the initial alpha prior (default: 1.0, must be > 0).
+            #[inline]
+            #[must_use]
+            pub fn initial_alpha(mut self, a: $ty) -> Self {
+                self.initial_alpha = a;
+                self
+            }
+
+            /// Sets the initial beta prior (default: 1.0, must be > 0).
+            #[inline]
+            #[must_use]
+            pub fn initial_beta(mut self, b: $ty) -> Self {
+                self.initial_beta = b;
+                self
+            }
+
+            /// Sets the decay factor (default: 1.0, in (0, 1]).
+            #[inline]
+            #[must_use]
+            pub fn decay(mut self, d: $ty) -> Self {
+                self.decay = d;
+                self
+            }
+
+            /// Sets the minimum samples before `is_primed()` returns true.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = Option::Some(n);
+                self
+            }
+
+            /// Builds the bandit.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let arms = self
+                    .arms
+                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+                if arms < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+                }
+                if self.initial_alpha <= 0.0 as $ty || !self.initial_alpha.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "initial_alpha must be positive and finite",
+                    ));
+                }
+                if self.initial_beta <= 0.0 as $ty || !self.initial_beta.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "initial_beta must be positive and finite",
+                    ));
+                }
+                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "decay must be in (0, 1]",
+                    ));
+                }
+                let min_samples = self.min_samples.unwrap_or(arms as u64);
+                Ok($name {
+                    alphas: vec![self.initial_alpha; arms].into_boxed_slice(),
+                    betas: vec![self.initial_beta; arms].into_boxed_slice(),
+                    initial_alpha: self.initial_alpha,
+                    initial_beta: self.initial_beta,
+                    decay: self.decay,
+                    total_pulls: 0,
+                    num_arms: arms,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_thompson_beta!(ThompsonBetaF64, ThompsonBetaF64Builder, f64, f64_impl);
+impl_thompson_beta!(ThompsonBetaF32, ThompsonBetaF32Builder, f32, f32_impl);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng(seed: u64) -> impl FnMut() -> f64 {
+        let mut state = seed;
+        move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / (1u64 << 31) as f64
+        }
+    }
+
+    #[test]
+    fn uniform_prior_explores() {
+        let bandit = ThompsonBetaF64::builder().arms(3).build().unwrap();
+        let mut rng = make_rng(42);
+        let mut counts = [0u32; 3];
+        for _ in 0..300 {
+            counts[bandit.select(&mut rng)] += 1;
+        }
+        // With uniform prior, all arms should get some selections
+        for (i, &c) in counts.iter().enumerate() {
+            assert!(c > 10, "arm {i} only selected {c} times with uniform prior");
+        }
+    }
+
+    #[test]
+    fn converges_to_best() {
+        let mut bandit = ThompsonBetaF64::builder().arms(3).build().unwrap();
+        let mut rng = make_rng(42);
+
+        for _ in 0..500 {
+            let arm = bandit.select(&mut rng);
+            let reward = if arm == 1 { 0.9 } else { 0.1 };
+            bandit.update(arm, reward).unwrap();
+        }
+
+        assert!(
+            bandit.mean_reward(1) > bandit.mean_reward(0),
+            "arm 1 mean {} should exceed arm 0 mean {}",
+            bandit.mean_reward(1),
+            bandit.mean_reward(0),
+        );
+    }
+
+    #[test]
+    fn binary_rewards() {
+        let mut bandit = ThompsonBetaF64::builder().arms(2).build().unwrap();
+        for _ in 0..100 {
+            bandit.update(0, 1.0).unwrap(); // always success
+            bandit.update(1, 0.0).unwrap(); // always failure
+        }
+        // alpha[0] >> beta[0], alpha[1] << beta[1]
+        assert!(bandit.mean_reward(0) > 0.9);
+        assert!(bandit.mean_reward(1) < 0.1);
+    }
+
+    #[test]
+    fn continuous_rewards() {
+        let mut bandit = ThompsonBetaF64::builder().arms(2).build().unwrap();
+        for _ in 0..200 {
+            bandit.update(0, 0.7).unwrap();
+            bandit.update(1, 0.3).unwrap();
+        }
+        assert!(
+            (bandit.mean_reward(0) - 0.7).abs() < 0.1,
+            "mean_reward(0) = {}",
+            bandit.mean_reward(0)
+        );
+    }
+
+    #[test]
+    fn decay_adapts() {
+        let mut bandit = ThompsonBetaF64::builder()
+            .arms(2)
+            .decay(0.95)
+            .build()
+            .unwrap();
+
+        // Phase 1: arm 0 is best
+        for _ in 0..50 {
+            bandit.update(0, 1.0).unwrap();
+            bandit.update(1, 0.0).unwrap();
+        }
+        assert!(bandit.mean_reward(0) > bandit.mean_reward(1));
+
+        // Phase 2: arm 1 is best
+        for _ in 0..100 {
+            bandit.update(0, 0.0).unwrap();
+            bandit.update(1, 1.0).unwrap();
+        }
+        assert!(
+            bandit.mean_reward(1) > bandit.mean_reward(0),
+            "should adapt: arm0={}, arm1={}",
+            bandit.mean_reward(0),
+            bandit.mean_reward(1),
+        );
+    }
+
+    #[test]
+    fn reset_restores_prior() {
+        let mut bandit = ThompsonBetaF64::builder()
+            .arms(2)
+            .initial_alpha(2.0)
+            .initial_beta(3.0)
+            .build()
+            .unwrap();
+
+        bandit.update(0, 1.0).unwrap();
+        bandit.update(1, 0.0).unwrap();
+        bandit.reset();
+
+        assert_eq!(bandit.total_pulls(), 0);
+        let expected_mean = 2.0 / (2.0 + 3.0);
+        assert!(
+            (bandit.mean_reward(0) - expected_mean).abs() < 1e-12,
+            "mean after reset: {}",
+            bandit.mean_reward(0)
+        );
+    }
+
+    #[test]
+    fn reward_out_of_range() {
+        let mut bandit = ThompsonBetaF64::builder().arms(2).build().unwrap();
+        assert!(bandit.update(0, -0.1).is_err());
+        assert!(bandit.update(0, 1.1).is_err());
+        assert!(bandit.update(0, f64::NAN).is_err());
+        assert!(bandit.update(0, f64::INFINITY).is_err());
+        assert_eq!(bandit.total_pulls(), 0);
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(ThompsonBetaF64::builder().arms(1).build().is_err());
+        assert!(
+            ThompsonBetaF64::builder()
+                .arms(2)
+                .initial_alpha(0.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            ThompsonBetaF64::builder()
+                .arms(2)
+                .initial_beta(-1.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            ThompsonBetaF64::builder()
+                .arms(2)
+                .decay(0.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            ThompsonBetaF64::builder()
+                .arms(2)
+                .decay(1.5)
+                .build()
+                .is_err()
+        );
+    }
+}

--- a/nexus-stats-regression/src/learning/thompson_gamma.rs
+++ b/nexus-stats-regression/src/learning/thompson_gamma.rs
@@ -85,10 +85,9 @@ macro_rules! impl_thompson_gamma {
             pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
                 let mut best_arm = 0;
                 let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
-                for i in 0..self.num_arms {
-                    // Sample Gamma(shape, rate) = Gamma(shape, 1) / rate
-                    let g = super::sampling::$sampling::gamma_sample(self.shapes[i], rng);
-                    let sample = g / self.rates[i];
+                for (i, (&shape, &rate)) in self.shapes.iter().zip(self.rates.iter()).enumerate() {
+                    let g = super::sampling::$sampling::gamma_sample(shape, rng);
+                    let sample = g / rate;
                     if sample > best_sample {
                         best_sample = sample;
                         best_arm = i;
@@ -126,9 +125,10 @@ macro_rules! impl_thompson_gamma {
                 );
 
                 if self.decay < 1.0 as $ty {
-                    for i in 0..self.num_arms {
-                        self.shapes[i] *= self.decay;
-                        self.rates[i] *= self.decay;
+                    let decay = self.decay;
+                    for (s, r) in self.shapes.iter_mut().zip(self.rates.iter_mut()) {
+                        *s *= decay;
+                        *r *= decay;
                     }
                 }
 

--- a/nexus-stats-regression/src/learning/thompson_gamma.rs
+++ b/nexus-stats-regression/src/learning/thompson_gamma.rs
@@ -1,0 +1,428 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+macro_rules! impl_thompson_gamma {
+    ($name:ident, $builder:ident, $ty:ty, $sampling:ident) => {
+        /// Thompson Sampling with Gamma prior.
+        ///
+        /// Each arm maintains Gamma(shape, rate) parameters. Selection
+        /// samples from each arm's Gamma posterior and picks the highest
+        /// sample. For positive continuous rewards where Beta (bounded
+        /// [0, 1]) is too restrictive.
+        ///
+        /// Conjugate update: shape += reward, rate += 1.
+        /// Posterior mean: shape / rate (approximates sample mean).
+        ///
+        /// # Parameters
+        ///
+        /// - `arms` — number of arms (>= 2)
+        /// - `initial_shape` — prior shape for all arms (default: 1.0)
+        /// - `initial_rate` — prior rate for all arms (default: 1.0)
+        /// - `decay` — multiplicative discount on shape, rate per update (default: 1.0)
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_regression::learning::ThompsonGammaF64;
+        ///
+        /// let mut bandit = ThompsonGammaF64::builder()
+        ///     .arms(3)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// let mut s: u64 = 42;
+        /// let mut rng = || -> f64 {
+        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ///     (s >> 33) as f64 / (1u64 << 31) as f64
+        /// };
+        /// let arm = bandit.select(&mut rng);
+        /// bandit.update(arm, 2.5).unwrap();
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            shapes: Box<[$ty]>,
+            rates: Box<[$ty]>,
+            initial_shape: $ty,
+            initial_rate: $ty,
+            decay: $ty,
+            total_pulls: u64,
+            num_arms: usize,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            arms: Option<usize>,
+            initial_shape: $ty,
+            initial_rate: $ty,
+            decay: $ty,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    arms: Option::None,
+                    initial_shape: 1.0 as $ty,
+                    initial_rate: 1.0 as $ty,
+                    decay: 1.0 as $ty,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Samples from each arm's Gamma posterior, returns the arm
+            /// with the highest sample.
+            ///
+            /// `rng` must return independent uniform samples in [0, 1).
+            #[must_use]
+            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
+                let mut best_arm = 0;
+                let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
+                for i in 0..self.num_arms {
+                    // Sample Gamma(shape, rate) = Gamma(shape, 1) / rate
+                    let g = super::sampling::$sampling::gamma_sample(self.shapes[i], rng);
+                    let sample = g / self.rates[i];
+                    if sample > best_sample {
+                        best_sample = sample;
+                        best_arm = i;
+                    }
+                }
+                best_arm
+            }
+
+            /// Records a positive reward for an arm.
+            ///
+            /// Updates: shape += reward, rate += 1.
+            /// If `decay < 1.0`, all shape/rate are discounted first.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError` if reward is NaN, infinite, or <= 0.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `arm >= num_arms`.
+            #[inline]
+            pub fn update(
+                &mut self,
+                arm: usize,
+                reward: $ty,
+            ) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(reward);
+                if reward <= 0.0 as $ty {
+                    return Err(nexus_stats_core::DataError::Negative);
+                }
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+
+                if self.decay < 1.0 as $ty {
+                    for i in 0..self.num_arms {
+                        self.shapes[i] *= self.decay;
+                        self.rates[i] *= self.decay;
+                    }
+                }
+
+                self.shapes[arm] += reward;
+                self.rates[arm] += 1.0 as $ty;
+                self.total_pulls += 1;
+                Ok(())
+            }
+
+            /// Posterior mean for an arm: shape / rate.
+            #[inline]
+            #[must_use]
+            pub fn mean_reward(&self, arm: usize) -> $ty {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                self.shapes[arm] / self.rates[arm]
+            }
+
+            /// Total pulls across all arms.
+            #[inline]
+            #[must_use]
+            pub fn total_pulls(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Number of arms.
+            #[inline]
+            #[must_use]
+            pub fn num_arms(&self) -> usize {
+                self.num_arms
+            }
+
+            /// Whether total pulls >= min_samples.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.total_pulls >= self.min_samples
+            }
+
+            /// Returns the number of updates performed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Resets shape/rate to initial priors.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.shapes.fill(self.initial_shape);
+                self.rates.fill(self.initial_rate);
+                self.total_pulls = 0;
+            }
+        }
+
+        impl $builder {
+            /// Sets the number of arms (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn arms(mut self, n: usize) -> Self {
+                self.arms = Option::Some(n);
+                self
+            }
+
+            /// Sets the initial shape prior (default: 1.0, must be > 0).
+            #[inline]
+            #[must_use]
+            pub fn initial_shape(mut self, s: $ty) -> Self {
+                self.initial_shape = s;
+                self
+            }
+
+            /// Sets the initial rate prior (default: 1.0, must be > 0).
+            #[inline]
+            #[must_use]
+            pub fn initial_rate(mut self, r: $ty) -> Self {
+                self.initial_rate = r;
+                self
+            }
+
+            /// Sets the decay factor (default: 1.0, in (0, 1]).
+            #[inline]
+            #[must_use]
+            pub fn decay(mut self, d: $ty) -> Self {
+                self.decay = d;
+                self
+            }
+
+            /// Sets the minimum samples before `is_primed()` returns true.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = Option::Some(n);
+                self
+            }
+
+            /// Builds the bandit.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let arms = self
+                    .arms
+                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+                if arms < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+                }
+                if self.initial_shape <= 0.0 as $ty || !self.initial_shape.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "initial_shape must be positive and finite",
+                    ));
+                }
+                if self.initial_rate <= 0.0 as $ty || !self.initial_rate.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "initial_rate must be positive and finite",
+                    ));
+                }
+                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "decay must be in (0, 1]",
+                    ));
+                }
+                let min_samples = self.min_samples.unwrap_or(arms as u64);
+                Ok($name {
+                    shapes: vec![self.initial_shape; arms].into_boxed_slice(),
+                    rates: vec![self.initial_rate; arms].into_boxed_slice(),
+                    initial_shape: self.initial_shape,
+                    initial_rate: self.initial_rate,
+                    decay: self.decay,
+                    total_pulls: 0,
+                    num_arms: arms,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_thompson_gamma!(ThompsonGammaF64, ThompsonGammaF64Builder, f64, f64_impl);
+impl_thompson_gamma!(ThompsonGammaF32, ThompsonGammaF32Builder, f32, f32_impl);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng(seed: u64) -> impl FnMut() -> f64 {
+        let mut state = seed;
+        move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / (1u64 << 31) as f64
+        }
+    }
+
+    #[test]
+    fn explores_with_weak_prior() {
+        let bandit = ThompsonGammaF64::builder().arms(3).build().unwrap();
+        let mut rng = make_rng(42);
+        let mut counts = [0u32; 3];
+        for _ in 0..300 {
+            counts[bandit.select(&mut rng)] += 1;
+        }
+        for (i, &c) in counts.iter().enumerate() {
+            assert!(c > 10, "arm {i} only selected {c} times");
+        }
+    }
+
+    #[test]
+    fn converges_to_best() {
+        let mut bandit = ThompsonGammaF64::builder().arms(3).build().unwrap();
+        let mut rng = make_rng(42);
+
+        for _ in 0..500 {
+            let arm = bandit.select(&mut rng);
+            let reward = if arm == 1 { 5.0 } else { 1.0 };
+            bandit.update(arm, reward).unwrap();
+        }
+
+        assert!(
+            bandit.mean_reward(1) > bandit.mean_reward(0),
+            "arm 1 mean {} should exceed arm 0 mean {}",
+            bandit.mean_reward(1),
+            bandit.mean_reward(0),
+        );
+    }
+
+    #[test]
+    fn mean_reward_tracks() {
+        let mut bandit = ThompsonGammaF64::builder().arms(2).build().unwrap();
+        for _ in 0..200 {
+            bandit.update(0, 3.0).unwrap();
+            bandit.update(1, 7.0).unwrap();
+        }
+        // Posterior mean = (initial_shape + sum_rewards) / (initial_rate + n)
+        // Arm 0: (1 + 600) / (1 + 200) = 601/201 ≈ 2.99
+        // Arm 1: (1 + 1400) / (1 + 200) = 1401/201 ≈ 6.97
+        let m0 = bandit.mean_reward(0);
+        let m1 = bandit.mean_reward(1);
+        assert!((m0 - 3.0).abs() < 0.1, "m0={m0}, expected ~3.0");
+        assert!((m1 - 7.0).abs() < 0.1, "m1={m1}, expected ~7.0");
+    }
+
+    #[test]
+    fn decay_adapts() {
+        let mut bandit = ThompsonGammaF64::builder()
+            .arms(2)
+            .decay(0.95)
+            .build()
+            .unwrap();
+
+        // Phase 1: arm 0 higher reward
+        for _ in 0..50 {
+            bandit.update(0, 5.0).unwrap();
+            bandit.update(1, 1.0).unwrap();
+        }
+
+        // Phase 2: arm 1 higher reward
+        for _ in 0..100 {
+            bandit.update(0, 1.0).unwrap();
+            bandit.update(1, 5.0).unwrap();
+        }
+
+        // With decay, arm 1's higher recent rewards should dominate
+        // shape/rate for arm 1 should reflect recent high rewards
+        assert!(bandit.mean_reward(1) > 0.0);
+    }
+
+    #[test]
+    fn negative_reward_rejected() {
+        let mut bandit = ThompsonGammaF64::builder().arms(2).build().unwrap();
+        assert!(bandit.update(0, -1.0).is_err());
+        assert!(bandit.update(0, 0.0).is_err());
+        assert_eq!(bandit.total_pulls(), 0);
+    }
+
+    #[test]
+    fn reset_restores_prior() {
+        let mut bandit = ThompsonGammaF64::builder()
+            .arms(2)
+            .initial_shape(2.0)
+            .initial_rate(3.0)
+            .build()
+            .unwrap();
+
+        bandit.update(0, 5.0).unwrap();
+        bandit.reset();
+
+        assert_eq!(bandit.total_pulls(), 0);
+        let expected = 2.0 / 3.0;
+        assert!(
+            (bandit.mean_reward(0) - expected).abs() < 1e-12,
+            "mean after reset: {}",
+            bandit.mean_reward(0),
+        );
+    }
+
+    #[test]
+    fn nan_inf_rejected() {
+        let mut bandit = ThompsonGammaF64::builder().arms(2).build().unwrap();
+        assert_eq!(
+            bandit.update(0, f64::NAN),
+            Err(nexus_stats_core::DataError::NotANumber)
+        );
+        assert_eq!(
+            bandit.update(0, f64::INFINITY),
+            Err(nexus_stats_core::DataError::Infinite)
+        );
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(ThompsonGammaF64::builder().arms(1).build().is_err());
+        assert!(
+            ThompsonGammaF64::builder()
+                .arms(2)
+                .initial_shape(0.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            ThompsonGammaF64::builder()
+                .arms(2)
+                .initial_rate(-1.0)
+                .build()
+                .is_err()
+        );
+        assert!(
+            ThompsonGammaF64::builder()
+                .arms(2)
+                .decay(0.0)
+                .build()
+                .is_err()
+        );
+    }
+}

--- a/nexus-stats-regression/src/learning/ucb1.rs
+++ b/nexus-stats-regression/src/learning/ucb1.rs
@@ -84,8 +84,8 @@ macro_rules! impl_ucb1 {
             #[must_use]
             #[allow(clippy::cast_possible_truncation, clippy::float_cmp)]
             pub fn select(&self) -> usize {
-                for i in 0..self.num_arms {
-                    if self.counts[i] == 0.0 as $ty {
+                for (i, &c) in self.counts.iter().enumerate() {
+                    if c == 0.0 as $ty {
                         return i;
                     }
                 }
@@ -95,10 +95,11 @@ macro_rules! impl_ucb1 {
 
                 let mut best_arm = 0;
                 let mut best_score = -(1.0 as $ty / 0.0 as $ty); // -inf
-                for i in 0..self.num_arms {
-                    let mean = self.rewards[i] / self.counts[i];
-                    let bonus = self.exploration
-                        * nexus_stats_core::math::sqrt((ln_total / self.counts[i]) as f64) as $ty;
+                let exploration = self.exploration;
+                for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
+                    let mean = r / c;
+                    let bonus = exploration
+                        * nexus_stats_core::math::sqrt((ln_total / c) as f64) as $ty;
                     let score = mean + bonus;
                     if score > best_score {
                         best_score = score;
@@ -134,9 +135,10 @@ macro_rules! impl_ucb1 {
                 );
 
                 if self.decay < 1.0 as $ty {
-                    for i in 0..self.num_arms {
-                        self.counts[i] *= self.decay;
-                        self.rewards[i] *= self.decay;
+                    let decay = self.decay;
+                    for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
+                        *c *= decay;
+                        *r *= decay;
                     }
                 }
 

--- a/nexus-stats-regression/src/learning/ucb1.rs
+++ b/nexus-stats-regression/src/learning/ucb1.rs
@@ -92,14 +92,16 @@ macro_rules! impl_ucb1 {
 
                 let total_eff: $ty = self.counts.iter().copied().sum();
                 let ln_total = nexus_stats_core::math::ln(total_eff as f64) as $ty;
+                let scaled_exp = self.exploration
+                    * nexus_stats_core::math::sqrt(ln_total as f64) as $ty;
 
                 let mut best_arm = 0;
                 let mut best_score = -(1.0 as $ty / 0.0 as $ty); // -inf
-                let exploration = self.exploration;
                 for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
-                    let mean = r / c;
-                    let bonus = exploration
-                        * nexus_stats_core::math::sqrt((ln_total / c) as f64) as $ty;
+                    let inv_c = 1.0 as $ty / c;
+                    let mean = r * inv_c;
+                    let bonus = scaled_exp
+                        * nexus_stats_core::math::sqrt(inv_c as f64) as $ty;
                     let score = mean + bonus;
                     if score > best_score {
                         best_score = score;

--- a/nexus-stats-regression/src/learning/ucb1.rs
+++ b/nexus-stats-regression/src/learning/ucb1.rs
@@ -1,0 +1,456 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec;
+
+macro_rules! impl_ucb1 {
+    ($name:ident, $builder:ident, $ty:ty) => {
+        /// UCB1 multi-armed bandit.
+        ///
+        /// Selects the arm maximizing `mean + c * sqrt(ln(N) / n_i)` where
+        /// `c` is the exploration constant, `N` is total effective pulls,
+        /// and `n_i` is the effective pull count for arm `i`. Arms with
+        /// zero pulls are selected first (lowest index priority).
+        ///
+        /// Deterministic — no RNG needed for selection.
+        ///
+        /// Auer, Cesa-Bianchi, Fischer (2002).
+        ///
+        /// # Parameters
+        ///
+        /// - `arms` — number of arms (>= 2)
+        /// - `exploration` — confidence scale `c` (default: sqrt(2) ≈ 1.414)
+        /// - `decay` — exponential discount on counts/rewards per update
+        ///   (default: 1.0 = stationary). Set < 1.0 for non-stationary rewards.
+        ///
+        /// # Reward scaling
+        ///
+        /// UCB1's regret bound assumes rewards in [0, 1]. The exploration
+        /// constant `c` should be scaled for other ranges.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use nexus_stats_regression::learning::Ucb1F64;
+        ///
+        /// let mut bandit = Ucb1F64::builder()
+        ///     .arms(3)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// let arm = bandit.select();
+        /// bandit.update(arm, 1.0).unwrap();
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            counts: Box<[$ty]>,
+            rewards: Box<[$ty]>,
+            exploration: $ty,
+            decay: $ty,
+            total_pulls: u64,
+            num_arms: usize,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            arms: Option<usize>,
+            exploration: $ty,
+            decay: $ty,
+            min_samples: Option<u64>,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                #[allow(clippy::cast_possible_truncation)]
+                let sqrt2 = nexus_stats_core::math::sqrt(2.0) as $ty;
+                $builder {
+                    arms: Option::None,
+                    exploration: sqrt2,
+                    decay: 1.0 as $ty,
+                    min_samples: Option::None,
+                }
+            }
+
+            /// Selects the arm with the highest UCB score.
+            ///
+            /// Arms with zero pulls are returned first (lowest index).
+            /// Ties among pulled arms are broken by lowest index.
+            #[must_use]
+            #[allow(clippy::cast_possible_truncation, clippy::float_cmp)]
+            pub fn select(&self) -> usize {
+                for i in 0..self.num_arms {
+                    if self.counts[i] == 0.0 as $ty {
+                        return i;
+                    }
+                }
+
+                let total_eff: $ty = self.counts.iter().copied().sum();
+                let ln_total = nexus_stats_core::math::ln(total_eff as f64) as $ty;
+
+                let mut best_arm = 0;
+                let mut best_score = -(1.0 as $ty / 0.0 as $ty); // -inf
+                for i in 0..self.num_arms {
+                    let mean = self.rewards[i] / self.counts[i];
+                    let bonus = self.exploration
+                        * nexus_stats_core::math::sqrt((ln_total / self.counts[i]) as f64) as $ty;
+                    let score = mean + bonus;
+                    if score > best_score {
+                        best_score = score;
+                        best_arm = i;
+                    }
+                }
+                best_arm
+            }
+
+            /// Records a reward for an arm.
+            ///
+            /// If `decay < 1.0`, all arm counts and rewards are multiplied
+            /// by `decay` before incorporating the new observation.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError` if reward is NaN or infinite.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `arm >= num_arms`.
+            #[inline]
+            pub fn update(
+                &mut self,
+                arm: usize,
+                reward: $ty,
+            ) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(reward);
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+
+                if self.decay < 1.0 as $ty {
+                    for i in 0..self.num_arms {
+                        self.counts[i] *= self.decay;
+                        self.rewards[i] *= self.decay;
+                    }
+                }
+
+                self.counts[arm] += 1.0 as $ty;
+                self.rewards[arm] += reward;
+                self.total_pulls += 1;
+                Ok(())
+            }
+
+            /// Mean reward for an arm, or `None` if never pulled.
+            #[inline]
+            #[must_use]
+            #[allow(clippy::float_cmp)]
+            pub fn mean_reward(&self, arm: usize) -> Option<$ty> {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                if self.counts[arm] == 0.0 as $ty {
+                    return Option::None;
+                }
+                Option::Some(self.rewards[arm] / self.counts[arm])
+            }
+
+            /// Effective pull count for an arm (decayed).
+            #[inline]
+            #[must_use]
+            pub fn pulls(&self, arm: usize) -> $ty {
+                assert!(
+                    arm < self.num_arms,
+                    "arm {arm} >= num_arms {}",
+                    self.num_arms
+                );
+                self.counts[arm]
+            }
+
+            /// Total pulls across all arms (un-decayed counter).
+            #[inline]
+            #[must_use]
+            pub fn total_pulls(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Number of arms.
+            #[inline]
+            #[must_use]
+            pub fn num_arms(&self) -> usize {
+                self.num_arms
+            }
+
+            /// Whether all arms have been pulled at least once
+            /// and `total_pulls >= min_samples`.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0 as $ty)
+            }
+
+            /// Returns the number of updates performed.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.total_pulls
+            }
+
+            /// Resets all state, keeping configuration.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.counts.fill(0.0 as $ty);
+                self.rewards.fill(0.0 as $ty);
+                self.total_pulls = 0;
+            }
+        }
+
+        impl $builder {
+            /// Sets the number of arms (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn arms(mut self, n: usize) -> Self {
+                self.arms = Option::Some(n);
+                self
+            }
+
+            /// Sets the exploration constant `c` (default: sqrt(2)).
+            #[inline]
+            #[must_use]
+            pub fn exploration(mut self, c: $ty) -> Self {
+                self.exploration = c;
+                self
+            }
+
+            /// Sets the decay factor for non-stationary rewards (default: 1.0).
+            #[inline]
+            #[must_use]
+            pub fn decay(mut self, d: $ty) -> Self {
+                self.decay = d;
+                self
+            }
+
+            /// Sets the minimum samples before `is_primed()` returns true (default: arms).
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = Option::Some(n);
+                self
+            }
+
+            /// Builds the bandit.
+            #[inline]
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let arms = self
+                    .arms
+                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+                if arms < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+                }
+                if self.exploration <= 0.0 as $ty || !self.exploration.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "exploration must be positive and finite",
+                    ));
+                }
+                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "decay must be in (0, 1]",
+                    ));
+                }
+                let min_samples = self.min_samples.unwrap_or(arms as u64);
+                Ok($name {
+                    counts: vec![0.0 as $ty; arms].into_boxed_slice(),
+                    rewards: vec![0.0 as $ty; arms].into_boxed_slice(),
+                    exploration: self.exploration,
+                    decay: self.decay,
+                    total_pulls: 0,
+                    num_arms: arms,
+                    min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_ucb1!(Ucb1F64, Ucb1F64Builder, f64);
+impl_ucb1!(Ucb1F32, Ucb1F32Builder, f32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explore_all_first() {
+        let mut bandit = Ucb1F64::builder().arms(3).build().unwrap();
+        let a0 = bandit.select();
+        bandit.update(a0, 0.5).unwrap();
+        let a1 = bandit.select();
+        assert_ne!(a1, a0);
+        bandit.update(a1, 0.5).unwrap();
+        let a2 = bandit.select();
+        assert_ne!(a2, a0);
+        assert_ne!(a2, a1);
+    }
+
+    #[test]
+    fn exploits_best_arm() {
+        let mut bandit = Ucb1F64::builder().arms(3).build().unwrap();
+        // Seed all arms
+        for i in 0..3 {
+            bandit.update(i, if i == 1 { 1.0 } else { 0.0 }).unwrap();
+        }
+        // Arm 1 consistently best
+        let mut counts = [0u64; 3];
+        for _ in 0..200 {
+            let arm = bandit.select();
+            let reward = if arm == 1 { 1.0 } else { 0.0 };
+            bandit.update(arm, reward).unwrap();
+            counts[arm] += 1;
+        }
+        assert!(
+            counts[1] > counts[0] && counts[1] > counts[2],
+            "arm 1 should dominate: {counts:?}"
+        );
+    }
+
+    #[test]
+    fn exploration_decreases() {
+        let mut bandit = Ucb1F64::builder().arms(2).build().unwrap();
+        bandit.update(0, 0.8).unwrap();
+        bandit.update(1, 0.2).unwrap();
+
+        // UCB bonus for arm 1 after few pulls
+        let early_bonus = {
+            let total: f64 = bandit.counts.iter().sum();
+            let ln_t = (total as f64).ln();
+            bandit.exploration * (ln_t / bandit.counts[1] as f64).sqrt()
+        };
+
+        for _ in 0..100 {
+            let arm = bandit.select();
+            bandit
+                .update(arm, if arm == 0 { 0.8 } else { 0.2 })
+                .unwrap();
+        }
+
+        let late_bonus = {
+            let total: f64 = bandit.counts.iter().sum();
+            let ln_t = (total as f64).ln();
+            bandit.exploration * (ln_t / bandit.counts[1] as f64).sqrt()
+        };
+
+        assert!(
+            late_bonus < early_bonus,
+            "bonus should decrease: early={early_bonus}, late={late_bonus}"
+        );
+    }
+
+    #[test]
+    fn decay_forgets() {
+        let mut bandit = Ucb1F64::builder().arms(2).decay(0.95).build().unwrap();
+
+        bandit.update(0, 1.0).unwrap();
+        bandit.update(1, 0.0).unwrap();
+        let initial_count = bandit.pulls(0);
+
+        for _ in 0..20 {
+            bandit.update(1, 0.0).unwrap();
+        }
+
+        assert!(
+            bandit.pulls(0) < initial_count,
+            "decayed count {} should be less than initial {}",
+            bandit.pulls(0),
+            initial_count
+        );
+    }
+
+    #[test]
+    fn decay_regime_shift() {
+        let mut bandit = Ucb1F64::builder().arms(2).decay(0.9).build().unwrap();
+
+        // Phase 1: arm 0 is best
+        for _ in 0..50 {
+            bandit.update(0, 1.0).unwrap();
+            bandit.update(1, 0.0).unwrap();
+        }
+        assert!(
+            bandit.mean_reward(0).unwrap() > bandit.mean_reward(1).unwrap(),
+            "arm 0 should lead after phase 1"
+        );
+
+        // Phase 2: arm 1 is best
+        for _ in 0..100 {
+            bandit.update(0, 0.0).unwrap();
+            bandit.update(1, 1.0).unwrap();
+        }
+        assert!(
+            bandit.mean_reward(1).unwrap() > bandit.mean_reward(0).unwrap(),
+            "arm 1 should lead after phase 2"
+        );
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut bandit = Ucb1F64::builder().arms(3).build().unwrap();
+        bandit.update(0, 1.0).unwrap();
+        bandit.update(1, 0.5).unwrap();
+        assert_eq!(bandit.total_pulls(), 2);
+
+        bandit.reset();
+        assert_eq!(bandit.total_pulls(), 0);
+        assert_eq!(bandit.mean_reward(0), Option::None);
+        assert_eq!(bandit.mean_reward(1), Option::None);
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let mut bandit = Ucb1F64::builder().arms(2).build().unwrap();
+        assert_eq!(
+            bandit.update(0, f64::NAN),
+            Err(nexus_stats_core::DataError::NotANumber)
+        );
+        assert_eq!(bandit.total_pulls(), 0);
+    }
+
+    #[test]
+    fn inf_rejected() {
+        let mut bandit = Ucb1F64::builder().arms(2).build().unwrap();
+        assert_eq!(
+            bandit.update(0, f64::INFINITY),
+            Err(nexus_stats_core::DataError::Infinite)
+        );
+    }
+
+    #[test]
+    fn builder_validation() {
+        assert!(Ucb1F64::builder().arms(1).build().is_err());
+        assert!(Ucb1F64::builder().arms(2).exploration(0.0).build().is_err());
+        assert!(
+            Ucb1F64::builder()
+                .arms(2)
+                .exploration(-1.0)
+                .build()
+                .is_err()
+        );
+        assert!(Ucb1F64::builder().arms(2).decay(0.0).build().is_err());
+        assert!(Ucb1F64::builder().arms(2).decay(1.1).build().is_err());
+        assert!(Ucb1F64::builder().build().is_err()); // missing arms
+    }
+
+    #[test]
+    fn f32_basic() {
+        let mut bandit = Ucb1F32::builder().arms(2).build().unwrap();
+        bandit.update(0, 1.0).unwrap();
+        bandit.update(1, 0.0).unwrap();
+        let arm = bandit.select();
+        assert_eq!(arm, 0);
+    }
+}

--- a/nexus-stats/CHANGELOG.md
+++ b/nexus-stats/CHANGELOG.md
@@ -19,6 +19,11 @@ contained.
 - **`PageHinkleyF64/F32`** — Page-Hinkley change detection (detection feature).
 - **`AdwinF64/F32`** — ADWIN adaptive windowing (detection feature).
 - **`PredictiveInfoBoundF64/F32`** — predictive information bound (detection feature).
+- **`Ucb1F64/F32`** — UCB1 multi-armed bandit (regression feature).
+- **`ThompsonBetaF64/F32`** — Thompson Sampling with Beta prior (regression feature).
+- **`ThompsonGammaF64/F32`** — Thompson Sampling with Gamma prior (regression feature).
+- **`EpsilonGreedyF64/F32`** — epsilon-greedy bandit (regression feature).
+- **`Exp3F64/F32`** — EXP3 adversarial bandit (regression feature).
 
 ## [5.0.0] — 2026-05-18
 

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -100,6 +100,16 @@ for deep-dives on each algorithm.
 | `LogarithmicRegressionF64` | Logarithmic fit (`y = a·ln(x) + b`) | TBD |
 | `PowerRegressionF64` | Power law fit (`y = ax^b`) | TBD |
 
+### Multi-Armed Bandits *(alloc, std|libm)*
+
+| Type | What It Does | p50 |
+|------|-------------|-----|
+| `Ucb1F64` | UCB1 — deterministic explore/exploit | TBD |
+| `ThompsonBetaF64` | Thompson Sampling — Beta prior for [0,1] rewards | TBD |
+| `ThompsonGammaF64` | Thompson Sampling — Gamma prior for positive rewards | TBD |
+| `EpsilonGreedyF64` | ε-greedy — simplest bandit baseline | TBD |
+| `Exp3F64` | EXP3 — adversarial bandit (no stochastic assumption) | TBD |
+
 ### Signal Analysis
 
 | Type | What It Computes | p50 |
@@ -184,6 +194,7 @@ intrinsics; integer types use bit-shift arithmetic.
 | HawkesIntensity | ✓ | ✓ | | | |
 | Saturation, ErrorRate, TrendAlert | ✓ | ✓ | | | |
 | ShiryaevRoberts | | ✓ | | | |
+| Ucb1, ThompsonBeta, ThompsonGamma, EpsilonGreedy, Exp3 | ✓ | ✓ | | | |
 
 ## Common API Patterns
 
@@ -284,6 +295,9 @@ See [`docs/use-cases/trading.md`](docs/use-cases/trading.md) for full guide with
 | Noise-corrected realized vol | `TwoScaleRvF64` | core |
 | Bursty event intensity | `HawkesIntensityF64` | core |
 | Conditional smoothing | `ConditionalEmaF64` | smoothing |
+| Venue selection | `ThompsonBetaF64` / `Ucb1F64` | regression |
+| Parameter A/B testing | `Ucb1F64` / `EpsilonGreedyF64` | regression |
+| Adversarial strategy | `Exp3F64` | regression |
 
 ## License
 

--- a/nexus-stats/benches/update_bench.rs
+++ b/nexus-stats/benches/update_bench.rs
@@ -18,8 +18,8 @@ use nexus_stats::{
     },
     estimation::{Kalman2dF64, Kalman3dF64},
     learning::{
-        AdaGradF64, AdamF64, LmsFilterF64, NlmsFilterF64, OnlineGdF64, OnlineKMeansF64,
-        RlsFilterF64,
+        AdaGradF64, AdamF64, EpsilonGreedyF64, Exp3F64, LmsFilterF64, NlmsFilterF64, OnlineGdF64,
+        OnlineKMeansF64, RlsFilterF64, ThompsonBetaF64, ThompsonGammaF64, Ucb1F64,
     },
     monitoring::{
         DrawdownF64, ErrorRateF64, JitterF64, RunningMaxF64, RunningMinF64, SaturationF64,
@@ -51,6 +51,10 @@ impl Lcg {
         self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
         // Map to [-1, 1) range — realistic for feature vectors
         ((self.0 >> 33) as f64 / (1u64 << 31) as f64) * 2.0 - 1.0
+    }
+    fn next_unit(&mut self) -> f64 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 33) as f64 / (1u64 << 31) as f64
     }
 }
 
@@ -938,6 +942,138 @@ fn bench_entropy_query(c: &mut Criterion) {
 }
 
 // ============================================================
+// Group 8: Bandits
+// ============================================================
+
+fn bench_ucb1_select(c: &mut Criterion) {
+    for k in [2, 5, 10, 25, 50] {
+        let mut rng = Lcg::new(42);
+        let mut b = Ucb1F64::builder().arms(k).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("Ucb1F64::select (K={k})"), |bench| {
+            bench.iter(|| black_box(b.select()))
+        });
+    }
+}
+
+fn bench_ucb1_update(c: &mut Criterion) {
+    let mut rng = Lcg::new(42);
+    for k in [2, 5, 10, 25, 50] {
+        let mut b = Ucb1F64::builder().arms(k).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("Ucb1F64::update (K={k})"), |bench| {
+            let mut arm = 0;
+            bench.iter(|| {
+                arm = (arm + 1) % k;
+                b.update(black_box(arm), black_box(rng.next_unit())).unwrap()
+            })
+        });
+    }
+}
+
+fn bench_ucb1_update_decay(c: &mut Criterion) {
+    let mut rng = Lcg::new(42);
+    for k in [2, 5, 10, 25, 50] {
+        let mut b = Ucb1F64::builder().arms(k).decay(0.99).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("Ucb1F64::update decay=0.99 (K={k})"), |bench| {
+            let mut arm = 0;
+            bench.iter(|| {
+                arm = (arm + 1) % k;
+                b.update(black_box(arm), black_box(rng.next_unit())).unwrap()
+            })
+        });
+    }
+}
+
+fn bench_thompson_beta_select(c: &mut Criterion) {
+    for k in [2, 5, 10, 25, 50] {
+        let mut rng = Lcg::new(42);
+        let mut b = ThompsonBetaF64::builder().arms(k).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || rng.next_unit());
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("ThompsonBetaF64::select (K={k})"), |bench| {
+            bench.iter(|| black_box(b.select(&mut || rng.next_unit())))
+        });
+    }
+}
+
+fn bench_thompson_beta_update(c: &mut Criterion) {
+    let mut rng = Lcg::new(42);
+    for k in [2, 5, 10, 25, 50] {
+        let mut b = ThompsonBetaF64::builder().arms(k).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || rng.next_unit());
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("ThompsonBetaF64::update (K={k})"), |bench| {
+            let mut arm = 0;
+            bench.iter(|| {
+                arm = (arm + 1) % k;
+                b.update(black_box(arm), black_box(rng.next_unit())).unwrap()
+            })
+        });
+    }
+}
+
+fn bench_thompson_gamma_select(c: &mut Criterion) {
+    for k in [2, 5, 10, 25, 50] {
+        let mut rng = Lcg::new(42);
+        let mut b = ThompsonGammaF64::builder().arms(k).build().unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || rng.next_unit());
+            let _ = b.update(arm, rng.next_unit() + 0.01);
+        }
+        c.bench_function(&format!("ThompsonGammaF64::select (K={k})"), |bench| {
+            bench.iter(|| black_box(b.select(&mut || rng.next_unit())))
+        });
+    }
+}
+
+fn bench_epsilon_greedy_select(c: &mut Criterion) {
+    for k in [2, 5, 10, 25, 50] {
+        let mut rng = Lcg::new(42);
+        let mut b = EpsilonGreedyF64::builder()
+            .arms(k)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || rng.next_unit());
+            let _ = b.update(arm, rng.next_unit());
+        }
+        c.bench_function(&format!("EpsilonGreedyF64::select (K={k})"), |bench| {
+            bench.iter(|| black_box(b.select(&mut || rng.next_unit())))
+        });
+    }
+}
+
+fn bench_exp3_select(c: &mut Criterion) {
+    for k in [2, 5, 10, 25, 50] {
+        let mut rng = Lcg::new(42);
+        let mut b = Exp3F64::builder().arms(k).gamma(0.1).build().unwrap();
+        for _ in 0..(k * 100) {
+            let (arm, prob) = b.select(&mut || rng.next_unit());
+            let _ = b.update(arm, rng.next_unit(), prob);
+        }
+        c.bench_function(&format!("Exp3F64::select (K={k})"), |bench| {
+            bench.iter(|| black_box(b.select(&mut || rng.next_unit())))
+        });
+    }
+}
+
+// ============================================================
 // Criterion groups and main
 // ============================================================
 
@@ -1013,6 +1149,18 @@ criterion_group!(
     bench_entropy_query,
 );
 
+criterion_group!(
+    bandits,
+    bench_ucb1_select,
+    bench_ucb1_update,
+    bench_ucb1_update_decay,
+    bench_thompson_beta_select,
+    bench_thompson_beta_update,
+    bench_thompson_gamma_select,
+    bench_epsilon_greedy_select,
+    bench_exp3_select,
+);
+
 criterion_main!(
     core_stats,
     const_generic,
@@ -1021,4 +1169,5 @@ criterion_main!(
     state_estimation,
     optimizers,
     queries,
+    bandits,
 );

--- a/nexus-stats/examples/perf_stats.rs
+++ b/nexus-stats/examples/perf_stats.rs
@@ -12,6 +12,7 @@ use nexus_stats::{
     control::{BoolWindow, HysteresisF64},
     detection::{CusumF64, CusumI64, MosumF64, MultiGateF64, RobustZScoreF64, ShiryaevRobertsF64},
     frequency::TopK,
+    learning::{EpsilonGreedyF64, Exp3F64, ThompsonBetaF64, ThompsonGammaF64, Ucb1F64},
     monitoring::{
         CoDelI64, DrawdownF64, EventRateF64, LivenessF64, PeakHoldF64, RunningMaxF64,
         RunningMinF64, WindowedMaxF64, WindowedMinF64,
@@ -89,6 +90,11 @@ fn next_val(state: &mut u64) -> u64 {
     *state ^= *state >> 7;
     *state ^= *state << 17;
     *state
+}
+
+#[inline(always)]
+fn next_unit(state: &mut u64) -> f64 {
+    (next_val(state) >> 33) as f64 / (1u64 << 31) as f64
 }
 
 // ============================================================================
@@ -812,6 +818,172 @@ fn bench_transfer_entropy_f64(samples: &mut [u64]) {
 // Main
 // ============================================================================
 
+// ============================================================================
+// Bandits — parameterized by K
+// ============================================================================
+
+const BANDIT_KS: &[usize] = &[2, 5, 10, 25, 50];
+
+fn bench_bandit_select_sweep(samples: &mut [u64]) {
+    println!(
+        "\n  {:<28} {:>6} {:>6} {:>6} {:>7} {:>7}",
+        "(cycles/op)", "p50", "p90", "p99", "p99.9", "max"
+    );
+
+    for &k in BANDIT_KS {
+        // UCB1
+        let mut b = Ucb1F64::builder().arms(k).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, next_unit(&mut rng));
+        }
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                black_box(b.select());
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("Ucb1::select K={k}"), samples);
+    }
+
+    println!();
+    for &k in BANDIT_KS {
+        // ThompsonBeta
+        let mut b = ThompsonBetaF64::builder().arms(k).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || next_unit(&mut rng));
+            let _ = b.update(arm, next_unit(&mut rng));
+        }
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                black_box(b.select(&mut || next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("ThompsonBeta::select K={k}"), samples);
+    }
+
+    println!();
+    for &k in BANDIT_KS {
+        // ThompsonGamma
+        let mut b = ThompsonGammaF64::builder().arms(k).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || next_unit(&mut rng));
+            let _ = b.update(arm, next_unit(&mut rng) + 0.01);
+        }
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                black_box(b.select(&mut || next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("ThompsonGamma::select K={k}"), samples);
+    }
+
+    println!();
+    for &k in BANDIT_KS {
+        // EpsilonGreedy
+        let mut b = EpsilonGreedyF64::builder()
+            .arms(k)
+            .epsilon(0.1)
+            .build()
+            .unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select(&mut || next_unit(&mut rng));
+            let _ = b.update(arm, next_unit(&mut rng));
+        }
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                black_box(b.select(&mut || next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("EpsGreedy::select K={k}"), samples);
+    }
+
+    println!();
+    for &k in BANDIT_KS {
+        // EXP3
+        let mut b = Exp3F64::builder().arms(k).gamma(0.1).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let (arm, prob) = b.select(&mut || next_unit(&mut rng));
+            let _ = b.update(arm, next_unit(&mut rng), prob);
+        }
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                black_box(b.select(&mut || next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("Exp3::select K={k}"), samples);
+    }
+}
+
+fn bench_bandit_update_sweep(samples: &mut [u64]) {
+    println!(
+        "\n  {:<28} {:>6} {:>6} {:>6} {:>7} {:>7}",
+        "(cycles/op)", "p50", "p90", "p99", "p99.9", "max"
+    );
+
+    for &k in BANDIT_KS {
+        // UCB1 stationary
+        let mut b = Ucb1F64::builder().arms(k).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, next_unit(&mut rng));
+        }
+        let mut arm_cycle: usize = 0;
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                arm_cycle = (arm_cycle + 1) % k;
+                let _ = b.update(black_box(arm_cycle), black_box(next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("Ucb1::update K={k}"), samples);
+    }
+
+    println!();
+    for &k in BANDIT_KS {
+        // UCB1 decay
+        let mut b = Ucb1F64::builder().arms(k).decay(0.99).build().unwrap();
+        let mut rng = 12345u64;
+        for _ in 0..(k * 100) {
+            let arm = b.select();
+            let _ = b.update(arm, next_unit(&mut rng));
+        }
+        let mut arm_cycle: usize = 0;
+        for s in samples.iter_mut() {
+            let start = rdtsc_start();
+            for _ in 0..BATCH {
+                arm_cycle = (arm_cycle + 1) % k;
+                let _ = b.update(black_box(arm_cycle), black_box(next_unit(&mut rng)));
+            }
+            let end = rdtsc_end();
+            *s = (end - start) / BATCH;
+        }
+        print_row(&format!("Ucb1::update(decay) K={k}"), samples);
+    }
+}
+
 fn main() {
     println!("\nnexus-stats benchmark — cycles per operation (batch={BATCH})");
     println!("=========================================================");
@@ -914,6 +1086,12 @@ fn main() {
     print_row("Entropy<8>::update", &mut buf);
     bench_transfer_entropy_f64(&mut buf);
     print_row("TransferEntropy(8,1)::update", &mut buf);
+
+    section("Bandits — select() scaling");
+    bench_bandit_select_sweep(&mut buf);
+
+    section("Bandits — update() scaling");
+    bench_bandit_update_sweep(&mut buf);
 
     println!();
 }

--- a/nexus-stats/src/lib.rs
+++ b/nexus-stats/src/lib.rs
@@ -80,7 +80,7 @@
 //! | `detection` | `signal` | Autocorrelation, CrossCorrelation, Entropy, TransferEntropy, PredictiveInfoBound |
 //! | `detection` | `estimation` | + SPRT |
 //! | `regression` | `regression` | Linear, Polynomial, EW variants, Transformed, LogisticRegression |
-//! | `regression` | `learning` | LMS, NLMS, RLS, OnlineKMeans, GD, AdaGrad, Adam |
+//! | `regression` | `learning` | LMS, NLMS, RLS, OnlineKMeans, GD, AdaGrad, Adam, UCB1, ThompsonBeta, ThompsonGamma, EpsilonGreedy, EXP3 |
 //! | `regression` | `estimation` | + Kalman 2d/3d, BetaBinomial, GammaPoisson |
 //! | `control` | `control` | + PeakDetector, BoolWindow |
 //! | `control` | `frequency` | TopK, FlexProportion, DecayAccum |


### PR DESCRIPTION
## Summary

- **Ucb1F64/F32** — deterministic UCB1 selection (no RNG). Auer, Cesa-Bianchi, Fischer (2002).
- **ThompsonBetaF64/F32** — Thompson Sampling with Beta prior for binary/[0,1] rewards.
- **ThompsonGammaF64/F32** — Thompson Sampling with Gamma prior for positive continuous rewards.
- **EpsilonGreedyF64/F32** — epsilon-greedy baseline.
- **Exp3F64/F32** — EXP3 adversarial bandit, log-space weights. Auer, Cesa-Bianchi, Freund, Schapire (2002).
- Internal sampling utilities (Marsaglia polar, Marsaglia-Tsang Gamma, Beta via Gamma ratio).
- UCB1, ThompsonBeta, ThompsonGamma, EpsilonGreedy support exponential `decay` for non-stationary rewards.
- Decision guide at `docs/bandits.md` with trading examples and algorithm selection tree.
- Criterion benchmarks scaling K across [2, 5, 10, 25, 50].

All types: `alloc` + (`std` | `libm`). RNG via `&mut impl FnMut() -> $ty` — no `rand` dependency.

Bumps `nexus-stats-regression` 1.2.1 → 1.3.0.

Closes #271, closes #293.

## Performance (SSE2, uncontrolled)

### select() — ns median

| Algorithm | K=2 | K=5 | K=10 | K=25 | K=50 |
|-----------|----:|----:|-----:|-----:|-----:|
| UCB1 | 8.3 | 15.3 | 25.6 | 63.8 | 142 |
| ThompsonBeta | 82.5 | 193 | 420 | 1006 | 1943 |
| ThompsonGamma | 43.6 | 106 | 211 | 505 | 1017 |
| EpsilonGreedy | 4.0 | 6.7 | 12.6 | 28.5 | 66.1 |
| EXP3 | 22.0 | 46.8 | 65.4 | 135.8 | 256.5 |

### update() — ns median

| Algorithm | K=2 | K=5 | K=10 | K=25 | K=50 |
|-----------|----:|----:|-----:|-----:|-----:|
| UCB1 (no decay) | 4.2 | 4.4 | 4.3 | 3.9 | 4.4 |
| UCB1 (decay=0.99) | 5.0 | 6.7 | 7.6 | 10.0 | 15.8 |
| ThompsonBeta | 3.9 | 3.9 | 4.5 | 6.2 | 4.4 |

### Optimization highlights

- **Decay loops vectorized** (SSE2): iterator patterns give LLVM non-aliasing proof. UCB1 decay K=50: 48.9 → 15.8ns (3.1x).
- **UCB1 select**: sqrt hoisted, reciprocal precomputed. One fewer `divsd` per arm. K=50: 239 → 142ns (1.7x).
- **EXP3 log-space weights**: numerically bulletproof — no overflow regardless of learning rate or horizon. Scratch buffer caches exp() values from sum pass for CDF sampling (K=50: -21%).

## Test plan

- [x] `cargo test -p nexus-stats-regression --all-features` — 270 tests + 33 doctests
- [x] `cargo clippy -p nexus-stats-regression --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Codegen review (Casey) — decay loops vectorize, select paths optimized, bounds checks eliminated
- [x] Correctness review (John) — all algorithms traced against reference papers
- [x] EXP3 default eta bug found and fixed (was `gamma/K`, now `gamma`)
- [x] EXP3 converted to log-space weights — eliminates overflow class of bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)