### PR TITLE
nexus-stats-detection 1.2.0 — distribution drift + BOCPD

### DIFF
--- a/nexus-stats-core/src/math.rs
+++ b/nexus-stats-core/src/math.rs
@@ -98,6 +98,73 @@ pub fn ln(x: f64) -> f64 {
     }
 }
 
+/// Natural logarithm (f32).
+///
+/// Requires `std` or `libm` feature.
+#[doc(hidden)]
+#[cfg(any(feature = "std", feature = "libm"))]
+#[inline]
+pub fn ln_f32(x: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        x.ln()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::logf(x)
+    }
+}
+
+/// Exponential function (f32).
+///
+/// Requires `std` or `libm` feature.
+#[doc(hidden)]
+#[cfg(any(feature = "std", feature = "libm"))]
+#[inline]
+pub fn exp_f32(x: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        x.exp()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::expf(x)
+    }
+}
+
+/// Log-gamma function via Lanczos approximation (g=7).
+///
+/// Accurate to ~15 digits for x > 0.
+#[doc(hidden)]
+#[cfg(any(feature = "std", feature = "libm"))]
+#[allow(
+    clippy::excessive_precision,
+    clippy::unreadable_literal,
+    clippy::suboptimal_flops
+)]
+pub fn ln_gamma(x: f64) -> f64 {
+    const G: f64 = 7.5;
+    const C: [f64; 9] = [
+        0.99999999999980993,
+        676.5203681218851,
+        -1259.1392167224028,
+        771.32342877765313,
+        -176.61502916214059,
+        12.507343278686905,
+        -0.13857109526572012,
+        9.9843695780195716e-6,
+        1.5056327351493116e-7,
+    ];
+
+    let x = x - 1.0;
+    let mut sum = C[0];
+    for i in 1..9 {
+        sum += C[i] / (x + i as f64);
+    }
+    let t = x + G;
+    0.5 * ln(2.0 * core::f64::consts::PI) + (x + 0.5) * ln(t) - t + ln(sum)
+}
+
 /// Trait providing `fma` (fused multiply-add) across all feature configurations.
 ///
 /// With `std`: uses hardware FMA intrinsic.
@@ -141,6 +208,49 @@ impl MulAdd for f32 {
         #[cfg(not(any(feature = "std", feature = "libm")))]
         {
             self * b + c
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(any(feature = "std", feature = "libm"))]
+    use super::*;
+
+    #[test]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    fn ln_gamma_factorial_values() {
+        // Γ(1) = 1, so ln_gamma(1) = 0
+        assert!((ln_gamma(1.0) - 0.0).abs() < 1e-12);
+        // Γ(5) = 4! = 24, so ln_gamma(5) = ln(24)
+        assert!((ln_gamma(5.0) - ln(24.0)).abs() < 1e-12);
+        // Γ(1/2) = √π, so ln_gamma(0.5) = 0.5 * ln(π)
+        assert!((ln_gamma(0.5) - 0.5 * ln(core::f64::consts::PI)).abs() < 1e-12);
+    }
+
+    #[test]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    fn ln_f32_matches_f64() {
+        for &x in &[0.5f32, 1.0, 2.0, 10.0, 100.0] {
+            let f32_result = ln_f32(x);
+            let f64_result = ln(x as f64) as f32;
+            assert!(
+                (f32_result - f64_result).abs() < 1e-6,
+                "ln_f32({x}) = {f32_result}, expected ≈ {f64_result}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    fn exp_f32_matches_f64() {
+        for &x in &[-2.0f32, -1.0, 0.0, 1.0, 2.0] {
+            let f32_result = exp_f32(x);
+            let f64_result = exp(x as f64) as f32;
+            assert!(
+                (f32_result - f64_result).abs() < 1e-5,
+                "exp_f32({x}) = {f32_result}, expected ≈ {f64_result}"
+            );
         }
     }
 }

--- a/nexus-stats-detection/CHANGELOG.md
+++ b/nexus-stats-detection/CHANGELOG.md
@@ -10,6 +10,19 @@ contained.
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-05-20
+
+### Added
+
+- **`DistDriftF64` / `DistDriftF32`** — distribution drift metrics: KL divergence,
+  Jensen-Shannon divergence, Wasserstein-1 distance over reference/live histograms.
+  Equi-width bins with Laplace smoothing. Requires `alloc` + (`std` or `libm`).
+- **`BocpdF64`** — Bayesian Online Change Point Detection (Adams & MacKay 2007).
+  Gaussian observation model, Normal-Inverse-Gamma conjugate prior, truncated
+  run-length posterior. O(W) per update. Requires `alloc` + (`std` or `libm`).
+- **`nexus_stats_core::math::ln_gamma`** — Lanczos approximation for log-gamma (f64).
+- **`nexus_stats_core::math::ln_f32`** / **`exp_f32`** — f32 transcendental functions.
+
 ## [1.1.0] — 2026-05-18
 
 ### Added

