### PR TITLE
nexus-inference: activation extraction + AVX-512 dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.90"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Abso1ut3Zer0/nexus"
 keywords = ["lock-free", "concurrent", "data-structures", "trading"]

--- a/nexus-inference/benches/temporal_bench.rs
+++ b/nexus-inference/benches/temporal_bench.rs
@@ -29,18 +29,21 @@ fn make_gru(input: usize, hidden: usize, output: usize) -> TinyGruF32 {
     .unwrap()
 }
 
-fn make_conv(
-    input_ch: usize,
-    kernel: usize,
-    filters: usize,
-    output: usize,
-) -> Causal1dConvF32 {
+fn make_conv(input_ch: usize, kernel: usize, filters: usize, output: usize) -> Causal1dConvF32 {
     let w_conv = vec![0.1_f32; filters * kernel * input_ch];
     let b_conv = vec![0.0_f32; filters];
     let w_out = vec![0.1_f32; output * filters];
     let b_out = vec![0.0_f32; output];
     Causal1dConvF32::from_parts(
-        input_ch, kernel, filters, output, &w_conv, &b_conv, &w_out, &b_out, Activation::Relu,
+        input_ch,
+        kernel,
+        filters,
+        output,
+        &w_conv,
+        &b_conv,
+        &w_out,
+        &b_out,
+        Activation::Relu,
     )
     .unwrap()
 }
@@ -51,25 +54,33 @@ fn bench_lstm(c: &mut Criterion) {
     let input_16 = vec![0.5_f32; 16];
 
     let mut m = make_lstm(4, 8, 1);
-    for _ in 0..100 { m.step(&input_4); } // warm hidden state
+    for _ in 0..100 {
+        m.step(&input_4);
+    } // warm hidden state
     c.bench_function("LSTM 4→8→1", |b| {
         b.iter(|| m.step(black_box(&input_4)));
     });
 
     let mut m = make_lstm(8, 16, 1);
-    for _ in 0..100 { m.step(&input_8); }
+    for _ in 0..100 {
+        m.step(&input_8);
+    }
     c.bench_function("LSTM 8→16→1", |b| {
         b.iter(|| m.step(black_box(&input_8)));
     });
 
     let mut m = make_lstm(8, 32, 1);
-    for _ in 0..100 { m.step(&input_8); }
+    for _ in 0..100 {
+        m.step(&input_8);
+    }
     c.bench_function("LSTM 8→32→1", |b| {
         b.iter(|| m.step(black_box(&input_8)));
     });
 
     let mut m = make_lstm(16, 64, 1);
-    for _ in 0..100 { m.step(&input_16); }
+    for _ in 0..100 {
+        m.step(&input_16);
+    }
     c.bench_function("LSTM 16→64→1", |b| {
         b.iter(|| m.step(black_box(&input_16)));
     });
@@ -80,19 +91,25 @@ fn bench_gru(c: &mut Criterion) {
     let input_16 = vec![0.5_f32; 16];
 
     let mut m = make_gru(8, 16, 1);
-    for _ in 0..100 { m.step(&input_8); }
+    for _ in 0..100 {
+        m.step(&input_8);
+    }
     c.bench_function("GRU 8→16→1", |b| {
         b.iter(|| m.step(black_box(&input_8)));
     });
 
     let mut m = make_gru(8, 32, 1);
-    for _ in 0..100 { m.step(&input_8); }
+    for _ in 0..100 {
+        m.step(&input_8);
+    }
     c.bench_function("GRU 8→32→1", |b| {
         b.iter(|| m.step(black_box(&input_8)));
     });
 
     let mut m = make_gru(16, 64, 1);
-    for _ in 0..100 { m.step(&input_16); }
+    for _ in 0..100 {
+        m.step(&input_16);
+    }
     c.bench_function("GRU 16→64→1", |b| {
         b.iter(|| m.step(black_box(&input_16)));
     });
@@ -103,19 +120,25 @@ fn bench_conv(c: &mut Criterion) {
     let input_8 = vec![0.5_f32; 8];
 
     let mut m = make_conv(4, 4, 8, 1);
-    for _ in 0..10 { m.step(&input_4); } // prime buffer
+    for _ in 0..10 {
+        m.step(&input_4);
+    } // prime buffer
     c.bench_function("Conv 4ch×4k×8f→1", |b| {
         b.iter(|| m.step(black_box(&input_4)));
     });
 
     let mut m = make_conv(4, 8, 16, 1);
-    for _ in 0..10 { m.step(&input_4); }
+    for _ in 0..10 {
+        m.step(&input_4);
+    }
     c.bench_function("Conv 4ch×8k×16f→1", |b| {
         b.iter(|| m.step(black_box(&input_4)));
     });
 
     let mut m = make_conv(8, 8, 32, 1);
-    for _ in 0..10 { m.step(&input_8); }
+    for _ in 0..10 {
+        m.step(&input_8);
+    }
     c.bench_function("Conv 8ch×8k×32f→1", |b| {
         b.iter(|| m.step(black_box(&input_8)));
     });

--- a/nexus-inference/src/activation.rs
+++ b/nexus-inference/src/activation.rs
@@ -1,0 +1,244 @@
+/// Activation function for hidden layers and convolution outputs.
+///
+/// Applied element-wise. `Relu`, `LeakyRelu`, `Identity` are always
+/// available. `Tanh`, `Sigmoid`, `Elu`, `Gelu`, `Swish` require
+/// `std` or `libm`.
+#[derive(Debug, Clone, Copy)]
+pub enum Activation {
+    /// max(0, x)
+    Relu,
+    /// x if x >= 0, alpha * x otherwise.
+    LeakyRelu(f64),
+    /// Hyperbolic tangent. Requires `std` or `libm`.
+    Tanh,
+    /// 1 / (1 + exp(-x)). Requires `std` or `libm`.
+    Sigmoid,
+    /// Pass-through (no transformation).
+    Identity,
+    /// x if x >= 0, alpha * (exp(x) - 1) otherwise. Requires `std` or `libm`.
+    Elu(f64),
+    /// Gaussian error linear unit (tanh approximation). Requires `std` or `libm`.
+    Gelu,
+    /// x * sigmoid(x), also known as SiLU in PyTorch. Requires `std` or `libm`.
+    Swish,
+}
+
+#[inline(always)]
+pub(crate) fn activate_f32(x: f32, activation: Activation) -> f32 {
+    match activation {
+        Activation::Relu => {
+            if x > 0.0 {
+                x
+            } else if x <= 0.0 {
+                0.0
+            } else {
+                x // NaN
+            }
+        }
+        Activation::LeakyRelu(alpha) => {
+            if x >= 0.0 {
+                x
+            } else {
+                x * alpha as f32
+            }
+        }
+        Activation::Identity => x,
+        Activation::Tanh => {
+            #[cfg(feature = "std")]
+            {
+                (x as f64).tanh() as f32
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                libm::tanh(x as f64) as f32
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Sigmoid => {
+            #[cfg(feature = "std")]
+            {
+                (1.0_f64 / (1.0_f64 + (-(x as f64)).exp())) as f32
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                (1.0_f64 / (1.0_f64 + libm::exp(-(x as f64)))) as f32
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Elu(alpha) => {
+            if x >= 0.0 {
+                x
+            } else {
+                #[cfg(feature = "std")]
+                {
+                    alpha as f32 * (x as f64).exp_m1() as f32
+                }
+                #[cfg(all(not(feature = "std"), feature = "libm"))]
+                {
+                    alpha as f32 * libm::expm1(x as f64) as f32
+                }
+                #[cfg(not(any(feature = "std", feature = "libm")))]
+                {
+                    let _ = (x, alpha);
+                    unreachable!()
+                }
+            }
+        }
+        Activation::Gelu => {
+            #[cfg(feature = "std")]
+            {
+                let xf = x as f64;
+                let inner = (0.044_715 * xf * xf).mul_add(xf, xf)
+                    * core::f64::consts::FRAC_2_SQRT_PI
+                    * core::f64::consts::FRAC_1_SQRT_2;
+                (0.5 * xf * (1.0 + inner.tanh())) as f32
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                let xf = x as f64;
+                let inner = (0.044_715 * xf * xf * xf + xf)
+                    * core::f64::consts::FRAC_2_SQRT_PI
+                    * core::f64::consts::FRAC_1_SQRT_2;
+                (0.5 * xf * (1.0 + libm::tanh(inner))) as f32
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Swish => {
+            #[cfg(feature = "std")]
+            {
+                let xf = x as f64;
+                (xf / (1.0 + (-xf).exp())) as f32
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                let xf = x as f64;
+                (xf / (1.0 + libm::exp(-xf))) as f32
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn activate_f64(x: f64, activation: Activation) -> f64 {
+    match activation {
+        Activation::Relu => {
+            if x > 0.0 {
+                x
+            } else if x <= 0.0 {
+                0.0
+            } else {
+                x
+            }
+        }
+        Activation::LeakyRelu(alpha) => {
+            if x >= 0.0 {
+                x
+            } else {
+                x * alpha
+            }
+        }
+        Activation::Identity => x,
+        Activation::Tanh => {
+            #[cfg(feature = "std")]
+            {
+                x.tanh()
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                libm::tanh(x)
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Sigmoid => {
+            #[cfg(feature = "std")]
+            {
+                1.0 / (1.0 + (-x).exp())
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                1.0 / (1.0 + libm::exp(-x))
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Elu(alpha) => {
+            if x >= 0.0 {
+                x
+            } else {
+                #[cfg(feature = "std")]
+                {
+                    alpha * x.exp_m1()
+                }
+                #[cfg(all(not(feature = "std"), feature = "libm"))]
+                {
+                    alpha * libm::expm1(x)
+                }
+                #[cfg(not(any(feature = "std", feature = "libm")))]
+                {
+                    let _ = (x, alpha);
+                    unreachable!()
+                }
+            }
+        }
+        Activation::Gelu => {
+            #[cfg(feature = "std")]
+            {
+                let inner = (0.044_715 * x * x).mul_add(x, x)
+                    * core::f64::consts::FRAC_2_SQRT_PI
+                    * core::f64::consts::FRAC_1_SQRT_2;
+                0.5 * x * (1.0 + inner.tanh())
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                let inner = (0.044_715 * x * x * x + x)
+                    * core::f64::consts::FRAC_2_SQRT_PI
+                    * core::f64::consts::FRAC_1_SQRT_2;
+                0.5 * x * (1.0 + libm::tanh(inner))
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+        Activation::Swish => {
+            #[cfg(feature = "std")]
+            {
+                x / (1.0 + (-x).exp())
+            }
+            #[cfg(all(not(feature = "std"), feature = "libm"))]
+            {
+                x / (1.0 + libm::exp(-x))
+            }
+            #[cfg(not(any(feature = "std", feature = "libm")))]
+            {
+                let _ = x;
+                unreachable!()
+            }
+        }
+    }
+}

--- a/nexus-inference/src/conv/causal1d.rs
+++ b/nexus-inference/src/conv/causal1d.rs
@@ -3,8 +3,8 @@ extern crate alloc;
 use alloc::{boxed::Box, vec};
 
 use crate::LoadError;
+use crate::activation::{Activation, activate_f32};
 use crate::dot::{dot_f32, dot4_f32, matvec_bias_f32};
-use crate::mlp::Activation;
 
 /// Streaming causal 1D convolution.
 ///
@@ -188,15 +188,19 @@ impl Causal1dConvF32 {
         while f < filters_4 {
             let rows = &self.w_conv[f * conv_len..(f + 4) * conv_len];
             let dots = dot4_f32(rows, lin);
-            self.filter_scratch[f] = activate(self.b_conv[f] + dots[0], self.activation);
-            self.filter_scratch[f + 1] = activate(self.b_conv[f + 1] + dots[1], self.activation);
-            self.filter_scratch[f + 2] = activate(self.b_conv[f + 2] + dots[2], self.activation);
-            self.filter_scratch[f + 3] = activate(self.b_conv[f + 3] + dots[3], self.activation);
+            self.filter_scratch[f] = activate_f32(self.b_conv[f] + dots[0], self.activation);
+            self.filter_scratch[f + 1] =
+                activate_f32(self.b_conv[f + 1] + dots[1], self.activation);
+            self.filter_scratch[f + 2] =
+                activate_f32(self.b_conv[f + 2] + dots[2], self.activation);
+            self.filter_scratch[f + 3] =
+                activate_f32(self.b_conv[f + 3] + dots[3], self.activation);
             f += 4;
         }
         while f < n_filters {
             let row = &self.w_conv[f * conv_len..(f + 1) * conv_len];
-            self.filter_scratch[f] = activate(self.b_conv[f] + dot_f32(row, lin), self.activation);
+            self.filter_scratch[f] =
+                activate_f32(self.b_conv[f] + dot_f32(row, lin), self.activation);
             f += 1;
         }
 
@@ -251,118 +255,6 @@ impl Causal1dConvF32 {
     /// Activation function applied to convolution outputs.
     pub fn activation(&self) -> Activation {
         self.activation
-    }
-}
-
-#[inline(always)]
-fn activate(x: f32, activation: Activation) -> f32 {
-    match activation {
-        Activation::Relu => {
-            if x > 0.0 {
-                x
-            } else if x <= 0.0 {
-                0.0
-            } else {
-                x // NaN
-            }
-        }
-        Activation::LeakyRelu(alpha) => {
-            if x >= 0.0 {
-                x
-            } else {
-                x * alpha as f32
-            }
-        }
-        Activation::Identity => x,
-        Activation::Tanh => {
-            #[cfg(feature = "std")]
-            {
-                (x as f64).tanh() as f32
-            }
-            #[cfg(all(not(feature = "std"), feature = "libm"))]
-            {
-                libm::tanh(x as f64) as f32
-            }
-            #[cfg(not(any(feature = "std", feature = "libm")))]
-            {
-                let _ = x;
-                unreachable!()
-            }
-        }
-        Activation::Sigmoid => {
-            #[cfg(feature = "std")]
-            {
-                (1.0_f64 / (1.0_f64 + (-(x as f64)).exp())) as f32
-            }
-            #[cfg(all(not(feature = "std"), feature = "libm"))]
-            {
-                (1.0_f64 / (1.0_f64 + libm::exp(-(x as f64)))) as f32
-            }
-            #[cfg(not(any(feature = "std", feature = "libm")))]
-            {
-                let _ = x;
-                unreachable!()
-            }
-        }
-        Activation::Elu(alpha) => {
-            if x >= 0.0 {
-                x
-            } else {
-                #[cfg(feature = "std")]
-                {
-                    alpha as f32 * (x as f64).exp_m1() as f32
-                }
-                #[cfg(all(not(feature = "std"), feature = "libm"))]
-                {
-                    alpha as f32 * libm::expm1(x as f64) as f32
-                }
-                #[cfg(not(any(feature = "std", feature = "libm")))]
-                {
-                    let _ = (x, alpha);
-                    unreachable!()
-                }
-            }
-        }
-        Activation::Gelu => {
-            #[cfg(feature = "std")]
-            {
-                let xf = x as f64;
-                let inner = (0.044_715 * xf * xf).mul_add(xf, xf)
-                    * core::f64::consts::FRAC_2_SQRT_PI
-                    * std::f64::consts::FRAC_1_SQRT_2;
-                (0.5 * xf * (1.0 + inner.tanh())) as f32
-            }
-            #[cfg(all(not(feature = "std"), feature = "libm"))]
-            {
-                let xf = x as f64;
-                let inner = ((0.044_715 * xf * xf) * xf + xf)
-                    * core::f64::consts::FRAC_2_SQRT_PI
-                    * 0.7071067811865476; // 1/sqrt(2)
-                (0.5 * xf * (1.0 + libm::tanh(inner))) as f32
-            }
-            #[cfg(not(any(feature = "std", feature = "libm")))]
-            {
-                let _ = x;
-                unreachable!()
-            }
-        }
-        Activation::Swish => {
-            #[cfg(feature = "std")]
-            {
-                let sig = 1.0_f64 / (1.0_f64 + (-(x as f64)).exp());
-                (x as f64 * sig) as f32
-            }
-            #[cfg(all(not(feature = "std"), feature = "libm"))]
-            {
-                let sig = 1.0_f64 / (1.0_f64 + libm::exp(-(x as f64)));
-                (x as f64 * sig) as f32
-            }
-            #[cfg(not(any(feature = "std", feature = "libm")))]
-            {
-                let _ = x;
-                unreachable!()
-            }
-        }
     }
 }
 

--- a/nexus-inference/src/dot/avx512.rs
+++ b/nexus-inference/src/dot/avx512.rs
@@ -1,0 +1,268 @@
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use super::scalar;
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+unsafe fn hsum_f64(v: __m512d) -> f64 {
+    unsafe {
+        let hi = _mm512_extractf64x4_pd(v, 1);
+        let lo = _mm512_castpd512_pd256(v);
+        let sum = _mm256_add_pd(lo, hi);
+        let hi128 = _mm256_extractf128_pd(sum, 1);
+        let lo128 = _mm256_castpd256_pd128(sum);
+        let pair = _mm_add_pd(lo128, hi128);
+        let high_lane = _mm_unpackhi_pd(pair, pair);
+        _mm_cvtsd_f64(_mm_add_sd(pair, high_lane))
+    }
+}
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+unsafe fn hsum_f32(v: __m512) -> f32 {
+    unsafe {
+        let lo = _mm512_castps512_ps256(v);
+        let hi = _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(v), 1));
+        let sum = _mm256_add_ps(lo, hi);
+        let hi128 = _mm256_extractf128_ps(sum, 1);
+        let lo128 = _mm256_castps256_ps128(sum);
+        let sum128 = _mm_add_ps(lo128, hi128);
+        let shuf = _mm_movehdup_ps(sum128);
+        let sums = _mm_add_ps(sum128, shuf);
+        let shuf2 = _mm_movehl_ps(sums, sums);
+        _mm_cvtss_f32(_mm_add_ss(sums, shuf2))
+    }
+}
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn dot_f64(a: &[f64], b: &[f64]) -> f64 {
+    let len = a.len();
+    let mut i = 0;
+
+    // SAFETY: AVX-512F guaranteed by target_feature cfg on parent module.
+    // All pointer offsets satisfy i + N <= len before access.
+    let sum = unsafe {
+        let mut acc0 = _mm512_setzero_pd();
+        let mut acc1 = _mm512_setzero_pd();
+        let mut acc2 = _mm512_setzero_pd();
+        let mut acc3 = _mm512_setzero_pd();
+
+        while i + 32 <= len {
+            let a0 = _mm512_loadu_pd(a.as_ptr().add(i));
+            let b0 = _mm512_loadu_pd(b.as_ptr().add(i));
+            let a1 = _mm512_loadu_pd(a.as_ptr().add(i + 8));
+            let b1 = _mm512_loadu_pd(b.as_ptr().add(i + 8));
+            let a2 = _mm512_loadu_pd(a.as_ptr().add(i + 16));
+            let b2 = _mm512_loadu_pd(b.as_ptr().add(i + 16));
+            let a3 = _mm512_loadu_pd(a.as_ptr().add(i + 24));
+            let b3 = _mm512_loadu_pd(b.as_ptr().add(i + 24));
+            acc0 = _mm512_fmadd_pd(a0, b0, acc0);
+            acc1 = _mm512_fmadd_pd(a1, b1, acc1);
+            acc2 = _mm512_fmadd_pd(a2, b2, acc2);
+            acc3 = _mm512_fmadd_pd(a3, b3, acc3);
+            i += 32;
+        }
+
+        while i + 8 <= len {
+            let av = _mm512_loadu_pd(a.as_ptr().add(i));
+            let bv = _mm512_loadu_pd(b.as_ptr().add(i));
+            acc0 = _mm512_fmadd_pd(av, bv, acc0);
+            i += 8;
+        }
+
+        acc0 = _mm512_add_pd(_mm512_add_pd(acc0, acc1), _mm512_add_pd(acc2, acc3));
+
+        hsum_f64(acc0)
+    };
+
+    sum + scalar::dot_f64(&a[i..], &b[i..])
+}
+
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
+    let len = a.len();
+    let mut i = 0;
+
+    // SAFETY: AVX-512F guaranteed by target_feature cfg on parent module.
+    // All pointer offsets satisfy i + N <= len before access.
+    let sum = unsafe {
+        let mut acc0 = _mm512_setzero_ps();
+        let mut acc1 = _mm512_setzero_ps();
+        let mut acc2 = _mm512_setzero_ps();
+        let mut acc3 = _mm512_setzero_ps();
+
+        while i + 64 <= len {
+            let a0 = _mm512_loadu_ps(a.as_ptr().add(i));
+            let b0 = _mm512_loadu_ps(b.as_ptr().add(i));
+            let a1 = _mm512_loadu_ps(a.as_ptr().add(i + 16));
+            let b1 = _mm512_loadu_ps(b.as_ptr().add(i + 16));
+            let a2 = _mm512_loadu_ps(a.as_ptr().add(i + 32));
+            let b2 = _mm512_loadu_ps(b.as_ptr().add(i + 32));
+            let a3 = _mm512_loadu_ps(a.as_ptr().add(i + 48));
+            let b3 = _mm512_loadu_ps(b.as_ptr().add(i + 48));
+            acc0 = _mm512_fmadd_ps(a0, b0, acc0);
+            acc1 = _mm512_fmadd_ps(a1, b1, acc1);
+            acc2 = _mm512_fmadd_ps(a2, b2, acc2);
+            acc3 = _mm512_fmadd_ps(a3, b3, acc3);
+            i += 64;
+        }
+
+        while i + 16 <= len {
+            let av = _mm512_loadu_ps(a.as_ptr().add(i));
+            let bv = _mm512_loadu_ps(b.as_ptr().add(i));
+            acc0 = _mm512_fmadd_ps(av, bv, acc0);
+            i += 16;
+        }
+
+        acc0 = _mm512_add_ps(_mm512_add_ps(acc0, acc1), _mm512_add_ps(acc2, acc3));
+
+        hsum_f32(acc0)
+    };
+
+    sum + scalar::dot_f32(&a[i..], &b[i..])
+}
+
+/// 4 simultaneous f64 dot products sharing input loads.
+/// 2 accumulators per neuron (8 total) to hide FMA latency.
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn dot4_f64(rows: &[f64], input: &[f64]) -> [f64; 4] {
+    let in_size = input.len();
+    let mut i = 0;
+
+    // SAFETY: AVX-512F guaranteed by target_feature cfg on parent module.
+    // Row pointers: rows.len() == 4 * in_size, offsets k * in_size + i where k < 4.
+    // Input pointer: i + N <= in_size before every access.
+    let sums = unsafe {
+        let mut a0a = _mm512_setzero_pd();
+        let mut a0b = _mm512_setzero_pd();
+        let mut a1a = _mm512_setzero_pd();
+        let mut a1b = _mm512_setzero_pd();
+        let mut a2a = _mm512_setzero_pd();
+        let mut a2b = _mm512_setzero_pd();
+        let mut a3a = _mm512_setzero_pd();
+        let mut a3b = _mm512_setzero_pd();
+
+        let r0 = rows.as_ptr();
+        let r1 = r0.add(in_size);
+        let r2 = r1.add(in_size);
+        let r3 = r2.add(in_size);
+        let inp = input.as_ptr();
+
+        while i + 16 <= in_size {
+            let x0 = _mm512_loadu_pd(inp.add(i));
+            let x1 = _mm512_loadu_pd(inp.add(i + 8));
+
+            a0a = _mm512_fmadd_pd(_mm512_loadu_pd(r0.add(i)), x0, a0a);
+            a0b = _mm512_fmadd_pd(_mm512_loadu_pd(r0.add(i + 8)), x1, a0b);
+            a1a = _mm512_fmadd_pd(_mm512_loadu_pd(r1.add(i)), x0, a1a);
+            a1b = _mm512_fmadd_pd(_mm512_loadu_pd(r1.add(i + 8)), x1, a1b);
+            a2a = _mm512_fmadd_pd(_mm512_loadu_pd(r2.add(i)), x0, a2a);
+            a2b = _mm512_fmadd_pd(_mm512_loadu_pd(r2.add(i + 8)), x1, a2b);
+            a3a = _mm512_fmadd_pd(_mm512_loadu_pd(r3.add(i)), x0, a3a);
+            a3b = _mm512_fmadd_pd(_mm512_loadu_pd(r3.add(i + 8)), x1, a3b);
+
+            i += 16;
+        }
+
+        if i + 8 <= in_size {
+            let x = _mm512_loadu_pd(inp.add(i));
+            a0a = _mm512_fmadd_pd(_mm512_loadu_pd(r0.add(i)), x, a0a);
+            a1a = _mm512_fmadd_pd(_mm512_loadu_pd(r1.add(i)), x, a1a);
+            a2a = _mm512_fmadd_pd(_mm512_loadu_pd(r2.add(i)), x, a2a);
+            a3a = _mm512_fmadd_pd(_mm512_loadu_pd(r3.add(i)), x, a3a);
+            i += 8;
+        }
+
+        a0a = _mm512_add_pd(a0a, a0b);
+        a1a = _mm512_add_pd(a1a, a1b);
+        a2a = _mm512_add_pd(a2a, a2b);
+        a3a = _mm512_add_pd(a3a, a3b);
+
+        [hsum_f64(a0a), hsum_f64(a1a), hsum_f64(a2a), hsum_f64(a3a)]
+    };
+
+    let mut out = sums;
+    for k in i..in_size {
+        let x = input[k];
+        out[0] += rows[k] * x;
+        out[1] += rows[in_size + k] * x;
+        out[2] += rows[2 * in_size + k] * x;
+        out[3] += rows[3 * in_size + k] * x;
+    }
+    out
+}
+
+/// 4 simultaneous f32 dot products sharing input loads.
+/// 2 accumulators per neuron (8 total) to hide FMA latency.
+#[inline]
+#[cfg(target_arch = "x86_64")]
+pub fn dot4_f32(rows: &[f32], input: &[f32]) -> [f32; 4] {
+    let in_size = input.len();
+    let mut i = 0;
+
+    // SAFETY: AVX-512F guaranteed by target_feature cfg on parent module.
+    // Row pointers: rows.len() == 4 * in_size, offsets k * in_size + i where k < 4.
+    // Input pointer: i + N <= in_size before every access.
+    let sums = unsafe {
+        let mut a0a = _mm512_setzero_ps();
+        let mut a0b = _mm512_setzero_ps();
+        let mut a1a = _mm512_setzero_ps();
+        let mut a1b = _mm512_setzero_ps();
+        let mut a2a = _mm512_setzero_ps();
+        let mut a2b = _mm512_setzero_ps();
+        let mut a3a = _mm512_setzero_ps();
+        let mut a3b = _mm512_setzero_ps();
+
+        let r0 = rows.as_ptr();
+        let r1 = r0.add(in_size);
+        let r2 = r1.add(in_size);
+        let r3 = r2.add(in_size);
+        let inp = input.as_ptr();
+
+        while i + 32 <= in_size {
+            let x0 = _mm512_loadu_ps(inp.add(i));
+            let x1 = _mm512_loadu_ps(inp.add(i + 16));
+
+            a0a = _mm512_fmadd_ps(_mm512_loadu_ps(r0.add(i)), x0, a0a);
+            a0b = _mm512_fmadd_ps(_mm512_loadu_ps(r0.add(i + 16)), x1, a0b);
+            a1a = _mm512_fmadd_ps(_mm512_loadu_ps(r1.add(i)), x0, a1a);
+            a1b = _mm512_fmadd_ps(_mm512_loadu_ps(r1.add(i + 16)), x1, a1b);
+            a2a = _mm512_fmadd_ps(_mm512_loadu_ps(r2.add(i)), x0, a2a);
+            a2b = _mm512_fmadd_ps(_mm512_loadu_ps(r2.add(i + 16)), x1, a2b);
+            a3a = _mm512_fmadd_ps(_mm512_loadu_ps(r3.add(i)), x0, a3a);
+            a3b = _mm512_fmadd_ps(_mm512_loadu_ps(r3.add(i + 16)), x1, a3b);
+
+            i += 32;
+        }
+
+        if i + 16 <= in_size {
+            let x = _mm512_loadu_ps(inp.add(i));
+            a0a = _mm512_fmadd_ps(_mm512_loadu_ps(r0.add(i)), x, a0a);
+            a1a = _mm512_fmadd_ps(_mm512_loadu_ps(r1.add(i)), x, a1a);
+            a2a = _mm512_fmadd_ps(_mm512_loadu_ps(r2.add(i)), x, a2a);
+            a3a = _mm512_fmadd_ps(_mm512_loadu_ps(r3.add(i)), x, a3a);
+            i += 16;
+        }
+
+        a0a = _mm512_add_ps(a0a, a0b);
+        a1a = _mm512_add_ps(a1a, a1b);
+        a2a = _mm512_add_ps(a2a, a2b);
+        a3a = _mm512_add_ps(a3a, a3b);
+
+        [hsum_f32(a0a), hsum_f32(a1a), hsum_f32(a2a), hsum_f32(a3a)]
+    };
+
+    let mut out = sums;
+    for k in i..in_size {
+        let x = input[k];
+        out[0] += rows[k] * x;
+        out[1] += rows[in_size + k] * x;
+        out[2] += rows[2 * in_size + k] * x;
+        out[3] += rows[3 * in_size + k] * x;
+    }
+    out
+}

--- a/nexus-inference/src/dot/mod.rs
+++ b/nexus-inference/src/dot/mod.rs
@@ -1,10 +1,14 @@
 #[allow(dead_code)]
 mod scalar;
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+mod avx512;
+
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    target_feature = "fma"
+    target_feature = "fma",
+    not(target_feature = "avx512f"),
 ))]
 mod avx2;
 
@@ -12,10 +16,16 @@ mod avx2;
 pub(crate) fn dot_f64(a: &[f64], b: &[f64]) -> f64 {
     debug_assert_eq!(a.len(), b.len());
 
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    {
+        avx512::dot_f64(a, b)
+    }
+
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        target_feature = "fma"
+        target_feature = "fma",
+        not(target_feature = "avx512f"),
     ))]
     {
         avx2::dot_f64(a, b)
@@ -23,8 +33,10 @@ pub(crate) fn dot_f64(a: &[f64], b: &[f64]) -> f64 {
 
     #[cfg(not(all(
         target_arch = "x86_64",
-        target_feature = "avx2",
-        target_feature = "fma"
+        any(
+            target_feature = "avx512f",
+            all(target_feature = "avx2", target_feature = "fma"),
+        )
     )))]
     {
         scalar::dot_f64(a, b)
@@ -35,10 +47,16 @@ pub(crate) fn dot_f64(a: &[f64], b: &[f64]) -> f64 {
 pub(crate) fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
 
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    {
+        avx512::dot_f32(a, b)
+    }
+
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        target_feature = "fma"
+        target_feature = "fma",
+        not(target_feature = "avx512f"),
     ))]
     {
         avx2::dot_f32(a, b)
@@ -46,8 +64,10 @@ pub(crate) fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
 
     #[cfg(not(all(
         target_arch = "x86_64",
-        target_feature = "avx2",
-        target_feature = "fma"
+        any(
+            target_feature = "avx512f",
+            all(target_feature = "avx2", target_feature = "fma"),
+        )
     )))]
     {
         scalar::dot_f32(a, b)
@@ -60,10 +80,16 @@ pub(crate) fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
 pub(crate) fn dot4_f64(rows: &[f64], input: &[f64]) -> [f64; 4] {
     debug_assert_eq!(rows.len(), 4 * input.len());
 
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    {
+        avx512::dot4_f64(rows, input)
+    }
+
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        target_feature = "fma"
+        target_feature = "fma",
+        not(target_feature = "avx512f"),
     ))]
     {
         avx2::dot4_f64(rows, input)
@@ -71,8 +97,10 @@ pub(crate) fn dot4_f64(rows: &[f64], input: &[f64]) -> [f64; 4] {
 
     #[cfg(not(all(
         target_arch = "x86_64",
-        target_feature = "avx2",
-        target_feature = "fma"
+        any(
+            target_feature = "avx512f",
+            all(target_feature = "avx2", target_feature = "fma"),
+        )
     )))]
     {
         scalar::dot4_f64(rows, input)
@@ -146,10 +174,16 @@ pub(crate) fn matvec_f32(
 pub(crate) fn dot4_f32(rows: &[f32], input: &[f32]) -> [f32; 4] {
     debug_assert_eq!(rows.len(), 4 * input.len());
 
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    {
+        avx512::dot4_f32(rows, input)
+    }
+
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        target_feature = "fma"
+        target_feature = "fma",
+        not(target_feature = "avx512f"),
     ))]
     {
         avx2::dot4_f32(rows, input)
@@ -157,8 +191,10 @@ pub(crate) fn dot4_f32(rows: &[f32], input: &[f32]) -> [f32; 4] {
 
     #[cfg(not(all(
         target_arch = "x86_64",
-        target_feature = "avx2",
-        target_feature = "fma"
+        any(
+            target_feature = "avx512f",
+            all(target_feature = "avx2", target_feature = "fma"),
+        )
     )))]
     {
         scalar::dot4_f32(rows, input)

--- a/nexus-inference/src/lib.rs
+++ b/nexus-inference/src/lib.rs
@@ -25,6 +25,8 @@
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
+mod activation;
+#[cfg(feature = "alloc")]
 mod dot;
 mod error;
 mod gbdt;
@@ -41,6 +43,8 @@ mod conv;
 mod loader;
 
 #[cfg(feature = "alloc")]
+pub use activation::Activation;
+#[cfg(feature = "alloc")]
 pub use conv::Causal1dConvF32;
 pub use error::LoadError;
 #[cfg(feature = "alloc")]
@@ -48,6 +52,6 @@ pub use gbdt::{GbdtF32, GbdtF64};
 #[cfg(feature = "alloc")]
 pub use lut::{LutF32, LutF64};
 #[cfg(feature = "alloc")]
-pub use mlp::{Activation, MlpF32, MlpF64};
+pub use mlp::{MlpF32, MlpF64};
 #[cfg(any(feature = "std", feature = "libm"))]
 pub use rnn::{TinyGruF32, TinyLstmF32};

--- a/nexus-inference/src/loader/lightgbm.rs
+++ b/nexus-inference/src/loader/lightgbm.rs
@@ -84,16 +84,16 @@ fn parse_tree_block(lines: &[&str]) -> Result<TreeBlock, LoadError> {
         }
     }
 
-    if let Some(nc) = num_cat {
-        if nc > 0 {
-            return Err(LoadError::Validation("categorical splits not supported"));
-        }
+    if let Some(nc) = num_cat
+        && nc > 0
+    {
+        return Err(LoadError::Validation("categorical splits not supported"));
     }
 
-    if let Some(il) = is_linear {
-        if il > 0 {
-            return Err(LoadError::Validation("linear trees not supported"));
-        }
+    if let Some(il) = is_linear
+        && il > 0
+    {
+        return Err(LoadError::Validation("linear trees not supported"));
     }
 
     let num_leaves = num_leaves.ok_or(LoadError::Parse("missing num_leaves in tree block"))?;

--- a/nexus-inference/src/mlp.rs
+++ b/nexus-inference/src/mlp.rs
@@ -6,35 +6,12 @@ use alloc::{boxed::Box, vec::Vec};
 
 #[cfg(feature = "alloc")]
 use crate::LoadError;
-
-/// Hidden-layer activation function.
-///
-/// Applied to all hidden layers. The output layer always produces raw
-/// linear scores (caller applies sigmoid/softmax if needed).
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Copy)]
-pub enum Activation {
-    /// max(0, x)
-    Relu,
-    /// x if x >= 0, alpha * x otherwise.
-    LeakyRelu(f64),
-    /// Hyperbolic tangent. Requires `std` or `libm`.
-    Tanh,
-    /// 1 / (1 + exp(-x)). Requires `std` or `libm`.
-    Sigmoid,
-    /// Pass-through (no transformation).
-    Identity,
-    /// x if x >= 0, alpha * (exp(x) - 1) otherwise. Requires `std` or `libm`.
-    Elu(f64),
-    /// Gaussian error linear unit (tanh approximation). Requires `std` or `libm`.
-    Gelu,
-    /// x * sigmoid(x), also known as SiLU in PyTorch. Requires `std` or `libm`.
-    Swish,
-}
+use crate::activation::Activation;
 
 #[cfg(feature = "alloc")]
 macro_rules! impl_mlp {
-    ($name:ident, $ty:ty, $dot_fn:path, $dot4_fn:path) => {
+    ($name:ident, $ty:ty, $dot_fn:path, $dot4_fn:path, $activate_fn:path) => {
         /// Feedforward neural network (multi-layer perceptron).
         ///
         /// Immutable after construction. All prediction methods take `&self`.
@@ -196,7 +173,7 @@ macro_rules! impl_mlp {
                         for k in 0..4 {
                             let mut sum = self.biases[b_offset + j + k] + dots[k];
                             if !is_last {
-                                sum = Self::activate(sum, self.activation);
+                                sum = $activate_fn(sum, self.activation);
                             }
                             if is_last {
                                 output[j + k] = sum;
@@ -213,7 +190,7 @@ macro_rules! impl_mlp {
                         let src = if src_is_a { &self.scratch_a[..in_size] } else { &self.scratch_b[..in_size] };
                         let mut sum = self.biases[b_offset + j] + $dot_fn(row, src);
                         if !is_last {
-                            sum = Self::activate(sum, self.activation);
+                            sum = $activate_fn(sum, self.activation);
                         }
                         if is_last {
                             output[j] = sum;
@@ -250,77 +227,26 @@ macro_rules! impl_mlp {
             pub fn activation(&self) -> Activation {
                 self.activation
             }
-
-            #[inline(always)]
-            fn activate(x: $ty, activation: Activation) -> $ty {
-                match activation {
-                    Activation::Relu => {
-                        if x > 0.0 as $ty { x } else if x <= 0.0 as $ty { 0.0 as $ty } else { x }
-                    }
-                    Activation::LeakyRelu(alpha) => {
-                        if x >= 0.0 as $ty { x } else { x * alpha as $ty }
-                    }
-                    Activation::Tanh => {
-                        #[cfg(feature = "std")]
-                        { (x as f64).tanh() as $ty }
-                        #[cfg(all(not(feature = "std"), feature = "libm"))]
-                        { libm::tanh(x as f64) as $ty }
-                        #[cfg(not(any(feature = "std", feature = "libm")))]
-                        { let _ = x; unreachable!() }
-                    }
-                    Activation::Sigmoid => {
-                        #[cfg(feature = "std")]
-                        { (1.0 / (1.0 + (-(x as f64)).exp())) as $ty }
-                        #[cfg(all(not(feature = "std"), feature = "libm"))]
-                        { (1.0 / (1.0 + libm::exp(-(x as f64)))) as $ty }
-                        #[cfg(not(any(feature = "std", feature = "libm")))]
-                        { let _ = x; unreachable!() }
-                    }
-                    Activation::Identity => x,
-                    Activation::Elu(alpha) => {
-                        if x >= 0.0 as $ty {
-                            x
-                        } else {
-                            #[cfg(feature = "std")]
-                            { (alpha * (x as f64).exp_m1()) as $ty }
-                            #[cfg(all(not(feature = "std"), feature = "libm"))]
-                            { (alpha * libm::expm1(x as f64)) as $ty }
-                            #[cfg(not(any(feature = "std", feature = "libm")))]
-                            { let _ = (x, alpha); unreachable!() }
-                        }
-                    }
-                    Activation::Gelu => {
-                        #[cfg(feature = "std")]
-                        {
-                            let xf = x as f64;
-                            (0.5 * xf * (1.0 + (0.7978845608028654 * (0.044715 * xf * xf).mul_add(xf, xf)).tanh())) as $ty
-                        }
-                        #[cfg(all(not(feature = "std"), feature = "libm"))]
-                        {
-                            let xf = x as f64;
-                            (0.5 * xf * (1.0 + libm::tanh(0.7978845608028654 * (xf + 0.044715 * xf * xf * xf)))) as $ty
-                        }
-                        #[cfg(not(any(feature = "std", feature = "libm")))]
-                        { let _ = x; unreachable!() }
-                    }
-                    Activation::Swish => {
-                        #[cfg(feature = "std")]
-                        { let xf = x as f64; (xf / (1.0 + (-xf).exp())) as $ty }
-                        #[cfg(all(not(feature = "std"), feature = "libm"))]
-                        { let xf = x as f64; (xf / (1.0 + libm::exp(-xf))) as $ty }
-                        #[cfg(not(any(feature = "std", feature = "libm")))]
-                        { let _ = x; unreachable!() }
-                    }
-                }
-            }
         }
     };
 }
 
 #[cfg(feature = "alloc")]
-impl_mlp!(MlpF64, f64, crate::dot::dot_f64, crate::dot::dot4_f64);
+impl_mlp!(
+    MlpF64,
+    f64,
+    crate::dot::dot_f64,
+    crate::dot::dot4_f64,
+    crate::activation::activate_f64
+);
 #[cfg(feature = "alloc")]
-impl_mlp!(MlpF32, f32, crate::dot::dot_f32, crate::dot::dot4_f32);
+impl_mlp!(
+    MlpF32,
+    f32,
+    crate::dot::dot_f32,
+    crate::dot::dot4_f32,
+    crate::activation::activate_f32
+);
 
 #[cfg(test)]
 mod tests {

--- a/nexus-inference/src/rnn/avx2_gates.rs
+++ b/nexus-inference/src/rnn/avx2_gates.rs
@@ -163,17 +163,13 @@ pub(super) fn gru_gates_avx2(
 
     // Scalar tail
     while k < hidden {
-        let r = super::sigmoid_f32(
-            ih[k] + bias_ih[k] + hh[k] + bias_hh[k],
-        );
+        let r = super::sigmoid_f32(ih[k] + bias_ih[k] + hh[k] + bias_hh[k]);
         let z = super::sigmoid_f32(
             ih[hidden + k] + bias_ih[hidden + k] + hh[hidden + k] + bias_hh[hidden + k],
         );
         let hh_candidate = hh[2 * hidden + k] + bias_hh[2 * hidden + k];
-        let n = super::tanh_f32(r.mul_add(
-            hh_candidate,
-            ih[2 * hidden + k] + bias_ih[2 * hidden + k],
-        ));
+        let n =
+            super::tanh_f32(r.mul_add(hh_candidate, ih[2 * hidden + k] + bias_ih[2 * hidden + k]));
         h[k] = (1.0 - z).mul_add(n, z * h[k]);
         k += 1;
     }

--- a/nexus-inference/src/rnn/avx512_gates.rs
+++ b/nexus-inference/src/rnn/avx512_gates.rs
@@ -1,0 +1,175 @@
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// AVX-512 vectorized Padé [7,6] tanh on 16 lanes.
+#[inline(always)]
+#[cfg(target_arch = "x86_64")]
+unsafe fn tanh_16wide(x: __m512) -> __m512 {
+    unsafe {
+        let nan_mask = _mm512_cmp_ps_mask::<_CMP_UNORD_Q>(x, x);
+
+        let pos_clip = _mm512_set1_ps(4.97);
+        let neg_clip = _mm512_set1_ps(-4.97);
+        let xc = _mm512_min_ps(_mm512_max_ps(x, neg_clip), pos_clip);
+
+        let x2 = _mm512_mul_ps(xc, xc);
+
+        // num = x * (135_135 + x2 * (17_325 + x2 * (378 + x2)))
+        let n_inner = _mm512_fmadd_ps(x2, _mm512_set1_ps(1.0), _mm512_set1_ps(378.0));
+        let n_mid = _mm512_fmadd_ps(x2, n_inner, _mm512_set1_ps(17_325.0));
+        let n_outer = _mm512_fmadd_ps(x2, n_mid, _mm512_set1_ps(135_135.0));
+        let num = _mm512_mul_ps(xc, n_outer);
+
+        // den = 135_135 + x2 * (62_370 + x2 * (3_150 + x2 * 28))
+        let d_inner = _mm512_fmadd_ps(x2, _mm512_set1_ps(28.0), _mm512_set1_ps(3_150.0));
+        let d_mid = _mm512_fmadd_ps(x2, d_inner, _mm512_set1_ps(62_370.0));
+        let den = _mm512_fmadd_ps(x2, d_mid, _mm512_set1_ps(135_135.0));
+
+        let result = _mm512_div_ps(num, den);
+
+        // Restore NaN lanes that clamping would have silently replaced.
+        _mm512_mask_blend_ps(nan_mask, result, x)
+    }
+}
+
+/// AVX-512 vectorized sigmoid: 0.5 + 0.5 * tanh(x * 0.5)
+#[inline(always)]
+#[cfg(target_arch = "x86_64")]
+unsafe fn sigmoid_16wide(x: __m512) -> __m512 {
+    unsafe {
+        let half = _mm512_set1_ps(0.5);
+        let t = tanh_16wide(_mm512_mul_ps(x, half));
+        _mm512_fmadd_ps(half, t, half)
+    }
+}
+
+/// LSTM gate activation + cell/hidden update, 16 units at a time.
+///
+/// gates layout: [input_gate(H) | forget_gate(H) | cell_candidate(H) | output_gate(H)]
+/// Updates c and h in-place.
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::many_single_char_names)]
+pub(super) fn lstm_gates_avx512(gates: &[f32], c: &mut [f32], h: &mut [f32], hidden: usize) {
+    let mut k = 0;
+    let h16 = hidden & !15;
+
+    // SAFETY: AVX-512F guaranteed by cfg on parent module.
+    // All accesses: k + 16 <= hidden, gate offsets are k, h+k, 2h+k, 3h+k (all within 4*hidden).
+    unsafe {
+        while k < h16 {
+            let ig = sigmoid_16wide(_mm512_loadu_ps(gates.as_ptr().add(k)));
+            let fg = sigmoid_16wide(_mm512_loadu_ps(gates.as_ptr().add(hidden + k)));
+            let cg = tanh_16wide(_mm512_loadu_ps(gates.as_ptr().add(2 * hidden + k)));
+            let og = sigmoid_16wide(_mm512_loadu_ps(gates.as_ptr().add(3 * hidden + k)));
+
+            let c_old = _mm512_loadu_ps(c.as_ptr().add(k));
+            // c_new = fg * c_old + ig * cg
+            let c_new = _mm512_fmadd_ps(fg, c_old, _mm512_mul_ps(ig, cg));
+            _mm512_storeu_ps(c.as_mut_ptr().add(k), c_new);
+
+            // h_new = og * tanh(c_new)
+            let h_new = _mm512_mul_ps(og, tanh_16wide(c_new));
+            _mm512_storeu_ps(h.as_mut_ptr().add(k), h_new);
+
+            k += 16;
+        }
+    }
+
+    // Scalar tail for H % 16 != 0
+    while k < hidden {
+        let ig = super::sigmoid_f32(gates[k]);
+        let fg = super::sigmoid_f32(gates[hidden + k]);
+        let cg = super::tanh_f32(gates[2 * hidden + k]);
+        let og = super::sigmoid_f32(gates[3 * hidden + k]);
+
+        c[k] = fg.mul_add(c[k], ig * cg);
+        h[k] = og * super::tanh_f32(c[k]);
+        k += 1;
+    }
+}
+
+/// GRU gate activation + hidden update, 16 units at a time.
+///
+/// ih_scratch layout: [reset(H) | update(H) | candidate_ih(H)]
+/// hh_scratch layout: [reset(H) | update(H) | candidate_hh(H)]
+/// bias_ih/bias_hh: same layout as scratch
+/// Updates h in-place.
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::many_single_char_names)]
+pub(super) fn gru_gates_avx512(
+    ih: &[f32],
+    hh: &[f32],
+    bias_ih: &[f32],
+    bias_hh: &[f32],
+    h: &mut [f32],
+    hidden: usize,
+) {
+    let mut k = 0;
+    let h16 = hidden & !15;
+
+    // SAFETY: AVX-512F guaranteed by cfg on parent module.
+    // All offsets: k, hidden+k, 2*hidden+k within 3*hidden total.
+    unsafe {
+        let one = _mm512_set1_ps(1.0);
+
+        while k < h16 {
+            // r = sigmoid(ih[k] + b_ih[k] + hh[k] + b_hh[k])
+            let r_sum = _mm512_add_ps(
+                _mm512_add_ps(
+                    _mm512_loadu_ps(ih.as_ptr().add(k)),
+                    _mm512_loadu_ps(bias_ih.as_ptr().add(k)),
+                ),
+                _mm512_add_ps(
+                    _mm512_loadu_ps(hh.as_ptr().add(k)),
+                    _mm512_loadu_ps(bias_hh.as_ptr().add(k)),
+                ),
+            );
+            let r = sigmoid_16wide(r_sum);
+
+            // z = sigmoid(ih[H+k] + b_ih[H+k] + hh[H+k] + b_hh[H+k])
+            let z_sum = _mm512_add_ps(
+                _mm512_add_ps(
+                    _mm512_loadu_ps(ih.as_ptr().add(hidden + k)),
+                    _mm512_loadu_ps(bias_ih.as_ptr().add(hidden + k)),
+                ),
+                _mm512_add_ps(
+                    _mm512_loadu_ps(hh.as_ptr().add(hidden + k)),
+                    _mm512_loadu_ps(bias_hh.as_ptr().add(hidden + k)),
+                ),
+            );
+            let z = sigmoid_16wide(z_sum);
+
+            // n = tanh(ih[2H+k] + b_ih[2H+k] + r * (hh[2H+k] + b_hh[2H+k]))
+            let hh_cand = _mm512_add_ps(
+                _mm512_loadu_ps(hh.as_ptr().add(2 * hidden + k)),
+                _mm512_loadu_ps(bias_hh.as_ptr().add(2 * hidden + k)),
+            );
+            let ih_cand = _mm512_add_ps(
+                _mm512_loadu_ps(ih.as_ptr().add(2 * hidden + k)),
+                _mm512_loadu_ps(bias_ih.as_ptr().add(2 * hidden + k)),
+            );
+            let n = tanh_16wide(_mm512_fmadd_ps(r, hh_cand, ih_cand));
+
+            // h' = (1 - z) * n + z * h
+            let h_old = _mm512_loadu_ps(h.as_ptr().add(k));
+            let one_minus_z = _mm512_sub_ps(one, z);
+            let h_new = _mm512_fmadd_ps(one_minus_z, n, _mm512_mul_ps(z, h_old));
+            _mm512_storeu_ps(h.as_mut_ptr().add(k), h_new);
+
+            k += 16;
+        }
+    }
+
+    // Scalar tail
+    while k < hidden {
+        let r = super::sigmoid_f32(ih[k] + bias_ih[k] + hh[k] + bias_hh[k]);
+        let z = super::sigmoid_f32(
+            ih[hidden + k] + bias_ih[hidden + k] + hh[hidden + k] + bias_hh[hidden + k],
+        );
+        let hh_candidate = hh[2 * hidden + k] + bias_hh[2 * hidden + k];
+        let n =
+            super::tanh_f32(r.mul_add(hh_candidate, ih[2 * hidden + k] + bias_ih[2 * hidden + k]));
+        h[k] = (1.0 - z).mul_add(n, z * h[k]);
+        k += 1;
+    }
+}

--- a/nexus-inference/src/rnn/gru.rs
+++ b/nexus-inference/src/rnn/gru.rs
@@ -200,10 +200,23 @@ impl TinyGruF32 {
             hi,
         );
 
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+        {
+            super::avx512_gates::gru_gates_avx512(
+                &self.ih_scratch,
+                &self.hh_scratch,
+                &self.bias_ih,
+                &self.bias_hh,
+                &mut self.h,
+                hi,
+            );
+        }
+
         #[cfg(all(
             target_arch = "x86_64",
             target_feature = "avx2",
-            target_feature = "fma"
+            target_feature = "fma",
+            not(target_feature = "avx512f"),
         ))]
         {
             super::avx2_gates::gru_gates_avx2(
@@ -218,8 +231,10 @@ impl TinyGruF32 {
 
         #[cfg(not(all(
             target_arch = "x86_64",
-            target_feature = "avx2",
-            target_feature = "fma"
+            any(
+                target_feature = "avx512f",
+                all(target_feature = "avx2", target_feature = "fma"),
+            )
         )))]
         {
             for k in 0..hi {

--- a/nexus-inference/src/rnn/lstm.rs
+++ b/nexus-inference/src/rnn/lstm.rs
@@ -211,10 +211,16 @@ impl TinyLstmF32 {
             concat_size,
         );
 
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+        {
+            super::avx512_gates::lstm_gates_avx512(&self.gates, &mut self.c, &mut self.h, h);
+        }
+
         #[cfg(all(
             target_arch = "x86_64",
             target_feature = "avx2",
-            target_feature = "fma"
+            target_feature = "fma",
+            not(target_feature = "avx512f"),
         ))]
         {
             super::avx2_gates::lstm_gates_avx2(&self.gates, &mut self.c, &mut self.h, h);
@@ -222,8 +228,10 @@ impl TinyLstmF32 {
 
         #[cfg(not(all(
             target_arch = "x86_64",
-            target_feature = "avx2",
-            target_feature = "fma"
+            any(
+                target_feature = "avx512f",
+                all(target_feature = "avx2", target_feature = "fma"),
+            )
         )))]
         {
             for k in 0..h {

--- a/nexus-inference/src/rnn/mod.rs
+++ b/nexus-inference/src/rnn/mod.rs
@@ -1,10 +1,14 @@
 mod gru;
 mod lstm;
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+mod avx512_gates;
+
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    target_feature = "fma"
+    target_feature = "fma",
+    not(target_feature = "avx512f"),
 ))]
 mod avx2_gates;
 