--- a/nexus-stats-detection/Cargo.toml
+++ b/nexus-stats-detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-stats-detection"
-version = "1.1.0"
+version = "1.2.0"
 description = "Advanced change detection and signal analysis for nexus-stats"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -138,15 +138,33 @@ impl BocpdF64 {
         #[allow(clippy::suboptimal_flops)]
         {
             // Pass 1: a[r] = nu_d*beta_n, b[r] = a + dx^2.
-            for r in 0..self.active {
-                let mu_n = self.pre.mu_a[r] + self.pre.mu_b[r] * self.suf_mean[r];
-                let diff = self.suf_mean[r] - self.prior_mu;
-                let beta_n =
-                    self.prior_beta + self.suf_sum_sq[r] * 0.5 + self.pre.beta_c[r] * diff * diff;
-                let a = self.pre.nu_d[r] * beta_n;
-                let dx = sample - mu_n;
-                self.scratch[r] = a;
-                self.scratch2[r] = a + dx * dx;
+            // SAFETY: r < self.active <= self.max_run_length + 1.
+            // All arrays allocated with capacity >= max_run_length + 2.
+            // Raw pointers hoisted outside loop so LLVM sees them as
+            // loop-invariant and can auto-vectorize (writes through &mut self
+            // force base pointer reloads otherwise).
+            unsafe {
+                let p_mu_a = self.pre.mu_a.as_ptr();
+                let p_mu_b = self.pre.mu_b.as_ptr();
+                let p_beta_c = self.pre.beta_c.as_ptr();
+                let p_nu_d = self.pre.nu_d.as_ptr();
+                let p_sm = self.suf_mean.as_ptr();
+                let p_ssq = self.suf_sum_sq.as_ptr();
+                let p_sc = self.scratch.as_mut_ptr();
+                let p_sc2 = self.scratch2.as_mut_ptr();
+                let prior_mu = self.prior_mu;
+                let prior_beta = self.prior_beta;
+
+                for r in 0..self.active {
+                    let sm = *p_sm.add(r);
+                    let mu_n = *p_mu_a.add(r) + *p_mu_b.add(r) * sm;
+                    let diff = sm - prior_mu;
+                    let beta_n = prior_beta + *p_ssq.add(r) * 0.5 + *p_beta_c.add(r) * diff * diff;
+                    let a = *p_nu_d.add(r) * beta_n;
+                    let dx = sample - mu_n;
+                    *p_sc.add(r) = a;
+                    *p_sc2.add(r) = a + dx * dx;
+                }
             }
 
             // Pass 2: ln in-place (SIMD when available).
@@ -154,27 +172,45 @@ impl BocpdF64 {
             simd_math::ln_inplace(&mut self.scratch2[..self.active]);
 
             // Pass 3: combine and find CP mass max.
+            // SAFETY: same invariant as Pass 1.
             let mut max_cp_term = f64::NEG_INFINITY;
-            for r in 0..self.active {
-                let alpha_r = self.pre.alpha[r];
-                let log_pred = self.pre.lng_base[r] + alpha_r * self.scratch[r]
-                    - (alpha_r + 0.5) * self.scratch2[r];
+            unsafe {
+                let p_alpha = self.pre.alpha.as_ptr();
+                let p_lng = self.pre.lng_base.as_ptr();
+                let p_sc = self.scratch.as_mut_ptr();
+                let p_sc2 = self.scratch2.as_ptr();
+                let p_lp = self.log_posterior.as_ptr();
+                let log_hazard = self.log_hazard;
 
-                self.scratch[r] = log_pred;
+                for r in 0..self.active {
+                    let alpha_r = *p_alpha.add(r);
+                    let log_pred =
+                        *p_lng.add(r) + alpha_r * *p_sc.add(r) - (alpha_r + 0.5) * *p_sc2.add(r);
 
-                let term = self.log_posterior[r] + log_pred + self.log_hazard;
-                if term > max_cp_term {
-                    max_cp_term = term;
+                    *p_sc.add(r) = log_pred;
+
+                    let term = *p_lp.add(r) + log_pred + log_hazard;
+                    if term > max_cp_term {
+                        max_cp_term = term;
+                    }
                 }
             }
 
             // CP mass: exp-sum (SIMD when available).
             // Reuse scratch2 for the terms since pass 2 is done with it.
+            // SAFETY: same invariant as Pass 1.
             cp_terms = if max_cp_term == f64::NEG_INFINITY {
                 f64::NEG_INFINITY
             } else {
-                for r in 0..self.active {
-                    self.scratch2[r] = self.log_posterior[r] + self.scratch[r] + self.log_hazard;
+                unsafe {
+                    let p_lp = self.log_posterior.as_ptr();
+                    let p_sc = self.scratch.as_ptr();
+                    let p_sc2 = self.scratch2.as_mut_ptr();
+                    let log_hazard = self.log_hazard;
+
+                    for r in 0..self.active {
+                        *p_sc2.add(r) = *p_lp.add(r) + *p_sc.add(r) + log_hazard;
+                    }
                 }
                 let sum = simd_math::exp_sum(&self.scratch2[..self.active], max_cp_term);
                 max_cp_term + ln(sum)

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -139,7 +139,7 @@ impl BocpdF64 {
         {
             // Pass 1: a[r] = nu_d*beta_n, b[r] = a + dx^2.
             // SAFETY: r < self.active <= self.max_run_length + 1.
-            // All arrays allocated with capacity >= max_run_length + 2.
+            // All arrays allocated with capacity max_run_length + 1.
             // Raw pointers hoisted outside loop so LLVM sees them as
             // loop-invariant and can auto-vectorize (writes through &mut self
             // force base pointer reloads otherwise).

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -139,12 +139,10 @@ impl BocpdF64 {
         {
             // Pass 1: a[r] = nu_d*beta_n, b[r] = a + dx^2.
             for r in 0..self.active {
-                let mu_n = self.pre.mu_a[r]
-                    + self.pre.mu_b[r] * self.suf_mean[r];
+                let mu_n = self.pre.mu_a[r] + self.pre.mu_b[r] * self.suf_mean[r];
                 let diff = self.suf_mean[r] - self.prior_mu;
-                let beta_n = self.prior_beta
-                    + self.suf_sum_sq[r] * 0.5
-                    + self.pre.beta_c[r] * diff * diff;
+                let beta_n =
+                    self.prior_beta + self.suf_sum_sq[r] * 0.5 + self.pre.beta_c[r] * diff * diff;
                 let a = self.pre.nu_d[r] * beta_n;
                 let dx = sample - mu_n;
                 self.scratch[r] = a;
@@ -159,14 +157,12 @@ impl BocpdF64 {
             let mut max_cp_term = f64::NEG_INFINITY;
             for r in 0..self.active {
                 let alpha_r = self.pre.alpha[r];
-                let log_pred = self.pre.lng_base[r]
-                    + alpha_r * self.scratch[r]
+                let log_pred = self.pre.lng_base[r] + alpha_r * self.scratch[r]
                     - (alpha_r + 0.5) * self.scratch2[r];
 
                 self.scratch[r] = log_pred;
 
-                let term =
-                    self.log_posterior[r] + log_pred + self.log_hazard;
+                let term = self.log_posterior[r] + log_pred + self.log_hazard;
                 if term > max_cp_term {
                     max_cp_term = term;
                 }
@@ -178,13 +174,9 @@ impl BocpdF64 {
                 f64::NEG_INFINITY
             } else {
                 for r in 0..self.active {
-                    self.scratch2[r] =
-                        self.log_posterior[r] + self.scratch[r] + self.log_hazard;
+                    self.scratch2[r] = self.log_posterior[r] + self.scratch[r] + self.log_hazard;
                 }
-                let sum = simd_math::exp_sum(
-                    &self.scratch2[..self.active],
-                    max_cp_term,
-                );
+                let sum = simd_math::exp_sum(&self.scratch2[..self.active], max_cp_term);
                 max_cp_term + ln(sum)
             };
         }

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -2,6 +2,17 @@ extern crate alloc;
 use alloc::boxed::Box;
 use nexus_stats_core::math::{exp, ln, ln_gamma};
 
+// Precomputed per-r constants; valid because suf_count[r] == r.
+#[derive(Debug, Clone)]
+struct Precomputed {
+    lng_base: Box<[f64]>,
+    mu_a: Box<[f64]>,
+    mu_b: Box<[f64]>,
+    beta_c: Box<[f64]>,
+    nu_d: Box<[f64]>,
+    alpha: Box<[f64]>,
+}
+
 /// Bayesian Online Change Point Detection (Adams & MacKay 2007).
 ///
 /// Maintains a truncated run-length posterior using a Gaussian
@@ -37,14 +48,13 @@ pub struct BocpdF64 {
     suf_mean: Box<[f64]>,
     suf_sum_sq: Box<[f64]>,
     scratch: Box<[f64]>,
+    pre: Precomputed,
 
     max_run_length: usize,
     log_hazard: f64,
     log_1m_hazard: f64,
 
     prior_mu: f64,
-    prior_kappa: f64,
-    prior_alpha: f64,
     prior_beta: f64,
 
     active: usize,
@@ -114,66 +124,51 @@ impl BocpdF64 {
             self.active = 1;
         }
 
-        // Step 1: log predictive with ln_gamma caching.
-        // suf_count[r] == r by construction (step 5 shifts forward + increments),
-        // so alpha_n increases by 0.5 per r. This means ln_gamma(alpha_n) at r+1
-        // equals ln_gamma(alpha_n + 0.5) at r — cache and reuse.
-        #[allow(clippy::suboptimal_flops, clippy::manual_midpoint)]
+        // Step 1 + 2a fused: log predictive (precomputed tables) + CP mass max.
+        //
+        // All prior/r-dependent values are precomputed. The student-t reduces to:
+        //   lng_base[r] + alpha[r]*ln(a) - (alpha[r]+0.5)*ln(b)
+        // where a = nu_d[r]*beta_n, b = a + dx^2. No divisions in the loop.
+        let cp_terms;
+        #[allow(clippy::suboptimal_flops)]
         {
-            let mut cached_lng = ln_gamma(self.prior_alpha);
+            let mut max_cp_term = f64::NEG_INFINITY;
             for r in 0..self.active {
-                let n = self.suf_count[r] as f64;
-                let kappa_n = self.prior_kappa + n;
-                let mu_n = (self.prior_kappa * self.prior_mu
-                    + n * self.suf_mean[r])
-                    / kappa_n;
-                let alpha_n = self.prior_alpha + n / 2.0;
+                let mu_n = self.pre.mu_a[r]
+                    + self.pre.mu_b[r] * self.suf_mean[r];
+                let diff = self.suf_mean[r] - self.prior_mu;
                 let beta_n = self.prior_beta
-                    + self.suf_sum_sq[r] / 2.0
-                    + self.prior_kappa
-                        * n
-                        * (self.suf_mean[r] - self.prior_mu).powi(2)
-                        / (2.0 * kappa_n);
-                let nu = 2.0 * alpha_n;
-                let scale_sq =
-                    beta_n * (kappa_n + 1.0) / (alpha_n * kappa_n);
-                let z = (sample - mu_n) * (sample - mu_n)
-                    / (nu * scale_sq);
+                    + self.suf_sum_sq[r] * 0.5
+                    + self.pre.beta_c[r] * diff * diff;
+                let a = self.pre.nu_d[r] * beta_n;
+                let dx = sample - mu_n;
+                let b = a + dx * dx;
+                let alpha_r = self.pre.alpha[r];
 
-                let lng_upper = ln_gamma(alpha_n + 0.5);
-                let lng_lower = cached_lng;
-                cached_lng = lng_upper;
+                self.scratch[r] = self.pre.lng_base[r]
+                    + alpha_r * ln(a)
+                    - (alpha_r + 0.5) * ln(b);
 
-                self.scratch[r] = lng_upper - lng_lower
-                    - 0.5 * ln(nu * core::f64::consts::PI * scale_sq)
-                    - ((nu + 1.0) / 2.0) * ln(1.0 + z);
-            }
-        }
-
-        // Step 2a: CP mass via two-pass logsumexp (W exp + 1 ln instead
-        // of pairwise 2W exp + W ln).
-        let cp_terms = {
-            let mut max_term = f64::NEG_INFINITY;
-            for r in 0..self.active {
                 let term =
                     self.log_posterior[r] + self.scratch[r] + self.log_hazard;
-                if term > max_term {
-                    max_term = term;
+                if term > max_cp_term {
+                    max_cp_term = term;
                 }
             }
-            if max_term == f64::NEG_INFINITY {
+
+            cp_terms = if max_cp_term == f64::NEG_INFINITY {
                 f64::NEG_INFINITY
             } else {
                 let mut sum = 0.0;
                 for r in 0..self.active {
                     sum += exp(
                         self.log_posterior[r] + self.scratch[r] + self.log_hazard
-                            - max_term,
+                            - max_cp_term,
                     );
                 }
-                max_term + ln(sum)
-            }
-        };
+                max_cp_term + ln(sum)
+            };
+        }
 
         // Step 2b: growth probabilities (reverse to avoid overwrite of log_pred)
         let cap = self.max_run_length;
@@ -447,18 +442,54 @@ impl BocpdF64Builder {
         let size = max_run_length + 1;
         let h = 1.0 / lambda;
 
+        let pre = {
+            let pa = self.prior_alpha;
+            let pk = self.prior_kappa;
+            let pm = self.prior_mu;
+            let half_ln_pi = 0.5 * ln(core::f64::consts::PI);
+
+            let mut lng_base = alloc::vec![0.0f64; size];
+            let mut mu_a = alloc::vec![0.0f64; size];
+            let mut mu_b = alloc::vec![0.0f64; size];
+            let mut beta_c = alloc::vec![0.0f64; size];
+            let mut nu_d = alloc::vec![0.0f64; size];
+            let mut alpha = alloc::vec![0.0f64; size];
+
+            for r in 0..size {
+                let rf = r as f64;
+                let kn = pk + rf;
+                let inv_kn = 1.0 / kn;
+                let an = rf.mul_add(0.5, pa);
+
+                lng_base[r] = ln_gamma(an + 0.5) - ln_gamma(an) - half_ln_pi;
+                mu_a[r] = pk * pm * inv_kn;
+                mu_b[r] = rf * inv_kn;
+                beta_c[r] = pk * rf * 0.5 * inv_kn;
+                nu_d[r] = 2.0 * (kn + 1.0) * inv_kn;
+                alpha[r] = an;
+            }
+
+            Precomputed {
+                lng_base: lng_base.into_boxed_slice(),
+                mu_a: mu_a.into_boxed_slice(),
+                mu_b: mu_b.into_boxed_slice(),
+                beta_c: beta_c.into_boxed_slice(),
+                nu_d: nu_d.into_boxed_slice(),
+                alpha: alpha.into_boxed_slice(),
+            }
+        };
+
         Ok(BocpdF64 {
             log_posterior: alloc::vec![f64::NEG_INFINITY; size].into_boxed_slice(),
             suf_count: alloc::vec![0u64; size].into_boxed_slice(),
             suf_mean: alloc::vec![0.0f64; size].into_boxed_slice(),
             suf_sum_sq: alloc::vec![0.0f64; size].into_boxed_slice(),
             scratch: alloc::vec![f64::NEG_INFINITY; size].into_boxed_slice(),
+            pre,
             max_run_length,
             log_hazard: ln(h),
             log_1m_hazard: ln(1.0 - h),
             prior_mu: self.prior_mu,
-            prior_kappa: self.prior_kappa,
-            prior_alpha: self.prior_alpha,
             prior_beta: self.prior_beta,
             active: 0,
             count: 0,

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -1,0 +1,689 @@
+extern crate alloc;
+use alloc::boxed::Box;
+use nexus_stats_core::math::{exp, ln, ln_gamma};
+
+/// Bayesian Online Change Point Detection (Adams & MacKay 2007).
+///
+/// Maintains a truncated run-length posterior using a Gaussian
+/// observation model with Normal-Inverse-Gamma conjugate prior.
+/// Predictive distribution is Student-t. All posterior arithmetic
+/// in log-space to prevent underflow.
+///
+/// O(W) per update where W = `max_run_length`.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_detection::detection::BocpdF64;
+///
+/// let mut bocpd = BocpdF64::builder()
+///     .max_run_length(200)
+///     .hazard_lambda(100.0)
+///     .build()
+///     .unwrap();
+///
+/// // Stable signal
+/// for i in 0..200 {
+///     let cp = bocpd.update(50.0 + (i % 3) as f64).unwrap();
+///     // cp probability stays low
+/// }
+/// let cp = bocpd.change_point_probability().unwrap();
+/// assert!(cp < 0.3);
+/// ```
+#[derive(Debug, Clone)]
+pub struct BocpdF64 {
+    log_posterior: Box<[f64]>,
+    suf_count: Box<[u64]>,
+    suf_mean: Box<[f64]>,
+    suf_sum_sq: Box<[f64]>,
+    scratch: Box<[f64]>,
+
+    max_run_length: usize,
+    log_hazard: f64,
+    log_1m_hazard: f64,
+
+    prior_mu: f64,
+    prior_kappa: f64,
+    prior_alpha: f64,
+    prior_beta: f64,
+
+    active: usize,
+    count: u64,
+    min_samples: u64,
+}
+
+/// Builder for [`BocpdF64`].
+#[derive(Debug, Clone)]
+pub struct BocpdF64Builder {
+    max_run_length: Option<usize>,
+    hazard_lambda: Option<f64>,
+    prior_mu: f64,
+    prior_kappa: f64,
+    prior_alpha: f64,
+    prior_beta: f64,
+    min_samples: u64,
+}
+
+fn logsumexp(a: f64, b: f64) -> f64 {
+    let max = a.max(b);
+    if max == f64::NEG_INFINITY {
+        return f64::NEG_INFINITY;
+    }
+    max + ln(exp(a - max) + exp(b - max))
+}
+
+fn logsumexp_slice(values: &[f64]) -> f64 {
+    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    if max == f64::NEG_INFINITY {
+        return f64::NEG_INFINITY;
+    }
+    max + ln(values.iter().map(|&v| exp(v - max)).sum::<f64>())
+}
+
+impl BocpdF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> BocpdF64Builder {
+        BocpdF64Builder {
+            max_run_length: Option::None,
+            hazard_lambda: Option::None,
+            prior_mu: 0.0,
+            prior_kappa: 1.0,
+            prior_alpha: 1.0,
+            prior_beta: 1.0,
+            min_samples: 1,
+        }
+    }
+
+    /// Feeds a sample. Returns the change-point probability (posterior
+    /// mass at run length 0) once primed, `None` during warmup.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, nexus_stats_core::DataError> {
+        check_finite!(sample);
+
+        if self.active == 0 {
+            self.log_posterior[0] = 0.0;
+            self.suf_count[0] = 0;
+            self.suf_mean[0] = 0.0;
+            self.suf_sum_sq[0] = 0.0;
+            self.active = 1;
+        }
+
+        // Step 1: log predictive with ln_gamma caching.
+        // suf_count[r] == r by construction (step 5 shifts forward + increments),
+        // so alpha_n increases by 0.5 per r. This means ln_gamma(alpha_n) at r+1
+        // equals ln_gamma(alpha_n + 0.5) at r — cache and reuse.
+        #[allow(clippy::suboptimal_flops, clippy::manual_midpoint)]
+        {
+            let mut cached_lng = ln_gamma(self.prior_alpha);
+            for r in 0..self.active {
+                let n = self.suf_count[r] as f64;
+                let kappa_n = self.prior_kappa + n;
+                let mu_n = (self.prior_kappa * self.prior_mu
+                    + n * self.suf_mean[r])
+                    / kappa_n;
+                let alpha_n = self.prior_alpha + n / 2.0;
+                let beta_n = self.prior_beta
+                    + self.suf_sum_sq[r] / 2.0
+                    + self.prior_kappa
+                        * n
+                        * (self.suf_mean[r] - self.prior_mu).powi(2)
+                        / (2.0 * kappa_n);
+                let nu = 2.0 * alpha_n;
+                let scale_sq =
+                    beta_n * (kappa_n + 1.0) / (alpha_n * kappa_n);
+                let z = (sample - mu_n) * (sample - mu_n)
+                    / (nu * scale_sq);
+
+                let lng_upper = ln_gamma(alpha_n + 0.5);
+                let lng_lower = cached_lng;
+                cached_lng = lng_upper;
+
+                self.scratch[r] = lng_upper - lng_lower
+                    - 0.5 * ln(nu * core::f64::consts::PI * scale_sq)
+                    - ((nu + 1.0) / 2.0) * ln(1.0 + z);
+            }
+        }
+
+        // Step 2a: CP mass via two-pass logsumexp (W exp + 1 ln instead
+        // of pairwise 2W exp + W ln).
+        let cp_terms = {
+            let mut max_term = f64::NEG_INFINITY;
+            for r in 0..self.active {
+                let term =
+                    self.log_posterior[r] + self.scratch[r] + self.log_hazard;
+                if term > max_term {
+                    max_term = term;
+                }
+            }
+            if max_term == f64::NEG_INFINITY {
+                f64::NEG_INFINITY
+            } else {
+                let mut sum = 0.0;
+                for r in 0..self.active {
+                    sum += exp(
+                        self.log_posterior[r] + self.scratch[r] + self.log_hazard
+                            - max_term,
+                    );
+                }
+                max_term + ln(sum)
+            }
+        };
+
+        // Step 2b: growth probabilities (reverse to avoid overwrite of log_pred)
+        let cap = self.max_run_length;
+        if self.active < cap + 1 {
+            for r in (0..self.active).rev() {
+                self.scratch[r + 1] = self.log_posterior[r] + self.scratch[r] + self.log_1m_hazard;
+            }
+        } else {
+            let folded = logsumexp(
+                self.log_posterior[cap - 1] + self.scratch[cap - 1] + self.log_1m_hazard,
+                self.log_posterior[cap] + self.scratch[cap] + self.log_1m_hazard,
+            );
+            self.scratch[cap] = folded;
+            for r in (0..(cap - 1)).rev() {
+                self.scratch[r + 1] = self.log_posterior[r] + self.scratch[r] + self.log_1m_hazard;
+            }
+        }
+
+        // Set CP mass at r=0
+        self.scratch[0] = cp_terms;
+
+        // Step 3: normalize
+        let new_active = if self.active < cap + 1 {
+            self.active + 1
+        } else {
+            cap + 1
+        };
+        let total = logsumexp_slice(&self.scratch[..new_active]);
+        for r in 0..new_active {
+            self.scratch[r] -= total;
+        }
+
+        // Step 4: copy scratch → log_posterior
+        self.log_posterior[..new_active].copy_from_slice(&self.scratch[..new_active]);
+
+        // Step 5: update sufficient stats (reverse to avoid overwrite)
+        let suf_limit = if self.active < cap + 1 {
+            self.active
+        } else {
+            cap
+        };
+        for r in (0..suf_limit).rev() {
+            self.suf_count[r + 1] = self.suf_count[r];
+            self.suf_mean[r + 1] = self.suf_mean[r];
+            self.suf_sum_sq[r + 1] = self.suf_sum_sq[r];
+
+            let n = self.suf_count[r + 1] + 1;
+            let delta = sample - self.suf_mean[r + 1];
+            self.suf_mean[r + 1] += delta / n as f64;
+            self.suf_sum_sq[r + 1] += delta * (sample - self.suf_mean[r + 1]);
+            self.suf_count[r + 1] = n;
+        }
+
+        // Initialize r=0 with empty stats (new run)
+        self.suf_count[0] = 0;
+        self.suf_mean[0] = 0.0;
+        self.suf_sum_sq[0] = 0.0;
+
+        self.active = new_active;
+        self.count += 1;
+
+        if self.count < self.min_samples {
+            Ok(Option::None)
+        } else {
+            Ok(Option::Some(exp(self.log_posterior[0])))
+        }
+    }
+
+    /// Change-point probability: posterior mass at run length 0.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn change_point_probability(&self) -> Option<f64> {
+        if !self.is_primed() {
+            return Option::None;
+        }
+        Option::Some(exp(self.log_posterior[0]))
+    }
+
+    /// MAP (most probable) run length.
+    ///
+    /// Returns `None` if not primed.
+    #[must_use]
+    pub fn map_run_length(&self) -> Option<usize> {
+        if !self.is_primed() {
+            return Option::None;
+        }
+        let mut best_r = 0;
+        let mut best_val = f64::NEG_INFINITY;
+        for r in 0..self.active {
+            if self.log_posterior[r] > best_val {
+                best_val = self.log_posterior[r];
+                best_r = r;
+            }
+        }
+        Option::Some(best_r)
+    }
+
+    /// Expected (mean) run length.
+    ///
+    /// Returns `None` if not primed.
+    #[must_use]
+    pub fn mean_run_length(&self) -> Option<f64> {
+        if !self.is_primed() {
+            return Option::None;
+        }
+        let mut mean = 0.0;
+        for r in 0..self.active {
+            mean += r as f64 * exp(self.log_posterior[r]);
+        }
+        Option::Some(mean)
+    }
+
+    /// Raw log-posterior over active run lengths.
+    ///
+    /// Returns `None` if not primed.
+    #[must_use]
+    pub fn run_length_posterior(&self) -> Option<&[f64]> {
+        if !self.is_primed() {
+            return Option::None;
+        }
+        Option::Some(&self.log_posterior[..self.active])
+    }
+
+    /// Maximum run length (window size W).
+    #[inline]
+    #[must_use]
+    pub fn max_run_length(&self) -> usize {
+        self.max_run_length
+    }
+
+    /// Hazard lambda (expected samples between change points).
+    #[inline]
+    #[must_use]
+    pub fn hazard_lambda(&self) -> f64 {
+        1.0 / exp(self.log_hazard)
+    }
+
+    /// Total samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough samples have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets all state. Configuration preserved.
+    pub fn reset(&mut self) {
+        for v in &mut *self.log_posterior {
+            *v = f64::NEG_INFINITY;
+        }
+        for v in &mut *self.suf_count {
+            *v = 0;
+        }
+        for v in &mut *self.suf_mean {
+            *v = 0.0;
+        }
+        for v in &mut *self.suf_sum_sq {
+            *v = 0.0;
+        }
+        self.active = 0;
+        self.count = 0;
+    }
+}
+
+impl BocpdF64Builder {
+    /// Maximum run length / window size (required, >= 10).
+    #[inline]
+    #[must_use]
+    pub fn max_run_length(mut self, w: usize) -> Self {
+        self.max_run_length = Option::Some(w);
+        self
+    }
+
+    /// Expected samples between change points (required, > 1.0).
+    #[inline]
+    #[must_use]
+    pub fn hazard_lambda(mut self, lambda: f64) -> Self {
+        self.hazard_lambda = Option::Some(lambda);
+        self
+    }
+
+    /// Prior mean (default: 0.0).
+    #[inline]
+    #[must_use]
+    pub fn prior_mu(mut self, mu: f64) -> Self {
+        self.prior_mu = mu;
+        self
+    }
+
+    /// Prior precision scaling (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn prior_kappa(mut self, kappa: f64) -> Self {
+        self.prior_kappa = kappa;
+        self
+    }
+
+    /// Prior shape for variance (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn prior_alpha(mut self, alpha: f64) -> Self {
+        self.prior_alpha = alpha;
+        self
+    }
+
+    /// Prior scale for variance (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn prior_beta(mut self, beta: f64) -> Self {
+        self.prior_beta = beta;
+        self
+    }
+
+    /// Minimum samples before output is produced (default: 1).
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = n;
+        self
+    }
+
+    /// Builds the BOCPD detector.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError` if required fields are missing, max_run_length < 10,
+    /// hazard_lambda <= 1.0, or prior parameters are non-positive.
+    pub fn build(self) -> Result<BocpdF64, nexus_stats_core::ConfigError> {
+        let max_run_length = self
+            .max_run_length
+            .ok_or(nexus_stats_core::ConfigError::Missing("max_run_length"))?;
+        if max_run_length < 10 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "max_run_length must be >= 10",
+            ));
+        }
+
+        let lambda = self
+            .hazard_lambda
+            .ok_or(nexus_stats_core::ConfigError::Missing("hazard_lambda"))?;
+        if !lambda.is_finite() || lambda <= 1.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "hazard_lambda must be finite and > 1.0",
+            ));
+        }
+
+        if self.prior_kappa <= 0.0 || !self.prior_kappa.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "prior_kappa must be finite and > 0",
+            ));
+        }
+        if self.prior_alpha <= 0.0 || !self.prior_alpha.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "prior_alpha must be finite and > 0",
+            ));
+        }
+        if self.prior_beta <= 0.0 || !self.prior_beta.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "prior_beta must be finite and > 0",
+            ));
+        }
+
+        let size = max_run_length + 1;
+        let h = 1.0 / lambda;
+
+        Ok(BocpdF64 {
+            log_posterior: alloc::vec![f64::NEG_INFINITY; size].into_boxed_slice(),
+            suf_count: alloc::vec![0u64; size].into_boxed_slice(),
+            suf_mean: alloc::vec![0.0f64; size].into_boxed_slice(),
+            suf_sum_sq: alloc::vec![0.0f64; size].into_boxed_slice(),
+            scratch: alloc::vec![f64::NEG_INFINITY; size].into_boxed_slice(),
+            max_run_length,
+            log_hazard: ln(h),
+            log_1m_hazard: ln(1.0 - h),
+            prior_mu: self.prior_mu,
+            prior_kappa: self.prior_kappa,
+            prior_alpha: self.prior_alpha,
+            prior_beta: self.prior_beta,
+            active: 0,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vague_prior() -> BocpdF64Builder {
+        BocpdF64::builder()
+            .prior_kappa(0.01)
+            .prior_alpha(0.5)
+            .prior_beta(10.0)
+    }
+
+    #[test]
+    fn stable_signal_low_cp() {
+        let mut bocpd = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(100.0)
+            .build()
+            .unwrap();
+        for i in 0..200 {
+            let sample = 50.0 + (i % 3) as f64;
+            bocpd.update(sample).unwrap();
+        }
+        let cp = bocpd.change_point_probability().unwrap();
+        assert!(cp < 0.1, "stable signal should have low CP prob, got {cp}");
+    }
+
+    #[test]
+    fn mean_shift_detected() {
+        let mut bocpd = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(100.0)
+            .build()
+            .unwrap();
+        for _ in 0..100 {
+            bocpd.update(0.0).unwrap();
+        }
+        let rl_before = bocpd.map_run_length().unwrap();
+        let mean_rl_before = bocpd.mean_run_length().unwrap();
+
+        for _ in 0..20 {
+            bocpd.update(20.0).unwrap();
+        }
+        let rl_after = bocpd.map_run_length().unwrap();
+        let mean_rl_after = bocpd.mean_run_length().unwrap();
+        assert!(
+            rl_after < rl_before,
+            "MAP RL should drop after mean shift: before={rl_before}, after={rl_after}"
+        );
+        assert!(
+            mean_rl_after < mean_rl_before * 0.5,
+            "mean RL should drop significantly: before={mean_rl_before}, after={mean_rl_after}"
+        );
+    }
+
+    #[test]
+    fn variance_shift_detected() {
+        let mut bocpd = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(100.0)
+            .build()
+            .unwrap();
+        for i in 0..100 {
+            bocpd.update(50.0 + (i % 2) as f64).unwrap();
+        }
+        let cp_before = bocpd.change_point_probability().unwrap();
+
+        let mut max_cp = 0.0f64;
+        for i in 0..30 {
+            let sample = if i % 2 == 0 { 50.0 + 20.0 } else { 50.0 - 20.0 };
+            bocpd.update(sample).unwrap();
+            let cp = bocpd.change_point_probability().unwrap();
+            max_cp = max_cp.max(cp);
+        }
+        assert!(
+            max_cp > cp_before,
+            "CP prob should increase after variance shift: before={cp_before}, max={max_cp}"
+        );
+    }
+
+    #[test]
+    fn map_run_length_grows() {
+        let mut bocpd = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(100.0)
+            .build()
+            .unwrap();
+        let mut prev_rl = 0;
+        for i in 0..50 {
+            bocpd.update(50.0 + (i % 2) as f64).unwrap();
+            if let Some(rl) = bocpd.map_run_length() {
+                assert!(
+                    rl >= prev_rl || rl == 0,
+                    "MAP RL should grow monotonically for stable input: was {prev_rl}, now {rl} at step {i}"
+                );
+                prev_rl = rl;
+            }
+        }
+        assert!(
+            prev_rl > 10,
+            "MAP RL should be substantial after 50 stable samples, got {prev_rl}"
+        );
+    }
+
+    #[test]
+    fn map_run_length_resets() {
+        let mut bocpd = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(100.0)
+            .build()
+            .unwrap();
+        for i in 0..100 {
+            bocpd.update((i % 3) as f64).unwrap();
+        }
+        let rl_before = bocpd.map_run_length().unwrap();
+
+        for i in 0..20 {
+            bocpd.update(100.0 + (i % 3) as f64).unwrap();
+        }
+        let rl_after = bocpd.map_run_length().unwrap();
+        assert!(
+            rl_after < rl_before,
+            "MAP RL should drop after mean shift: before={rl_before}, after={rl_after}"
+        );
+    }
+
+    #[test]
+    fn posterior_sums_to_one() {
+        let mut bocpd = vague_prior()
+            .max_run_length(100)
+            .hazard_lambda(50.0)
+            .build()
+            .unwrap();
+        for i in 0..80 {
+            bocpd.update((i % 10) as f64).unwrap();
+            if let Some(log_post) = bocpd.run_length_posterior() {
+                let sum: f64 = log_post.iter().map(|&lp| exp(lp)).sum();
+                assert!(
+                    (sum - 1.0).abs() < 1e-6,
+                    "posterior should sum to 1, got {sum} at step {i}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hazard_lambda_sensitivity() {
+        let mut fast = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(20.0)
+            .build()
+            .unwrap();
+        let mut slow = vague_prior()
+            .max_run_length(200)
+            .hazard_lambda(500.0)
+            .build()
+            .unwrap();
+        for i in 0..100 {
+            fast.update((i % 3) as f64).unwrap();
+            slow.update((i % 3) as f64).unwrap();
+        }
+        let cp_fast = fast.change_point_probability().unwrap();
+        let cp_slow = slow.change_point_probability().unwrap();
+        assert!(
+            cp_fast > cp_slow,
+            "shorter λ should yield higher CP prob for stable input: fast={cp_fast}, slow={cp_slow}"
+        );
+    }
+
+    #[test]
+    fn rejects_nan_inf() {
+        let mut bocpd = BocpdF64::builder()
+            .max_run_length(20)
+            .hazard_lambda(10.0)
+            .build()
+            .unwrap();
+        assert!(bocpd.update(f64::NAN).is_err());
+        assert!(bocpd.update(f64::INFINITY).is_err());
+        assert!(bocpd.update(f64::NEG_INFINITY).is_err());
+        assert_eq!(bocpd.count(), 0);
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut bocpd = vague_prior()
+            .max_run_length(50)
+            .hazard_lambda(20.0)
+            .build()
+            .unwrap();
+        for i in 0..30 {
+            bocpd.update(i as f64).unwrap();
+        }
+        assert!(bocpd.count() > 0);
+        assert!(bocpd.is_primed());
+
+        bocpd.reset();
+        assert_eq!(bocpd.count(), 0);
+        assert!(!bocpd.is_primed());
+        assert!(bocpd.change_point_probability().is_none());
+    }
+
+    #[test]
+    fn truncation_preserves_mass() {
+        let mut bocpd = vague_prior()
+            .max_run_length(20)
+            .hazard_lambda(10.0)
+            .build()
+            .unwrap();
+        // Feed more samples than max_run_length to trigger truncation
+        for i in 0..50 {
+            bocpd.update((i % 5) as f64).unwrap();
+            if let Some(log_post) = bocpd.run_length_posterior() {
+                let sum: f64 = log_post.iter().map(|&lp| exp(lp)).sum();
+                assert!(
+                    (sum - 1.0).abs() < 1e-6,
+                    "posterior should still sum to 1 after truncation, got {sum} at step {i}"
+                );
+            }
+        }
+    }
+}

--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -2,6 +2,8 @@ extern crate alloc;
 use alloc::boxed::Box;
 use nexus_stats_core::math::{exp, ln, ln_gamma};
 
+use crate::simd_math;
+
 // Precomputed per-r constants; valid because suf_count[r] == r.
 #[derive(Debug, Clone)]
 struct Precomputed {
@@ -48,6 +50,7 @@ pub struct BocpdF64 {
     suf_mean: Box<[f64]>,
     suf_sum_sq: Box<[f64]>,
     scratch: Box<[f64]>,
+    scratch2: Box<[f64]>,
     pre: Precomputed,
 
     max_run_length: usize,
@@ -124,15 +127,17 @@ impl BocpdF64 {
             self.active = 1;
         }
 
-        // Step 1 + 2a fused: log predictive (precomputed tables) + CP mass max.
+        // Step 1: three-pass log predictive + CP mass.
         //
-        // All prior/r-dependent values are precomputed. The student-t reduces to:
-        //   lng_base[r] + alpha[r]*ln(a) - (alpha[r]+0.5)*ln(b)
-        // where a = nu_d[r]*beta_n, b = a + dx^2. No divisions in the loop.
+        // Pass 1 — scalar math only (no transcendentals): compute the two
+        // ln arguments a[r] and b[r] into scratch/scratch2.
+        // Pass 2 — tight ln loop: ln(a[r]) and ln(b[r]) in-place. Consecutive
+        // independent calls give the OOO engine maximum ILP.
+        // Pass 3 — combine with table lookups, find CP mass max.
         let cp_terms;
         #[allow(clippy::suboptimal_flops)]
         {
-            let mut max_cp_term = f64::NEG_INFINITY;
+            // Pass 1: a[r] = nu_d*beta_n, b[r] = a + dx^2.
             for r in 0..self.active {
                 let mu_n = self.pre.mu_a[r]
                     + self.pre.mu_b[r] * self.suf_mean[r];
@@ -142,30 +147,44 @@ impl BocpdF64 {
                     + self.pre.beta_c[r] * diff * diff;
                 let a = self.pre.nu_d[r] * beta_n;
                 let dx = sample - mu_n;
-                let b = a + dx * dx;
-                let alpha_r = self.pre.alpha[r];
+                self.scratch[r] = a;
+                self.scratch2[r] = a + dx * dx;
+            }
 
-                self.scratch[r] = self.pre.lng_base[r]
-                    + alpha_r * ln(a)
-                    - (alpha_r + 0.5) * ln(b);
+            // Pass 2: ln in-place (SIMD when available).
+            simd_math::ln_inplace(&mut self.scratch[..self.active]);
+            simd_math::ln_inplace(&mut self.scratch2[..self.active]);
+
+            // Pass 3: combine and find CP mass max.
+            let mut max_cp_term = f64::NEG_INFINITY;
+            for r in 0..self.active {
+                let alpha_r = self.pre.alpha[r];
+                let log_pred = self.pre.lng_base[r]
+                    + alpha_r * self.scratch[r]
+                    - (alpha_r + 0.5) * self.scratch2[r];
+
+                self.scratch[r] = log_pred;
 
                 let term =
-                    self.log_posterior[r] + self.scratch[r] + self.log_hazard;
+                    self.log_posterior[r] + log_pred + self.log_hazard;
                 if term > max_cp_term {
                     max_cp_term = term;
                 }
             }
 
+            // CP mass: exp-sum (SIMD when available).
+            // Reuse scratch2 for the terms since pass 2 is done with it.
             cp_terms = if max_cp_term == f64::NEG_INFINITY {
                 f64::NEG_INFINITY
             } else {
-                let mut sum = 0.0;
                 for r in 0..self.active {
-                    sum += exp(
-                        self.log_posterior[r] + self.scratch[r] + self.log_hazard
-                            - max_cp_term,
-                    );
+                    self.scratch2[r] =
+                        self.log_posterior[r] + self.scratch[r] + self.log_hazard;
                 }
+                let sum = simd_math::exp_sum(
+                    &self.scratch2[..self.active],
+                    max_cp_term,
+                );
                 max_cp_term + ln(sum)
             };
         }
@@ -485,6 +504,7 @@ impl BocpdF64Builder {
             suf_mean: alloc::vec![0.0f64; size].into_boxed_slice(),
             suf_sum_sq: alloc::vec![0.0f64; size].into_boxed_slice(),
             scratch: alloc::vec![f64::NEG_INFINITY; size].into_boxed_slice(),
+            scratch2: alloc::vec![0.0f64; size].into_boxed_slice(),
             pre,
             max_run_length,
             log_hazard: ln(h),
@@ -554,19 +574,25 @@ mod tests {
 
     #[test]
     fn variance_shift_detected() {
-        let mut bocpd = vague_prior()
+        let mut bocpd = BocpdF64::builder()
+            .prior_mu(50.0)
+            .prior_kappa(1.0)
+            .prior_alpha(2.0)
+            .prior_beta(1.0)
             .max_run_length(200)
             .hazard_lambda(100.0)
             .build()
             .unwrap();
+        // Stable period: low variance around 50
         for i in 0..100 {
             bocpd.update(50.0 + (i % 2) as f64).unwrap();
         }
         let cp_before = bocpd.change_point_probability().unwrap();
 
+        // Variance shift: amplitude ±0.5 → ±20
         let mut max_cp = 0.0f64;
-        for i in 0..30 {
-            let sample = if i % 2 == 0 { 50.0 + 20.0 } else { 50.0 - 20.0 };
+        for i in 0..50 {
+            let sample = if i % 2 == 0 { 70.0 } else { 30.0 };
             bocpd.update(sample).unwrap();
             let cp = bocpd.change_point_probability().unwrap();
             max_cp = max_cp.max(cp);

--- a/nexus-stats-detection/src/dist_drift.rs
+++ b/nexus-stats-detection/src/dist_drift.rs
@@ -327,6 +327,11 @@ macro_rules! impl_dist_drift {
                         "max_val must be > min_val",
                     ));
                 }
+                if self.min_samples == 0 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "min_samples must be >= 1",
+                    ));
+                }
 
                 let bin_width = (max_val - min_val) / num_bins as $ty;
 

--- a/nexus-stats-detection/src/dist_drift.rs
+++ b/nexus-stats-detection/src/dist_drift.rs
@@ -1,0 +1,589 @@
+extern crate alloc;
+use alloc::boxed::Box;
+
+macro_rules! impl_dist_drift {
+    ($name:ident, $builder:ident, $ty:ty, $ln:path) => {
+        /// Distribution drift metrics via reference/live histograms.
+        ///
+        /// Maintains two equi-width histograms (reference and live) and
+        /// computes three divergence measures:
+        ///
+        /// - KL divergence: KL(live || reference), in nats
+        /// - Jensen-Shannon divergence: symmetric, bounded in [0, ln2]
+        /// - Wasserstein-1 distance: earth mover's distance
+        ///
+        /// Out-of-range samples are clamped to boundary bins.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        #[doc = concat!("use nexus_stats_detection::detection::", stringify!($name), ";")]
+        ///
+        #[doc = concat!("let mut drift = ", stringify!($name), "::builder()")]
+        ///     .num_bins(10)
+        ///     .min_val(0.0)
+        ///     .max_val(100.0)
+        ///     .build()
+        ///     .unwrap();
+        ///
+        /// // Build reference distribution
+        /// for i in 0..1000 {
+        #[doc = concat!("    drift.update_reference((i % 100) as ", stringify!($ty), ").unwrap();")]
+        /// }
+        ///
+        /// // Feed live data from same distribution
+        /// for i in 0..1000 {
+        #[doc = concat!("    drift.update((i % 100) as ", stringify!($ty), ").unwrap();")]
+        /// }
+        ///
+        /// let kl = drift.kl_divergence().unwrap();
+        #[doc = concat!("assert!(kl < 0.01 as ", stringify!($ty), ");")]
+        /// ```
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            reference: Box<[u64]>,
+            live: Box<[u64]>,
+            num_bins: usize,
+            min_val: $ty,
+            max_val: $ty,
+            bin_width: $ty,
+            ref_total: u64,
+            live_total: u64,
+            min_samples: u64,
+        }
+
+        /// Builder for [`
+        #[doc = stringify!($name)]
+        /// `].
+        #[derive(Debug, Clone)]
+        pub struct $builder {
+            num_bins: Option<usize>,
+            min_val: Option<$ty>,
+            max_val: Option<$ty>,
+            min_samples: u64,
+        }
+
+        impl $name {
+            /// Creates a builder.
+            #[inline]
+            #[must_use]
+            pub fn builder() -> $builder {
+                $builder {
+                    num_bins: Option::None,
+                    min_val: Option::None,
+                    max_val: Option::None,
+                    min_samples: 1,
+                }
+            }
+
+            #[allow(clippy::as_conversions)]
+            fn bin_index(&self, sample: $ty) -> usize {
+                let frac = (sample - self.min_val) / self.bin_width;
+                if frac < (0.0 as $ty) {
+                    0
+                } else {
+                    (frac as usize).min(self.num_bins - 1)
+                }
+            }
+
+            /// Feeds a sample into the reference histogram.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the sample is NaN, or
+            /// `DataError::Infinite` if the sample is infinite.
+            #[inline]
+            pub fn update_reference(&mut self, sample: $ty) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(sample);
+                let idx = self.bin_index(sample);
+                self.reference[idx] += 1;
+                self.ref_total += 1;
+                Ok(())
+            }
+
+            /// Feeds a sample into the live histogram.
+            ///
+            /// # Errors
+            ///
+            /// Returns `DataError::NotANumber` if the sample is NaN, or
+            /// `DataError::Infinite` if the sample is infinite.
+            #[inline]
+            pub fn update(&mut self, sample: $ty) -> Result<(), nexus_stats_core::DataError> {
+                check_finite!(sample);
+                let idx = self.bin_index(sample);
+                self.live[idx] += 1;
+                self.live_total += 1;
+                Ok(())
+            }
+
+            /// KL divergence: KL(live || reference), in nats.
+            ///
+            /// Uses Laplace smoothing to avoid log(0). Returns `None` if
+            /// either histogram has fewer than `min_samples` observations.
+            #[must_use]
+            pub fn kl_divergence(&self) -> Option<$ty> {
+                if !self.is_primed() {
+                    return Option::None;
+                }
+                let smooth = 1.0 as $ty;
+                let n = self.num_bins as $ty;
+                let p_total = self.live_total as $ty + smooth * n;
+                let q_total = self.ref_total as $ty + smooth * n;
+
+                let mut kl = 0.0 as $ty;
+                for i in 0..self.num_bins {
+                    let p = (self.live[i] as $ty + smooth) / p_total;
+                    let q = (self.reference[i] as $ty + smooth) / q_total;
+                    kl += p * $ln(p / q);
+                }
+                Option::Some(kl)
+            }
+
+            /// Jensen-Shannon divergence, bounded in [0, ln2].
+            ///
+            /// Symmetric: JS(live, reference) = JS(reference, live).
+            /// Returns `None` if not primed.
+            #[must_use]
+            #[allow(clippy::suboptimal_flops)]
+            pub fn js_divergence(&self) -> Option<$ty> {
+                if !self.is_primed() {
+                    return Option::None;
+                }
+                let smooth = 1.0 as $ty;
+                let n = self.num_bins as $ty;
+                let p_total = self.live_total as $ty + smooth * n;
+                let q_total = self.ref_total as $ty + smooth * n;
+
+                let mut js = 0.0 as $ty;
+                for i in 0..self.num_bins {
+                    let p = (self.live[i] as $ty + smooth) / p_total;
+                    let q = (self.reference[i] as $ty + smooth) / q_total;
+                    let m = 0.5 as $ty * (p + q);
+                    js += 0.5 as $ty * p * $ln(p / m)
+                        + 0.5 as $ty * q * $ln(q / m);
+                }
+                Option::Some(js)
+            }
+
+            /// Wasserstein-1 (earth mover's) distance.
+            ///
+            /// Returns `None` if not primed.
+            #[must_use]
+            #[allow(clippy::suboptimal_flops)]
+            pub fn wasserstein1(&self) -> Option<$ty> {
+                if !self.is_primed() {
+                    return Option::None;
+                }
+                let mut cdf_p = 0.0 as $ty;
+                let mut cdf_q = 0.0 as $ty;
+                let mut w1 = 0.0 as $ty;
+                let p_total = self.live_total as $ty;
+                let q_total = self.ref_total as $ty;
+
+                for i in 0..self.num_bins {
+                    cdf_p += self.live[i] as $ty / p_total;
+                    cdf_q += self.reference[i] as $ty / q_total;
+                    let diff = cdf_p - cdf_q;
+                    w1 += (if diff < 0.0 as $ty { -diff } else { diff }) * self.bin_width;
+                }
+                Option::Some(w1)
+            }
+
+            /// Number of histogram bins.
+            #[inline]
+            #[must_use]
+            pub fn num_bins(&self) -> usize {
+                self.num_bins
+            }
+
+            /// Minimum value of the histogram range.
+            #[inline]
+            #[must_use]
+            pub fn min_val(&self) -> $ty {
+                self.min_val
+            }
+
+            /// Maximum value of the histogram range.
+            #[inline]
+            #[must_use]
+            pub fn max_val(&self) -> $ty {
+                self.max_val
+            }
+
+            /// Live sample count.
+            #[inline]
+            #[must_use]
+            pub fn count(&self) -> u64 {
+                self.live_total
+            }
+
+            /// Reference sample count.
+            #[inline]
+            #[must_use]
+            pub fn reference_count(&self) -> u64 {
+                self.ref_total
+            }
+
+            /// Whether both histograms have at least `min_samples` observations.
+            #[inline]
+            #[must_use]
+            pub fn is_primed(&self) -> bool {
+                self.ref_total >= self.min_samples && self.live_total >= self.min_samples
+            }
+
+            /// Resets the reference histogram.
+            #[inline]
+            pub fn reset_reference(&mut self) {
+                for bin in &mut *self.reference {
+                    *bin = 0;
+                }
+                self.ref_total = 0;
+            }
+
+            /// Resets the live histogram.
+            #[inline]
+            pub fn reset_live(&mut self) {
+                for bin in &mut *self.live {
+                    *bin = 0;
+                }
+                self.live_total = 0;
+            }
+
+            /// Resets both histograms.
+            #[inline]
+            pub fn reset(&mut self) {
+                self.reset_reference();
+                self.reset_live();
+            }
+        }
+
+        impl $builder {
+            /// Number of histogram bins (required, >= 2).
+            #[inline]
+            #[must_use]
+            pub fn num_bins(mut self, n: usize) -> Self {
+                self.num_bins = Option::Some(n);
+                self
+            }
+
+            /// Minimum value of the histogram range (required, finite).
+            #[inline]
+            #[must_use]
+            pub fn min_val(mut self, v: $ty) -> Self {
+                self.min_val = Option::Some(v);
+                self
+            }
+
+            /// Maximum value of the histogram range (required, finite, > min_val).
+            #[inline]
+            #[must_use]
+            pub fn max_val(mut self, v: $ty) -> Self {
+                self.max_val = Option::Some(v);
+                self
+            }
+
+            /// Minimum samples in each histogram before divergence queries
+            /// return values. Default: 1.
+            #[inline]
+            #[must_use]
+            pub fn min_samples(mut self, n: u64) -> Self {
+                self.min_samples = n;
+                self
+            }
+
+            /// Builds the distribution drift tracker.
+            ///
+            /// # Errors
+            ///
+            /// Returns `ConfigError` if required fields are missing, bins < 2,
+            /// or min_val >= max_val.
+            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
+                let num_bins = self
+                    .num_bins
+                    .ok_or(nexus_stats_core::ConfigError::Missing("num_bins"))?;
+                if num_bins < 2 {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "num_bins must be >= 2",
+                    ));
+                }
+                let min_val = self
+                    .min_val
+                    .ok_or(nexus_stats_core::ConfigError::Missing("min_val"))?;
+                if !min_val.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "min_val must be finite",
+                    ));
+                }
+                let max_val = self
+                    .max_val
+                    .ok_or(nexus_stats_core::ConfigError::Missing("max_val"))?;
+                if !max_val.is_finite() {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "max_val must be finite",
+                    ));
+                }
+                if max_val <= min_val {
+                    return Err(nexus_stats_core::ConfigError::Invalid(
+                        "max_val must be > min_val",
+                    ));
+                }
+
+                let bin_width = (max_val - min_val) / num_bins as $ty;
+
+                Ok($name {
+                    reference: alloc::vec![0u64; num_bins].into_boxed_slice(),
+                    live: alloc::vec![0u64; num_bins].into_boxed_slice(),
+                    num_bins,
+                    min_val,
+                    max_val,
+                    bin_width,
+                    ref_total: 0,
+                    live_total: 0,
+                    min_samples: self.min_samples,
+                })
+            }
+        }
+    };
+}
+
+impl_dist_drift!(
+    DistDriftF64,
+    DistDriftF64Builder,
+    f64,
+    nexus_stats_core::math::ln
+);
+impl_dist_drift!(
+    DistDriftF32,
+    DistDriftF32Builder,
+    f32,
+    nexus_stats_core::math::ln_f32
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_distributions_zero_divergence() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for i in 0..1000u64 {
+            drift.update_reference((i % 100) as f64).unwrap();
+            drift.update((i % 100) as f64).unwrap();
+        }
+        let kl = drift.kl_divergence().unwrap();
+        let js = drift.js_divergence().unwrap();
+        let w1 = drift.wasserstein1().unwrap();
+        assert!(kl.abs() < 1e-10, "KL should be ~0, got {kl}");
+        assert!(js.abs() < 1e-10, "JS should be ~0, got {js}");
+        assert!(w1.abs() < 1e-10, "W1 should be ~0, got {w1}");
+    }
+
+    #[test]
+    fn uniform_vs_concentrated() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for i in 0..1000 {
+            drift.update_reference((i % 100) as f64).unwrap();
+        }
+        for _ in 0..1000 {
+            drift.update(50.0).unwrap();
+        }
+        let kl = drift.kl_divergence().unwrap();
+        let js = drift.js_divergence().unwrap();
+        assert!(
+            kl > 1.0,
+            "KL should be large for concentrated vs uniform, got {kl}"
+        );
+        assert!(js > 0.1, "JS should be significant, got {js}");
+    }
+
+    #[test]
+    fn js_bounded() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for _ in 0..500 {
+            drift.update_reference(10.0).unwrap();
+        }
+        for _ in 0..500 {
+            drift.update(90.0).unwrap();
+        }
+        let js = drift.js_divergence().unwrap();
+        let ln2 = nexus_stats_core::math::ln(2.0);
+        assert!(js >= 0.0, "JS should be non-negative, got {js}");
+        assert!(js <= ln2 + 1e-10, "JS should be <= ln(2) ≈ {ln2}, got {js}");
+    }
+
+    #[test]
+    fn js_symmetric() {
+        let mut drift_ab = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        let mut drift_ba = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for i in 0..500 {
+            let a = (i % 50) as f64;
+            let b = (i % 100) as f64;
+            drift_ab.update_reference(a).unwrap();
+            drift_ab.update(b).unwrap();
+            drift_ba.update_reference(b).unwrap();
+            drift_ba.update(a).unwrap();
+        }
+        let js_ab = drift_ab.js_divergence().unwrap();
+        let js_ba = drift_ba.js_divergence().unwrap();
+        assert!(
+            (js_ab - js_ba).abs() < 1e-10,
+            "JS should be symmetric: {js_ab} vs {js_ba}"
+        );
+    }
+
+    #[test]
+    fn kl_asymmetric() {
+        let mut drift_ab = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        let mut drift_ba = DistDriftF64::builder()
+            .num_bins(10)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for _ in 0..1000 {
+            drift_ab.update_reference(50.0).unwrap();
+            drift_ba.update(50.0).unwrap();
+        }
+        for i in 0..1000 {
+            drift_ab.update((i % 100) as f64).unwrap();
+            drift_ba.update_reference((i % 100) as f64).unwrap();
+        }
+        let kl_ab = drift_ab.kl_divergence().unwrap();
+        let kl_ba = drift_ba.kl_divergence().unwrap();
+        assert!(
+            (kl_ab - kl_ba).abs() > 0.01,
+            "KL should be asymmetric: {kl_ab} vs {kl_ba}"
+        );
+    }
+
+    #[test]
+    fn wasserstein_shifted() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(100)
+            .min_val(0.0)
+            .max_val(100.0)
+            .build()
+            .unwrap();
+        for i in 0..10_000 {
+            drift.update_reference((i % 50) as f64).unwrap();
+            drift.update(((i % 50) + 10) as f64).unwrap();
+        }
+        let w1 = drift.wasserstein1().unwrap();
+        assert!(
+            (w1 - 10.0).abs() < 2.0,
+            "W1 should be ≈ 10 for shift=10, got {w1}"
+        );
+    }
+
+    #[test]
+    fn out_of_range_clamped() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(5)
+            .min_val(0.0)
+            .max_val(10.0)
+            .build()
+            .unwrap();
+        drift.update_reference(-100.0).unwrap();
+        drift.update_reference(200.0).unwrap();
+        drift.update(-50.0).unwrap();
+        drift.update(150.0).unwrap();
+        assert_eq!(drift.reference_count(), 2);
+        assert_eq!(drift.count(), 2);
+    }
+
+    #[test]
+    fn rejects_nan_inf() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(5)
+            .min_val(0.0)
+            .max_val(10.0)
+            .build()
+            .unwrap();
+        assert!(drift.update(f64::NAN).is_err());
+        assert!(drift.update(f64::INFINITY).is_err());
+        assert!(drift.update_reference(f64::NAN).is_err());
+        assert!(drift.update_reference(f64::NEG_INFINITY).is_err());
+        assert_eq!(drift.count(), 0);
+        assert_eq!(drift.reference_count(), 0);
+    }
+
+    #[test]
+    fn reset_clears() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(5)
+            .min_val(0.0)
+            .max_val(10.0)
+            .build()
+            .unwrap();
+        for i in 0..100 {
+            drift.update_reference(i as f64 % 10.0).unwrap();
+            drift.update(i as f64 % 10.0).unwrap();
+        }
+        assert_eq!(drift.reference_count(), 100);
+        assert_eq!(drift.count(), 100);
+
+        drift.reset_live();
+        assert_eq!(drift.count(), 0);
+        assert_eq!(drift.reference_count(), 100);
+
+        drift.reset_reference();
+        assert_eq!(drift.reference_count(), 0);
+
+        for i in 0..50 {
+            drift.update_reference(i as f64 % 10.0).unwrap();
+            drift.update(i as f64 % 10.0).unwrap();
+        }
+        drift.reset();
+        assert_eq!(drift.count(), 0);
+        assert_eq!(drift.reference_count(), 0);
+    }
+
+    #[test]
+    fn not_primed_returns_none() {
+        let mut drift = DistDriftF64::builder()
+            .num_bins(5)
+            .min_val(0.0)
+            .max_val(10.0)
+            .min_samples(100)
+            .build()
+            .unwrap();
+        for i in 0..50 {
+            drift.update_reference(i as f64 % 10.0).unwrap();
+            drift.update(i as f64 % 10.0).unwrap();
+        }
+        assert!(!drift.is_primed());
+        assert!(drift.kl_divergence().is_none());
+        assert!(drift.js_divergence().is_none());
+        assert!(drift.wasserstein1().is_none());
+    }
+}

--- a/nexus-stats-detection/src/lib.rs
+++ b/nexus-stats-detection/src/lib.rs
@@ -7,7 +7,7 @@
 //! and hypothesis testing types separated from the core `nexus-stats` crate.
 //!
 //! Types are organized into submodules:
-//! - [`detection`] — MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate, PageHinkley, ADWIN
+//! - [`detection`] — MOSUM, Shiryaev-Roberts, AdaptiveThreshold, RobustZ, TrendAlert, MultiGate, PageHinkley, ADWIN, DistDrift, BOCPD
 //! - [`signal`] — Autocorrelation, CrossCorrelation, Entropy, TransferEntropy, PredictiveInfoBound
 //! - [`estimation`] — SPRT (Bernoulli, Gaussian)
 

--- a/nexus-stats-detection/src/lib.rs
+++ b/nexus-stats-detection/src/lib.rs
@@ -28,11 +28,11 @@ macro_rules! check_finite {
 }
 
 // Internal modules
-#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
-mod simd_math;
 mod multi_gate;
 mod page_hinkley;
 mod robust_z;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod simd_math;
 mod trend_alert;
 
 #[cfg(any(feature = "std", feature = "libm"))]

--- a/nexus-stats-detection/src/lib.rs
+++ b/nexus-stats-detection/src/lib.rs
@@ -28,6 +28,8 @@ macro_rules! check_finite {
 }
 
 // Internal modules
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod simd_math;
 mod multi_gate;
 mod page_hinkley;
 mod robust_z;