--- a/nexus-notify/BENCHMARKS.md
+++ b/nexus-notify/BENCHMARKS.md
@@ -7,7 +7,7 @@ Criterion benchmarks provide detailed statistical analysis of performance.
 
 - CPU: AMD (hybrid, P-cores + E-cores)
 - OS: Arch Linux 6.18.2
-- Rust: stable 1.85+
+- Rust: stable 1.90+
 - Profile: `--release`
 
 ## Event Queue (non-blocking)

--- a/nexus-pool/README.md
+++ b/nexus-pool/README.md
@@ -185,7 +185,7 @@ loop {
 
 ## Minimum Supported Rust Version
 
-Rust 1.85 or later.
+Rust 1.90 or later.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **Activation extraction**: Moved duplicated `Activation` enum and `activate_f32`/`activate_f64` from `mlp.rs` (macro-inlined) and `conv/causal1d.rs` (copy-pasted) into shared `src/activation.rs`. MLP macro now takes `$activate_fn` as a path parameter. ~150 lines of duplication removed.
- **AVX-512 SIMD paths**: Added 512-bit dot product kernels (`dot_f32`, `dot_f64`, `dot4_f32`, `dot4_f64`) and gate activation kernels (`lstm_gates_avx512`, `gru_gates_avx512`) with 16-wide Padé [7,6] tanh/sigmoid. Three-tier compile-time dispatch: AVX-512F > AVX2+FMA > scalar.
- **MSRV bump**: Workspace MSRV raised from 1.85 to 1.90 (AVX-512 intrinsics stabilized in 1.89). Fixed newly-surfaced `collapsible_if` lint in lightgbm loader with let-chains.

## Details

AVX-512 dot kernels process 16 f32s / 8 f64s per register with 4-accumulator unrolling (64 f32s / 32 f64s per main loop iteration). Gate kernels process 16 hidden units per iteration vs AVX2's 8. NaN propagation in gate kernels uses `__mmask16` registers (`_mm512_cmp_ps_mask` + `_mm512_mask_blend_ps`), matching the AVX2 fix from the previous PR.

Cannot runtime-test AVX-512 on current hardware (Intel Core Ultra 7 165U, no AVX-512). Compile-checked via `RUSTFLAGS="-C target-feature=+avx512f" cargo clippy --target x86_64-unknown-linux-gnu`.

Closes #346.

## Test plan

- [x] `cargo test -p nexus-inference --all-features` — 96 unit + 9 doc tests pass
- [x] `cargo clippy -p nexus-inference --all-features -- -D warnings` — clean (AVX2 path)
- [x] `RUSTFLAGS="-C target-feature=+avx512f" cargo clippy --target x86_64-unknown-linux-gnu` — clean (AVX-512 path)
- [x] `cargo fmt --check` — clean
- [ ] Runtime validation on AVX-512 hardware (CI or manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)