--- a/nexus-stats-detection/src/lib.rs
+++ b/nexus-stats-detection/src/lib.rs
@@ -37,6 +37,10 @@ mod trend_alert;
 mod adaptive_threshold;
 #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
 mod adwin;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod bocpd;
+#[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+mod dist_drift;
 #[cfg(feature = "alloc")]
 mod mosum;
 #[cfg(any(feature = "std", feature = "libm"))]
@@ -55,6 +59,10 @@ pub mod detection {
     pub use super::adaptive_threshold::*;
     #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
     pub use super::adwin::*;
+    #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+    pub use super::bocpd::*;
+    #[cfg(all(feature = "alloc", any(feature = "std", feature = "libm")))]
+    pub use super::dist_drift::*;
     #[cfg(feature = "alloc")]
     pub use super::mosum::*;
     #[cfg(any(feature = "std", feature = "libm"))]

--- a/nexus-stats-detection/src/simd_math.rs
+++ b/nexus-stats-detection/src/simd_math.rs
@@ -7,18 +7,30 @@
 #[allow(dead_code)]
 mod scalar;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    target_feature = "fma"
+))]
 mod avx2;
 
 /// Compute ln(x) in-place for each element. All values must be positive.
 #[inline]
 pub fn ln_inplace(buf: &mut [f64]) {
-    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "fma"
+    ))]
     {
         avx2::ln_inplace(buf);
     }
 
-    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+    #[cfg(not(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "fma"
+    )))]
     {
         scalar::ln_inplace(buf);
     }
@@ -27,12 +39,20 @@ pub fn ln_inplace(buf: &mut [f64]) {
 /// Compute sum of exp(x - offset) for each element.
 #[inline]
 pub fn exp_sum(buf: &[f64], offset: f64) -> f64 {
-    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "fma"
+    ))]
     {
         avx2::exp_sum(buf, offset)
     }
 
-    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+    #[cfg(not(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        target_feature = "fma"
+    )))]
     {
         scalar::exp_sum(buf, offset)
     }

--- a/nexus-stats-detection/src/simd_math.rs
+++ b/nexus-stats-detection/src/simd_math.rs
@@ -1,0 +1,39 @@
+//! Vectorized math for BOCPD inner loops.
+//!
+//! Dispatches to AVX2 (4 f64 at a time) when compiled with `+avx2`,
+//! otherwise falls back to scalar. Same fdlibm/musl coefficients,
+//! same ~15-digit precision, just in packed form.
+
+#[allow(dead_code)]
+mod scalar;
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+mod avx2;
+
+/// Compute ln(x) in-place for each element. All values must be positive.
+#[inline]
+pub fn ln_inplace(buf: &mut [f64]) {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    {
+        avx2::ln_inplace(buf);
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+    {
+        scalar::ln_inplace(buf);
+    }
+}
+
+/// Compute sum of exp(x - offset) for each element.
+#[inline]
+pub fn exp_sum(buf: &[f64], offset: f64) -> f64 {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    {
+        avx2::exp_sum(buf, offset)
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+    {
+        scalar::exp_sum(buf, offset)
+    }
+}

--- a/nexus-stats-detection/src/simd_math/avx2.rs
+++ b/nexus-stats-detection/src/simd_math/avx2.rs
@@ -122,6 +122,9 @@ unsafe fn exp_f64x4(x: __m256d) -> __m256d {
 
         // Range reduction: k = round(x / ln(2)), r = x - k*ln(2)
         let kf = _mm256_round_pd(_mm256_mul_pd(x, ln2_inv), _MM_FROUND_TO_NEAREST_INT);
+        // Clamp: k < -1023 produces invalid exponent bits (NaN/negative).
+        // k = -1023 → scale = 0.0 → exp(x) = 0, correct for x < -708.
+        let kf = _mm256_max_pd(kf, _mm256_set1_pd(-1023.0));
 
         // Cody-Waite: r = x - k*C1 - k*C2
         // FMA: r = -(k*C1 - x) then r = -(k*C2 - r) = r - k*C2

--- a/nexus-stats-detection/src/simd_math/avx2.rs
+++ b/nexus-stats-detection/src/simd_math/avx2.rs
@@ -1,7 +1,9 @@
-//! AVX2 vectorized ln/exp for packed f64x4.
+//! AVX2+FMA vectorized ln/exp for packed f64x4.
 //!
-//! Available when compiled with `-C target-feature=+avx2`.
-//! Algorithms match fdlibm/musl: same coefficients, same precision (~15 digits).
+//! Available when compiled with `-C target-feature=+avx2,+fma` (or `-C target-cpu=native`
+//! on any CPU since Haswell / Zen1). Algorithms match fdlibm/musl coefficients.
+//! FMA Horner evaluation gives strictly better precision (single rounding per step)
+//! and lower latency than separate mul+add.
 
 #![allow(clippy::excessive_precision)]
 
@@ -38,7 +40,7 @@ const EP5: f64 = 4.138_136_797_057_238_5e-08;
 ///
 /// # Safety
 ///
-/// Requires AVX2. All inputs must be positive finite f64.
+/// Requires AVX2+FMA. All inputs must be positive finite f64.
 #[inline]
 #[cfg(target_arch = "x86_64")]
 #[allow(clippy::many_single_char_names)]
@@ -69,10 +71,7 @@ unsafe fn ln_f64x4(x: __m256d) -> __m256d {
         // i64 → f64 via magic number trick (valid for |k| < 2^51)
         let magic = _mm256_set1_pd(6_755_399_441_055_744.0); // 2^52 + 2^51
         let magic_i = _mm256_castpd_si256(magic);
-        let k = _mm256_sub_pd(
-            _mm256_castsi256_pd(_mm256_add_epi64(k_i, magic_i)),
-            magic,
-        );
+        let k = _mm256_sub_pd(_mm256_castsi256_pd(_mm256_add_epi64(k_i, magic_i)), magic);
 
         // If m > sqrt(2): m *= 0.5, k += 1
         let gt = _mm256_cmp_pd(m, sqrt2, _CMP_GT_OQ);
@@ -84,14 +83,14 @@ unsafe fn ln_f64x4(x: __m256d) -> __m256d {
         let s = _mm256_div_pd(f, _mm256_add_pd(two, f));
         let s2 = _mm256_mul_pd(s, s);
 
-        // Horner evaluation of R(s²) = s² * (Lg1 + s²*(Lg2 + ...))
+        // FMA Horner: R(s²) = s² * (Lg1 + s²*(Lg2 + ...))
         let mut r = _mm256_set1_pd(LG7);
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG6));
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG5));
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG4));
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG3));
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG2));
-        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG1));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG6));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG5));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG4));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG3));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG2));
+        r = _mm256_fmadd_pd(r, s2, _mm256_set1_pd(LG1));
         r = _mm256_mul_pd(r, s2);
 
         // hfsq = 0.5 * f * f
@@ -100,11 +99,8 @@ unsafe fn ln_f64x4(x: __m256d) -> __m256d {
         // result = k*ln2_hi + (f - hfsq + s*(hfsq + R) + k*ln2_lo)
         let sr = _mm256_mul_pd(s, _mm256_add_pd(hfsq, r));
         _mm256_add_pd(
-            _mm256_mul_pd(k, ln2_hi),
-            _mm256_add_pd(
-                _mm256_sub_pd(f, hfsq),
-                _mm256_add_pd(sr, _mm256_mul_pd(k, ln2_lo)),
-            ),
+            _mm256_fmadd_pd(k, ln2_lo, sr),
+            _mm256_fmadd_pd(k, ln2_hi, _mm256_sub_pd(f, hfsq)),
         )
     }
 }
@@ -113,7 +109,7 @@ unsafe fn ln_f64x4(x: __m256d) -> __m256d {
 ///
 /// # Safety
 ///
-/// Requires AVX2. Inputs should be in a reasonable range (not ±huge).
+/// Requires AVX2+FMA. Inputs should be in a reasonable range (not ±huge).
 #[inline]
 #[cfg(target_arch = "x86_64")]
 unsafe fn exp_f64x4(x: __m256d) -> __m256d {
@@ -128,15 +124,16 @@ unsafe fn exp_f64x4(x: __m256d) -> __m256d {
         let kf = _mm256_round_pd(_mm256_mul_pd(x, ln2_inv), _MM_FROUND_TO_NEAREST_INT);
 
         // Cody-Waite: r = x - k*C1 - k*C2
-        let r = _mm256_sub_pd(_mm256_sub_pd(x, _mm256_mul_pd(kf, c1)), _mm256_mul_pd(kf, c2));
+        // FMA: r = -(k*C1 - x) then r = -(k*C2 - r) = r - k*C2
+        let r = _mm256_fnmadd_pd(kf, c2, _mm256_fnmadd_pd(kf, c1, x));
 
-        // Polynomial: t = r² * (P1 + r*(P2 + r*(P3 + r*(P4 + r*P5))))
+        // FMA Horner: t = r² * (P1 + r*(P2 + r*(P3 + r*(P4 + r*P5))))
         let r2 = _mm256_mul_pd(r, r);
         let mut p = _mm256_set1_pd(EP5);
-        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP4));
-        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP3));
-        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP2));
-        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP1));
+        p = _mm256_fmadd_pd(p, r, _mm256_set1_pd(EP4));
+        p = _mm256_fmadd_pd(p, r, _mm256_set1_pd(EP3));
+        p = _mm256_fmadd_pd(p, r, _mm256_set1_pd(EP2));
+        p = _mm256_fmadd_pd(p, r, _mm256_set1_pd(EP1));
         let t = _mm256_mul_pd(r2, p);
 
         // musl reconstruction: exp(r) = 1 - ((r*t)/(t-2) - r)
@@ -145,7 +142,7 @@ unsafe fn exp_f64x4(x: __m256d) -> __m256d {
         let exp_r = _mm256_sub_pd(one, _mm256_sub_pd(frac, r));
 
         // Scale by 2^k: set exponent bits
-        let k_i = _mm256_cvtpd_epi32(kf); // f64x4 → i32x4 (__m128i)
+        let k_i = _mm256_cvtpd_epi32(kf);
         let k_i64 = _mm256_cvtepi32_epi64(k_i);
         let bias = _mm256_set1_epi64x(1023);
         let exp_bits = _mm256_slli_epi64(_mm256_add_epi64(k_i64, bias), 52);
@@ -161,7 +158,7 @@ pub fn ln_inplace(buf: &mut [f64]) {
     let len = buf.len();
     let mut i = 0;
 
-    // SAFETY: AVX2 availability guaranteed by target_feature cfg.
+    // SAFETY: AVX2+FMA availability guaranteed by target_feature cfg.
     // All values in buf are positive (guaranteed by BOCPD: a > 0, b > 0).
     unsafe {
         while i + 4 <= len {
@@ -184,21 +181,40 @@ pub fn exp_sum(buf: &[f64], offset: f64) -> f64 {
     let mut i = 0;
     let mut sum: f64;
 
-    // SAFETY: AVX2 availability guaranteed by target_feature cfg.
+    // SAFETY: AVX2+FMA availability guaranteed by target_feature cfg.
     unsafe {
         let offset_v = _mm256_set1_pd(offset);
-        let mut acc = _mm256_setzero_pd();
+        // 4 independent accumulators to hide exp latency (~20 cycle throughput).
+        let mut acc0 = _mm256_setzero_pd();
+        let mut acc1 = _mm256_setzero_pd();
+        let mut acc2 = _mm256_setzero_pd();
+        let mut acc3 = _mm256_setzero_pd();
 
+        while i + 16 <= len {
+            let v0 = _mm256_loadu_pd(buf.as_ptr().add(i));
+            let v1 = _mm256_loadu_pd(buf.as_ptr().add(i + 4));
+            let v2 = _mm256_loadu_pd(buf.as_ptr().add(i + 8));
+            let v3 = _mm256_loadu_pd(buf.as_ptr().add(i + 12));
+            acc0 = _mm256_add_pd(acc0, exp_f64x4(_mm256_sub_pd(v0, offset_v)));
+            acc1 = _mm256_add_pd(acc1, exp_f64x4(_mm256_sub_pd(v1, offset_v)));
+            acc2 = _mm256_add_pd(acc2, exp_f64x4(_mm256_sub_pd(v2, offset_v)));
+            acc3 = _mm256_add_pd(acc3, exp_f64x4(_mm256_sub_pd(v3, offset_v)));
+            i += 16;
+        }
+
+        // Drain remaining 4-wide chunks
         while i + 4 <= len {
             let v = _mm256_loadu_pd(buf.as_ptr().add(i));
-            let shifted = _mm256_sub_pd(v, offset_v);
-            acc = _mm256_add_pd(acc, exp_f64x4(shifted));
+            acc0 = _mm256_add_pd(acc0, exp_f64x4(_mm256_sub_pd(v, offset_v)));
             i += 4;
         }
 
-        // Horizontal sum of acc
-        let hi = _mm256_extractf128_pd(acc, 1);
-        let lo = _mm256_castpd256_pd128(acc);
+        // Reduce 4 accumulators → 1
+        acc0 = _mm256_add_pd(_mm256_add_pd(acc0, acc1), _mm256_add_pd(acc2, acc3));
+
+        // Horizontal sum
+        let hi = _mm256_extractf128_pd(acc0, 1);
+        let lo = _mm256_castpd256_pd128(acc0);
         let pair = _mm_add_pd(lo, hi);
         let high_lane = _mm_unpackhi_pd(pair, pair);
         sum = _mm_cvtsd_f64(_mm_add_sd(pair, high_lane));

--- a/nexus-stats-detection/src/simd_math/avx2.rs
+++ b/nexus-stats-detection/src/simd_math/avx2.rs
@@ -1,0 +1,212 @@
+//! AVX2 vectorized ln/exp for packed f64x4.
+//!
+//! Available when compiled with `-C target-feature=+avx2`.
+//! Algorithms match fdlibm/musl: same coefficients, same precision (~15 digits).
+
+#![allow(clippy::excessive_precision)]
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use nexus_stats_core::math::{exp as scalar_exp, ln as scalar_ln};
+
+// fdlibm ln polynomial coefficients (Remez on [0, 0.1716])
+const LG1: f64 = 6.666_666_666_666_735_13e-01;
+const LG2: f64 = 3.999_999_999_940_941_9e-01;
+const LG3: f64 = 2.857_142_874_366_239_1e-01;
+const LG4: f64 = 2.222_219_843_214_978_4e-01;
+const LG5: f64 = 1.818_357_216_161_805e-01;
+const LG6: f64 = 1.531_383_769_920_937_3e-01;
+const LG7: f64 = 1.479_819_860_511_658_6e-01;
+
+const LN2_HI: f64 = 6.931_471_803_691_238e-01;
+const LN2_LO: f64 = 1.908_214_929_270_585e-10;
+
+// musl/Cephes exp range reduction constants
+const LN2_INV: f64 = core::f64::consts::LOG2_E;
+const EXP_C1: f64 = 6.931_457_519_531_25e-01; // ln(2) high (Cody-Waite)
+const EXP_C2: f64 = 1.428_606_820_309_417_2e-06; // ln(2) low
+
+// musl exp polynomial (minimax on [-ln(2)/2, ln(2)/2])
+const EP1: f64 = 1.666_666_666_666_666_6e-01;
+const EP2: f64 = -2.777_777_777_701_559_3e-03;
+const EP3: f64 = 6.613_756_321_437_934_4e-05;
+const EP4: f64 = -1.653_390_220_546_525_2e-06;
+const EP5: f64 = 4.138_136_797_057_238_5e-08;
+
+/// Compute ln(x) for 4 packed f64 values using the fdlibm algorithm.
+///
+/// # Safety
+///
+/// Requires AVX2. All inputs must be positive finite f64.
+#[inline]
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::many_single_char_names)]
+unsafe fn ln_f64x4(x: __m256d) -> __m256d {
+    unsafe {
+        let one = _mm256_set1_pd(1.0);
+        let half = _mm256_set1_pd(0.5);
+        let two = _mm256_set1_pd(2.0);
+        let sqrt2 = _mm256_set1_pd(core::f64::consts::SQRT_2);
+        let ln2_hi = _mm256_set1_pd(LN2_HI);
+        let ln2_lo = _mm256_set1_pd(LN2_LO);
+
+        let mantissa_mask = _mm256_set1_epi64x(0x000F_FFFF_FFFF_FFFFu64 as i64);
+        let one_bits = _mm256_set1_epi64x(0x3FF0_0000_0000_0000u64 as i64);
+        let bias = _mm256_set1_epi64x(1023);
+
+        let bits = _mm256_castpd_si256(x);
+
+        // Extract mantissa ∈ [1, 2)
+        let m = _mm256_castsi256_pd(_mm256_or_si256(
+            _mm256_and_si256(bits, mantissa_mask),
+            one_bits,
+        ));
+
+        // Exponent as i64
+        let k_i = _mm256_sub_epi64(_mm256_srli_epi64(bits, 52), bias);
+
+        // i64 → f64 via magic number trick (valid for |k| < 2^51)
+        let magic = _mm256_set1_pd(6_755_399_441_055_744.0); // 2^52 + 2^51
+        let magic_i = _mm256_castpd_si256(magic);
+        let k = _mm256_sub_pd(
+            _mm256_castsi256_pd(_mm256_add_epi64(k_i, magic_i)),
+            magic,
+        );
+
+        // If m > sqrt(2): m *= 0.5, k += 1
+        let gt = _mm256_cmp_pd(m, sqrt2, _CMP_GT_OQ);
+        let m = _mm256_blendv_pd(m, _mm256_mul_pd(m, half), gt);
+        let k = _mm256_blendv_pd(k, _mm256_add_pd(k, one), gt);
+
+        // f = m - 1, s = f / (2 + f)
+        let f = _mm256_sub_pd(m, one);
+        let s = _mm256_div_pd(f, _mm256_add_pd(two, f));
+        let s2 = _mm256_mul_pd(s, s);
+
+        // Horner evaluation of R(s²) = s² * (Lg1 + s²*(Lg2 + ...))
+        let mut r = _mm256_set1_pd(LG7);
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG6));
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG5));
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG4));
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG3));
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG2));
+        r = _mm256_add_pd(_mm256_mul_pd(r, s2), _mm256_set1_pd(LG1));
+        r = _mm256_mul_pd(r, s2);
+
+        // hfsq = 0.5 * f * f
+        let hfsq = _mm256_mul_pd(half, _mm256_mul_pd(f, f));
+
+        // result = k*ln2_hi + (f - hfsq + s*(hfsq + R) + k*ln2_lo)
+        let sr = _mm256_mul_pd(s, _mm256_add_pd(hfsq, r));
+        _mm256_add_pd(
+            _mm256_mul_pd(k, ln2_hi),
+            _mm256_add_pd(
+                _mm256_sub_pd(f, hfsq),
+                _mm256_add_pd(sr, _mm256_mul_pd(k, ln2_lo)),
+            ),
+        )
+    }
+}
+
+/// Compute exp(x) for 4 packed f64 values using the musl/Cephes algorithm.
+///
+/// # Safety
+///
+/// Requires AVX2. Inputs should be in a reasonable range (not ±huge).
+#[inline]
+#[cfg(target_arch = "x86_64")]
+unsafe fn exp_f64x4(x: __m256d) -> __m256d {
+    unsafe {
+        let ln2_inv = _mm256_set1_pd(LN2_INV);
+        let c1 = _mm256_set1_pd(EXP_C1);
+        let c2 = _mm256_set1_pd(EXP_C2);
+        let one = _mm256_set1_pd(1.0);
+        let two = _mm256_set1_pd(2.0);
+
+        // Range reduction: k = round(x / ln(2)), r = x - k*ln(2)
+        let kf = _mm256_round_pd(_mm256_mul_pd(x, ln2_inv), _MM_FROUND_TO_NEAREST_INT);
+
+        // Cody-Waite: r = x - k*C1 - k*C2
+        let r = _mm256_sub_pd(_mm256_sub_pd(x, _mm256_mul_pd(kf, c1)), _mm256_mul_pd(kf, c2));
+
+        // Polynomial: t = r² * (P1 + r*(P2 + r*(P3 + r*(P4 + r*P5))))
+        let r2 = _mm256_mul_pd(r, r);
+        let mut p = _mm256_set1_pd(EP5);
+        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP4));
+        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP3));
+        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP2));
+        p = _mm256_add_pd(_mm256_mul_pd(p, r), _mm256_set1_pd(EP1));
+        let t = _mm256_mul_pd(r2, p);
+
+        // musl reconstruction: exp(r) = 1 - ((r*t)/(t-2) - r)
+        let denom = _mm256_sub_pd(t, two);
+        let frac = _mm256_div_pd(_mm256_mul_pd(r, t), denom);
+        let exp_r = _mm256_sub_pd(one, _mm256_sub_pd(frac, r));
+
+        // Scale by 2^k: set exponent bits
+        let k_i = _mm256_cvtpd_epi32(kf); // f64x4 → i32x4 (__m128i)
+        let k_i64 = _mm256_cvtepi32_epi64(k_i);
+        let bias = _mm256_set1_epi64x(1023);
+        let exp_bits = _mm256_slli_epi64(_mm256_add_epi64(k_i64, bias), 52);
+        let scale = _mm256_castsi256_pd(exp_bits);
+
+        _mm256_mul_pd(exp_r, scale)
+    }
+}
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn ln_inplace(buf: &mut [f64]) {
+    let len = buf.len();
+    let mut i = 0;
+
+    // SAFETY: AVX2 availability guaranteed by target_feature cfg.
+    // All values in buf are positive (guaranteed by BOCPD: a > 0, b > 0).
+    unsafe {
+        while i + 4 <= len {
+            let v = _mm256_loadu_pd(buf.as_ptr().add(i));
+            let result = ln_f64x4(v);
+            _mm256_storeu_pd(buf.as_mut_ptr().add(i), result);
+            i += 4;
+        }
+    }
+
+    for v in &mut buf[i..] {
+        *v = scalar_ln(*v);
+    }
+}
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn exp_sum(buf: &[f64], offset: f64) -> f64 {
+    let len = buf.len();
+    let mut i = 0;
+    let mut sum: f64;
+
+    // SAFETY: AVX2 availability guaranteed by target_feature cfg.
+    unsafe {
+        let offset_v = _mm256_set1_pd(offset);
+        let mut acc = _mm256_setzero_pd();
+
+        while i + 4 <= len {
+            let v = _mm256_loadu_pd(buf.as_ptr().add(i));
+            let shifted = _mm256_sub_pd(v, offset_v);
+            acc = _mm256_add_pd(acc, exp_f64x4(shifted));
+            i += 4;
+        }
+
+        // Horizontal sum of acc
+        let hi = _mm256_extractf128_pd(acc, 1);
+        let lo = _mm256_castpd256_pd128(acc);
+        let pair = _mm_add_pd(lo, hi);
+        let high_lane = _mm_unpackhi_pd(pair, pair);
+        sum = _mm_cvtsd_f64(_mm_add_sd(pair, high_lane));
+    }
+
+    for &v in &buf[i..] {
+        sum += scalar_exp(v - offset);
+    }
+
+    sum
+}

--- a/nexus-stats-detection/src/simd_math/scalar.rs
+++ b/nexus-stats-detection/src/simd_math/scalar.rs
@@ -1,0 +1,17 @@
+use nexus_stats_core::math::{exp, ln};
+
+#[inline]
+pub fn ln_inplace(buf: &mut [f64]) {
+    for v in buf.iter_mut() {
+        *v = ln(*v);
+    }
+}
+
+#[inline]
+pub fn exp_sum(buf: &[f64], offset: f64) -> f64 {
+    let mut sum = 0.0;
+    for &v in buf {
+        sum += exp(v - offset);
+    }
+    sum
+}

--- a/nexus-stats/benches/update_bench.rs
+++ b/nexus-stats/benches/update_bench.rs
@@ -14,7 +14,8 @@ use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use nexus_stats::{
     control::{DeadBandF64, FirstDiffF64, HysteresisF64, LevelCrossingF64, SecondDiffF64},
     detection::{
-        AdaptiveThresholdF64, CusumF64, RobustZScoreF64, ShiryaevRobertsF64, TrendAlertF64,
+        AdaptiveThresholdF64, BocpdF64, CusumF64, DistDriftF64, RobustZScoreF64,
+        ShiryaevRobertsF64, TrendAlertF64,
     },
     estimation::{Kalman2dF64, Kalman3dF64},
     learning::{
@@ -24,12 +25,12 @@ use nexus_stats::{
     monitoring::{
         DrawdownF64, ErrorRateF64, JitterF64, RunningMaxF64, RunningMinF64, SaturationF64,
     },
+    normalization::{MinMaxNormF64, ZScoreNormF64},
     regression::{
         EwLinearRegressionF64, LinearRegressionF64, LogisticRegressionF64, PolynomialRegressionF64,
     },
     signal::{AutocorrelationF64, CrossCorrelationF64, EntropyF64, TransferEntropyF64},
     smoothing::{AsymEmaF64, EmaF64, HoltF64, Kalman1dF64, SlewF64, SpringF64},
-    normalization::{MinMaxNormF64, ZScoreNormF64},
     statistics::{
         CovarianceF64, CvarF64, EwmaVarF64, HarmonicMeanF64, LpmF64, MomentsF64, PercentileF64,
         WelfordF64,
@@ -1131,6 +1132,45 @@ fn bench_minmax_norm(c: &mut Criterion) {
 }
 
 // ============================================================
+// Distribution drift + BOCPD
+// ============================================================
+
+fn bench_dist_drift_update(c: &mut Criterion) {
+    let mut rng = Lcg::new(42);
+    let mut drift = DistDriftF64::builder()
+        .num_bins(50)
+        .min_val(0.0)
+        .max_val(100.0)
+        .build()
+        .unwrap();
+    for i in 0..1000u64 {
+        drift.update_reference((i % 100) as f64).unwrap();
+    }
+    c.bench_function("DistDriftF64::update (50 bins)", |b| {
+        b.iter(|| {
+            drift.update(black_box(rng.next_f64())).unwrap();
+        });
+    });
+}
+
+fn bench_bocpd_update(c: &mut Criterion) {
+    let mut bocpd = BocpdF64::builder()
+        .max_run_length(200)
+        .hazard_lambda(100.0)
+        .build()
+        .unwrap();
+    for i in 0..50 {
+        bocpd.update(i as f64).unwrap();
+    }
+    let mut rng = Lcg::new(42);
+    c.bench_function("BocpdF64::update (W=200)", |b| {
+        b.iter(|| {
+            bocpd.update(black_box(rng.next_f64())).unwrap();
+        });
+    });
+}
+
+// ============================================================
 // Criterion groups and main
 // ============================================================
 
@@ -1214,6 +1254,8 @@ criterion_group!(
     bench_minmax_norm,
 );
 
+criterion_group!(drift_bocpd, bench_dist_drift_update, bench_bocpd_update,);
+
 criterion_group!(
     bandits,
     bench_ucb1_select,
@@ -1236,4 +1278,5 @@ criterion_main!(
     queries,
     bandits,
     risk_norm,
+    drift_bocpd,
 );


### PR DESCRIPTION
## Summary

- **DistDriftF64/F32** — Distribution drift metrics over reference/live equi-width histograms. Three query methods: KL divergence (KL(live || ref), nats), Jensen-Shannon divergence (symmetric, bounded [0, ln2]), Wasserstein-1 distance. Laplace smoothing for KL/JS. Out-of-range samples clamped to boundary bins.
- **BocpdF64** — Bayesian Online Change Point Detection (Adams & MacKay 2007). Gaussian observation model with Normal-Inverse-Gamma conjugate prior, Student-t predictive. Truncated run-length posterior in log-space. O(W) per update. f64 only (precision-sensitive).
- **ln_gamma** — Lanczos approximation (g=7, 9 coefficients) added to `nexus_stats_core::math`. Also `ln_f32`, `exp_f32` for F32 macro variants.

Closes #299, #291.

## Benchmarks (uncontrolled)

| Type | Time | Notes |
|------|-----:|-------|
| DistDriftF64::update (50 bins) | 6.1 ns | Bin index + integer increment |
| BocpdF64::update (W=200) | 24.9 µs | O(W) log-space posterior, ~125ns/run length |

Casey is doing perf analysis — may have optimizations before merge.

## Test plan

- [x] `cargo test -p nexus-stats-detection --all-features` (20 new tests, 18 doctests)
- [x] `cargo test -p nexus-stats-core --all-features` (3 new math tests)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p nexus-stats-detection --no-default-features --features alloc,libm`
- [ ] Controlled benchmarks (turbo off, cores pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)