### PR TITLE
stripping unnecessary types from nexus-stats-core

### DIFF
--- a/nexus-stats-core/src/control/dead_band.rs
+++ b/nexus-stats-core/src/control/dead_band.rs
@@ -1,165 +1,151 @@
-macro_rules! impl_dead_band_float {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Dead band filter — suppresses small changes, reports significant ones.
-        ///
-        /// Only emits a new value when the sample deviates from the last reported
-        /// value by more than the threshold. Prevents noisy oscillation around
-        /// a stable value from generating unnecessary updates.
-        ///
-        /// # Use Cases
-        /// - Reducing update frequency for slowly-changing metrics
-        /// - Hysteresis-free change suppression
-        /// - Sensor noise filtering
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            threshold: $ty,
-            last_reported: $ty,
-            initialized: bool,
-        }
-
-        impl $name {
-            /// Creates a new dead band filter with the given threshold.
-            #[inline]
-            #[must_use]
-            pub fn new(threshold: $ty) -> Self {
-                Self {
-                    threshold,
-                    last_reported: $zero,
-                    initialized: false,
-                }
-            }
-
-            /// Feeds a sample. Returns `Ok(Some(value))` if the change exceeds
-            /// the threshold, `Ok(None)` if suppressed.
-            ///
-            /// The first sample is always reported.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                if !self.initialized {
-                    self.last_reported = sample;
-                    self.initialized = true;
-                    return Ok(Option::Some(sample));
-                }
-
-                let delta = sample - self.last_reported;
-                let abs_delta = if delta < $zero { $zero - delta } else { delta };
-
-                if abs_delta > self.threshold {
-                    self.last_reported = sample;
-                    Ok(Option::Some(sample))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Last reported value, or `None` if no sample has been processed.
-            #[inline]
-            #[must_use]
-            pub fn last_reported(&self) -> Option<$ty> {
-                if self.initialized {
-                    Option::Some(self.last_reported)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.last_reported = $zero;
-                self.initialized = false;
-            }
-        }
-    };
+/// Dead band filter — suppresses small changes, reports significant ones.
+///
+/// Only emits a new value when the sample deviates from the last reported
+/// value by more than the threshold. Prevents noisy oscillation around
+/// a stable value from generating unnecessary updates.
+///
+/// # Use Cases
+/// - Reducing update frequency for slowly-changing metrics
+/// - Hysteresis-free change suppression
+/// - Sensor noise filtering
+#[derive(Debug, Clone)]
+pub struct DeadBandF64 {
+    threshold: f64,
+    last_reported: f64,
+    initialized: bool,
 }
 
-macro_rules! impl_dead_band_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Dead band filter — suppresses small changes, reports significant ones.
-        ///
-        /// Only emits a new value when the sample deviates from the last reported
-        /// value by more than the threshold. Prevents noisy oscillation around
-        /// a stable value from generating unnecessary updates.
-        ///
-        /// # Use Cases
-        /// - Reducing update frequency for slowly-changing metrics
-        /// - Hysteresis-free change suppression
-        /// - Sensor noise filtering
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            threshold: $ty,
-            last_reported: $ty,
-            initialized: bool,
+impl DeadBandF64 {
+    /// Creates a new dead band filter with the given threshold.
+    #[inline]
+    #[must_use]
+    pub fn new(threshold: f64) -> Self {
+        Self {
+            threshold,
+            last_reported: 0.0,
+            initialized: false,
+        }
+    }
+
+    /// Feeds a sample. Returns `Ok(Some(value))` if the change exceeds
+    /// the threshold, `Ok(None)` if suppressed.
+    ///
+    /// The first sample is always reported.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        if !self.initialized {
+            self.last_reported = sample;
+            self.initialized = true;
+            return Ok(Option::Some(sample));
         }
 
-        impl $name {
-            /// Creates a new dead band filter with the given threshold.
-            #[inline]
-            #[must_use]
-            pub fn new(threshold: $ty) -> Self {
-                Self {
-                    threshold,
-                    last_reported: $zero,
-                    initialized: false,
-                }
-            }
+        let delta = sample - self.last_reported;
+        let abs_delta = if delta < 0.0 { 0.0 - delta } else { delta };
 
-            /// Feeds a sample. Returns `Some(value)` if the change exceeds
-            /// the threshold, `None` if suppressed.
-            ///
-            /// The first sample is always reported.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                if !self.initialized {
-                    self.last_reported = sample;
-                    self.initialized = true;
-                    return Option::Some(sample);
-                }
-
-                let delta = sample - self.last_reported;
-                let abs_delta = if delta < $zero { $zero - delta } else { delta };
-
-                if abs_delta > self.threshold {
-                    self.last_reported = sample;
-                    Option::Some(sample)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Last reported value, or `None` if no sample has been processed.
-            #[inline]
-            #[must_use]
-            pub fn last_reported(&self) -> Option<$ty> {
-                if self.initialized {
-                    Option::Some(self.last_reported)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.last_reported = $zero;
-                self.initialized = false;
-            }
+        if abs_delta > self.threshold {
+            self.last_reported = sample;
+            Ok(Option::Some(sample))
+        } else {
+            Ok(Option::None)
         }
-    };
+    }
+
+    /// Last reported value, or `None` if no sample has been processed.
+    #[inline]
+    #[must_use]
+    pub fn last_reported(&self) -> Option<f64> {
+        if self.initialized {
+            Option::Some(self.last_reported)
+        } else {
+            Option::None
+        }
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.last_reported = 0.0;
+        self.initialized = false;
+    }
 }
 
-impl_dead_band_float!(DeadBandF64, f64, 0.0);
-impl_dead_band_float!(DeadBandF32, f32, 0.0);
-impl_dead_band_int!(DeadBandI64, i64, 0);
-impl_dead_band_int!(DeadBandI32, i32, 0);
-impl_dead_band_int!(DeadBandI128, i128, 0);
+/// Dead band filter — suppresses small changes, reports significant ones.
+///
+/// Only emits a new value when the sample deviates from the last reported
+/// value by more than the threshold. Prevents noisy oscillation around
+/// a stable value from generating unnecessary updates.
+///
+/// # Use Cases
+/// - Reducing update frequency for slowly-changing metrics
+/// - Hysteresis-free change suppression
+/// - Sensor noise filtering
+#[derive(Debug, Clone)]
+pub struct DeadBandI64 {
+    threshold: i64,
+    last_reported: i64,
+    initialized: bool,
+}
+
+impl DeadBandI64 {
+    /// Creates a new dead band filter with the given threshold.
+    #[inline]
+    #[must_use]
+    pub fn new(threshold: i64) -> Self {
+        Self {
+            threshold,
+            last_reported: 0,
+            initialized: false,
+        }
+    }
+
+    /// Feeds a sample. Returns `Some(value)` if the change exceeds
+    /// the threshold, `None` if suppressed.
+    ///
+    /// The first sample is always reported.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> Option<i64> {
+        if !self.initialized {
+            self.last_reported = sample;
+            self.initialized = true;
+            return Option::Some(sample);
+        }
+
+        let delta = sample - self.last_reported;
+        let abs_delta = if delta < 0 { 0 - delta } else { delta };
+
+        if abs_delta > self.threshold {
+            self.last_reported = sample;
+            Option::Some(sample)
+        } else {
+            Option::None
+        }
+    }
+
+    /// Last reported value, or `None` if no sample has been processed.
+    #[inline]
+    #[must_use]
+    pub fn last_reported(&self) -> Option<i64> {
+        if self.initialized {
+            Option::Some(self.last_reported)
+        } else {
+            Option::None
+        }
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.last_reported = 0;
+        self.initialized = false;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -202,14 +188,6 @@ mod tests {
         let _ = db.update(100.0).unwrap();
         db.reset();
         assert!(db.last_reported().is_none());
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut db = DeadBandI128::new(10);
-        assert_eq!(db.update(100), Some(100));
-        assert_eq!(db.update(105), None);
-        assert_eq!(db.update(115), Some(115));
     }
 
     #[test]

--- a/nexus-stats-core/src/control/dead_band.rs
+++ b/nexus-stats-core/src/control/dead_band.rs
@@ -87,7 +87,7 @@ impl DeadBandF64 {
 /// - Sensor noise filtering
 #[derive(Debug, Clone)]
 pub struct DeadBandI64 {
-    threshold: i64,
+    threshold: u64,
     last_reported: i64,
     initialized: bool,
 }
@@ -96,7 +96,7 @@ impl DeadBandI64 {
     /// Creates a new dead band filter with the given threshold.
     #[inline]
     #[must_use]
-    pub fn new(threshold: i64) -> Self {
+    pub fn new(threshold: u64) -> Self {
         Self {
             threshold,
             last_reported: 0,
@@ -117,10 +117,7 @@ impl DeadBandI64 {
             return Option::Some(sample);
         }
 
-        let delta = sample - self.last_reported;
-        let abs_delta = if delta < 0 { 0 - delta } else { delta };
-
-        if abs_delta > self.threshold {
+        if sample.abs_diff(self.last_reported) > self.threshold {
             self.last_reported = sample;
             Option::Some(sample)
         } else {

--- a/nexus-stats-core/src/control/debounce.rs
+++ b/nexus-stats-core/src/control/debounce.rs
@@ -1,67 +1,60 @@
-macro_rules! impl_debounce {
-    ($name:ident, $ty:ty) => {
-        /// Debounce filter — requires N consecutive active signals to trigger.
-        ///
-        /// Prevents spurious single-sample activations from triggering.
-        /// Resets the consecutive counter on any inactive sample.
-        ///
-        /// # Use Cases
-        /// - Confirming a condition persists before acting
-        /// - Filtering noisy boolean signals
-        /// - "Only alert if elevated for N consecutive checks"
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            threshold: $ty,
-            consecutive: $ty,
-        }
-
-        impl $name {
-            /// Creates a new debounce filter.
-            ///
-            /// `threshold` is the number of consecutive active samples required
-            /// to trigger (return `true`).
-            #[inline]
-            pub fn new(threshold: $ty) -> Result<Self, crate::ConfigError> {
-                if threshold == 0 {
-                    return Err(crate::ConfigError::Invalid("threshold must be positive"));
-                }
-                Ok(Self {
-                    threshold,
-                    consecutive: 0,
-                })
-            }
-
-            /// Feeds a boolean signal. Returns `true` once the threshold of
-            /// consecutive active samples is reached.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, active: bool) -> bool {
-                if active {
-                    self.consecutive += 1;
-                } else {
-                    self.consecutive = 0;
-                }
-                self.consecutive >= self.threshold
-            }
-
-            /// Current consecutive count.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> $ty {
-                self.consecutive
-            }
-
-            /// Resets the consecutive counter.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.consecutive = 0;
-            }
-        }
-    };
+/// Debounce filter — requires N consecutive active signals to trigger.
+///
+/// Prevents spurious single-sample activations from triggering.
+/// Resets the consecutive counter on any inactive sample.
+///
+/// # Use Cases
+/// - Confirming a condition persists before acting
+/// - Filtering noisy boolean signals
+/// - "Only alert if elevated for N consecutive checks"
+#[derive(Debug, Clone)]
+pub struct DebounceU64 {
+    threshold: u64,
+    consecutive: u64,
 }
 
-impl_debounce!(DebounceU32, u32);
-impl_debounce!(DebounceU64, u64);
+impl DebounceU64 {
+    /// Creates a new debounce filter.
+    ///
+    /// `threshold` is the number of consecutive active samples required
+    /// to trigger (return `true`).
+    #[inline]
+    pub fn new(threshold: u64) -> Result<Self, crate::ConfigError> {
+        if threshold == 0 {
+            return Err(crate::ConfigError::Invalid("threshold must be positive"));
+        }
+        Ok(Self {
+            threshold,
+            consecutive: 0,
+        })
+    }
+
+    /// Feeds a boolean signal. Returns `true` once the threshold of
+    /// consecutive active samples is reached.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, active: bool) -> bool {
+        if active {
+            self.consecutive += 1;
+        } else {
+            self.consecutive = 0;
+        }
+        self.consecutive >= self.threshold
+    }
+
+    /// Current consecutive count.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.consecutive
+    }
+
+    /// Resets the consecutive counter.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.consecutive = 0;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -69,7 +62,7 @@ mod tests {
 
     #[test]
     fn triggers_after_threshold() {
-        let mut d = DebounceU32::new(3).unwrap();
+        let mut d = DebounceU64::new(3).unwrap();
         assert!(!d.update(true));
         assert!(!d.update(true));
         assert!(d.update(true)); // 3rd consecutive
@@ -77,7 +70,7 @@ mod tests {
 
     #[test]
     fn resets_on_false() {
-        let mut d = DebounceU32::new(3).unwrap();
+        let mut d = DebounceU64::new(3).unwrap();
         assert!(!d.update(true));
         assert!(!d.update(true));
         assert!(!d.update(false)); // reset
@@ -88,7 +81,7 @@ mod tests {
 
     #[test]
     fn no_false_trigger_at_threshold_minus_one() {
-        let mut d = DebounceU32::new(5).unwrap();
+        let mut d = DebounceU64::new(5).unwrap();
         for _ in 0..4 {
             assert!(!d.update(true));
         }
@@ -98,22 +91,15 @@ mod tests {
 
     #[test]
     fn stays_triggered() {
-        let mut d = DebounceU32::new(2).unwrap();
+        let mut d = DebounceU64::new(2).unwrap();
         assert!(!d.update(true));
         assert!(d.update(true));
         assert!(d.update(true)); // stays triggered
     }
 
     #[test]
-    fn u64_basic() {
-        let mut d = DebounceU64::new(2).unwrap();
-        assert!(!d.update(true));
-        assert!(d.update(true));
-    }
-
-    #[test]
     fn reset() {
-        let mut d = DebounceU32::new(2).unwrap();
+        let mut d = DebounceU64::new(2).unwrap();
         let _ = d.update(true);
         d.reset();
         assert_eq!(d.count(), 0);
@@ -121,10 +107,6 @@ mod tests {
 
     #[test]
     fn rejects_zero_threshold() {
-        assert!(matches!(
-            DebounceU32::new(0),
-            Err(crate::ConfigError::Invalid(_))
-        ));
         assert!(matches!(
             DebounceU64::new(0),
             Err(crate::ConfigError::Invalid(_))

--- a/nexus-stats-core/src/control/diff.rs
+++ b/nexus-stats-core/src/control/diff.rs
@@ -1,270 +1,241 @@
-macro_rules! impl_first_diff_float {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// First difference — `x[n] - x[n-1]`.
-        ///
-        /// Returns the change between consecutive samples.
-        /// `None` on the first sample (no previous value to diff against).
-        ///
-        /// # Use Cases
-        /// - Computing returns from prices
-        /// - Velocity from position
-        /// - Rate of change of any signal
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prev: $ty,
-            initialized: bool,
-        }
-
-        impl $name {
-            /// Creates a new first-difference filter.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    prev: $zero,
-                    initialized: false,
-                }
-            }
-
-            /// Feeds a sample. Returns `Ok(Some(x[n] - x[n-1]))` or `Ok(None)` on first sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                if !self.initialized {
-                    self.prev = sample;
-                    self.initialized = true;
-                    return Ok(Option::None);
-                }
-                let diff = sample - self.prev;
-                self.prev = sample;
-                Ok(Option::Some(diff))
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.prev = $zero;
-                self.initialized = false;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// First difference — `x[n] - x[n-1]`.
+///
+/// Returns the change between consecutive samples.
+/// `None` on the first sample (no previous value to diff against).
+///
+/// # Use Cases
+/// - Computing returns from prices
+/// - Velocity from position
+/// - Rate of change of any signal
+#[derive(Debug, Clone)]
+pub struct FirstDiffF64 {
+    prev: f64,
+    initialized: bool,
 }
 
-macro_rules! impl_first_diff_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// First difference — `x[n] - x[n-1]`.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prev: $ty,
-            initialized: bool,
+impl FirstDiffF64 {
+    /// Creates a new first-difference filter.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev: 0.0,
+            initialized: false,
         }
+    }
 
-        impl $name {
-            /// Creates a new first-difference filter.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    prev: $zero,
-                    initialized: false,
-                }
-            }
-
-            /// Feeds a sample. Returns `Some(x[n] - x[n-1])` or `None` on first sample.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                if !self.initialized {
-                    self.prev = sample;
-                    self.initialized = true;
-                    return Option::None;
-                }
-                let diff = sample - self.prev;
-                self.prev = sample;
-                Option::Some(diff)
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.prev = $zero;
-                self.initialized = false;
-            }
+    /// Feeds a sample. Returns `Ok(Some(x[n] - x[n-1]))` or `Ok(None)` on first sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        if !self.initialized {
+            self.prev = sample;
+            self.initialized = true;
+            return Ok(Option::None);
         }
+        let diff = sample - self.prev;
+        self.prev = sample;
+        Ok(Option::Some(diff))
+    }
 
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.prev = 0.0;
+        self.initialized = false;
+    }
 }
 
-macro_rules! impl_second_diff_float {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Second difference — `x[n] - 2*x[n-1] + x[n-2]`.
-        ///
-        /// Returns the acceleration (change in change) of a signal.
-        /// `None` until the third sample.
-        ///
-        /// # Use Cases
-        /// - Acceleration from position
-        /// - Curvature detection
-        /// - "Is the rate of change itself changing?"
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prev2: $ty,
-            prev1: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new second-difference filter.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    prev2: $zero,
-                    prev1: $zero,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns `Ok(Some(x[n] - 2*x[n-1] + x[n-2]))` or `Ok(None)`
-            /// until 3 samples have been fed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.prev1 = sample;
-                    return Ok(Option::None);
-                }
-                if self.count == 2 {
-                    self.prev2 = self.prev1;
-                    self.prev1 = sample;
-                    return Ok(Option::None);
-                }
-
-                let two = (2 as $ty);
-                let diff2 = sample - two * self.prev1 + self.prev2;
-                self.prev2 = self.prev1;
-                self.prev1 = sample;
-                Ok(Option::Some(diff2))
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.prev2 = $zero;
-                self.prev1 = $zero;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+impl Default for FirstDiffF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
-macro_rules! impl_second_diff_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Second difference — `x[n] - 2*x[n-1] + x[n-2]`.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prev2: $ty,
-            prev1: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new second-difference filter.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    prev2: $zero,
-                    prev1: $zero,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns `Some(x[n] - 2*x[n-1] + x[n-2])` or `None`
-            /// until 3 samples have been fed.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.prev1 = sample;
-                    return Option::None;
-                }
-                if self.count == 2 {
-                    self.prev2 = self.prev1;
-                    self.prev1 = sample;
-                    return Option::None;
-                }
-
-                let two = (2 as $ty);
-                let diff2 = sample - two * self.prev1 + self.prev2;
-                self.prev2 = self.prev1;
-                self.prev1 = sample;
-                Option::Some(diff2)
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.prev2 = $zero;
-                self.prev1 = $zero;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// First difference — `x[n] - x[n-1]`.
+#[derive(Debug, Clone)]
+pub struct FirstDiffI64 {
+    prev: i64,
+    initialized: bool,
 }
 
-impl_first_diff_float!(FirstDiffF64, f64, 0.0);
-impl_first_diff_float!(FirstDiffF32, f32, 0.0);
-impl_first_diff_int!(FirstDiffI64, i64, 0);
-impl_first_diff_int!(FirstDiffI32, i32, 0);
-impl_first_diff_int!(FirstDiffI128, i128, 0);
+impl FirstDiffI64 {
+    /// Creates a new first-difference filter.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev: 0,
+            initialized: false,
+        }
+    }
 
-impl_second_diff_float!(SecondDiffF64, f64, 0.0);
-impl_second_diff_float!(SecondDiffF32, f32, 0.0);
-impl_second_diff_int!(SecondDiffI64, i64, 0);
-impl_second_diff_int!(SecondDiffI32, i32, 0);
-impl_second_diff_int!(SecondDiffI128, i128, 0);
+    /// Feeds a sample. Returns `Some(x[n] - x[n-1])` or `None` on first sample.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> Option<i64> {
+        if !self.initialized {
+            self.prev = sample;
+            self.initialized = true;
+            return Option::None;
+        }
+        let diff = sample - self.prev;
+        self.prev = sample;
+        Option::Some(diff)
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.prev = 0;
+        self.initialized = false;
+    }
+}
+
+impl Default for FirstDiffI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Second difference — `x[n] - 2*x[n-1] + x[n-2]`.
+///
+/// Returns the acceleration (change in change) of a signal.
+/// `None` until the third sample.
+///
+/// # Use Cases
+/// - Acceleration from position
+/// - Curvature detection
+/// - "Is the rate of change itself changing?"
+#[derive(Debug, Clone)]
+pub struct SecondDiffF64 {
+    prev2: f64,
+    prev1: f64,
+    count: u64,
+}
+
+impl SecondDiffF64 {
+    /// Creates a new second-difference filter.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev2: 0.0,
+            prev1: 0.0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns `Ok(Some(x[n] - 2*x[n-1] + x[n-2]))` or `Ok(None)`
+    /// until 3 samples have been fed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    #[allow(clippy::suboptimal_flops)]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.prev1 = sample;
+            return Ok(Option::None);
+        }
+        if self.count == 2 {
+            self.prev2 = self.prev1;
+            self.prev1 = sample;
+            return Ok(Option::None);
+        }
+
+        let diff2 = sample - 2.0 * self.prev1 + self.prev2;
+        self.prev2 = self.prev1;
+        self.prev1 = sample;
+        Ok(Option::Some(diff2))
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.prev2 = 0.0;
+        self.prev1 = 0.0;
+        self.count = 0;
+    }
+}
+
+impl Default for SecondDiffF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Second difference — `x[n] - 2*x[n-1] + x[n-2]`.
+#[derive(Debug, Clone)]
+pub struct SecondDiffI64 {
+    prev2: i64,
+    prev1: i64,
+    count: u64,
+}
+
+impl SecondDiffI64 {
+    /// Creates a new second-difference filter.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev2: 0,
+            prev1: 0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns `Some(x[n] - 2*x[n-1] + x[n-2])` or `None`
+    /// until 3 samples have been fed.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> Option<i64> {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.prev1 = sample;
+            return Option::None;
+        }
+        if self.count == 2 {
+            self.prev2 = self.prev1;
+            self.prev1 = sample;
+            return Option::None;
+        }
+
+        let diff2 = sample - 2 * self.prev1 + self.prev2;
+        self.prev2 = self.prev1;
+        self.prev1 = sample;
+        Option::Some(diff2)
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.prev2 = 0;
+        self.prev1 = 0;
+        self.count = 0;
+    }
+}
+
+impl Default for SecondDiffI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -346,21 +317,6 @@ mod tests {
         let _ = sd.update(2.0).unwrap();
         sd.reset();
         assert!(sd.update(5.0).unwrap().is_none());
-    }
-
-    #[test]
-    fn first_diff_i128() {
-        let mut fd = FirstDiffI128::new();
-        let _ = fd.update(100);
-        assert_eq!(fd.update(130), Some(30));
-    }
-
-    #[test]
-    fn second_diff_i128() {
-        let mut sd = SecondDiffI128::new();
-        let _ = sd.update(10);
-        let _ = sd.update(20);
-        assert_eq!(sd.update(30), Some(0)); // linear
     }
 
     #[test]

--- a/nexus-stats-core/src/control/hysteresis.rs
+++ b/nexus-stats-core/src/control/hysteresis.rs
@@ -1,150 +1,129 @@
-macro_rules! impl_hysteresis_float {
-    ($name:ident, $ty:ty) => {
-        /// Hysteresis filter — Schmitt trigger with separate high/low thresholds.
-        ///
-        /// Transitions to `true` when sample exceeds the high threshold.
-        /// Transitions to `false` when sample drops below the low threshold.
-        /// Between the thresholds, the state is unchanged — preventing oscillation.
-        ///
-        /// # Use Cases
-        /// - Thermostat logic (turn on at low, turn off at high)
-        /// - Alert suppression (don't flap at boundary)
-        /// - Binary state from a noisy analog signal
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            low: $ty,
-            high: $ty,
-            state: bool,
-        }
-
-        impl $name {
-            /// Creates a new hysteresis filter.
-            ///
-            /// `low_threshold` must be less than `high_threshold`.
-            #[inline]
-            pub fn new(
-                low_threshold: $ty,
-                high_threshold: $ty,
-            ) -> Result<Self, crate::ConfigError> {
-                #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                if !(low_threshold < high_threshold) {
-                    return Err(crate::ConfigError::Invalid(
-                        "low threshold must be less than high",
-                    ));
-                }
-                Ok(Self {
-                    low: low_threshold,
-                    high: high_threshold,
-                    state: false,
-                })
-            }
-
-            /// Feeds a sample. Returns the current state.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<bool, crate::DataError> {
-                check_finite!(sample);
-                if sample >= self.high {
-                    self.state = true;
-                } else if sample <= self.low {
-                    self.state = false;
-                }
-                Ok(self.state)
-            }
-
-            /// Current state.
-            #[inline]
-            #[must_use]
-            pub fn state(&self) -> bool {
-                self.state
-            }
-
-            /// Resets state to false.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.state = false;
-            }
-        }
-    };
+/// Hysteresis filter — Schmitt trigger with separate high/low thresholds.
+///
+/// Transitions to `true` when sample exceeds the high threshold.
+/// Transitions to `false` when sample drops below the low threshold.
+/// Between the thresholds, the state is unchanged — preventing oscillation.
+///
+/// # Use Cases
+/// - Thermostat logic (turn on at low, turn off at high)
+/// - Alert suppression (don't flap at boundary)
+/// - Binary state from a noisy analog signal
+#[derive(Debug, Clone)]
+pub struct HysteresisF64 {
+    low: f64,
+    high: f64,
+    state: bool,
 }
 
-macro_rules! impl_hysteresis_int {
-    ($name:ident, $ty:ty) => {
-        /// Hysteresis filter — Schmitt trigger with separate high/low thresholds.
-        ///
-        /// Transitions to `true` when sample exceeds the high threshold.
-        /// Transitions to `false` when sample drops below the low threshold.
-        /// Between the thresholds, the state is unchanged — preventing oscillation.
-        ///
-        /// # Use Cases
-        /// - Thermostat logic (turn on at low, turn off at high)
-        /// - Alert suppression (don't flap at boundary)
-        /// - Binary state from a noisy analog signal
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            low: $ty,
-            high: $ty,
-            state: bool,
+impl HysteresisF64 {
+    /// Creates a new hysteresis filter.
+    ///
+    /// `low_threshold` must be less than `high_threshold`.
+    #[inline]
+    pub fn new(low_threshold: f64, high_threshold: f64) -> Result<Self, crate::ConfigError> {
+        if low_threshold >= high_threshold {
+            return Err(crate::ConfigError::Invalid(
+                "low threshold must be less than high",
+            ));
         }
+        Ok(Self {
+            low: low_threshold,
+            high: high_threshold,
+            state: false,
+        })
+    }
 
-        impl $name {
-            /// Creates a new hysteresis filter.
-            ///
-            /// `low_threshold` must be less than `high_threshold`.
-            #[inline]
-            pub fn new(
-                low_threshold: $ty,
-                high_threshold: $ty,
-            ) -> Result<Self, crate::ConfigError> {
-                if !(low_threshold < high_threshold) {
-                    return Err(crate::ConfigError::Invalid(
-                        "low threshold must be less than high",
-                    ));
-                }
-                Ok(Self {
-                    low: low_threshold,
-                    high: high_threshold,
-                    state: false,
-                })
-            }
-
-            /// Feeds a sample. Returns the current state.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> bool {
-                if sample >= self.high {
-                    self.state = true;
-                } else if sample <= self.low {
-                    self.state = false;
-                }
-                self.state
-            }
-
-            /// Current state.
-            #[inline]
-            #[must_use]
-            pub fn state(&self) -> bool {
-                self.state
-            }
-
-            /// Resets state to false.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.state = false;
-            }
+    /// Feeds a sample. Returns the current state.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<bool, crate::DataError> {
+        check_finite!(sample);
+        if sample >= self.high {
+            self.state = true;
+        } else if sample <= self.low {
+            self.state = false;
         }
-    };
+        Ok(self.state)
+    }
+
+    /// Current state.
+    #[inline]
+    #[must_use]
+    pub fn state(&self) -> bool {
+        self.state
+    }
+
+    /// Resets state to false.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.state = false;
+    }
 }
 
-impl_hysteresis_float!(HysteresisF64, f64);
-impl_hysteresis_float!(HysteresisF32, f32);
-impl_hysteresis_int!(HysteresisI64, i64);
-impl_hysteresis_int!(HysteresisI32, i32);
-impl_hysteresis_int!(HysteresisI128, i128);
+/// Hysteresis filter — Schmitt trigger with separate high/low thresholds.
+///
+/// Transitions to `true` when sample exceeds the high threshold.
+/// Transitions to `false` when sample drops below the low threshold.
+/// Between the thresholds, the state is unchanged — preventing oscillation.
+///
+/// # Use Cases
+/// - Thermostat logic (turn on at low, turn off at high)
+/// - Alert suppression (don't flap at boundary)
+/// - Binary state from a noisy analog signal
+#[derive(Debug, Clone)]
+pub struct HysteresisI64 {
+    low: i64,
+    high: i64,
+    state: bool,
+}
+
+impl HysteresisI64 {
+    /// Creates a new hysteresis filter.
+    ///
+    /// `low_threshold` must be less than `high_threshold`.
+    #[inline]
+    pub fn new(low_threshold: i64, high_threshold: i64) -> Result<Self, crate::ConfigError> {
+        if low_threshold >= high_threshold {
+            return Err(crate::ConfigError::Invalid(
+                "low threshold must be less than high",
+            ));
+        }
+        Ok(Self {
+            low: low_threshold,
+            high: high_threshold,
+            state: false,
+        })
+    }
+
+    /// Feeds a sample. Returns the current state.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> bool {
+        if sample >= self.high {
+            self.state = true;
+        } else if sample <= self.low {
+            self.state = false;
+        }
+        self.state
+    }
+
+    /// Current state.
+    #[inline]
+    #[must_use]
+    pub fn state(&self) -> bool {
+        self.state
+    }
+
+    /// Resets state to false.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.state = false;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -201,14 +180,6 @@ mod tests {
             HysteresisF64::new(70.0, 30.0),
             Err(crate::ConfigError::Invalid(_))
         ));
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut h = HysteresisI128::new(30, 70).unwrap();
-        assert!(!h.update(50));
-        assert!(h.update(75));
-        assert!(!h.update(25));
     }
 
     #[test]

--- a/nexus-stats-core/src/control/hysteresis.rs
+++ b/nexus-stats-core/src/control/hysteresis.rs
@@ -20,8 +20,10 @@ impl HysteresisF64 {
     ///
     /// `low_threshold` must be less than `high_threshold`.
     #[inline]
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     pub fn new(low_threshold: f64, high_threshold: f64) -> Result<Self, crate::ConfigError> {
-        if low_threshold >= high_threshold {
+        // Negated form rejects NaN (all NaN comparisons are false, so !(NaN < x) → true → reject).
+        if !(low_threshold < high_threshold) {
             return Err(crate::ConfigError::Invalid(
                 "low threshold must be less than high",
             ));

--- a/nexus-stats-core/src/control/level_crossing.rs
+++ b/nexus-stats-core/src/control/level_crossing.rs
@@ -1,147 +1,133 @@
-macro_rules! impl_level_crossing_float {
-    ($name:ident, $ty:ty) => {
-        /// Level crossing detector — signals when a value crosses a threshold.
-        ///
-        /// Returns `true` on the sample where the signal crosses the threshold
-        /// in either direction. Tracks total crossing count.
-        ///
-        /// # Use Cases
-        /// - Zero-crossing detection
-        /// - Alert when metric crosses a boundary
-        /// - Counting oscillation frequency
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            threshold: $ty,
-            was_above: bool,
-            crossings: u64,
-            initialized: bool,
-        }
-
-        impl $name {
-            /// Creates a new level crossing detector at the given threshold.
-            #[inline]
-            #[must_use]
-            pub fn new(threshold: $ty) -> Self {
-                Self {
-                    threshold,
-                    was_above: false,
-                    crossings: 0,
-                    initialized: false,
-                }
-            }
-
-            /// Feeds a sample. Returns `Ok(true)` if a crossing occurred.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<bool, crate::DataError> {
-                check_finite!(sample);
-                let is_above = sample >= self.threshold;
-
-                if !self.initialized {
-                    self.was_above = is_above;
-                    self.initialized = true;
-                    return Ok(false);
-                }
-
-                if is_above != self.was_above {
-                    self.was_above = is_above;
-                    self.crossings += 1;
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-
-            /// Total number of crossings detected.
-            #[inline]
-            #[must_use]
-            pub fn crossing_count(&self) -> u64 {
-                self.crossings
-            }
-
-            /// Resets the detector.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.was_above = false;
-                self.crossings = 0;
-                self.initialized = false;
-            }
-        }
-    };
+/// Level crossing detector — signals when a value crosses a threshold.
+///
+/// Returns `true` on the sample where the signal crosses the threshold
+/// in either direction. Tracks total crossing count.
+///
+/// # Use Cases
+/// - Zero-crossing detection
+/// - Alert when metric crosses a boundary
+/// - Counting oscillation frequency
+#[derive(Debug, Clone)]
+pub struct LevelCrossingF64 {
+    threshold: f64,
+    was_above: bool,
+    crossings: u64,
+    initialized: bool,
 }
 
-macro_rules! impl_level_crossing_int {
-    ($name:ident, $ty:ty) => {
-        /// Level crossing detector — signals when a value crosses a threshold.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            threshold: $ty,
-            was_above: bool,
-            crossings: u64,
-            initialized: bool,
+impl LevelCrossingF64 {
+    /// Creates a new level crossing detector at the given threshold.
+    #[inline]
+    #[must_use]
+    pub fn new(threshold: f64) -> Self {
+        Self {
+            threshold,
+            was_above: false,
+            crossings: 0,
+            initialized: false,
+        }
+    }
+
+    /// Feeds a sample. Returns `Ok(true)` if a crossing occurred.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<bool, crate::DataError> {
+        check_finite!(sample);
+        let is_above = sample >= self.threshold;
+
+        if !self.initialized {
+            self.was_above = is_above;
+            self.initialized = true;
+            return Ok(false);
         }
 
-        impl $name {
-            /// Creates a new level crossing detector at the given threshold.
-            #[inline]
-            #[must_use]
-            pub fn new(threshold: $ty) -> Self {
-                Self {
-                    threshold,
-                    was_above: false,
-                    crossings: 0,
-                    initialized: false,
-                }
-            }
-
-            /// Feeds a sample. Returns `true` if a crossing occurred.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> bool {
-                let is_above = sample >= self.threshold;
-
-                if !self.initialized {
-                    self.was_above = is_above;
-                    self.initialized = true;
-                    return false;
-                }
-
-                if is_above != self.was_above {
-                    self.was_above = is_above;
-                    self.crossings += 1;
-                    true
-                } else {
-                    false
-                }
-            }
-
-            /// Total number of crossings detected.
-            #[inline]
-            #[must_use]
-            pub fn crossing_count(&self) -> u64 {
-                self.crossings
-            }
-
-            /// Resets the detector.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.was_above = false;
-                self.crossings = 0;
-                self.initialized = false;
-            }
+        if is_above == self.was_above {
+            Ok(false)
+        } else {
+            self.was_above = is_above;
+            self.crossings += 1;
+            Ok(true)
         }
-    };
+    }
+
+    /// Total number of crossings detected.
+    #[inline]
+    #[must_use]
+    pub fn crossing_count(&self) -> u64 {
+        self.crossings
+    }
+
+    /// Resets the detector.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.was_above = false;
+        self.crossings = 0;
+        self.initialized = false;
+    }
 }
 
-impl_level_crossing_float!(LevelCrossingF64, f64);
-impl_level_crossing_float!(LevelCrossingF32, f32);
-impl_level_crossing_int!(LevelCrossingI64, i64);
-impl_level_crossing_int!(LevelCrossingI32, i32);
-impl_level_crossing_int!(LevelCrossingI128, i128);
+/// Level crossing detector — signals when a value crosses a threshold.
+#[derive(Debug, Clone)]
+pub struct LevelCrossingI64 {
+    threshold: i64,
+    was_above: bool,
+    crossings: u64,
+    initialized: bool,
+}
+
+impl LevelCrossingI64 {
+    /// Creates a new level crossing detector at the given threshold.
+    #[inline]
+    #[must_use]
+    pub fn new(threshold: i64) -> Self {
+        Self {
+            threshold,
+            was_above: false,
+            crossings: 0,
+            initialized: false,
+        }
+    }
+
+    /// Feeds a sample. Returns `true` if a crossing occurred.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> bool {
+        let is_above = sample >= self.threshold;
+
+        if !self.initialized {
+            self.was_above = is_above;
+            self.initialized = true;
+            return false;
+        }
+
+        if is_above == self.was_above {
+            false
+        } else {
+            self.was_above = is_above;
+            self.crossings += 1;
+            true
+        }
+    }
+
+    /// Total number of crossings detected.
+    #[inline]
+    #[must_use]
+    pub fn crossing_count(&self) -> u64 {
+        self.crossings
+    }
+
+    /// Resets the detector.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.was_above = false;
+        self.crossings = 0;
+        self.initialized = false;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -201,13 +187,6 @@ mod tests {
         let _ = lc.update(60.0).unwrap();
         lc.reset();
         assert_eq!(lc.crossing_count(), 0);
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut lc = LevelCrossingI128::new(100);
-        assert!(!lc.update(50));
-        assert!(lc.update(150));
     }
 
     #[test]

--- a/nexus-stats-core/src/detection/cusum.rs
+++ b/nexus-stats-core/src/detection/cusum.rs
@@ -1,471 +1,444 @@
 use crate::Direction;
 
-/// Generates the CUSUM update method — float variant validates input,
-/// integer variant passes through without validation.
-macro_rules! impl_cusum_update {
-    (float, $ty:ty) => {
-        /// Feeds a sample. Returns shift direction once primed.
-        ///
-        /// Returns `Ok(None)` until `min_samples` have been processed.
-        /// After priming, returns `Ok(Some(Direction::Rising))`, `Ok(Some(Direction::Falling))`,
-        /// or `Ok(Some(Direction::Neutral))`.
-        ///
-        /// # Errors
-        ///
-        /// Returns `DataError::NotANumber` if the sample is NaN, or
-        /// `DataError::Infinite` if the sample is infinite.
-        #[inline]
-        pub fn update(&mut self, sample: $ty) -> Result<Option<Direction>, crate::DataError> {
-            check_finite!(sample);
-            self.count += 1;
-
-            let diff = sample - self.target;
-
-            let s_high = self.upper + diff - self.slack_upper;
-            self.upper = s_high.max(0 as $ty);
-
-            let s_low = self.lower - diff - self.slack_lower;
-            self.lower = s_low.max(0 as $ty);
-
-            if self.count < self.min_samples {
-                return Ok(Option::None);
-            }
-
-            Ok(if self.upper > self.threshold_upper {
-                Option::Some(Direction::Rising)
-            } else if self.lower > self.threshold_lower {
-                Option::Some(Direction::Falling)
-            } else {
-                Option::Some(Direction::Neutral)
-            })
-        }
-    };
-    (int, $ty:ty) => {
-        /// Feeds a sample. Returns shift direction once primed.
-        ///
-        /// Returns `None` until `min_samples` have been processed.
-        /// After priming, returns `Some(Direction::Rising)`, `Some(Direction::Falling)`,
-        /// or `Some(Direction::Neutral)`.
-        #[inline]
-        #[must_use]
-        pub fn update(&mut self, sample: $ty) -> Option<Direction> {
-            self.count += 1;
-
-            let diff = sample - self.target;
-
-            let s_high = self.upper + diff - self.slack_upper;
-            self.upper = s_high.max(0 as $ty);
-
-            let s_low = self.lower - diff - self.slack_lower;
-            self.lower = s_low.max(0 as $ty);
-
-            if self.count < self.min_samples {
-                return Option::None;
-            }
-
-            if self.upper > self.threshold_upper {
-                Option::Some(Direction::Rising)
-            } else if self.lower > self.threshold_lower {
-                Option::Some(Direction::Falling)
-            } else {
-                Option::Some(Direction::Neutral)
-            }
-        }
-    };
+/// CUSUM — Cumulative Sum change detector (Page, 1954).
+///
+/// Detects persistent shifts in the mean of a streaming process
+/// in either direction. Signals when cumulative deviation from a
+/// target exceeds a threshold.
+///
+/// Supports asymmetric slack and threshold parameters for different
+/// sensitivity to upward vs downward shifts.
+///
+/// # Use Cases
+/// - Exchange ack latency degradation (detect shift up)
+/// - Recovery detection (detect shift back down)
+/// - Market data feed quality monitoring
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct CusumF64 {
+    target: f64,
+    slack_upper: f64,
+    slack_lower: f64,
+    threshold_upper: f64,
+    threshold_lower: f64,
+    upper: f64,
+    lower: f64,
+    count: u64,
+    min_samples: u64,
+    // Track whether user explicitly set slack/threshold so
+    // reset_with_target knows whether to recompute defaults.
+    slack_upper_explicit: bool,
+    slack_lower_explicit: bool,
+    threshold_upper_explicit: bool,
+    threshold_lower_explicit: bool,
 }
 
-macro_rules! impl_cusum {
-    ($name:ident, $builder:ident, $ty:ty, $kind:tt, min_slack = $min_slack:expr) => {
-        /// CUSUM — Cumulative Sum change detector (Page, 1954).
-        ///
-        /// Detects persistent shifts in the mean of a streaming process
-        /// in either direction. Signals when cumulative deviation from a
-        /// target exceeds a threshold.
-        ///
-        /// Supports asymmetric slack and threshold parameters for different
-        /// sensitivity to upward vs downward shifts.
-        ///
-        /// # Use Cases
-        /// - Exchange ack latency degradation (detect shift up)
-        /// - Recovery detection (detect shift back down)
-        /// - Market data feed quality monitoring
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            target: $ty,
-            slack_upper: $ty,
-            slack_lower: $ty,
-            threshold_upper: $ty,
-            threshold_lower: $ty,
-            upper: $ty,
-            lower: $ty,
-            count: u64,
-            min_samples: u64,
-            // Track whether user explicitly set slack/threshold so
-            // reset_with_target knows whether to recompute defaults.
-            slack_upper_explicit: bool,
-            slack_lower_explicit: bool,
-            threshold_upper_explicit: bool,
-            threshold_lower_explicit: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// use nexus_stats_core::detection::*;
-        #[doc = concat!("let mut cusum = ", stringify!($name), "::builder(100 as ", stringify!($ty), ")")]
-        ///     .slack(5 as _)
-        ///     .threshold(50 as _)
-        ///     .min_samples(20)
-        ///     .build()
-        ///     .unwrap();
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            target: $ty,
-            slack_upper: Option<$ty>,
-            slack_lower: Option<$ty>,
-            threshold_upper: Option<$ty>,
-            threshold_lower: Option<$ty>,
-            min_samples: u64,
-            seed_upper: Option<$ty>,
-            seed_lower: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder with the target (expected baseline mean).
-            #[inline]
-            #[must_use]
-            pub fn builder(target: $ty) -> $builder {
-                $builder {
-                    target,
-                    slack_upper: Option::None,
-                    slack_lower: Option::None,
-                    threshold_upper: Option::None,
-                    threshold_lower: Option::None,
-                    min_samples: 0,
-                    seed_upper: Option::None,
-                    seed_lower: Option::None,
-                }
-            }
-
-            impl_cusum_update!($kind, $ty);
-
-            /// Upper cumulative sum (tracks upward drift).
-            #[inline]
-            #[must_use]
-            pub fn upper(&self) -> $ty {
-                self.upper
-            }
-
-            /// Lower cumulative sum (tracks downward drift).
-            #[inline]
-            #[must_use]
-            pub fn lower(&self) -> $ty {
-                self.lower
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the detector has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets cumulative sums and count to zero. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.upper = 0 as $ty;
-                self.lower = 0 as $ty;
-                self.count = 0;
-            }
-
-            /// Resets and updates the target mean.
-            ///
-            /// If slack or threshold were not explicitly set by the user,
-            /// they are recomputed from the new target using the defaults
-            /// (5% and 50% of target respectively).
-            #[inline]
-            pub fn reset_with_target(&mut self, new_target: $ty) {
-                self.target = new_target;
-                self.upper = 0 as $ty;
-                self.lower = 0 as $ty;
-                self.count = 0;
-
-                if !self.slack_upper_explicit {
-                    self.slack_upper = $builder::default_slack(new_target);
-                }
-                if !self.slack_lower_explicit {
-                    self.slack_lower = $builder::default_slack(new_target);
-                }
-                if !self.threshold_upper_explicit {
-                    self.threshold_upper = $builder::default_threshold(new_target);
-                }
-                if !self.threshold_lower_explicit {
-                    self.threshold_lower = $builder::default_threshold(new_target);
-                }
-            }
-
-            /// The target (expected baseline mean).
-            #[inline]
-            #[must_use]
-            pub fn target(&self) -> $ty {
-                self.target
-            }
-
-            /// Upper slack parameter.
-            #[inline]
-            #[must_use]
-            pub fn slack_upper(&self) -> $ty {
-                self.slack_upper
-            }
-
-            /// Lower slack parameter.
-            #[inline]
-            #[must_use]
-            pub fn slack_lower(&self) -> $ty {
-                self.slack_lower
-            }
-
-            /// Upper threshold parameter.
-            #[inline]
-            #[must_use]
-            pub fn threshold_upper(&self) -> $ty {
-                self.threshold_upper
-            }
-
-            /// Lower threshold parameter.
-            #[inline]
-            #[must_use]
-            pub fn threshold_lower(&self) -> $ty {
-                self.threshold_lower
-            }
-
-            /// Minimum samples required before detection activates.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(&self) -> u64 {
-                self.min_samples
-            }
-
-            /// Updates all tuning parameters without resetting cumulative sums or count.
-            ///
-            /// # Errors
-            ///
-            /// - Slack values must be non-negative.
-            /// - Threshold values must be positive.
-            #[inline]
-            pub fn reconfigure(
-                &mut self,
-                target: $ty,
-                slack_upper: $ty,
-                slack_lower: $ty,
-                threshold_upper: $ty,
-                threshold_lower: $ty,
-            ) -> Result<(), crate::ConfigError> {
-                if slack_upper < (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("slack_upper must be non-negative"));
-                }
-                if slack_lower < (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("slack_lower must be non-negative"));
-                }
-                if threshold_upper <= (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("threshold_upper must be positive"));
-                }
-                if threshold_lower <= (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("threshold_lower must be positive"));
-                }
-
-                self.target = target;
-                self.slack_upper = slack_upper;
-                self.slack_lower = slack_lower;
-                self.threshold_upper = threshold_upper;
-                self.threshold_lower = threshold_lower;
-                self.slack_upper_explicit = true;
-                self.slack_lower_explicit = true;
-                self.threshold_upper_explicit = true;
-                self.threshold_lower_explicit = true;
-                Ok(())
-            }
-        }
-
-        impl $builder {
-            #[inline]
-            fn default_slack(target: $ty) -> $ty {
-                // 5% of target magnitude, floored to $min_slack
-                let abs_target = if target < (0 as $ty) { (0 as $ty) - target } else { target };
-                let slack = abs_target / (20 as $ty);
-                if slack < ($min_slack as $ty) { $min_slack as $ty } else { slack }
-            }
-
-            #[inline]
-            fn default_threshold(target: $ty) -> $ty {
-                // 50% of target magnitude
-                let abs_target = if target < (0 as $ty) { (0 as $ty) - target } else { target };
-                abs_target / (2 as $ty)
-            }
-
-            /// Sets both upper and lower slack (symmetric sensitivity).
-            ///
-            /// Slack controls sensitivity — smaller values detect smaller shifts
-            /// but increase false alarm rate. Typically set to half the minimum
-            /// shift you want to detect.
-            #[inline]
-            #[must_use]
-            pub fn slack(mut self, slack: $ty) -> Self {
-                self.slack_upper = Option::Some(slack);
-                self.slack_lower = Option::Some(slack);
-                self
-            }
-
-            /// Sets the upper slack independently.
-            ///
-            /// Controls sensitivity to upward shifts only.
-            #[inline]
-            #[must_use]
-            pub fn slack_upper(mut self, slack: $ty) -> Self {
-                self.slack_upper = Option::Some(slack);
-                self
-            }
-
-            /// Sets the lower slack independently.
-            ///
-            /// Controls sensitivity to downward shifts only.
-            #[inline]
-            #[must_use]
-            pub fn slack_lower(mut self, slack: $ty) -> Self {
-                self.slack_lower = Option::Some(slack);
-                self
-            }
-
-            /// Sets both upper and lower thresholds (symmetric decision boundary).
-            ///
-            /// Larger thresholds mean fewer false alarms but slower detection.
-            #[inline]
-            #[must_use]
-            pub fn threshold(mut self, threshold: $ty) -> Self {
-                self.threshold_upper = Option::Some(threshold);
-                self.threshold_lower = Option::Some(threshold);
-                self
-            }
-
-            /// Sets the upper threshold independently.
-            ///
-            /// Decision boundary for upward shift detection only.
-            #[inline]
-            #[must_use]
-            pub fn threshold_upper(mut self, threshold: $ty) -> Self {
-                self.threshold_upper = Option::Some(threshold);
-                self
-            }
-
-            /// Sets the lower threshold independently.
-            ///
-            /// Decision boundary for downward shift detection only.
-            #[inline]
-            #[must_use]
-            pub fn threshold_lower(mut self, threshold: $ty) -> Self {
-                self.threshold_lower = Option::Some(threshold);
-                self
-            }
-
-            /// Minimum samples before detection activates. Default: 0.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-loads the upper cumulative sum from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately.
-            #[inline]
-            #[must_use]
-            pub fn seed_upper(mut self, val: $ty) -> Self {
-                self.seed_upper = Option::Some(val);
-                self
-            }
-
-            /// Pre-loads the lower cumulative sum from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately.
-            #[inline]
-            #[must_use]
-            pub fn seed_lower(mut self, val: $ty) -> Self {
-                self.seed_lower = Option::Some(val);
-                self
-            }
-
-            /// Builds the detector.
-            ///
-            /// # Errors
-            ///
-            /// - Slack values must be non-negative.
-            /// - Threshold values must be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let slack_upper_explicit = self.slack_upper.is_some();
-                let slack_lower_explicit = self.slack_lower.is_some();
-                let threshold_upper_explicit = self.threshold_upper.is_some();
-                let threshold_lower_explicit = self.threshold_lower.is_some();
-
-                let slack_upper = self.slack_upper.unwrap_or_else(|| Self::default_slack(self.target));
-                let slack_lower = self.slack_lower.unwrap_or_else(|| Self::default_slack(self.target));
-                let threshold_upper = self.threshold_upper.unwrap_or_else(|| Self::default_threshold(self.target));
-                let threshold_lower = self.threshold_lower.unwrap_or_else(|| Self::default_threshold(self.target));
-
-                if slack_upper < (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("slack_upper must be non-negative"));
-                }
-                if slack_lower < (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("slack_lower must be non-negative"));
-                }
-                if threshold_upper <= (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("threshold_upper must be positive"));
-                }
-                if threshold_lower <= (0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("threshold_lower must be positive"));
-                }
-
-                let seeded = self.seed_upper.is_some() || self.seed_lower.is_some();
-                let initial_count = if seeded { self.min_samples } else { 0 };
-
-                Ok($name {
-                    target: self.target,
-                    slack_upper,
-                    slack_lower,
-                    threshold_upper,
-                    threshold_lower,
-                    upper: self.seed_upper.unwrap_or(0 as $ty),
-                    lower: self.seed_lower.unwrap_or(0 as $ty),
-                    count: initial_count,
-                    min_samples: self.min_samples,
-                    slack_upper_explicit,
-                    slack_lower_explicit,
-                    threshold_upper_explicit,
-                    threshold_lower_explicit,
-                })
-            }
-        }
-    };
+/// Builder for [`CusumF64`].
+///
+/// # Example
+///
+/// ```
+/// use nexus_stats_core::detection::*;
+/// let mut cusum = CusumF64::builder(100.0)
+///     .slack(5.0)
+///     .threshold(50.0)
+///     .min_samples(20)
+///     .build()
+///     .unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct CusumF64Builder {
+    target: f64,
+    slack_upper: Option<f64>,
+    slack_lower: Option<f64>,
+    threshold_upper: Option<f64>,
+    threshold_lower: Option<f64>,
+    min_samples: u64,
+    seed_upper: Option<f64>,
+    seed_lower: Option<f64>,
 }
 
-impl_cusum!(CusumF64, CusumF64Builder, f64, float, min_slack = 0.0);
-impl_cusum!(CusumF32, CusumF32Builder, f32, float, min_slack = 0.0);
-impl_cusum!(CusumI64, CusumI64Builder, i64, int, min_slack = 1);
-impl_cusum!(CusumI32, CusumI32Builder, i32, int, min_slack = 1);
-impl_cusum!(CusumI128, CusumI128Builder, i128, int, min_slack = 1);
+impl CusumF64 {
+    /// Creates a builder with the target (expected baseline mean).
+    #[inline]
+    #[must_use]
+    pub fn builder(target: f64) -> CusumF64Builder {
+        CusumF64Builder {
+            target,
+            slack_upper: None,
+            slack_lower: None,
+            threshold_upper: None,
+            threshold_lower: None,
+            min_samples: 0,
+            seed_upper: None,
+            seed_lower: None,
+        }
+    }
+
+    /// Feeds a sample. Returns shift direction once primed.
+    ///
+    /// Returns `Ok(None)` until `min_samples` have been processed.
+    /// After priming, returns `Ok(Some(Direction::Rising))`, `Ok(Some(Direction::Falling))`,
+    /// or `Ok(Some(Direction::Neutral))`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<Direction>, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        let diff = sample - self.target;
+
+        let s_high = self.upper + diff - self.slack_upper;
+        self.upper = s_high.max(0.0);
+
+        let s_low = self.lower - diff - self.slack_lower;
+        self.lower = s_low.max(0.0);
+
+        if self.count < self.min_samples {
+            return Ok(None);
+        }
+
+        Ok(if self.upper > self.threshold_upper {
+            Some(Direction::Rising)
+        } else if self.lower > self.threshold_lower {
+            Some(Direction::Falling)
+        } else {
+            Some(Direction::Neutral)
+        })
+    }
+
+    /// Upper cumulative sum (tracks upward drift).
+    #[inline]
+    #[must_use]
+    pub fn upper(&self) -> f64 {
+        self.upper
+    }
+
+    /// Lower cumulative sum (tracks downward drift).
+    #[inline]
+    #[must_use]
+    pub fn lower(&self) -> f64 {
+        self.lower
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the detector has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets cumulative sums and count to zero. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.upper = 0.0;
+        self.lower = 0.0;
+        self.count = 0;
+    }
+
+    /// Resets and updates the target mean.
+    ///
+    /// If slack or threshold were not explicitly set by the user,
+    /// they are recomputed from the new target using the defaults
+    /// (5% and 50% of target respectively).
+    #[inline]
+    pub fn reset_with_target(&mut self, new_target: f64) {
+        self.target = new_target;
+        self.upper = 0.0;
+        self.lower = 0.0;
+        self.count = 0;
+
+        if !self.slack_upper_explicit {
+            self.slack_upper = CusumF64Builder::default_slack(new_target);
+        }
+        if !self.slack_lower_explicit {
+            self.slack_lower = CusumF64Builder::default_slack(new_target);
+        }
+        if !self.threshold_upper_explicit {
+            self.threshold_upper = CusumF64Builder::default_threshold(new_target);
+        }
+        if !self.threshold_lower_explicit {
+            self.threshold_lower = CusumF64Builder::default_threshold(new_target);
+        }
+    }
+
+    /// The target (expected baseline mean).
+    #[inline]
+    #[must_use]
+    pub fn target(&self) -> f64 {
+        self.target
+    }
+
+    /// Upper slack parameter.
+    #[inline]
+    #[must_use]
+    pub fn slack_upper(&self) -> f64 {
+        self.slack_upper
+    }
+
+    /// Lower slack parameter.
+    #[inline]
+    #[must_use]
+    pub fn slack_lower(&self) -> f64 {
+        self.slack_lower
+    }
+
+    /// Upper threshold parameter.
+    #[inline]
+    #[must_use]
+    pub fn threshold_upper(&self) -> f64 {
+        self.threshold_upper
+    }
+
+    /// Lower threshold parameter.
+    #[inline]
+    #[must_use]
+    pub fn threshold_lower(&self) -> f64 {
+        self.threshold_lower
+    }
+
+    /// Minimum samples required before detection activates.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(&self) -> u64 {
+        self.min_samples
+    }
+
+    /// Updates all tuning parameters without resetting cumulative sums or count.
+    ///
+    /// # Errors
+    ///
+    /// - Slack values must be non-negative.
+    /// - Threshold values must be positive.
+    #[inline]
+    pub fn reconfigure(
+        &mut self,
+        target: f64,
+        slack_upper: f64,
+        slack_lower: f64,
+        threshold_upper: f64,
+        threshold_lower: f64,
+    ) -> Result<(), crate::ConfigError> {
+        if slack_upper < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "slack_upper must be non-negative",
+            ));
+        }
+        if slack_lower < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "slack_lower must be non-negative",
+            ));
+        }
+        if threshold_upper <= 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold_upper must be positive",
+            ));
+        }
+        if threshold_lower <= 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold_lower must be positive",
+            ));
+        }
+
+        self.target = target;
+        self.slack_upper = slack_upper;
+        self.slack_lower = slack_lower;
+        self.threshold_upper = threshold_upper;
+        self.threshold_lower = threshold_lower;
+        self.slack_upper_explicit = true;
+        self.slack_lower_explicit = true;
+        self.threshold_upper_explicit = true;
+        self.threshold_lower_explicit = true;
+        Ok(())
+    }
+}
+
+impl CusumF64Builder {
+    #[inline]
+    fn default_slack(target: f64) -> f64 {
+        // 5% of target magnitude, floored to 0.0
+        let abs_target = target.abs();
+        let slack = abs_target / 20.0;
+        if slack < 0.0 { 0.0 } else { slack }
+    }
+
+    #[inline]
+    fn default_threshold(target: f64) -> f64 {
+        // 50% of target magnitude
+        let abs_target = target.abs();
+        abs_target / 2.0
+    }
+
+    /// Sets both upper and lower slack (symmetric sensitivity).
+    ///
+    /// Slack controls sensitivity — smaller values detect smaller shifts
+    /// but increase false alarm rate. Typically set to half the minimum
+    /// shift you want to detect.
+    #[inline]
+    #[must_use]
+    pub fn slack(mut self, slack: f64) -> Self {
+        self.slack_upper = Some(slack);
+        self.slack_lower = Some(slack);
+        self
+    }
+
+    /// Sets the upper slack independently.
+    ///
+    /// Controls sensitivity to upward shifts only.
+    #[inline]
+    #[must_use]
+    pub fn slack_upper(mut self, slack: f64) -> Self {
+        self.slack_upper = Some(slack);
+        self
+    }
+
+    /// Sets the lower slack independently.
+    ///
+    /// Controls sensitivity to downward shifts only.
+    #[inline]
+    #[must_use]
+    pub fn slack_lower(mut self, slack: f64) -> Self {
+        self.slack_lower = Some(slack);
+        self
+    }
+
+    /// Sets both upper and lower thresholds (symmetric decision boundary).
+    ///
+    /// Larger thresholds mean fewer false alarms but slower detection.
+    #[inline]
+    #[must_use]
+    pub fn threshold(mut self, threshold: f64) -> Self {
+        self.threshold_upper = Some(threshold);
+        self.threshold_lower = Some(threshold);
+        self
+    }
+
+    /// Sets the upper threshold independently.
+    ///
+    /// Decision boundary for upward shift detection only.
+    #[inline]
+    #[must_use]
+    pub fn threshold_upper(mut self, threshold: f64) -> Self {
+        self.threshold_upper = Some(threshold);
+        self
+    }
+
+    /// Sets the lower threshold independently.
+    ///
+    /// Decision boundary for downward shift detection only.
+    #[inline]
+    #[must_use]
+    pub fn threshold_lower(mut self, threshold: f64) -> Self {
+        self.threshold_lower = Some(threshold);
+        self
+    }
+
+    /// Minimum samples before detection activates. Default: 0.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Pre-loads the upper cumulative sum from calibration data.
+    ///
+    /// When seeded, `is_primed()` returns true immediately.
+    #[inline]
+    #[must_use]
+    pub fn seed_upper(mut self, val: f64) -> Self {
+        self.seed_upper = Some(val);
+        self
+    }
+
+    /// Pre-loads the lower cumulative sum from calibration data.
+    ///
+    /// When seeded, `is_primed()` returns true immediately.
+    #[inline]
+    #[must_use]
+    pub fn seed_lower(mut self, val: f64) -> Self {
+        self.seed_lower = Some(val);
+        self
+    }
+
+    /// Builds the detector.
+    ///
+    /// # Errors
+    ///
+    /// - Slack values must be non-negative.
+    /// - Threshold values must be positive.
+    #[inline]
+    pub fn build(self) -> Result<CusumF64, crate::ConfigError> {
+        let slack_upper_explicit = self.slack_upper.is_some();
+        let slack_lower_explicit = self.slack_lower.is_some();
+        let threshold_upper_explicit = self.threshold_upper.is_some();
+        let threshold_lower_explicit = self.threshold_lower.is_some();
+
+        let slack_upper = self
+            .slack_upper
+            .unwrap_or_else(|| Self::default_slack(self.target));
+        let slack_lower = self
+            .slack_lower
+            .unwrap_or_else(|| Self::default_slack(self.target));
+        let threshold_upper = self
+            .threshold_upper
+            .unwrap_or_else(|| Self::default_threshold(self.target));
+        let threshold_lower = self
+            .threshold_lower
+            .unwrap_or_else(|| Self::default_threshold(self.target));
+
+        if slack_upper < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "slack_upper must be non-negative",
+            ));
+        }
+        if slack_lower < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "slack_lower must be non-negative",
+            ));
+        }
+        if threshold_upper <= 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold_upper must be positive",
+            ));
+        }
+        if threshold_lower <= 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold_lower must be positive",
+            ));
+        }
+
+        let seeded = self.seed_upper.is_some() || self.seed_lower.is_some();
+        let initial_count = if seeded { self.min_samples } else { 0 };
+
+        Ok(CusumF64 {
+            target: self.target,
+            slack_upper,
+            slack_lower,
+            threshold_upper,
+            threshold_lower,
+            upper: self.seed_upper.unwrap_or(0.0),
+            lower: self.seed_lower.unwrap_or(0.0),
+            count: initial_count,
+            min_samples: self.min_samples,
+            slack_upper_explicit,
+            slack_lower_explicit,
+            threshold_upper_explicit,
+            threshold_lower_explicit,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -762,50 +735,6 @@ mod tests {
     }
 
     // =========================================================================
-    // Integer variants
-    // =========================================================================
-
-    #[test]
-    fn i64_detects_upward_shift() {
-        let mut cusum = CusumI64::builder(1000)
-            .slack(50)
-            .threshold(500)
-            .build()
-            .unwrap();
-
-        let mut triggered = false;
-        for _ in 0..100 {
-            if cusum.update(1200) == Some(Direction::Rising) {
-                triggered = true;
-                break;
-            }
-        }
-        assert!(triggered);
-    }
-
-    #[test]
-    fn i32_basic() {
-        let mut cusum = CusumI32::builder(100)
-            .slack(5)
-            .threshold(50)
-            .build()
-            .unwrap();
-
-        assert_eq!(cusum.update(100), Some(Direction::Neutral));
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut cusum = CusumF32::builder(100.0)
-            .slack(5.0)
-            .threshold(50.0)
-            .build()
-            .unwrap();
-
-        assert_eq!(cusum.update(100.0).unwrap(), Some(Direction::Neutral));
-    }
-
-    // =========================================================================
     // Edge cases
     // =========================================================================
 
@@ -899,31 +828,6 @@ mod tests {
         assert!(cusum.reconfigure(100.0, 0.0, -1.0, 1.0, 1.0).is_err());
         assert!(cusum.reconfigure(100.0, 0.0, 0.0, 0.0, 1.0).is_err());
         assert!(cusum.reconfigure(100.0, 0.0, 0.0, 1.0, 0.0).is_err());
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut cusum = CusumI128::builder(100)
-            .slack(5)
-            .threshold(50)
-            .build()
-            .unwrap();
-
-        assert_eq!(cusum.update(100), Some(Direction::Neutral));
-    }
-
-    #[test]
-    fn integer_default_slack_floor() {
-        // target=10, 10/20 = 0 would truncate, but floor is 1
-        // Ensures at least 1 unit of noise tolerance for integer types
-        let cusum = CusumI64::builder(10).threshold(5).build().unwrap();
-
-        assert_eq!(cusum.slack_upper(), 1);
-        assert_eq!(cusum.slack_lower(), 1);
-
-        // Larger target: 100/20 = 5, no floor needed
-        let cusum = CusumI64::builder(100).threshold(50).build().unwrap();
-        assert_eq!(cusum.slack_upper(), 5);
     }
 
     #[test]

--- a/nexus-stats-core/src/detection/distribution_shift.rs
+++ b/nexus-stats-core/src/detection/distribution_shift.rs
@@ -101,15 +101,15 @@ impl DistributionShiftF64 {
     #[inline]
     #[must_use]
     pub fn is_shifted(&self, threshold: f64) -> bool {
-        if let Some(ks) = self.kurtosis_shift() {
-            if ks.abs() > threshold {
-                return true;
-            }
+        if let Some(ks) = self.kurtosis_shift()
+            && ks.abs() > threshold
+        {
+            return true;
         }
-        if let Some(ss) = self.skewness_shift() {
-            if ss.abs() > threshold {
-                return true;
-            }
+        if let Some(ss) = self.skewness_shift()
+            && ss.abs() > threshold
+        {
+            return true;
         }
         false
     }

--- a/nexus-stats-core/src/monitoring/codel.rs
+++ b/nexus-stats-core/src/monitoring/codel.rs
@@ -1,337 +1,309 @@
-use super::windowed::{
-    WindowedMinF32, WindowedMinF64, WindowedMinI32, WindowedMinI64, WindowedMinI128,
-};
+use super::windowed::{WindowedMinF64, WindowedMinI64};
 use crate::Condition;
 
 // =========================================================================
 // Raw (u64 timestamp) variants — no_std compatible
 // =========================================================================
 
-macro_rules! impl_codel_raw_int {
-    ($name:ident, $builder:ident, $ty:ty, $windowed_min_raw:ty) => {
-        /// CoDel — Controlled Delay queue monitor (Nichols & Jacobson, 2012).
-        ///
-        /// Composes a windowed minimum of sojourn times with a threshold.
-        /// Reports `Degraded` when even the minimum sojourn time in the
-        /// observation window exceeds the target. `no_std` compatible.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            windowed_min: $windowed_min_raw,
-            target: $ty,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            target: Option<$ty>,
-            window: Option<u64>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    target: Option::None,
-                    window: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Feeds a sojourn time at the given timestamp.
-            ///
-            /// Returns `Some(Condition)` once primed, `None` before.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, timestamp: u64, sojourn: $ty) -> Option<Condition> {
-                let min = self.windowed_min.update(timestamp, sojourn);
-
-                if self.windowed_min.count() < self.min_samples {
-                    return Option::None;
-                }
-
-                if min > self.target {
-                    Option::Some(Condition::Degraded)
-                } else {
-                    Option::Some(Condition::Normal)
-                }
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            #[must_use]
-            pub fn update_i64(&mut self, timestamp: i64, sojourn: $ty) -> Option<Condition> {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, sojourn)
-            }
-
-            /// Current windowed minimum sojourn time, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min_sojourn(&self) -> Option<$ty> {
-                self.windowed_min.min()
-            }
-
-            /// Whether the queue is currently elevated.
-            #[inline]
-            #[must_use]
-            pub fn is_elevated(&self) -> bool {
-                if let Some(min) = self.windowed_min.min() {
-                    min > self.target
-                } else {
-                    false
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.windowed_min.count()
-            }
-
-            /// Whether the monitor has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.windowed_min.count() >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.windowed_min.reset();
-            }
-        }
-
-        impl $builder {
-            /// Target sojourn time. Elevated when minimum exceeds this.
-            #[inline]
-            #[must_use]
-            pub fn target(mut self, target: $ty) -> Self {
-                self.target = Option::Some(target);
-                self
-            }
-
-            /// Observation window in raw units (same as timestamps).
-            #[inline]
-            #[must_use]
-            pub fn window(mut self, window: u64) -> Self {
-                self.window = Option::Some(window);
-                self
-            }
-
-            /// Minimum samples before monitoring activates. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the CoDel monitor.
-            ///
-            /// # Errors
-            ///
-            /// - Target must have been set.
-            /// - Window must have been set and be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let target = self.target.ok_or(crate::ConfigError::Missing("target"))?;
-                let window = self.window.ok_or(crate::ConfigError::Missing("window"))?;
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("CoDel window must be positive"));
-                }
-
-                Ok($name {
-                    windowed_min: <$windowed_min_raw>::new(window)?,
-                    target,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// CoDel — Controlled Delay queue monitor (Nichols & Jacobson, 2012).
+///
+/// Composes a windowed minimum of sojourn times with a threshold.
+/// Reports `Degraded` when even the minimum sojourn time in the
+/// observation window exceeds the target. `no_std` compatible.
+#[derive(Debug, Clone)]
+pub struct CoDelI64 {
+    windowed_min: WindowedMinI64,
+    target: i64,
+    min_samples: u64,
 }
 
-macro_rules! impl_codel_raw_float {
-    ($name:ident, $builder:ident, $ty:ty, $windowed_min_raw:ty) => {
-        /// CoDel — Controlled Delay queue monitor (Nichols & Jacobson, 2012).
-        ///
-        /// Composes a windowed minimum of sojourn times with a threshold.
-        /// Reports `Degraded` when even the minimum sojourn time in the
-        /// observation window exceeds the target. `no_std` compatible.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            windowed_min: $windowed_min_raw,
-            target: $ty,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            target: Option<$ty>,
-            window: Option<u64>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    target: Option::None,
-                    window: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Feeds a sojourn time at the given timestamp.
-            ///
-            /// Returns `Some(Condition)` once primed, `None` before.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sojourn is NaN, or
-            /// `DataError::Infinite` if the sojourn is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                timestamp: u64,
-                sojourn: $ty,
-            ) -> Result<Option<Condition>, crate::DataError> {
-                check_finite!(sojourn);
-                let min = self.windowed_min.update(timestamp, sojourn)?;
-
-                if self.windowed_min.count() < self.min_samples {
-                    return Ok(Option::None);
-                }
-
-                if min > self.target {
-                    Ok(Option::Some(Condition::Degraded))
-                } else {
-                    Ok(Option::Some(Condition::Normal))
-                }
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            pub fn update_i64(
-                &mut self,
-                timestamp: i64,
-                sojourn: $ty,
-            ) -> Result<Option<Condition>, crate::DataError> {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, sojourn)
-            }
-
-            /// Current windowed minimum sojourn time, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min_sojourn(&self) -> Option<$ty> {
-                self.windowed_min.min()
-            }
-
-            /// Whether the queue is currently elevated.
-            #[inline]
-            #[must_use]
-            pub fn is_elevated(&self) -> bool {
-                if let Some(min) = self.windowed_min.min() {
-                    min > self.target
-                } else {
-                    false
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.windowed_min.count()
-            }
-
-            /// Whether the monitor has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.windowed_min.count() >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.windowed_min.reset();
-            }
-        }
-
-        impl $builder {
-            /// Target sojourn time. Elevated when minimum exceeds this.
-            #[inline]
-            #[must_use]
-            pub fn target(mut self, target: $ty) -> Self {
-                self.target = Option::Some(target);
-                self
-            }
-
-            /// Observation window in raw units (same as timestamps).
-            #[inline]
-            #[must_use]
-            pub fn window(mut self, window: u64) -> Self {
-                self.window = Option::Some(window);
-                self
-            }
-
-            /// Minimum samples before monitoring activates. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the CoDel monitor.
-            ///
-            /// # Errors
-            ///
-            /// - Target must have been set.
-            /// - Window must have been set and be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let target = self.target.ok_or(crate::ConfigError::Missing("target"))?;
-                let window = self.window.ok_or(crate::ConfigError::Missing("window"))?;
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("CoDel window must be positive"));
-                }
-
-                Ok($name {
-                    windowed_min: <$windowed_min_raw>::new(window)?,
-                    target,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Builder for [`CoDelI64`].
+#[derive(Debug, Clone)]
+pub struct CoDelI64Builder {
+    target: Option<i64>,
+    window: Option<u64>,
+    min_samples: u64,
 }
 
-impl_codel_raw_int!(CoDelI64, CoDelI64Builder, i64, WindowedMinI64);
-impl_codel_raw_int!(CoDelI32, CoDelI32Builder, i32, WindowedMinI32);
-impl_codel_raw_int!(CoDelI128, CoDelI128Builder, i128, WindowedMinI128);
-impl_codel_raw_float!(CoDelF64, CoDelF64Builder, f64, WindowedMinF64);
-impl_codel_raw_float!(CoDelF32, CoDelF32Builder, f32, WindowedMinF32);
+impl CoDelI64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> CoDelI64Builder {
+        CoDelI64Builder {
+            target: None,
+            window: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Feeds a sojourn time at the given timestamp.
+    ///
+    /// Returns `Some(Condition)` once primed, `None` before.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, timestamp: u64, sojourn: i64) -> Option<Condition> {
+        let min = self.windowed_min.update(timestamp, sojourn);
+
+        if self.windowed_min.count() < self.min_samples {
+            return None;
+        }
+
+        if min > self.target {
+            Some(Condition::Degraded)
+        } else {
+            Some(Condition::Normal)
+        }
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    #[must_use]
+    pub fn update_i64(&mut self, timestamp: i64, sojourn: i64) -> Option<Condition> {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, sojourn)
+    }
+
+    /// Current windowed minimum sojourn time, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min_sojourn(&self) -> Option<i64> {
+        self.windowed_min.min()
+    }
+
+    /// Whether the queue is currently elevated.
+    #[inline]
+    #[must_use]
+    pub fn is_elevated(&self) -> bool {
+        self.windowed_min.min().is_some_and(|min| min > self.target)
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.windowed_min.count()
+    }
+
+    /// Whether the monitor has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.windowed_min.count() >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.windowed_min.reset();
+    }
+}
+
+impl CoDelI64Builder {
+    /// Target sojourn time. Elevated when minimum exceeds this.
+    #[inline]
+    #[must_use]
+    pub fn target(mut self, target: i64) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    /// Observation window in raw units (same as timestamps).
+    #[inline]
+    #[must_use]
+    pub fn window(mut self, window: u64) -> Self {
+        self.window = Some(window);
+        self
+    }
+
+    /// Minimum samples before monitoring activates. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the CoDel monitor.
+    ///
+    /// # Errors
+    ///
+    /// - Target must have been set.
+    /// - Window must have been set and be positive.
+    #[inline]
+    pub fn build(self) -> Result<CoDelI64, crate::ConfigError> {
+        let target = self.target.ok_or(crate::ConfigError::Missing("target"))?;
+        let window = self.window.ok_or(crate::ConfigError::Missing("window"))?;
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("CoDel window must be positive"));
+        }
+
+        Ok(CoDelI64 {
+            windowed_min: WindowedMinI64::new(window)?,
+            target,
+            min_samples: self.min_samples,
+        })
+    }
+}
+
+/// CoDel — Controlled Delay queue monitor (Nichols & Jacobson, 2012).
+///
+/// Composes a windowed minimum of sojourn times with a threshold.
+/// Reports `Degraded` when even the minimum sojourn time in the
+/// observation window exceeds the target. `no_std` compatible.
+#[derive(Debug, Clone)]
+pub struct CoDelF64 {
+    windowed_min: WindowedMinF64,
+    target: f64,
+    min_samples: u64,
+}
+
+/// Builder for [`CoDelF64`].
+#[derive(Debug, Clone)]
+pub struct CoDelF64Builder {
+    target: Option<f64>,
+    window: Option<u64>,
+    min_samples: u64,
+}
+
+impl CoDelF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> CoDelF64Builder {
+        CoDelF64Builder {
+            target: None,
+            window: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Feeds a sojourn time at the given timestamp.
+    ///
+    /// Returns `Some(Condition)` once primed, `None` before.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sojourn is NaN, or
+    /// `DataError::Infinite` if the sojourn is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        timestamp: u64,
+        sojourn: f64,
+    ) -> Result<Option<Condition>, crate::DataError> {
+        check_finite!(sojourn);
+        let min = self.windowed_min.update(timestamp, sojourn)?;
+
+        if self.windowed_min.count() < self.min_samples {
+            return Ok(None);
+        }
+
+        if min > self.target {
+            Ok(Some(Condition::Degraded))
+        } else {
+            Ok(Some(Condition::Normal))
+        }
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    pub fn update_i64(
+        &mut self,
+        timestamp: i64,
+        sojourn: f64,
+    ) -> Result<Option<Condition>, crate::DataError> {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, sojourn)
+    }
+
+    /// Current windowed minimum sojourn time, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min_sojourn(&self) -> Option<f64> {
+        self.windowed_min.min()
+    }
+
+    /// Whether the queue is currently elevated.
+    #[inline]
+    #[must_use]
+    pub fn is_elevated(&self) -> bool {
+        self.windowed_min.min().is_some_and(|min| min > self.target)
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.windowed_min.count()
+    }
+
+    /// Whether the monitor has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.windowed_min.count() >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.windowed_min.reset();
+    }
+}
+
+impl CoDelF64Builder {
+    /// Target sojourn time. Elevated when minimum exceeds this.
+    #[inline]
+    #[must_use]
+    pub fn target(mut self, target: f64) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    /// Observation window in raw units (same as timestamps).
+    #[inline]
+    #[must_use]
+    pub fn window(mut self, window: u64) -> Self {
+        self.window = Some(window);
+        self
+    }
+
+    /// Minimum samples before monitoring activates. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the CoDel monitor.
+    ///
+    /// # Errors
+    ///
+    /// - Target must have been set.
+    /// - Window must have been set and be positive.
+    #[inline]
+    pub fn build(self) -> Result<CoDelF64, crate::ConfigError> {
+        let target = self.target.ok_or(crate::ConfigError::Missing("target"))?;
+        let window = self.window.ok_or(crate::ConfigError::Missing("window"))?;
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("CoDel window must be positive"));
+        }
+
+        Ok(CoDelF64 {
+            windowed_min: WindowedMinF64::new(window)?,
+            target,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod raw_tests {

--- a/nexus-stats-core/src/monitoring/drawdown.rs
+++ b/nexus-stats-core/src/monitoring/drawdown.rs
@@ -1,241 +1,227 @@
-macro_rules! impl_drawdown_float {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Drawdown monitor — tracks peak value and current/maximum drawdown.
-        ///
-        /// Drawdown is the decline from peak to current value. Useful for risk
-        /// monitoring and circuit breakers ("if PnL drops $X from peak, halt").
-        ///
-        /// # Use Cases
-        /// - PnL circuit breaker
-        /// - Position risk monitoring
-        /// - Performance tracking (max drawdown as a risk metric)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            peak: $ty,
-            current: $ty,
-            max_drawdown: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new empty drawdown monitor.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    peak: $zero,
-                    current: $zero,
-                    max_drawdown: $zero,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current drawdown (peak - current).
-            /// Returns 0 at new peaks.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-                self.current = sample;
-
-                if self.count == 1 || sample > self.peak {
-                    self.peak = sample;
-                }
-
-                let dd = self.peak - self.current;
-                if dd > self.max_drawdown {
-                    self.max_drawdown = dd;
-                }
-
-                Ok(dd)
-            }
-
-            /// Highest value seen, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn peak(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.peak)
-                }
-            }
-
-            /// Current drawdown (peak - last sample). Zero if empty.
-            #[inline]
-            #[must_use]
-            pub fn drawdown(&self) -> $ty {
-                if self.count == 0 {
-                    $zero
-                } else {
-                    self.peak - self.current
-                }
-            }
-
-            /// Worst drawdown ever observed. Zero if empty.
-            #[inline]
-            #[must_use]
-            pub fn max_drawdown(&self) -> $ty {
-                self.max_drawdown
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.peak = $zero;
-                self.current = $zero;
-                self.max_drawdown = $zero;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Drawdown monitor — tracks peak value and current/maximum drawdown.
+///
+/// Drawdown is the decline from peak to current value. Useful for risk
+/// monitoring and circuit breakers ("if PnL drops $X from peak, halt").
+///
+/// # Use Cases
+/// - PnL circuit breaker
+/// - Position risk monitoring
+/// - Performance tracking (max drawdown as a risk metric)
+#[derive(Debug, Clone)]
+pub struct DrawdownF64 {
+    peak: f64,
+    current: f64,
+    max_drawdown: f64,
+    count: u64,
 }
 
-macro_rules! impl_drawdown_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Drawdown monitor — tracks peak value and current/maximum drawdown.
-        ///
-        /// Drawdown is the decline from peak to current value. Useful for risk
-        /// monitoring and circuit breakers ("if PnL drops $X from peak, halt").
-        ///
-        /// # Use Cases
-        /// - PnL circuit breaker
-        /// - Position risk monitoring
-        /// - Performance tracking (max drawdown as a risk metric)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            peak: $ty,
-            current: $ty,
-            max_drawdown: $ty,
-            count: u64,
+impl DrawdownF64 {
+    /// Creates a new empty drawdown monitor.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            peak: 0.0,
+            current: 0.0,
+            max_drawdown: 0.0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns the current drawdown (peak - current).
+    /// Returns 0 at new peaks.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<f64, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+        self.current = sample;
+
+        if self.count == 1 || sample > self.peak {
+            self.peak = sample;
         }
 
-        impl $name {
-            /// Creates a new empty drawdown monitor.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    peak: $zero,
-                    current: $zero,
-                    max_drawdown: $zero,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current drawdown (peak - current).
-            /// Returns 0 at new peaks.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> $ty {
-                self.count += 1;
-                self.current = sample;
-
-                if self.count == 1 || sample > self.peak {
-                    self.peak = sample;
-                }
-
-                let dd = self.peak - self.current;
-                if dd > self.max_drawdown {
-                    self.max_drawdown = dd;
-                }
-
-                dd
-            }
-
-            /// Highest value seen, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn peak(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.peak)
-                }
-            }
-
-            /// Current drawdown (peak - last sample). Zero if empty.
-            #[inline]
-            #[must_use]
-            pub fn drawdown(&self) -> $ty {
-                if self.count == 0 {
-                    $zero
-                } else {
-                    self.peak - self.current
-                }
-            }
-
-            /// Worst drawdown ever observed. Zero if empty.
-            #[inline]
-            #[must_use]
-            pub fn max_drawdown(&self) -> $ty {
-                self.max_drawdown
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.peak = $zero;
-                self.current = $zero;
-                self.max_drawdown = $zero;
-                self.count = 0;
-            }
+        let dd = self.peak - self.current;
+        if dd > self.max_drawdown {
+            self.max_drawdown = dd;
         }
 
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
+        Ok(dd)
+    }
+
+    /// Highest value seen, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn peak(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.peak)
         }
-    };
+    }
+
+    /// Current drawdown (peak - last sample). Zero if empty.
+    #[inline]
+    #[must_use]
+    pub fn drawdown(&self) -> f64 {
+        if self.count == 0 {
+            0.0
+        } else {
+            self.peak - self.current
+        }
+    }
+
+    /// Worst drawdown ever observed. Zero if empty.
+    #[inline]
+    #[must_use]
+    pub fn max_drawdown(&self) -> f64 {
+        self.max_drawdown
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.peak = 0.0;
+        self.current = 0.0;
+        self.max_drawdown = 0.0;
+        self.count = 0;
+    }
 }
 
-impl_drawdown_float!(DrawdownF64, f64, 0.0);
-impl_drawdown_float!(DrawdownF32, f32, 0.0);
-impl_drawdown_int!(DrawdownI64, i64, 0);
-impl_drawdown_int!(DrawdownI32, i32, 0);
-impl_drawdown_int!(DrawdownI128, i128, 0);
+impl Default for DrawdownF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Drawdown monitor — tracks peak value and current/maximum drawdown.
+///
+/// Drawdown is the decline from peak to current value. Useful for risk
+/// monitoring and circuit breakers ("if PnL drops $X from peak, halt").
+///
+/// # Use Cases
+/// - PnL circuit breaker
+/// - Position risk monitoring
+/// - Performance tracking (max drawdown as a risk metric)
+#[derive(Debug, Clone)]
+pub struct DrawdownI64 {
+    peak: i64,
+    current: i64,
+    max_drawdown: i64,
+    count: u64,
+}
+
+impl DrawdownI64 {
+    /// Creates a new empty drawdown monitor.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            peak: 0,
+            current: 0,
+            max_drawdown: 0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns the current drawdown (peak - current).
+    /// Returns 0 at new peaks.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> i64 {
+        self.count += 1;
+        self.current = sample;
+
+        if self.count == 1 || sample > self.peak {
+            self.peak = sample;
+        }
+
+        let dd = self.peak - self.current;
+        if dd > self.max_drawdown {
+            self.max_drawdown = dd;
+        }
+
+        dd
+    }
+
+    /// Highest value seen, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn peak(&self) -> Option<i64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.peak)
+        }
+    }
+
+    /// Current drawdown (peak - last sample). Zero if empty.
+    #[inline]
+    #[must_use]
+    pub fn drawdown(&self) -> i64 {
+        if self.count == 0 {
+            0
+        } else {
+            self.peak - self.current
+        }
+    }
+
+    /// Worst drawdown ever observed. Zero if empty.
+    #[inline]
+    #[must_use]
+    pub fn max_drawdown(&self) -> i64 {
+        self.max_drawdown
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.peak = 0;
+        self.current = 0;
+        self.max_drawdown = 0;
+        self.count = 0;
+    }
+}
+
+impl Default for DrawdownI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -325,28 +311,6 @@ mod tests {
     }
 
     #[test]
-    fn i32_basic() {
-        let mut dd = DrawdownI32::new();
-        let _ = dd.update(100);
-        assert_eq!(dd.update(90), 10);
-    }
-
-    #[test]
-    #[allow(clippy::float_cmp)]
-    fn f32_basic() {
-        let mut dd = DrawdownF32::new();
-        let _ = dd.update(100.0).unwrap();
-        assert_eq!(dd.update(95.0).unwrap(), 5.0);
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut dd = DrawdownI128::new();
-        let _ = dd.update(1000);
-        assert_eq!(dd.update(800), 200);
-    }
-
-    #[test]
     #[allow(clippy::float_cmp)]
     fn monotonic_increasing_no_drawdown() {
         let mut dd = DrawdownF64::new();
@@ -370,16 +334,6 @@ mod tests {
         ));
         assert!(matches!(
             dd.update(f64::NEG_INFINITY),
-            Err(crate::DataError::Infinite)
-        ));
-
-        let mut dd32 = DrawdownF32::new();
-        assert!(matches!(
-            dd32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
-        ));
-        assert!(matches!(
-            dd32.update(f32::INFINITY),
             Err(crate::DataError::Infinite)
         ));
     }

--- a/nexus-stats-core/src/monitoring/error_rate.rs
+++ b/nexus-stats-core/src/monitoring/error_rate.rs
@@ -1,237 +1,224 @@
 use crate::Condition;
 use crate::math::MulAdd;
 
-macro_rules! impl_error_rate {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Smoothed error rate tracker.
-        ///
-        /// Internally uses an EMA where success = 0.0 and failure = 1.0 (or
-        /// weighted). The smoothed value approximates the recent error rate.
-        ///
-        /// # Use Cases
-        /// - API error rate monitoring
-        /// - Exchange rejection rate tracking
-        /// - Weighted severity tracking (critical failures count more)
-        ///
-        /// # Weighted outcomes
-        ///
-        /// `update_weighted(false, 2.0)` feeds 2.0 to the EMA (a failure that
-        /// counts double). With weights > 1.0, the smoothed "rate" can exceed
-        /// 1.0 — it becomes a severity-weighted signal rather than a pure rate.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            value: $ty,
-            threshold: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            threshold: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    threshold: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Updates with an outcome with default weight 1.0.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, success: bool) -> Option<Condition> {
-                // Weight 1.0 is always finite — bypass validation.
-                self.update_weighted(success, 1.0 as $ty).unwrap()
-            }
-
-            /// Updates with an outcome with a severity weight.
-            ///
-            /// Success feeds `0.0`, failure feeds `weight`. The EMA smooths
-            /// this signal. With `weight=1.0`, the smoothed value is the
-            /// recent error rate in [0, 1]. With `weight > 1.0`, it can exceed 1.0.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the weight is NaN, or
-            /// `DataError::Infinite` if the weight is infinite.
-            #[inline]
-            pub fn update_weighted(
-                &mut self,
-                success: bool,
-                weight: $ty,
-            ) -> Result<Option<Condition>, crate::DataError> {
-                check_finite!(weight);
-                self.count += 1;
-
-                let sample = if success { 0.0 as $ty } else { weight };
-
-                if self.count == 1 {
-                    self.value = sample;
-                } else {
-                    self.value = self.alpha.fma(sample, self.one_minus_alpha * self.value);
-                }
-
-                if self.count < self.min_samples {
-                    return Ok(Option::None);
-                }
-
-                Ok(if self.value > self.threshold {
-                    Option::Some(Condition::Degraded)
-                } else {
-                    Option::Some(Condition::Normal)
-                })
-            }
-
-            /// Current smoothed error rate, or `None` if not primed.
-            ///
-            /// With unweighted `update()`, this is in [0.0, 1.0].
-            /// With weighted outcomes, it may exceed 1.0.
-            #[inline]
-            #[must_use]
-            pub fn error_rate(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.value)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of outcomes recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data has been collected.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.count = 0;
-            }
-
-            /// Updates the error rate threshold without resetting state.
-            ///
-            /// # Errors
-            ///
-            /// Threshold must be >= 0.
-            #[inline]
-            pub fn reconfigure_threshold(
-                &mut self,
-                threshold: $ty,
-            ) -> Result<(), crate::ConfigError> {
-                if threshold < (0.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid(
-                        "threshold must be non-negative",
-                    ));
-                }
-                self.threshold = threshold;
-                Ok(())
-            }
-        }
-
-        impl $builder {
-            /// Smoothing factor.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Halflife for smoothing.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                self.alpha =
-                    Option::Some(1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty);
-                self
-            }
-
-            /// Span for smoothing.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.alpha = Option::Some(2.0 as $ty / (n as $ty + 1.0 as $ty));
-                self
-            }
-
-            /// Error rate threshold. Degraded when smoothed rate exceeds this.
-            #[inline]
-            #[must_use]
-            pub fn threshold(mut self, threshold: $ty) -> Self {
-                self.threshold = Option::Some(threshold);
-                self
-            }
-
-            /// Minimum outcomes before detection activates. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the error rate tracker.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha and threshold must have been set.
-            /// - Alpha must be in (0, 1) exclusive.
-            /// - Threshold must be non-negative.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                let threshold = self
-                    .threshold
-                    .ok_or(crate::ConfigError::Missing("threshold"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("alpha must be in (0, 1)"));
-                }
-                if threshold < 0.0 as $ty {
-                    return Err(crate::ConfigError::Invalid(
-                        "threshold must be non-negative",
-                    ));
-                }
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    value: 0.0 as $ty,
-                    threshold,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Smoothed error rate tracker.
+///
+/// Internally uses an EMA where success = 0.0 and failure = 1.0 (or
+/// weighted). The smoothed value approximates the recent error rate.
+///
+/// # Use Cases
+/// - API error rate monitoring
+/// - Exchange rejection rate tracking
+/// - Weighted severity tracking (critical failures count more)
+///
+/// # Weighted outcomes
+///
+/// `update_weighted(false, 2.0)` feeds 2.0 to the EMA (a failure that
+/// counts double). With weights > 1.0, the smoothed "rate" can exceed
+/// 1.0 — it becomes a severity-weighted signal rather than a pure rate.
+#[derive(Debug, Clone)]
+pub struct ErrorRateF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    value: f64,
+    threshold: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_error_rate!(ErrorRateF64, ErrorRateF64Builder, f64);
-impl_error_rate!(ErrorRateF32, ErrorRateF32Builder, f32);
+/// Builder for [`ErrorRateF64`].
+#[derive(Debug, Clone)]
+pub struct ErrorRateF64Builder {
+    alpha: Option<f64>,
+    threshold: Option<f64>,
+    min_samples: u64,
+}
+
+impl ErrorRateF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> ErrorRateF64Builder {
+        ErrorRateF64Builder {
+            alpha: None,
+            threshold: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Updates with an outcome with default weight 1.0.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, success: bool) -> Option<Condition> {
+        // Weight 1.0 is always finite — bypass validation.
+        self.update_weighted(success, 1.0).unwrap()
+    }
+
+    /// Updates with an outcome with a severity weight.
+    ///
+    /// Success feeds `0.0`, failure feeds `weight`. The EMA smooths
+    /// this signal. With `weight=1.0`, the smoothed value is the
+    /// recent error rate in [0, 1]. With `weight > 1.0`, it can exceed 1.0.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the weight is NaN, or
+    /// `DataError::Infinite` if the weight is infinite.
+    #[inline]
+    pub fn update_weighted(
+        &mut self,
+        success: bool,
+        weight: f64,
+    ) -> Result<Option<Condition>, crate::DataError> {
+        check_finite!(weight);
+        self.count += 1;
+
+        let sample = if success { 0.0 } else { weight };
+
+        if self.count == 1 {
+            self.value = sample;
+        } else {
+            self.value = self.alpha.fma(sample, self.one_minus_alpha * self.value);
+        }
+
+        if self.count < self.min_samples {
+            return Ok(None);
+        }
+
+        Ok(if self.value > self.threshold {
+            Some(Condition::Degraded)
+        } else {
+            Some(Condition::Normal)
+        })
+    }
+
+    /// Current smoothed error rate, or `None` if not primed.
+    ///
+    /// With unweighted `update()`, this is in [0.0, 1.0].
+    /// With weighted outcomes, it may exceed 1.0.
+    #[inline]
+    #[must_use]
+    pub fn error_rate(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// Number of outcomes recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data has been collected.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.count = 0;
+    }
+
+    /// Updates the error rate threshold without resetting state.
+    ///
+    /// # Errors
+    ///
+    /// Threshold must be >= 0.
+    #[inline]
+    pub fn reconfigure_threshold(&mut self, threshold: f64) -> Result<(), crate::ConfigError> {
+        if threshold < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold must be non-negative",
+            ));
+        }
+        self.threshold = threshold;
+        Ok(())
+    }
+}
+
+impl ErrorRateF64Builder {
+    /// Smoothing factor.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Halflife for smoothing.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        self.alpha = Some(1.0 - crate::math::exp(-ln2 / halflife));
+        self
+    }
+
+    /// Span for smoothing.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.alpha = Some(2.0 / (n as f64 + 1.0));
+        self
+    }
+
+    /// Error rate threshold. Degraded when smoothed rate exceeds this.
+    #[inline]
+    #[must_use]
+    pub fn threshold(mut self, threshold: f64) -> Self {
+        self.threshold = Some(threshold);
+        self
+    }
+
+    /// Minimum outcomes before detection activates. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the error rate tracker.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha and threshold must have been set.
+    /// - Alpha must be in (0, 1) exclusive.
+    /// - Threshold must be non-negative.
+    #[inline]
+    pub fn build(self) -> Result<ErrorRateF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        let threshold = self
+            .threshold
+            .ok_or(crate::ConfigError::Missing("threshold"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid("alpha must be in (0, 1)"));
+        }
+        if threshold < 0.0 {
+            return Err(crate::ConfigError::Invalid(
+                "threshold must be non-negative",
+            ));
+        }
+
+        Ok(ErrorRateF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            value: 0.0,
+            threshold,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -346,17 +333,6 @@ mod tests {
         er.reset();
         assert_eq!(er.count(), 0);
         assert!(er.error_rate().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut er = ErrorRateF32::builder()
-            .alpha(0.3)
-            .threshold(0.05)
-            .build()
-            .unwrap();
-
-        assert_eq!(er.update(true), Some(Condition::Normal));
     }
 
     #[test]

--- a/nexus-stats-core/src/monitoring/event_rate.rs
+++ b/nexus-stats-core/src/monitoring/event_rate.rs
@@ -1,341 +1,182 @@
 use crate::math::MulAdd;
-macro_rules! impl_event_rate_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Smoothed event rate tracker.
-        ///
-        /// Uses an EMA of inter-arrival times, inverted on query to produce
-        /// a rate (events per unit time). The rate adapts smoothly to changes
-        /// in event frequency.
-        ///
-        /// # Use Cases
-        /// - Message throughput monitoring
-        /// - Order rate tracking
-        /// - Adaptive rate limiting input
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            interval: $ty,
-            last_timestamp: $ty,
-            count: u64,
-            min_samples: u64,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Updates with an event at the given timestamp.
-            ///
-            /// If two events share a timestamp, the interval is zero and
-            /// `rate()` returns `None` until a non-zero interval is observed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the timestamp is NaN, or
-            /// `DataError::Infinite` if the timestamp is infinite.
-            #[inline]
-            pub fn update(&mut self, timestamp: $ty) -> Result<(), crate::DataError> {
-                check_finite!(timestamp);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_timestamp = timestamp;
-                    return Ok(());
-                }
-
-                let dt = timestamp - self.last_timestamp;
-                self.last_timestamp = timestamp;
-
-                if self.count == 2 {
-                    self.interval = dt;
-                } else {
-                    self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
-                }
-                Ok(())
-            }
-
-            /// Current smoothed event rate (events per unit time).
-            ///
-            /// Returns `None` if not primed or if interval is zero.
-            #[inline]
-            #[must_use]
-            pub fn rate(&self) -> Option<$ty> {
-                if self.count < self.min_samples || self.interval <= (0.0 as $ty) {
-                    Option::None
-                } else {
-                    Option::Some(1.0 as $ty / self.interval)
-                }
-            }
-
-            /// Current smoothed inter-event interval, or `None` if < 2 events.
-            #[inline]
-            #[must_use]
-            pub fn interval(&self) -> Option<$ty> {
-                if self.count >= 2 {
-                    Option::Some(self.interval)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of events recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the tracker has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.interval = 0.0 as $ty;
-                self.last_timestamp = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Direct smoothing factor for interval EMA.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Halflife for interval smoothing.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                let alpha = 1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty;
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Span for interval smoothing.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                let alpha = 2.0 as $ty / (n as $ty + 1.0 as $ty);
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Minimum events before rate is valid. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the event rate tracker.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha must have been set.
-            /// - Alpha must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid(
-                        "EventRate alpha must be in (0, 1)",
-                    ));
-                }
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    interval: 0.0 as $ty,
-                    last_timestamp: 0.0 as $ty,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Smoothed event rate tracker.
+///
+/// Uses an EMA of inter-arrival times, inverted on query to produce
+/// a rate (events per unit time). The rate adapts smoothly to changes
+/// in event frequency.
+///
+/// # Use Cases
+/// - Message throughput monitoring
+/// - Order rate tracking
+/// - Adaptive rate limiting input
+#[derive(Debug, Clone)]
+pub struct EventRateF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    interval: f64,
+    last_timestamp: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_event_rate_float!(EventRateF64, EventRateF64Builder, f64);
-impl_event_rate_float!(EventRateF32, EventRateF32Builder, f32);
-
-macro_rules! impl_event_rate_int {
-    ($name:ident, $builder:ident, $ty:ty, $acc_ty:ty) => {
-        /// Smoothed event rate tracker (integer variant).
-        ///
-        /// Uses kernel-style fixed-point EMA on inter-arrival ticks.
-        /// Rate query returns `unit / smoothed_interval` where unit is
-        /// the caller's time unit.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            acc: $acc_ty,
-            shift: u32,
-            span: u64,
-            last_timestamp: $ty,
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            span: Option<u64>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    span: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Updates with an event at the given tick.
-            #[inline]
-            pub fn update(&mut self, timestamp: $ty) {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_timestamp = timestamp;
-                    return;
-                }
-
-                let dt = timestamp - self.last_timestamp;
-                self.last_timestamp = timestamp;
-
-                if !self.initialized {
-                    self.acc = (dt as $acc_ty) << self.shift;
-                    self.initialized = true;
-                } else {
-                    let dt_shifted = (dt as $acc_ty) << self.shift;
-                    self.acc += (dt_shifted - self.acc) >> self.shift;
-                }
-            }
-
-            /// Current smoothed inter-event interval, or `None` if < 2 events.
-            #[inline]
-            #[must_use]
-            pub fn interval(&self) -> Option<$ty> {
-                if self.count >= 2 && self.initialized {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Effective span after rounding.
-            #[inline]
-            #[must_use]
-            pub fn effective_span(&self) -> u64 {
-                self.span
-            }
-
-            /// Number of events recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the tracker has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.acc = 0;
-                self.last_timestamp = 0;
-                self.count = 0;
-                self.initialized = false;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing span. Rounded up to next `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.span = Option::Some(n);
-                self
-            }
-
-            /// Minimum events before rate is valid. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the event rate tracker.
-            ///
-            /// # Errors
-            ///
-            /// - Span must have been set and >= 1.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
-                if requested < 1 {
-                    return Err(crate::ConfigError::Invalid("EventRate span must be >= 1"));
-                }
-
-                let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
-                let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
-
-                Ok($name {
-                    acc: 0,
-                    shift,
-                    span: effective,
-                    last_timestamp: 0,
-                    count: 0,
-                    min_samples: self.min_samples,
-                    initialized: false,
-                })
-            }
-        }
-    };
+/// Builder for [`EventRateF64`].
+#[derive(Debug, Clone)]
+pub struct EventRateF64Builder {
+    alpha: Option<f64>,
+    min_samples: u64,
 }
 
-impl_event_rate_int!(EventRateI64, EventRateI64Builder, i64, i128);
-impl_event_rate_int!(EventRateI32, EventRateI32Builder, i32, i64);
+impl EventRateF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EventRateF64Builder {
+        EventRateF64Builder {
+            alpha: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Updates with an event at the given timestamp.
+    ///
+    /// If two events share a timestamp, the interval is zero and
+    /// `rate()` returns `None` until a non-zero interval is observed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the timestamp is NaN, or
+    /// `DataError::Infinite` if the timestamp is infinite.
+    #[inline]
+    pub fn update(&mut self, timestamp: f64) -> Result<(), crate::DataError> {
+        check_finite!(timestamp);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_timestamp = timestamp;
+            return Ok(());
+        }
+
+        let dt = timestamp - self.last_timestamp;
+        self.last_timestamp = timestamp;
+
+        if self.count == 2 {
+            self.interval = dt;
+        } else {
+            self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
+        }
+        Ok(())
+    }
+
+    /// Current smoothed event rate (events per unit time).
+    ///
+    /// Returns `None` if not primed or if interval is zero.
+    #[inline]
+    #[must_use]
+    pub fn rate(&self) -> Option<f64> {
+        if self.count < self.min_samples || self.interval <= 0.0 {
+            None
+        } else {
+            Some(1.0 / self.interval)
+        }
+    }
+
+    /// Current smoothed inter-event interval, or `None` if < 2 events.
+    #[inline]
+    #[must_use]
+    pub fn interval(&self) -> Option<f64> {
+        if self.count >= 2 {
+            Some(self.interval)
+        } else {
+            None
+        }
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the tracker has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.interval = 0.0;
+        self.last_timestamp = 0.0;
+        self.count = 0;
+    }
+}
+
+impl EventRateF64Builder {
+    /// Direct smoothing factor for interval EMA.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Halflife for interval smoothing.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        let alpha = 1.0 - crate::math::exp(-ln2 / halflife);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Span for interval smoothing.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        let alpha = 2.0 / (n as f64 + 1.0);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Minimum events before rate is valid. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the event rate tracker.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha must have been set.
+    /// - Alpha must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<EventRateF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid(
+                "EventRate alpha must be in (0, 1)",
+            ));
+        }
+
+        Ok(EventRateF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            interval: 0.0,
+            last_timestamp: 0.0,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -345,7 +186,7 @@ mod tests {
     fn constant_rate() {
         let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
 
-        // Events every 10 units → rate should converge to 0.1
+        // Events every 10 units -> rate should converge to 0.1
         for i in 0..100 {
             er.update(i as f64 * 10.0).unwrap();
         }
@@ -404,39 +245,10 @@ mod tests {
     }
 
     #[test]
-    fn f32_basic() {
-        let mut er = EventRateF32::builder().alpha(0.3).build().unwrap();
-        er.update(0.0).unwrap();
-        er.update(10.0).unwrap();
-        assert!(er.rate().is_some());
-    }
-
-    #[test]
-    fn i64_basic() {
-        let mut er = EventRateI64::builder().span(7).build().unwrap();
-        for i in 0..10 {
-            er.update(i * 100);
-        }
-        let interval = er.interval().unwrap();
-        assert!(
-            (interval - 100).abs() <= 1,
-            "interval should be ~100, got {interval}"
-        );
-    }
-
-    #[test]
-    fn i32_basic() {
-        let mut er = EventRateI32::builder().span(3).build().unwrap();
-        er.update(0);
-        er.update(50);
-        assert!(er.interval().is_some());
-    }
-
-    #[test]
     fn zero_interval_returns_none() {
         let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
         er.update(100.0).unwrap();
-        er.update(100.0).unwrap(); // same timestamp → interval = 0
+        er.update(100.0).unwrap(); // same timestamp -> interval = 0
         // rate() should return None (division by zero guard)
         assert!(
             er.rate().is_none(),
@@ -460,12 +272,6 @@ mod tests {
         assert!(matches!(
             er.update(f64::INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut er32 = EventRateF32::builder().alpha(0.3).build().unwrap();
-        assert!(matches!(
-            er32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/hawkes.rs
+++ b/nexus-stats-core/src/monitoring/hawkes.rs
@@ -1,246 +1,235 @@
-macro_rules! impl_hawkes {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Hawkes process intensity estimator.
-        ///
-        /// Self-exciting point process: each event increases the intensity,
-        /// which then decays exponentially. Models bursty arrivals where
-        /// events cluster (trade arrivals, order bursts, alert cascades).
-        ///
-        /// λ(t) = μ + α · Σ exp(-β · (t - t_i))
-        ///
-        /// Recursive form: O(1) per event.
-        ///
-        /// # Parameters
-        ///
-        /// - `mu` (μ) — baseline intensity (events per unit time)
-        /// - `alpha` (α) — excitation per event
-        /// - `beta` (β) — decay rate (higher = faster decay)
-        ///
-        /// Stability requires α < β (branching ratio α/β < 1).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_core::monitoring::HawkesIntensityF64;
-        ///
-        /// let mut h = HawkesIntensityF64::builder()
-        ///     .mu(1.0)
-        ///     .alpha(0.5)
-        ///     .beta(1.0)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// h.update(0);
-        /// h.update(100);
-        /// assert!(h.intensity() > 1.0); // above baseline after event
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            mu: $ty,
-            alpha: $ty,
-            beta: $ty,
-            excitation: $ty,
-            last_time: u64,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            mu: Option<$ty>,
-            alpha: Option<$ty>,
-            beta: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    mu: Option::None,
-                    alpha: Option::None,
-                    beta: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Records an event at the given timestamp.
-            ///
-            /// Timestamps are u64 (matching `Clock::stamp()`). The delta
-            /// between timestamps is computed with saturating subtraction.
-            #[inline]
-            pub fn update(&mut self, time: u64) {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.excitation = self.alpha;
-                    self.last_time = time;
-                    return;
-                }
-
-                let dt = time.saturating_sub(self.last_time);
-                #[allow(clippy::cast_possible_truncation)]
-                let decay = crate::math::exp(-(self.beta * dt as $ty) as f64) as $ty;
-                self.excitation = crate::math::MulAdd::fma(decay, self.excitation, self.alpha);
-                self.last_time = time;
-            }
-
-            /// Current intensity λ at last event time: `μ + excitation`.
-            #[inline]
-            #[must_use]
-            pub fn intensity(&self) -> $ty {
-                if self.count == 0 {
-                    self.mu
-                } else {
-                    self.mu + self.excitation
-                }
-            }
-
-            /// Intensity at an arbitrary time (without recording an event).
-            ///
-            /// Decays excitation from last event time to `time`. Assumes
-            /// monotonic timestamps; times before `last_time` are clamped
-            /// to zero delta, returning the current intensity.
-            #[inline]
-            #[must_use]
-            pub fn intensity_at(&self, time: u64) -> $ty {
-                if self.count == 0 {
-                    return self.mu;
-                }
-                let dt = time.saturating_sub(self.last_time);
-                #[allow(clippy::cast_possible_truncation)]
-                let decay = crate::math::exp(-(self.beta * dt as $ty) as f64) as $ty;
-                crate::math::MulAdd::fma(decay, self.excitation, self.mu)
-            }
-
-            /// Baseline intensity μ.
-            #[inline]
-            #[must_use]
-            pub fn baseline(&self) -> $ty {
-                self.mu
-            }
-
-            /// Branching ratio α/β. Must be < 1 for stability.
-            #[inline]
-            #[must_use]
-            pub fn branching_ratio(&self) -> $ty {
-                self.alpha / self.beta
-            }
-
-            /// Number of events recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough events have been observed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.excitation = 0.0 as $ty;
-                self.last_time = 0;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Baseline intensity μ (required, > 0).
-            #[inline]
-            #[must_use]
-            pub fn mu(mut self, mu: $ty) -> Self {
-                self.mu = Option::Some(mu);
-                self
-            }
-
-            /// Excitation per event α (required, >= 0).
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Decay rate β (required, > 0, must be > α for stability).
-            #[inline]
-            #[must_use]
-            pub fn beta(mut self, beta: $ty) -> Self {
-                self.beta = Option::Some(beta);
-                self
-            }
-
-            /// Minimum events before is_primed. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the Hawkes intensity estimator.
-            ///
-            /// # Errors
-            ///
-            /// - `mu` must be positive and finite.
-            /// - `alpha` must be non-negative and finite.
-            /// - `beta` must be positive and finite.
-            /// - `alpha` must be < `beta` (branching ratio < 1).
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let mu = self.mu.ok_or(crate::ConfigError::Missing("mu"))?;
-                if mu <= 0.0 as $ty || !mu.is_finite() {
-                    return Err(crate::ConfigError::Invalid(
-                        "Hawkes mu must be positive and finite",
-                    ));
-                }
-
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if alpha < 0.0 as $ty || !alpha.is_finite() {
-                    return Err(crate::ConfigError::Invalid(
-                        "Hawkes alpha must be non-negative and finite",
-                    ));
-                }
-
-                let beta = self.beta.ok_or(crate::ConfigError::Missing("beta"))?;
-                if beta <= 0.0 as $ty || !beta.is_finite() {
-                    return Err(crate::ConfigError::Invalid(
-                        "Hawkes beta must be positive and finite",
-                    ));
-                }
-
-                if alpha >= beta {
-                    return Err(crate::ConfigError::Invalid(
-                        "Hawkes alpha must be < beta (branching ratio < 1)",
-                    ));
-                }
-
-                Ok($name {
-                    mu,
-                    alpha,
-                    beta,
-                    excitation: 0.0 as $ty,
-                    last_time: 0,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Hawkes process intensity estimator.
+///
+/// Self-exciting point process: each event increases the intensity,
+/// which then decays exponentially. Models bursty arrivals where
+/// events cluster (trade arrivals, order bursts, alert cascades).
+///
+/// lambda(t) = mu + alpha * sum exp(-beta * (t - t_i))
+///
+/// Recursive form: O(1) per event.
+///
+/// # Parameters
+///
+/// - `mu` (mu) — baseline intensity (events per unit time)
+/// - `alpha` (alpha) — excitation per event
+/// - `beta` (beta) — decay rate (higher = faster decay)
+///
+/// Stability requires alpha < beta (branching ratio alpha/beta < 1).
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::monitoring::HawkesIntensityF64;
+///
+/// let mut h = HawkesIntensityF64::builder()
+///     .mu(1.0)
+///     .alpha(0.5)
+///     .beta(1.0)
+///     .build()
+///     .unwrap();
+///
+/// h.update(0);
+/// h.update(100);
+/// assert!(h.intensity() > 1.0); // above baseline after event
+/// ```
+#[derive(Debug, Clone)]
+pub struct HawkesIntensityF64 {
+    mu: f64,
+    alpha: f64,
+    beta: f64,
+    excitation: f64,
+    last_time: u64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_hawkes!(HawkesIntensityF64, HawkesIntensityF64Builder, f64);
-impl_hawkes!(HawkesIntensityF32, HawkesIntensityF32Builder, f32);
+/// Builder for [`HawkesIntensityF64`].
+#[derive(Debug, Clone)]
+pub struct HawkesIntensityF64Builder {
+    mu: Option<f64>,
+    alpha: Option<f64>,
+    beta: Option<f64>,
+    min_samples: u64,
+}
+
+impl HawkesIntensityF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> HawkesIntensityF64Builder {
+        HawkesIntensityF64Builder {
+            mu: None,
+            alpha: None,
+            beta: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Records an event at the given timestamp.
+    ///
+    /// Timestamps are u64 (matching `Clock::stamp()`). The delta
+    /// between timestamps is computed with saturating subtraction.
+    #[inline]
+    pub fn update(&mut self, time: u64) {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.excitation = self.alpha;
+            self.last_time = time;
+            return;
+        }
+
+        let dt = time.saturating_sub(self.last_time);
+        let decay = crate::math::exp(-(self.beta * dt as f64));
+        self.excitation = crate::math::MulAdd::fma(decay, self.excitation, self.alpha);
+        self.last_time = time;
+    }
+
+    /// Current intensity lambda at last event time: `mu + excitation`.
+    #[inline]
+    #[must_use]
+    pub fn intensity(&self) -> f64 {
+        if self.count == 0 {
+            self.mu
+        } else {
+            self.mu + self.excitation
+        }
+    }
+
+    /// Intensity at an arbitrary time (without recording an event).
+    ///
+    /// Decays excitation from last event time to `time`. Assumes
+    /// monotonic timestamps; times before `last_time` are clamped
+    /// to zero delta, returning the current intensity.
+    #[inline]
+    #[must_use]
+    pub fn intensity_at(&self, time: u64) -> f64 {
+        if self.count == 0 {
+            return self.mu;
+        }
+        let dt = time.saturating_sub(self.last_time);
+        let decay = crate::math::exp(-(self.beta * dt as f64));
+        crate::math::MulAdd::fma(decay, self.excitation, self.mu)
+    }
+
+    /// Baseline intensity mu.
+    #[inline]
+    #[must_use]
+    pub fn baseline(&self) -> f64 {
+        self.mu
+    }
+
+    /// Branching ratio alpha/beta. Must be < 1 for stability.
+    #[inline]
+    #[must_use]
+    pub fn branching_ratio(&self) -> f64 {
+        self.alpha / self.beta
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough events have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.excitation = 0.0;
+        self.last_time = 0;
+        self.count = 0;
+    }
+}
+
+impl HawkesIntensityF64Builder {
+    /// Baseline intensity mu (required, > 0).
+    #[inline]
+    #[must_use]
+    pub fn mu(mut self, mu: f64) -> Self {
+        self.mu = Some(mu);
+        self
+    }
+
+    /// Excitation per event alpha (required, >= 0).
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Decay rate beta (required, > 0, must be > alpha for stability).
+    #[inline]
+    #[must_use]
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.beta = Some(beta);
+        self
+    }
+
+    /// Minimum events before is_primed. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the Hawkes intensity estimator.
+    ///
+    /// # Errors
+    ///
+    /// - `mu` must be positive and finite.
+    /// - `alpha` must be non-negative and finite.
+    /// - `beta` must be positive and finite.
+    /// - `alpha` must be < `beta` (branching ratio < 1).
+    #[inline]
+    pub fn build(self) -> Result<HawkesIntensityF64, crate::ConfigError> {
+        let mu = self.mu.ok_or(crate::ConfigError::Missing("mu"))?;
+        if mu <= 0.0 || !mu.is_finite() {
+            return Err(crate::ConfigError::Invalid(
+                "Hawkes mu must be positive and finite",
+            ));
+        }
+
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if alpha < 0.0 || !alpha.is_finite() {
+            return Err(crate::ConfigError::Invalid(
+                "Hawkes alpha must be non-negative and finite",
+            ));
+        }
+
+        let beta = self.beta.ok_or(crate::ConfigError::Missing("beta"))?;
+        if beta <= 0.0 || !beta.is_finite() {
+            return Err(crate::ConfigError::Invalid(
+                "Hawkes beta must be positive and finite",
+            ));
+        }
+
+        if alpha >= beta {
+            return Err(crate::ConfigError::Invalid(
+                "Hawkes alpha must be < beta (branching ratio < 1)",
+            ));
+        }
+
+        Ok(HawkesIntensityF64 {
+            mu,
+            alpha,
+            beta,
+            excitation: 0.0,
+            last_time: 0,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-core/src/monitoring/jitter.rs
+++ b/nexus-stats-core/src/monitoring/jitter.rs
@@ -1,405 +1,386 @@
 use crate::math::MulAdd;
-macro_rules! impl_jitter_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Jitter tracker — smoothed absolute deviation between consecutive samples.
-        ///
-        /// Internally tracks an EMA of absolute consecutive deltas and an EMA of
-        /// values for computing the jitter ratio.
-        ///
-        /// # Use Cases
-        /// - Network jitter (variation in inter-packet delay)
-        /// - Latency jitter (variation in response times)
-        /// - Clock stability monitoring
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            jitter: $ty,
-            mean: $ty,
-            last_sample: $ty,
-            last_deviation: $ty,
-            count: u64,
-            min_samples: u64,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            min_samples: u64,
-            seed_value: Option<$ty>,
-            seed_jitter: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    min_samples: 2,
-                    seed_value: Option::None,
-                    seed_jitter: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed jitter once primed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_sample = sample;
-                    self.mean = sample;
-                    return Ok(Option::None);
-                }
-
-                let abs_delta = (sample - self.last_sample).abs();
-                self.last_deviation = abs_delta;
-                self.last_sample = sample;
-
-                if self.count == 2 {
-                    self.jitter = abs_delta;
-                    self.mean = self.alpha.fma(sample, self.one_minus_alpha * self.mean);
-                } else {
-                    self.jitter = self
-                        .alpha
-                        .fma(abs_delta, self.one_minus_alpha * self.jitter);
-                    self.mean = self.alpha.fma(sample, self.one_minus_alpha * self.mean);
-                }
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some(self.jitter))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Current smoothed jitter (absolute deviation), or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn jitter(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.jitter)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Jitter as a fraction of the smoothed mean, or `None` if not primed
-            /// or mean is near zero (absolute value < epsilon).
-            #[inline]
-            #[must_use]
-            pub fn jitter_ratio(&self) -> Option<$ty> {
-                if self.count >= self.min_samples && self.mean.abs() > <$ty>::EPSILON {
-                    Option::Some(self.jitter / self.mean)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Raw absolute deviation of the last two samples, or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            pub fn last_deviation(&self) -> Option<$ty> {
-                if self.count >= 2 {
-                    Option::Some(self.last_deviation)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data has been collected.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.jitter = 0.0 as $ty;
-                self.mean = 0.0 as $ty;
-                self.last_sample = 0.0 as $ty;
-                self.last_deviation = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing factor for jitter EMA.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Halflife for jitter smoothing.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                self.alpha =
-                    Option::Some(1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty);
-                self
-            }
-
-            /// Span for jitter smoothing.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.alpha = Option::Some(2.0 as $ty / (n as $ty + 1.0 as $ty));
-                self
-            }
-
-            /// Minimum samples before jitter is valid. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-loads the last sample value and smoothed jitter from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately and the
-            /// next `update()` computes a deviation against `value`.
-            #[inline]
-            #[must_use]
-            pub fn seed(mut self, value: $ty, jitter: $ty) -> Self {
-                self.seed_value = Option::Some(value);
-                self.seed_jitter = Option::Some(jitter);
-                self
-            }
-
-            /// Builds the jitter tracker.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha must have been set.
-            /// - Alpha must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid(
-                        "Jitter alpha must be in (0, 1)",
-                    ));
-                }
-
-                let (last_sample, jitter, mean, count) = match (self.seed_value, self.seed_jitter) {
-                    (Some(v), Some(j)) => (v, j, v, self.min_samples),
-                    _ => (0.0 as $ty, 0.0 as $ty, 0.0 as $ty, 0),
-                };
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    jitter,
-                    mean,
-                    last_sample,
-                    last_deviation: 0.0 as $ty,
-                    count,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Jitter tracker — smoothed absolute deviation between consecutive samples.
+///
+/// Internally tracks an EMA of absolute consecutive deltas and an EMA of
+/// values for computing the jitter ratio.
+///
+/// # Use Cases
+/// - Network jitter (variation in inter-packet delay)
+/// - Latency jitter (variation in response times)
+/// - Clock stability monitoring
+#[derive(Debug, Clone)]
+pub struct JitterF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    jitter: f64,
+    mean: f64,
+    last_sample: f64,
+    last_deviation: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_jitter_float!(JitterF64, JitterF64Builder, f64);
-impl_jitter_float!(JitterF32, JitterF32Builder, f32);
-
-macro_rules! impl_jitter_int {
-    ($name:ident, $builder:ident, $ty:ty, $acc_ty:ty) => {
-        /// Jitter tracker (integer variant) — fixed-point EMA of absolute deltas.
-        ///
-        /// Uses kernel-style bit-shift arithmetic. `jitter_ratio()` is not
-        /// available on integer types (integer division loses too much precision).
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            acc: $acc_ty,
-            shift: u32,
-            span: u64,
-            last_sample: $ty,
-            last_deviation: $ty,
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            span: Option<u64>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    span: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed jitter once primed.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_sample = sample;
-                    return Option::None;
-                }
-
-                let abs_delta = (sample - self.last_sample).abs();
-                self.last_deviation = abs_delta;
-                self.last_sample = sample;
-
-                if !self.initialized {
-                    self.acc = (abs_delta as $acc_ty) << self.shift;
-                    self.initialized = true;
-                } else {
-                    let delta_shifted = (abs_delta as $acc_ty) << self.shift;
-                    self.acc += (delta_shifted - self.acc) >> self.shift;
-                }
-
-                if self.count >= self.min_samples {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Current smoothed jitter, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn jitter(&self) -> Option<$ty> {
-                if self.count >= self.min_samples && self.initialized {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Raw absolute deviation of the last two samples, or `None` if < 2.
-            #[inline]
-            #[must_use]
-            pub fn last_deviation(&self) -> Option<$ty> {
-                if self.count >= 2 {
-                    Option::Some(self.last_deviation)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Effective span after rounding.
-            #[inline]
-            #[must_use]
-            pub fn effective_span(&self) -> u64 {
-                self.span
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data has been collected.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.acc = 0;
-                self.last_sample = 0;
-                self.last_deviation = 0;
-                self.count = 0;
-                self.initialized = false;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing span. Rounded up to next `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.span = Option::Some(n);
-                self
-            }
-
-            /// Minimum samples before jitter is valid. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the jitter tracker.
-            ///
-            /// # Errors
-            ///
-            /// - Span must have been set and >= 1.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
-                if requested < 1 {
-                    return Err(crate::ConfigError::Invalid("Jitter span must be >= 1"));
-                }
-
-                let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
-                let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
-
-                Ok($name {
-                    acc: 0,
-                    shift,
-                    span: effective,
-                    last_sample: 0,
-                    last_deviation: 0,
-                    count: 0,
-                    min_samples: self.min_samples,
-                    initialized: false,
-                })
-            }
-        }
-    };
+/// Builder for [`JitterF64`].
+#[derive(Debug, Clone)]
+pub struct JitterF64Builder {
+    alpha: Option<f64>,
+    min_samples: u64,
+    seed_value: Option<f64>,
+    seed_jitter: Option<f64>,
 }
 
-impl_jitter_int!(JitterI64, JitterI64Builder, i64, i128);
-impl_jitter_int!(JitterI32, JitterI32Builder, i32, i64);
+impl JitterF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> JitterF64Builder {
+        JitterF64Builder {
+            alpha: None,
+            min_samples: 2,
+            seed_value: None,
+            seed_jitter: None,
+        }
+    }
+
+    /// Feeds a sample. Returns smoothed jitter once primed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_sample = sample;
+            self.mean = sample;
+            return Ok(None);
+        }
+
+        let abs_delta = (sample - self.last_sample).abs();
+        self.last_deviation = abs_delta;
+        self.last_sample = sample;
+
+        if self.count == 2 {
+            self.jitter = abs_delta;
+        } else {
+            self.jitter = self
+                .alpha
+                .fma(abs_delta, self.one_minus_alpha * self.jitter);
+        }
+        self.mean = self.alpha.fma(sample, self.one_minus_alpha * self.mean);
+
+        if self.count >= self.min_samples {
+            Ok(Some(self.jitter))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current smoothed jitter (absolute deviation), or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn jitter(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.jitter)
+        } else {
+            None
+        }
+    }
+
+    /// Jitter as a fraction of the smoothed mean, or `None` if not primed
+    /// or mean is near zero (absolute value < epsilon).
+    #[inline]
+    #[must_use]
+    pub fn jitter_ratio(&self) -> Option<f64> {
+        if self.count >= self.min_samples && self.mean.abs() > f64::EPSILON {
+            Some(self.jitter / self.mean)
+        } else {
+            None
+        }
+    }
+
+    /// Raw absolute deviation of the last two samples, or `None` if < 2 samples.
+    #[inline]
+    #[must_use]
+    pub fn last_deviation(&self) -> Option<f64> {
+        if self.count >= 2 {
+            Some(self.last_deviation)
+        } else {
+            None
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data has been collected.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.jitter = 0.0;
+        self.mean = 0.0;
+        self.last_sample = 0.0;
+        self.last_deviation = 0.0;
+        self.count = 0;
+    }
+}
+
+impl JitterF64Builder {
+    /// Smoothing factor for jitter EMA.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Halflife for jitter smoothing.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        self.alpha = Some(1.0 - crate::math::exp(-ln2 / halflife));
+        self
+    }
+
+    /// Span for jitter smoothing.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.alpha = Some(2.0 / (n as f64 + 1.0));
+        self
+    }
+
+    /// Minimum samples before jitter is valid. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Pre-loads the last sample value and smoothed jitter from calibration data.
+    ///
+    /// When seeded, `is_primed()` returns true immediately and the
+    /// next `update()` computes a deviation against `value`.
+    #[inline]
+    #[must_use]
+    pub fn seed(mut self, value: f64, jitter: f64) -> Self {
+        self.seed_value = Some(value);
+        self.seed_jitter = Some(jitter);
+        self
+    }
+
+    /// Builds the jitter tracker.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha must have been set.
+    /// - Alpha must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<JitterF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid(
+                "Jitter alpha must be in (0, 1)",
+            ));
+        }
+
+        let (last_sample, jitter, mean, count) = match (self.seed_value, self.seed_jitter) {
+            (Some(v), Some(j)) => (v, j, v, self.min_samples),
+            _ => (0.0, 0.0, 0.0, 0),
+        };
+
+        Ok(JitterF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            jitter,
+            mean,
+            last_sample,
+            last_deviation: 0.0,
+            count,
+            min_samples: self.min_samples,
+        })
+    }
+}
+
+/// Jitter tracker (integer variant) — fixed-point EMA of absolute deltas.
+///
+/// Uses kernel-style bit-shift arithmetic. `jitter_ratio()` is not
+/// available on integer types (integer division loses too much precision).
+#[derive(Debug, Clone)]
+pub struct JitterI64 {
+    acc: i128,
+    shift: u32,
+    span: u64,
+    last_sample: i64,
+    last_deviation: i64,
+    count: u64,
+    min_samples: u64,
+    initialized: bool,
+}
+
+/// Builder for [`JitterI64`].
+#[derive(Debug, Clone)]
+pub struct JitterI64Builder {
+    span: Option<u64>,
+    min_samples: u64,
+}
+
+impl JitterI64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> JitterI64Builder {
+        JitterI64Builder {
+            span: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Feeds a sample. Returns smoothed jitter once primed.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> Option<i64> {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_sample = sample;
+            return None;
+        }
+
+        let abs_delta = (sample - self.last_sample).abs();
+        self.last_deviation = abs_delta;
+        self.last_sample = sample;
+
+        if self.initialized {
+            let delta_shifted = (abs_delta as i128) << self.shift;
+            self.acc += (delta_shifted - self.acc) >> self.shift;
+        } else {
+            self.acc = (abs_delta as i128) << self.shift;
+            self.initialized = true;
+        }
+
+        if self.count >= self.min_samples {
+            Some((self.acc >> self.shift) as i64)
+        } else {
+            None
+        }
+    }
+
+    /// Current smoothed jitter, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn jitter(&self) -> Option<i64> {
+        if self.count >= self.min_samples && self.initialized {
+            Some((self.acc >> self.shift) as i64)
+        } else {
+            None
+        }
+    }
+
+    /// Raw absolute deviation of the last two samples, or `None` if < 2.
+    #[inline]
+    #[must_use]
+    pub fn last_deviation(&self) -> Option<i64> {
+        if self.count >= 2 {
+            Some(self.last_deviation)
+        } else {
+            None
+        }
+    }
+
+    /// Effective span after rounding.
+    #[inline]
+    #[must_use]
+    pub fn effective_span(&self) -> u64 {
+        self.span
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data has been collected.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.acc = 0;
+        self.last_sample = 0;
+        self.last_deviation = 0;
+        self.count = 0;
+        self.initialized = false;
+    }
+}
+
+impl JitterI64Builder {
+    /// Smoothing span. Rounded up to next `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.span = Some(n);
+        self
+    }
+
+    /// Minimum samples before jitter is valid. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the jitter tracker.
+    ///
+    /// # Errors
+    ///
+    /// - Span must have been set and >= 1.
+    #[inline]
+    pub fn build(self) -> Result<JitterI64, crate::ConfigError> {
+        let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
+        if requested < 1 {
+            return Err(crate::ConfigError::Invalid("Jitter span must be >= 1"));
+        }
+
+        let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
+        let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
+
+        Ok(JitterI64 {
+            acc: 0,
+            shift,
+            span: effective,
+            last_sample: 0,
+            last_deviation: 0,
+            count: 0,
+            min_samples: self.min_samples,
+            initialized: false,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -479,23 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn i32_basic() {
-        let mut j = JitterI32::builder().span(3).build().unwrap();
-        let _ = j.update(50);
-        let _ = j.update(60);
-        assert!(j.jitter().is_some());
-    }
-
-    #[test]
-    #[allow(clippy::float_cmp)]
-    fn f32_basic() {
-        let mut j = JitterF32::builder().alpha(0.5).build().unwrap();
-        let _ = j.update(100.0).unwrap();
-        let _ = j.update(110.0).unwrap();
-        assert_eq!(j.last_deviation(), Some(10.0));
-    }
-
-    #[test]
     fn seeded_is_primed() {
         let j = JitterF64::builder()
             .alpha(0.3)
@@ -543,12 +507,6 @@ mod tests {
         assert!(matches!(
             j.update(f64::NEG_INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut j32 = JitterF32::builder().alpha(0.3).build().unwrap();
-        assert!(matches!(
-            j32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/liveness.rs
+++ b/nexus-stats-core/src/monitoring/liveness.rs
@@ -1,460 +1,447 @@
 use crate::math::MulAdd;
-macro_rules! impl_liveness_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Liveness detector — EMA of inter-arrival times with deadline threshold.
-        ///
-        /// Detects when a source goes quiet by tracking the smoothed interval
-        /// between events and comparing against a deadline.
-        ///
-        /// # Use Cases
-        /// - Stale quote detection
-        /// - Heartbeat monitoring
-        /// - Feed health checking
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            interval: $ty,
-            last_timestamp: $ty,
-            deadline_multiple: Option<$ty>,
-            deadline_absolute: Option<$ty>,
-            count: u64,
-            min_samples: u64,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            deadline_multiple: Option<$ty>,
-            deadline_absolute: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    deadline_multiple: Option::None,
-                    deadline_absolute: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Updates with an event at the given timestamp. Returns `true` if alive.
-            ///
-            /// The first event only records the timestamp. The second event
-            /// computes the first interval. Returns `true` until primed, then
-            /// checks against the deadline.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the timestamp is NaN, or
-            /// `DataError::Infinite` if the timestamp is infinite.
-            #[inline]
-            pub fn update(&mut self, timestamp: $ty) -> Result<bool, crate::DataError> {
-                check_finite!(timestamp);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_timestamp = timestamp;
-                    return Ok(true);
-                }
-
-                let dt = timestamp - self.last_timestamp;
-                self.last_timestamp = timestamp;
-
-                if self.count == 2 {
-                    self.interval = dt;
-                } else {
-                    self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
-                }
-
-                if self.count < self.min_samples {
-                    return Ok(true);
-                }
-
-                Ok(self.is_alive_at_interval(dt))
-            }
-
-            /// Checks liveness at the given timestamp without recording an event.
-            ///
-            /// Returns `true` if the time since the last event is within the deadline.
-            /// Returns `true` if not yet primed.
-            #[inline]
-            #[must_use]
-            pub fn check(&self, now: $ty) -> bool {
-                if self.count < self.min_samples {
-                    return true;
-                }
-
-                let dt = now - self.last_timestamp;
-                self.is_alive_at_interval(dt)
-            }
-
-            #[inline]
-            fn is_alive_at_interval(&self, dt: $ty) -> bool {
-                if let Some(multiple) = self.deadline_multiple {
-                    return dt <= self.interval * multiple;
-                }
-                if let Some(absolute) = self.deadline_absolute {
-                    return dt <= absolute;
-                }
-                true
-            }
-
-            /// Current smoothed inter-arrival time, or `None` if < 2 events.
-            #[inline]
-            #[must_use]
-            pub fn interval(&self) -> Option<$ty> {
-                if self.count >= 2 {
-                    Option::Some(self.interval)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of events recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the detector has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.interval = 0.0 as $ty;
-                self.last_timestamp = 0.0 as $ty;
-                self.count = 0;
-            }
-
-            /// Switches to a deadline-multiple threshold, clearing any absolute deadline.
-            #[inline]
-            pub fn reconfigure_deadline_multiple(&mut self, n: $ty) {
-                self.deadline_multiple = Option::Some(n);
-                self.deadline_absolute = Option::None;
-            }
-
-            /// Switches to an absolute deadline threshold, clearing any multiple deadline.
-            #[inline]
-            pub fn reconfigure_deadline_absolute(&mut self, t: $ty) {
-                self.deadline_absolute = Option::Some(t);
-                self.deadline_multiple = Option::None;
-            }
-        }
-
-        impl $builder {
-            /// Direct smoothing factor for interval EMA.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Halflife for interval smoothing.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                let alpha = 1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty;
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Span for interval smoothing.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                let alpha = 2.0 as $ty / (n as $ty + 1.0 as $ty);
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Alert when interval exceeds `n * smoothed_interval`.
-            ///
-            /// Typical values: 2.0-5.0.
-            #[inline]
-            #[must_use]
-            pub fn deadline_multiple(mut self, n: $ty) -> Self {
-                self.deadline_multiple = Option::Some(n);
-                self
-            }
-
-            /// Alert when interval exceeds a fixed deadline.
-            #[inline]
-            #[must_use]
-            pub fn deadline_absolute(mut self, t: $ty) -> Self {
-                self.deadline_absolute = Option::Some(t);
-                self
-            }
-
-            /// Minimum events before liveness checking activates. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the liveness detector.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha must have been set.
-            /// - Alpha must be in (0, 1) exclusive.
-            /// - At least one deadline (multiple or absolute) must be set.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("Liveness alpha must be in (0, 1)"));
-                }
-                if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
-                    return Err(crate::ConfigError::Invalid("Liveness requires a deadline (use .deadline_multiple() or .deadline_absolute())"));
-                }
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    interval: 0.0 as $ty,
-                    last_timestamp: 0.0 as $ty,
-                    deadline_multiple: self.deadline_multiple,
-                    deadline_absolute: self.deadline_absolute,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Liveness detector — EMA of inter-arrival times with deadline threshold.
+///
+/// Detects when a source goes quiet by tracking the smoothed interval
+/// between events and comparing against a deadline.
+///
+/// # Use Cases
+/// - Stale quote detection
+/// - Heartbeat monitoring
+/// - Feed health checking
+#[derive(Debug, Clone)]
+pub struct LivenessF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    interval: f64,
+    last_timestamp: f64,
+    deadline_multiple: Option<f64>,
+    deadline_absolute: Option<f64>,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_liveness_float!(LivenessF64, LivenessF64Builder, f64);
-impl_liveness_float!(LivenessF32, LivenessF32Builder, f32);
-
-macro_rules! impl_liveness_int {
-    ($name:ident, $builder:ident, $ty:ty, $acc_ty:ty) => {
-        /// Liveness detector (integer variant) — fixed-point EMA of inter-arrival ticks.
-        ///
-        /// Uses kernel-style bit-shift arithmetic for the interval smoothing.
-        /// Timestamps are integer ticks.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            acc: $acc_ty,
-            shift: u32,
-            span: u64,
-            last_timestamp: $ty,
-            deadline_multiple: Option<u64>,
-            deadline_absolute: Option<$ty>,
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            span: Option<u64>,
-            deadline_multiple: Option<u64>,
-            deadline_absolute: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    span: Option::None,
-                    deadline_multiple: Option::None,
-                    deadline_absolute: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Updates with an event at the given tick. Returns `true` if alive.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, timestamp: $ty) -> bool {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.last_timestamp = timestamp;
-                    return true;
-                }
-
-                let dt = timestamp - self.last_timestamp;
-                self.last_timestamp = timestamp;
-
-                if !self.initialized {
-                    self.acc = (dt as $acc_ty) << self.shift;
-                    self.initialized = true;
-                } else {
-                    let dt_shifted = (dt as $acc_ty) << self.shift;
-                    self.acc += (dt_shifted - self.acc) >> self.shift;
-                }
-
-                if self.count < self.min_samples {
-                    return true;
-                }
-
-                let smoothed = (self.acc >> self.shift) as $ty;
-                self.is_alive_with(dt, smoothed)
-            }
-
-            /// Checks liveness at the given tick without recording.
-            #[inline]
-            #[must_use]
-            pub fn check(&self, now: $ty) -> bool {
-                if self.count < self.min_samples || !self.initialized {
-                    return true;
-                }
-
-                let dt = now - self.last_timestamp;
-                let smoothed = (self.acc >> self.shift) as $ty;
-                self.is_alive_with(dt, smoothed)
-            }
-
-            #[inline]
-            fn is_alive_with(&self, dt: $ty, smoothed: $ty) -> bool {
-                if let Some(multiple) = self.deadline_multiple {
-                    return dt <= smoothed * (multiple as $ty);
-                }
-                if let Some(absolute) = self.deadline_absolute {
-                    return dt <= absolute;
-                }
-                true
-            }
-
-            /// Current smoothed inter-arrival interval, or `None` if < 2 events.
-            #[inline]
-            #[must_use]
-            pub fn interval(&self) -> Option<$ty> {
-                if self.count >= 2 && self.initialized {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Effective span after rounding.
-            #[inline]
-            #[must_use]
-            pub fn effective_span(&self) -> u64 {
-                self.span
-            }
-
-            /// Number of events recorded.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the detector has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.acc = 0;
-                self.last_timestamp = 0;
-                self.count = 0;
-                self.initialized = false;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing span. Rounded up to next `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.span = Option::Some(n);
-                self
-            }
-
-            /// Alert when interval exceeds `n * smoothed_interval`.
-            #[inline]
-            #[must_use]
-            pub fn deadline_multiple(mut self, n: u64) -> Self {
-                self.deadline_multiple = Option::Some(n);
-                self
-            }
-
-            /// Alert when interval exceeds a fixed deadline (in ticks).
-            #[inline]
-            #[must_use]
-            pub fn deadline_absolute(mut self, t: $ty) -> Self {
-                self.deadline_absolute = Option::Some(t);
-                self
-            }
-
-            /// Minimum events before liveness checking activates. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the liveness detector.
-            ///
-            /// # Errors
-            ///
-            /// - Span must have been set and >= 1.
-            /// - At least one deadline must be set.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
-                if requested < 1 {
-                    return Err(crate::ConfigError::Invalid("Liveness span must be >= 1"));
-                }
-                if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
-                    return Err(crate::ConfigError::Invalid("Liveness requires a deadline"));
-                }
-
-                let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
-                let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
-
-                Ok($name {
-                    acc: 0,
-                    shift,
-                    span: effective,
-                    last_timestamp: 0,
-                    deadline_multiple: self.deadline_multiple,
-                    deadline_absolute: self.deadline_absolute,
-                    count: 0,
-                    min_samples: self.min_samples,
-                    initialized: false,
-                })
-            }
-        }
-    };
+/// Builder for [`LivenessF64`].
+#[derive(Debug, Clone)]
+pub struct LivenessF64Builder {
+    alpha: Option<f64>,
+    deadline_multiple: Option<f64>,
+    deadline_absolute: Option<f64>,
+    min_samples: u64,
 }
 
-impl_liveness_int!(LivenessI64, LivenessI64Builder, i64, i128);
-impl_liveness_int!(LivenessI32, LivenessI32Builder, i32, i64);
+impl LivenessF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LivenessF64Builder {
+        LivenessF64Builder {
+            alpha: None,
+            deadline_multiple: None,
+            deadline_absolute: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Updates with an event at the given timestamp. Returns `true` if alive.
+    ///
+    /// The first event only records the timestamp. The second event
+    /// computes the first interval. Returns `true` until primed, then
+    /// checks against the deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the timestamp is NaN, or
+    /// `DataError::Infinite` if the timestamp is infinite.
+    #[inline]
+    pub fn update(&mut self, timestamp: f64) -> Result<bool, crate::DataError> {
+        check_finite!(timestamp);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_timestamp = timestamp;
+            return Ok(true);
+        }
+
+        let dt = timestamp - self.last_timestamp;
+        self.last_timestamp = timestamp;
+
+        if self.count == 2 {
+            self.interval = dt;
+        } else {
+            self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
+        }
+
+        if self.count < self.min_samples {
+            return Ok(true);
+        }
+
+        Ok(self.is_alive_at_interval(dt))
+    }
+
+    /// Checks liveness at the given timestamp without recording an event.
+    ///
+    /// Returns `true` if the time since the last event is within the deadline.
+    /// Returns `true` if not yet primed.
+    #[inline]
+    #[must_use]
+    pub fn check(&self, now: f64) -> bool {
+        if self.count < self.min_samples {
+            return true;
+        }
+
+        let dt = now - self.last_timestamp;
+        self.is_alive_at_interval(dt)
+    }
+
+    #[inline]
+    fn is_alive_at_interval(&self, dt: f64) -> bool {
+        if let Some(multiple) = self.deadline_multiple {
+            return dt <= self.interval * multiple;
+        }
+        if let Some(absolute) = self.deadline_absolute {
+            return dt <= absolute;
+        }
+        true
+    }
+
+    /// Current smoothed inter-arrival time, or `None` if < 2 events.
+    #[inline]
+    #[must_use]
+    pub fn interval(&self) -> Option<f64> {
+        if self.count >= 2 {
+            Some(self.interval)
+        } else {
+            None
+        }
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the detector has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.interval = 0.0;
+        self.last_timestamp = 0.0;
+        self.count = 0;
+    }
+
+    /// Switches to a deadline-multiple threshold, clearing any absolute deadline.
+    #[inline]
+    pub fn reconfigure_deadline_multiple(&mut self, n: f64) {
+        self.deadline_multiple = Some(n);
+        self.deadline_absolute = None;
+    }
+
+    /// Switches to an absolute deadline threshold, clearing any multiple deadline.
+    #[inline]
+    pub fn reconfigure_deadline_absolute(&mut self, t: f64) {
+        self.deadline_absolute = Some(t);
+        self.deadline_multiple = None;
+    }
+}
+
+impl LivenessF64Builder {
+    /// Direct smoothing factor for interval EMA.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Halflife for interval smoothing.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        let alpha = 1.0 - crate::math::exp(-ln2 / halflife);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Span for interval smoothing.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        let alpha = 2.0 / (n as f64 + 1.0);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Alert when interval exceeds `n * smoothed_interval`.
+    ///
+    /// Typical values: 2.0-5.0.
+    #[inline]
+    #[must_use]
+    pub fn deadline_multiple(mut self, n: f64) -> Self {
+        self.deadline_multiple = Some(n);
+        self
+    }
+
+    /// Alert when interval exceeds a fixed deadline.
+    #[inline]
+    #[must_use]
+    pub fn deadline_absolute(mut self, t: f64) -> Self {
+        self.deadline_absolute = Some(t);
+        self
+    }
+
+    /// Minimum events before liveness checking activates. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the liveness detector.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha must have been set.
+    /// - Alpha must be in (0, 1) exclusive.
+    /// - At least one deadline (multiple or absolute) must be set.
+    #[inline]
+    pub fn build(self) -> Result<LivenessF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid(
+                "Liveness alpha must be in (0, 1)",
+            ));
+        }
+        if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
+            return Err(crate::ConfigError::Invalid(
+                "Liveness requires a deadline (use .deadline_multiple() or .deadline_absolute())",
+            ));
+        }
+
+        Ok(LivenessF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            interval: 0.0,
+            last_timestamp: 0.0,
+            deadline_multiple: self.deadline_multiple,
+            deadline_absolute: self.deadline_absolute,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
+
+/// Liveness detector (integer variant) — fixed-point EMA of inter-arrival ticks.
+///
+/// Uses kernel-style bit-shift arithmetic for the interval smoothing.
+/// Timestamps are integer ticks.
+#[derive(Debug, Clone)]
+pub struct LivenessI64 {
+    acc: i128,
+    shift: u32,
+    span: u64,
+    last_timestamp: i64,
+    deadline_multiple: Option<u64>,
+    deadline_absolute: Option<i64>,
+    count: u64,
+    min_samples: u64,
+    initialized: bool,
+}
+
+/// Builder for [`LivenessI64`].
+#[derive(Debug, Clone)]
+pub struct LivenessI64Builder {
+    span: Option<u64>,
+    deadline_multiple: Option<u64>,
+    deadline_absolute: Option<i64>,
+    min_samples: u64,
+}
+
+impl LivenessI64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LivenessI64Builder {
+        LivenessI64Builder {
+            span: None,
+            deadline_multiple: None,
+            deadline_absolute: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Updates with an event at the given tick. Returns `true` if alive.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, timestamp: i64) -> bool {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_timestamp = timestamp;
+            return true;
+        }
+
+        let dt = timestamp - self.last_timestamp;
+        self.last_timestamp = timestamp;
+
+        if self.initialized {
+            let dt_shifted = (dt as i128) << self.shift;
+            self.acc += (dt_shifted - self.acc) >> self.shift;
+        } else {
+            self.acc = (dt as i128) << self.shift;
+            self.initialized = true;
+        }
+
+        if self.count < self.min_samples {
+            return true;
+        }
+
+        let smoothed = (self.acc >> self.shift) as i64;
+        self.is_alive_with(dt, smoothed)
+    }
+
+    /// Checks liveness at the given tick without recording.
+    #[inline]
+    #[must_use]
+    pub fn check(&self, now: i64) -> bool {
+        if self.count < self.min_samples || !self.initialized {
+            return true;
+        }
+
+        let dt = now - self.last_timestamp;
+        let smoothed = (self.acc >> self.shift) as i64;
+        self.is_alive_with(dt, smoothed)
+    }
+
+    #[inline]
+    fn is_alive_with(&self, dt: i64, smoothed: i64) -> bool {
+        if let Some(multiple) = self.deadline_multiple {
+            return dt <= smoothed * (multiple as i64);
+        }
+        if let Some(absolute) = self.deadline_absolute {
+            return dt <= absolute;
+        }
+        true
+    }
+
+    /// Current smoothed inter-arrival interval, or `None` if < 2 events.
+    #[inline]
+    #[must_use]
+    pub fn interval(&self) -> Option<i64> {
+        if self.count >= 2 && self.initialized {
+            Some((self.acc >> self.shift) as i64)
+        } else {
+            None
+        }
+    }
+
+    /// Effective span after rounding.
+    #[inline]
+    #[must_use]
+    pub fn effective_span(&self) -> u64 {
+        self.span
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the detector has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.acc = 0;
+        self.last_timestamp = 0;
+        self.count = 0;
+        self.initialized = false;
+    }
+}
+
+impl LivenessI64Builder {
+    /// Smoothing span. Rounded up to next `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.span = Some(n);
+        self
+    }
+
+    /// Alert when interval exceeds `n * smoothed_interval`.
+    #[inline]
+    #[must_use]
+    pub fn deadline_multiple(mut self, n: u64) -> Self {
+        self.deadline_multiple = Some(n);
+        self
+    }
+
+    /// Alert when interval exceeds a fixed deadline (in ticks).
+    #[inline]
+    #[must_use]
+    pub fn deadline_absolute(mut self, t: i64) -> Self {
+        self.deadline_absolute = Some(t);
+        self
+    }
+
+    /// Minimum events before liveness checking activates. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the liveness detector.
+    ///
+    /// # Errors
+    ///
+    /// - Span must have been set and >= 1.
+    /// - At least one deadline must be set.
+    #[inline]
+    pub fn build(self) -> Result<LivenessI64, crate::ConfigError> {
+        let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
+        if requested < 1 {
+            return Err(crate::ConfigError::Invalid("Liveness span must be >= 1"));
+        }
+        if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
+            return Err(crate::ConfigError::Invalid("Liveness requires a deadline"));
+        }
+
+        let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
+        let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
+
+        Ok(LivenessI64 {
+            acc: 0,
+            shift,
+            span: effective,
+            last_timestamp: 0,
+            deadline_multiple: self.deadline_multiple,
+            deadline_absolute: self.deadline_absolute,
+            count: 0,
+            min_samples: self.min_samples,
+            initialized: false,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -491,7 +478,7 @@ mod tests {
         }
 
         // Check after long silence — should be dead
-        // Smoothed interval ≈ 10, deadline = 3 * 10 = 30, silence = 100
+        // Smoothed interval ~= 10, deadline = 3 * 10 = 30, silence = 100
         assert!(!lv.check(190.0), "should be dead after long silence");
     }
 
@@ -561,20 +548,6 @@ mod tests {
 
         // Long silence
         assert!(!lv.check(2000));
-    }
-
-    #[test]
-    fn i32_basic() {
-        let mut lv = LivenessI32::builder()
-            .span(3)
-            .deadline_absolute(500)
-            .build()
-            .unwrap();
-
-        let _ = lv.update(0);
-        let _ = lv.update(100);
-        assert!(lv.check(400));
-        assert!(!lv.check(700));
     }
 
     #[test]
@@ -658,16 +631,6 @@ mod tests {
         assert!(matches!(
             lv.update(f64::INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut lv32 = LivenessF32::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
-            .build()
-            .unwrap();
-        assert!(matches!(
-            lv32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/max_gauge.rs
+++ b/nexus-stats-core/src/monitoring/max_gauge.rs
@@ -1,171 +1,149 @@
-macro_rules! impl_max_gauge_float {
-    ($name:ident, $ty:ty, $min_val:expr) => {
-        /// Max gauge — tracks the maximum since last take.
-        ///
-        /// `take()` returns the maximum and resets the gauge. Useful for
-        /// periodic reporting ("what was the peak since last report?").
-        ///
-        /// # Use Cases
-        /// - Peak latency per reporting interval
-        /// - High-water mark gauges (Prometheus-style)
-        /// - Periodic max collection
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max: $ty,
-            has_value: bool,
-        }
-
-        impl $name {
-            /// Creates a new empty gauge.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    max: $min_val,
-                    has_value: false,
-                }
-            }
-
-            /// Records a sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                if !self.has_value || sample > self.max {
-                    self.max = sample;
-                }
-                self.has_value = true;
-                Ok(())
-            }
-
-            /// Returns the max since last take/reset, and resets the gauge.
-            #[inline]
-            pub fn take(&mut self) -> Option<$ty> {
-                if self.has_value {
-                    let val = self.max;
-                    self.max = $min_val;
-                    self.has_value = false;
-                    Option::Some(val)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Peeks at the current max without resetting.
-            #[inline]
-            #[must_use]
-            pub fn peek(&self) -> Option<$ty> {
-                if self.has_value {
-                    Option::Some(self.max)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Resets the gauge.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.max = $min_val;
-                self.has_value = false;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Max gauge — tracks the maximum since last take.
+///
+/// `take()` returns the maximum and resets the gauge. Useful for
+/// periodic reporting ("what was the peak since last report?").
+///
+/// # Use Cases
+/// - Peak latency per reporting interval
+/// - High-water mark gauges (Prometheus-style)
+/// - Periodic max collection
+#[derive(Debug, Clone)]
+pub struct MaxGaugeF64 {
+    max: f64,
+    has_value: bool,
 }
 
-macro_rules! impl_max_gauge_int {
-    ($name:ident, $ty:ty, $min_val:expr) => {
-        /// Max gauge — tracks the maximum since last take.
-        ///
-        /// `take()` returns the maximum and resets the gauge. Useful for
-        /// periodic reporting ("what was the peak since last report?").
-        ///
-        /// # Use Cases
-        /// - Peak latency per reporting interval
-        /// - High-water mark gauges (Prometheus-style)
-        /// - Periodic max collection
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max: $ty,
-            has_value: bool,
+impl MaxGaugeF64 {
+    /// Creates a new empty gauge.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max: f64::MIN,
+            has_value: false,
         }
+    }
 
-        impl $name {
-            /// Creates a new empty gauge.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    max: $min_val,
-                    has_value: false,
-                }
-            }
-
-            /// Records a sample.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) {
-                if !self.has_value || sample > self.max {
-                    self.max = sample;
-                }
-                self.has_value = true;
-            }
-
-            /// Returns the max since last take/reset, and resets the gauge.
-            #[inline]
-            pub fn take(&mut self) -> Option<$ty> {
-                if self.has_value {
-                    let val = self.max;
-                    self.max = $min_val;
-                    self.has_value = false;
-                    Option::Some(val)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Peeks at the current max without resetting.
-            #[inline]
-            #[must_use]
-            pub fn peek(&self) -> Option<$ty> {
-                if self.has_value {
-                    Option::Some(self.max)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Resets the gauge.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.max = $min_val;
-                self.has_value = false;
-            }
+    /// Records a sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        if !self.has_value || sample > self.max {
+            self.max = sample;
         }
+        self.has_value = true;
+        Ok(())
+    }
 
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
+    /// Returns the max since last take/reset, and resets the gauge.
+    #[inline]
+    pub fn take(&mut self) -> Option<f64> {
+        if self.has_value {
+            let val = self.max;
+            self.max = f64::MIN;
+            self.has_value = false;
+            Some(val)
+        } else {
+            None
         }
-    };
+    }
+
+    /// Peeks at the current max without resetting.
+    #[inline]
+    #[must_use]
+    pub fn peek(&self) -> Option<f64> {
+        if self.has_value { Some(self.max) } else { None }
+    }
+
+    /// Resets the gauge.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.max = f64::MIN;
+        self.has_value = false;
+    }
 }
 
-impl_max_gauge_float!(MaxGaugeF64, f64, f64::MIN);
-impl_max_gauge_float!(MaxGaugeF32, f32, f32::MIN);
-impl_max_gauge_int!(MaxGaugeI64, i64, i64::MIN);
-impl_max_gauge_int!(MaxGaugeI32, i32, i32::MIN);
-impl_max_gauge_int!(MaxGaugeI128, i128, i128::MIN);
+impl Default for MaxGaugeF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Max gauge — tracks the maximum since last take.
+///
+/// `take()` returns the maximum and resets the gauge. Useful for
+/// periodic reporting ("what was the peak since last report?").
+///
+/// # Use Cases
+/// - Peak latency per reporting interval
+/// - High-water mark gauges (Prometheus-style)
+/// - Periodic max collection
+#[derive(Debug, Clone)]
+pub struct MaxGaugeI64 {
+    max: i64,
+    has_value: bool,
+}
+
+impl MaxGaugeI64 {
+    /// Creates a new empty gauge.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max: i64::MIN,
+            has_value: false,
+        }
+    }
+
+    /// Records a sample.
+    #[inline]
+    pub fn update(&mut self, sample: i64) {
+        if !self.has_value || sample > self.max {
+            self.max = sample;
+        }
+        self.has_value = true;
+    }
+
+    /// Returns the max since last take/reset, and resets the gauge.
+    #[inline]
+    pub fn take(&mut self) -> Option<i64> {
+        if self.has_value {
+            let val = self.max;
+            self.max = i64::MIN;
+            self.has_value = false;
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    /// Peeks at the current max without resetting.
+    #[inline]
+    #[must_use]
+    pub fn peek(&self) -> Option<i64> {
+        if self.has_value { Some(self.max) } else { None }
+    }
+
+    /// Resets the gauge.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.max = i64::MIN;
+        self.has_value = false;
+    }
+}
+
+impl Default for MaxGaugeI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -218,16 +196,8 @@ mod tests {
 
     #[test]
     fn default_is_empty() {
-        let g = MaxGaugeI32::default();
+        let g = MaxGaugeI64::default();
         assert!(g.peek().is_none());
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut g = MaxGaugeI128::new();
-        g.update(100);
-        g.update(200);
-        assert_eq!(g.take(), Some(200));
     }
 
     #[test]
@@ -244,12 +214,6 @@ mod tests {
         assert!(matches!(
             g.update(f64::NEG_INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut g32 = MaxGaugeF32::new();
-        assert!(matches!(
-            g32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/mod.rs
+++ b/nexus-stats-core/src/monitoring/mod.rs
@@ -12,7 +12,7 @@ mod max_gauge;
 mod peak_hold;
 mod running;
 mod saturation;
-mod windowed;
+pub(crate) mod windowed;
 
 pub use codel::*;
 pub use drawdown::*;

--- a/nexus-stats-core/src/monitoring/peak_hold.rs
+++ b/nexus-stats-core/src/monitoring/peak_hold.rs
@@ -1,257 +1,239 @@
-macro_rules! impl_peak_hold_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Peak hold with decay — instant attack, configurable hold, exponential decay.
-        ///
-        /// Captures peaks instantly, holds them for a configurable number of
-        /// samples, then decays exponentially.
-        ///
-        /// # Use Cases
-        /// - VU meter / level indicator behavior
-        /// - Peak envelope tracking
-        /// - "What was the recent peak?" with graceful decay
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            peak: $ty,
-            hold_samples: u64,
-            decay_rate: $ty,
-            hold_remaining: u64,
-            count: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            hold_samples: u64,
-            decay_rate: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    hold_samples: 0,
-                    decay_rate: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns the current envelope value.
-            ///
-            /// New peaks are captured instantly. During the hold period, the
-            /// peak is maintained. After hold expires, the envelope decays
-            /// multiplicatively each sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                // Instant attack — new peak
-                if sample >= self.peak {
-                    self.peak = sample;
-                    self.hold_remaining = self.hold_samples;
-                    return Ok(self.peak);
-                }
-
-                // Hold period
-                if self.hold_remaining > 0 {
-                    self.hold_remaining -= 1;
-                    return Ok(self.peak);
-                }
-
-                // Decay
-                self.peak *= self.decay_rate;
-
-                // If sample is above decayed peak, capture it
-                if sample > self.peak {
-                    self.peak = sample;
-                    self.hold_remaining = self.hold_samples;
-                }
-
-                Ok(self.peak)
-            }
-
-            /// Current envelope value.
-            #[inline]
-            #[must_use]
-            pub fn peak(&self) -> $ty {
-                self.peak
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets the envelope.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.peak = 0.0 as $ty;
-                self.hold_remaining = 0;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Number of samples to hold the peak before decaying. Default: 0.
-            #[inline]
-            #[must_use]
-            pub fn hold_samples(mut self, n: u64) -> Self {
-                self.hold_samples = n;
-                self
-            }
-
-            /// Per-sample multiplicative decay rate (0 to 1). Default must be set.
-            ///
-            /// 0.99 = slow decay, 0.9 = fast decay.
-            #[inline]
-            #[must_use]
-            pub fn decay_rate(mut self, rate: $ty) -> Self {
-                self.decay_rate = Option::Some(rate);
-                self
-            }
-
-            /// Builds the peak hold envelope.
-            ///
-            /// # Errors
-            ///
-            /// - decay_rate must have been set.
-            /// - decay_rate must be in (0, 1].
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let rate = self
-                    .decay_rate
-                    .ok_or(crate::ConfigError::Missing("decay_rate"))?;
-                if !(rate > 0.0 as $ty && rate <= 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("decay_rate must be in (0, 1]"));
-                }
-
-                Ok($name {
-                    peak: 0.0 as $ty,
-                    hold_samples: self.hold_samples,
-                    decay_rate: rate,
-                    hold_remaining: 0,
-                    count: 0,
-                })
-            }
-        }
-    };
+/// Peak hold with decay — instant attack, configurable hold, exponential decay.
+///
+/// Captures peaks instantly, holds them for a configurable number of
+/// samples, then decays exponentially.
+///
+/// # Use Cases
+/// - VU meter / level indicator behavior
+/// - Peak envelope tracking
+/// - "What was the recent peak?" with graceful decay
+#[derive(Debug, Clone)]
+pub struct PeakHoldF64 {
+    peak: f64,
+    hold_samples: u64,
+    decay_rate: f64,
+    hold_remaining: u64,
+    count: u64,
 }
 
-macro_rules! impl_peak_hold_int {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Peak hold (integer) — instant attack, configurable hold, no decay.
-        ///
-        /// Integer variant tracks the peak during the hold window. After hold
-        /// expires, the peak resets to the current sample (no exponential decay
-        /// for integers — use the float variant for decay behavior).
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            peak: $ty,
-            hold_samples: u64,
-            hold_remaining: u64,
-            count: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            hold_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder { hold_samples: 0 }
-            }
-
-            /// Feeds a sample. Returns the current peak.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> $ty {
-                self.count += 1;
-
-                if sample >= self.peak || self.count == 1 {
-                    self.peak = sample;
-                    self.hold_remaining = self.hold_samples;
-                    return self.peak;
-                }
-
-                if self.hold_remaining > 0 {
-                    self.hold_remaining -= 1;
-                    return self.peak;
-                }
-
-                // Hold expired — reset to current sample
-                self.peak = sample;
-                self.hold_remaining = self.hold_samples;
-                self.peak
-            }
-
-            /// Current peak value.
-            #[inline]
-            #[must_use]
-            pub fn peak(&self) -> $ty {
-                self.peak
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets the peak.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.peak = 0;
-                self.hold_remaining = 0;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Number of samples to hold the peak. Default: 0.
-            #[inline]
-            #[must_use]
-            pub fn hold_samples(mut self, n: u64) -> Self {
-                self.hold_samples = n;
-                self
-            }
-
-            /// Builds the peak hold tracker.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                Ok($name {
-                    peak: 0,
-                    hold_samples: self.hold_samples,
-                    hold_remaining: 0,
-                    count: 0,
-                })
-            }
-        }
-    };
+/// Builder for [`PeakHoldF64`].
+#[derive(Debug, Clone)]
+pub struct PeakHoldF64Builder {
+    hold_samples: u64,
+    decay_rate: Option<f64>,
 }
 
-impl_peak_hold_float!(PeakHoldF64, PeakHoldF64Builder, f64);
-impl_peak_hold_float!(PeakHoldF32, PeakHoldF32Builder, f32);
-impl_peak_hold_int!(PeakHoldI64, PeakHoldI64Builder, i64);
-impl_peak_hold_int!(PeakHoldI32, PeakHoldI32Builder, i32);
-impl_peak_hold_int!(PeakHoldI128, PeakHoldI128Builder, i128);
+impl PeakHoldF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> PeakHoldF64Builder {
+        PeakHoldF64Builder {
+            hold_samples: 0,
+            decay_rate: None,
+        }
+    }
+
+    /// Feeds a sample. Returns the current envelope value.
+    ///
+    /// New peaks are captured instantly. During the hold period, the
+    /// peak is maintained. After hold expires, the envelope decays
+    /// multiplicatively each sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<f64, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        // Instant attack — new peak
+        if sample >= self.peak {
+            self.peak = sample;
+            self.hold_remaining = self.hold_samples;
+            return Ok(self.peak);
+        }
+
+        // Hold period
+        if self.hold_remaining > 0 {
+            self.hold_remaining -= 1;
+            return Ok(self.peak);
+        }
+
+        // Decay
+        self.peak *= self.decay_rate;
+
+        // If sample is above decayed peak, capture it
+        if sample > self.peak {
+            self.peak = sample;
+            self.hold_remaining = self.hold_samples;
+        }
+
+        Ok(self.peak)
+    }
+
+    /// Current envelope value.
+    #[inline]
+    #[must_use]
+    pub fn peak(&self) -> f64 {
+        self.peak
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets the envelope.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.peak = 0.0;
+        self.hold_remaining = 0;
+        self.count = 0;
+    }
+}
+
+impl PeakHoldF64Builder {
+    /// Number of samples to hold the peak before decaying. Default: 0.
+    #[inline]
+    #[must_use]
+    pub fn hold_samples(mut self, n: u64) -> Self {
+        self.hold_samples = n;
+        self
+    }
+
+    /// Per-sample multiplicative decay rate (0 to 1). Default must be set.
+    ///
+    /// 0.99 = slow decay, 0.9 = fast decay.
+    #[inline]
+    #[must_use]
+    pub fn decay_rate(mut self, rate: f64) -> Self {
+        self.decay_rate = Some(rate);
+        self
+    }
+
+    /// Builds the peak hold envelope.
+    ///
+    /// # Errors
+    ///
+    /// - decay_rate must have been set.
+    /// - decay_rate must be in (0, 1].
+    #[inline]
+    pub fn build(self) -> Result<PeakHoldF64, crate::ConfigError> {
+        let rate = self
+            .decay_rate
+            .ok_or(crate::ConfigError::Missing("decay_rate"))?;
+        if !(rate > 0.0 && rate <= 1.0) {
+            return Err(crate::ConfigError::Invalid("decay_rate must be in (0, 1]"));
+        }
+
+        Ok(PeakHoldF64 {
+            peak: 0.0,
+            hold_samples: self.hold_samples,
+            decay_rate: rate,
+            hold_remaining: 0,
+            count: 0,
+        })
+    }
+}
+
+/// Peak hold (integer) — instant attack, configurable hold, no decay.
+///
+/// Integer variant tracks the peak during the hold window. After hold
+/// expires, the peak resets to the current sample (no exponential decay
+/// for integers — use the float variant for decay behavior).
+#[derive(Debug, Clone)]
+pub struct PeakHoldI64 {
+    peak: i64,
+    hold_samples: u64,
+    hold_remaining: u64,
+    count: u64,
+}
+
+/// Builder for [`PeakHoldI64`].
+#[derive(Debug, Clone)]
+pub struct PeakHoldI64Builder {
+    hold_samples: u64,
+}
+
+impl PeakHoldI64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> PeakHoldI64Builder {
+        PeakHoldI64Builder { hold_samples: 0 }
+    }
+
+    /// Feeds a sample. Returns the current peak.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> i64 {
+        self.count += 1;
+
+        if sample >= self.peak || self.count == 1 {
+            self.peak = sample;
+            self.hold_remaining = self.hold_samples;
+            return self.peak;
+        }
+
+        if self.hold_remaining > 0 {
+            self.hold_remaining -= 1;
+            return self.peak;
+        }
+
+        // Hold expired — reset to current sample
+        self.peak = sample;
+        self.hold_remaining = self.hold_samples;
+        self.peak
+    }
+
+    /// Current peak value.
+    #[inline]
+    #[must_use]
+    pub fn peak(&self) -> i64 {
+        self.peak
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets the peak.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.peak = 0;
+        self.hold_remaining = 0;
+        self.count = 0;
+    }
+}
+
+impl PeakHoldI64Builder {
+    /// Number of samples to hold the peak. Default: 0.
+    #[inline]
+    #[must_use]
+    pub fn hold_samples(mut self, n: u64) -> Self {
+        self.hold_samples = n;
+        self
+    }
+
+    /// Builds the peak hold tracker.
+    #[inline]
+    pub fn build(self) -> Result<PeakHoldI64, crate::ConfigError> {
+        Ok(PeakHoldI64 {
+            peak: 0,
+            hold_samples: self.hold_samples,
+            hold_remaining: 0,
+            count: 0,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -336,13 +318,6 @@ mod tests {
     }
 
     #[test]
-    fn i128_basic() {
-        let mut ph = PeakHoldI128::builder().hold_samples(3).build().unwrap();
-        let _ = ph.update(100);
-        assert_eq!(ph.update(50), 100); // held
-    }
-
-    #[test]
     fn rejects_nan_and_inf() {
         let mut ph = PeakHoldF64::builder().decay_rate(0.95).build().unwrap();
         assert!(matches!(
@@ -356,12 +331,6 @@ mod tests {
         assert!(matches!(
             ph.update(f64::NEG_INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut ph32 = PeakHoldF32::builder().decay_rate(0.95).build().unwrap();
-        assert!(matches!(
-            ph32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/running.rs
+++ b/nexus-stats-core/src/monitoring/running.rs
@@ -1,344 +1,316 @@
-macro_rules! impl_running_min_float {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// All-time minimum tracker.
-        ///
-        /// Tracks the smallest value ever seen. One comparison per update.
-        ///
-        /// # Use Cases
-        /// - Best-case latency tracking (all-time min RTT)
-        /// - Low-water mark for prices or levels
-        /// - Input to range calculations (max - min)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            min: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new empty tracker.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    min: $init,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current all-time minimum.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-                if sample < self.min {
-                    self.min = sample;
-                }
-                Ok(self.min)
-            }
-
-            /// All-time minimum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.min)
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.min = $init;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// All-time minimum tracker.
+///
+/// Tracks the smallest value ever seen. One comparison per update.
+///
+/// # Use Cases
+/// - Best-case latency tracking (all-time min RTT)
+/// - Low-water mark for prices or levels
+/// - Input to range calculations (max - min)
+#[derive(Debug, Clone)]
+pub struct RunningMinF64 {
+    min: f64,
+    count: u64,
 }
 
-macro_rules! impl_running_min_int {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// All-time minimum tracker.
-        ///
-        /// Tracks the smallest value ever seen. One comparison per update.
-        ///
-        /// # Use Cases
-        /// - Best-case latency tracking (all-time min RTT)
-        /// - Low-water mark for prices or levels
-        /// - Input to range calculations (max - min)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            min: $ty,
-            count: u64,
+impl RunningMinF64 {
+    /// Creates a new empty tracker.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            min: f64::MAX,
+            count: 0,
         }
+    }
 
-        impl $name {
-            /// Creates a new empty tracker.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    min: $init,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current all-time minimum.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> $ty {
-                self.count += 1;
-                if sample < self.min {
-                    self.min = sample;
-                }
-                self.min
-            }
-
-            /// All-time minimum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.min)
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.min = $init;
-                self.count = 0;
-            }
+    /// Feeds a sample. Returns the current all-time minimum.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<f64, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+        if sample < self.min {
+            self.min = sample;
         }
+        Ok(self.min)
+    }
 
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
+    /// All-time minimum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.min)
         }
-    };
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.min = f64::MAX;
+        self.count = 0;
+    }
 }
 
-macro_rules! impl_running_max_float {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// All-time maximum tracker.
-        ///
-        /// Tracks the largest value ever seen. One comparison per update.
-        ///
-        /// # Use Cases
-        /// - High-water mark tracking (peak throughput, max latency)
-        /// - Capacity planning (peak resource usage)
-        /// - Input to range calculations (max - min)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new empty tracker.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    max: $init,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current all-time maximum.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-                if sample > self.max {
-                    self.max = sample;
-                }
-                Ok(self.max)
-            }
-
-            /// All-time maximum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn max(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.max)
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.max = $init;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+impl Default for RunningMinF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
-macro_rules! impl_running_max_int {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// All-time maximum tracker.
-        ///
-        /// Tracks the largest value ever seen. One comparison per update.
-        ///
-        /// # Use Cases
-        /// - High-water mark tracking (peak throughput, max latency)
-        /// - Capacity planning (peak resource usage)
-        /// - Input to range calculations (max - min)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new empty tracker.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    max: $init,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Returns the current all-time maximum.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> $ty {
-                self.count += 1;
-                if sample > self.max {
-                    self.max = sample;
-                }
-                self.max
-            }
-
-            /// All-time maximum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn max(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.max)
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been fed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.max = $init;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// All-time minimum tracker.
+///
+/// Tracks the smallest value ever seen. One comparison per update.
+///
+/// # Use Cases
+/// - Best-case latency tracking (all-time min RTT)
+/// - Low-water mark for prices or levels
+/// - Input to range calculations (max - min)
+#[derive(Debug, Clone)]
+pub struct RunningMinI64 {
+    min: i64,
+    count: u64,
 }
 
-impl_running_min_float!(RunningMinF64, f64, f64::MAX);
-impl_running_min_float!(RunningMinF32, f32, f32::MAX);
-impl_running_min_int!(RunningMinI64, i64, i64::MAX);
-impl_running_min_int!(RunningMinI32, i32, i32::MAX);
-impl_running_min_int!(RunningMinI128, i128, i128::MAX);
+impl RunningMinI64 {
+    /// Creates a new empty tracker.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            min: i64::MAX,
+            count: 0,
+        }
+    }
 
-impl_running_max_float!(RunningMaxF64, f64, f64::MIN);
-impl_running_max_float!(RunningMaxF32, f32, f32::MIN);
-impl_running_max_int!(RunningMaxI64, i64, i64::MIN);
-impl_running_max_int!(RunningMaxI32, i32, i32::MIN);
-impl_running_max_int!(RunningMaxI128, i128, i128::MIN);
+    /// Feeds a sample. Returns the current all-time minimum.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> i64 {
+        self.count += 1;
+        if sample < self.min {
+            self.min = sample;
+        }
+        self.min
+    }
+
+    /// All-time minimum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min(&self) -> Option<i64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.min)
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.min = i64::MAX;
+        self.count = 0;
+    }
+}
+
+impl Default for RunningMinI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// All-time maximum tracker.
+///
+/// Tracks the largest value ever seen. One comparison per update.
+///
+/// # Use Cases
+/// - High-water mark tracking (peak throughput, max latency)
+/// - Capacity planning (peak resource usage)
+/// - Input to range calculations (max - min)
+#[derive(Debug, Clone)]
+pub struct RunningMaxF64 {
+    max: f64,
+    count: u64,
+}
+
+impl RunningMaxF64 {
+    /// Creates a new empty tracker.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max: f64::MIN,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns the current all-time maximum.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<f64, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+        if sample > self.max {
+            self.max = sample;
+        }
+        Ok(self.max)
+    }
+
+    /// All-time maximum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn max(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.max)
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.max = f64::MIN;
+        self.count = 0;
+    }
+}
+
+impl Default for RunningMaxF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// All-time maximum tracker.
+///
+/// Tracks the largest value ever seen. One comparison per update.
+///
+/// # Use Cases
+/// - High-water mark tracking (peak throughput, max latency)
+/// - Capacity planning (peak resource usage)
+/// - Input to range calculations (max - min)
+#[derive(Debug, Clone)]
+pub struct RunningMaxI64 {
+    max: i64,
+    count: u64,
+}
+
+impl RunningMaxI64 {
+    /// Creates a new empty tracker.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max: i64::MIN,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Returns the current all-time maximum.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> i64 {
+        self.count += 1;
+        if sample > self.max {
+            self.max = sample;
+        }
+        self.max
+    }
+
+    /// All-time maximum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn max(&self) -> Option<i64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.max)
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been fed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.max = i64::MIN;
+        self.count = 0;
+    }
+}
+
+impl Default for RunningMaxI64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -410,45 +382,6 @@ mod tests {
     }
 
     #[test]
-    fn max_i32() {
-        let mut rm = RunningMaxI32::new();
-        assert_eq!(rm.update(10), 10);
-        assert_eq!(rm.update(20), 20);
-    }
-
-    #[test]
-    #[allow(clippy::float_cmp)]
-    fn min_f32() {
-        let mut rm = RunningMinF32::new();
-        assert_eq!(rm.update(50.0).unwrap(), 50.0);
-        assert_eq!(rm.update(30.0).unwrap(), 30.0);
-    }
-
-    #[test]
-    #[allow(clippy::float_cmp)]
-    fn max_f32() {
-        let mut rm = RunningMaxF32::new();
-        assert_eq!(rm.update(30.0).unwrap(), 30.0);
-        assert_eq!(rm.update(50.0).unwrap(), 50.0);
-    }
-
-    #[test]
-    fn min_i128() {
-        let mut rm = RunningMinI128::new();
-        assert_eq!(rm.update(100), 100);
-        assert_eq!(rm.update(50), 50);
-        assert_eq!(rm.update(75), 50);
-    }
-
-    #[test]
-    fn max_i128() {
-        let mut rm = RunningMaxI128::new();
-        assert_eq!(rm.update(50), 50);
-        assert_eq!(rm.update(100), 100);
-        assert_eq!(rm.update(75), 100);
-    }
-
-    #[test]
     fn rejects_nan_and_inf() {
         let mut min64 = RunningMinF64::new();
         assert!(matches!(
@@ -472,18 +405,6 @@ mod tests {
         assert!(matches!(
             max64.update(f64::INFINITY),
             Err(crate::DataError::Infinite)
-        ));
-
-        let mut min32 = RunningMinF32::new();
-        assert!(matches!(
-            min32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
-        ));
-
-        let mut max32 = RunningMaxF32::new();
-        assert!(matches!(
-            max32.update(f32::NAN),
-            Err(crate::DataError::NotANumber)
         ));
     }
 }

--- a/nexus-stats-core/src/monitoring/saturation.rs
+++ b/nexus-stats-core/src/monitoring/saturation.rs
@@ -1,196 +1,183 @@
 use crate::Condition;
 use crate::math::MulAdd;
 
-macro_rules! impl_saturation {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Saturation detector — smoothed utilization with threshold.
-        ///
-        /// Internally uses an EMA to smooth the utilization signal and
-        /// compares against a configured threshold.
-        ///
-        /// # Use Cases
-        /// - CPU/memory utilization monitoring
-        /// - Queue fill level monitoring
-        /// - Bandwidth saturation detection
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            value: $ty,
-            threshold: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            threshold: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    threshold: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Feeds a utilization sample. Returns pressure state once primed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                utilization: $ty,
-            ) -> Result<Option<Condition>, crate::DataError> {
-                check_finite!(utilization);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.value = utilization;
-                } else {
-                    self.value = self
-                        .alpha
-                        .fma(utilization, self.one_minus_alpha * self.value);
-                }
-
-                if self.count < self.min_samples {
-                    return Ok(Option::None);
-                }
-
-                Ok(if self.value > self.threshold {
-                    Option::Some(Condition::Degraded)
-                } else {
-                    Option::Some(Condition::Normal)
-                })
-            }
-
-            /// Current smoothed utilization, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn utilization(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.value)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data has been collected.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.count = 0;
-            }
-
-            /// Updates the saturation threshold without resetting state.
-            #[inline]
-            pub fn reconfigure_threshold(&mut self, threshold: $ty) {
-                self.threshold = threshold;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing factor.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Halflife for smoothing.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                self.alpha =
-                    Option::Some(1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty);
-                self
-            }
-
-            /// Span for smoothing.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.alpha = Option::Some(2.0 as $ty / (n as $ty + 1.0 as $ty));
-                self
-            }
-
-            /// Saturation threshold. Default must be set.
-            #[inline]
-            #[must_use]
-            pub fn threshold(mut self, threshold: $ty) -> Self {
-                self.threshold = Option::Some(threshold);
-                self
-            }
-
-            /// Minimum samples before detection activates. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the saturation detector.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha and threshold must have been set.
-            /// - Alpha must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                let threshold = self
-                    .threshold
-                    .ok_or(crate::ConfigError::Missing("threshold"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("alpha must be in (0, 1)"));
-                }
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    value: 0.0 as $ty,
-                    threshold,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Saturation detector — smoothed utilization with threshold.
+///
+/// Internally uses an EMA to smooth the utilization signal and
+/// compares against a configured threshold.
+///
+/// # Use Cases
+/// - CPU/memory utilization monitoring
+/// - Queue fill level monitoring
+/// - Bandwidth saturation detection
+#[derive(Debug, Clone)]
+pub struct SaturationF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    value: f64,
+    threshold: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_saturation!(SaturationF64, SaturationF64Builder, f64);
-impl_saturation!(SaturationF32, SaturationF32Builder, f32);
+/// Builder for [`SaturationF64`].
+#[derive(Debug, Clone)]
+pub struct SaturationF64Builder {
+    alpha: Option<f64>,
+    threshold: Option<f64>,
+    min_samples: u64,
+}
+
+impl SaturationF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> SaturationF64Builder {
+        SaturationF64Builder {
+            alpha: None,
+            threshold: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Feeds a utilization sample. Returns pressure state once primed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, utilization: f64) -> Result<Option<Condition>, crate::DataError> {
+        check_finite!(utilization);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.value = utilization;
+        } else {
+            self.value = self
+                .alpha
+                .fma(utilization, self.one_minus_alpha * self.value);
+        }
+
+        if self.count < self.min_samples {
+            return Ok(None);
+        }
+
+        Ok(if self.value > self.threshold {
+            Some(Condition::Degraded)
+        } else {
+            Some(Condition::Normal)
+        })
+    }
+
+    /// Current smoothed utilization, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn utilization(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data has been collected.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.count = 0;
+    }
+
+    /// Updates the saturation threshold without resetting state.
+    #[inline]
+    pub fn reconfigure_threshold(&mut self, threshold: f64) {
+        self.threshold = threshold;
+    }
+}
+
+impl SaturationF64Builder {
+    /// Smoothing factor.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Halflife for smoothing.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        self.alpha = Some(1.0 - crate::math::exp(-ln2 / halflife));
+        self
+    }
+
+    /// Span for smoothing.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.alpha = Some(2.0 / (n as f64 + 1.0));
+        self
+    }
+
+    /// Saturation threshold. Default must be set.
+    #[inline]
+    #[must_use]
+    pub fn threshold(mut self, threshold: f64) -> Self {
+        self.threshold = Some(threshold);
+        self
+    }
+
+    /// Minimum samples before detection activates. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the saturation detector.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha and threshold must have been set.
+    /// - Alpha must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<SaturationF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        let threshold = self
+            .threshold
+            .ok_or(crate::ConfigError::Missing("threshold"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid("alpha must be in (0, 1)"));
+        }
+
+        Ok(SaturationF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            value: 0.0,
+            threshold,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -273,17 +260,6 @@ mod tests {
         s.reset();
         assert_eq!(s.count(), 0);
         assert!(s.utilization().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut s = SaturationF32::builder()
-            .alpha(0.3)
-            .threshold(0.8)
-            .build()
-            .unwrap();
-
-        assert_eq!(s.update(0.5).unwrap(), Some(Condition::Normal));
     }
 
     #[test]

--- a/nexus-stats-core/src/monitoring/windowed.rs
+++ b/nexus-stats-core/src/monitoring/windowed.rs
@@ -14,556 +14,700 @@ struct Sample<T: Copy> {
     value: T,
 }
 
-macro_rules! impl_windowed_max_raw_float {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// Streaming windowed maximum over a sliding time window (Nichols' algorithm).
-        ///
-        /// Tracks the maximum value within a `u64` timestamp window using only
-        /// 3 stored samples. O(1) amortized per update, `no_std` compatible.
-        ///
-        /// # Use Cases
-        /// - Max throughput tracking
-        /// - BBR-style bandwidth estimation
-        /// - Peak detection within a time window
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            window: u64,
-            samples: [Sample<$ty>; 3],
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new windowed max tracker.
-            ///
-            /// `window` is in the same units as the timestamps you will pass
-            /// to [`update`](Self::update). Must be positive.
-            #[inline]
-            pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("window must be positive"));
-                }
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                Ok(Self {
-                    window,
-                    samples: [init; 3],
-                    count: 0,
-                })
-            }
-
-            /// Feeds a sample at the given timestamp. Returns current window max.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the value is NaN, or
-            /// `DataError::Infinite` if the value is infinite.
-            #[inline]
-            pub fn update(&mut self, timestamp: u64, value: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(value);
-                self.count += 1;
-                let win = self.window;
-                let s = &mut self.samples;
-
-                if value >= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
-                    s[0] = Sample { timestamp, value };
-                    s[1] = s[0];
-                    s[2] = s[0];
-                    return Ok(s[0].value);
-                }
-
-                if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if value >= s[1].value {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if value >= s[2].value {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if timestamp.wrapping_sub(s[0].timestamp) > win {
-                    s[0] = s[1];
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                }
-
-                Ok(s[0].value)
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            pub fn update_i64(
-                &mut self,
-                timestamp: i64,
-                value: $ty,
-            ) -> Result<$ty, crate::DataError> {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, value)
-            }
-
-            /// Current window maximum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn max(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.samples[0].value)
-                }
-            }
-
-            /// Window size in raw units.
-            #[inline]
-            #[must_use]
-            pub fn window(&self) -> u64 {
-                self.window
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to empty state. Window size is preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                self.samples = [init; 3];
-                self.count = 0;
-            }
-        }
-    };
+/// Streaming windowed maximum over a sliding time window (Nichols' algorithm).
+///
+/// Tracks the maximum value within a `u64` timestamp window using only
+/// 3 stored samples. O(1) amortized per update, `no_std` compatible.
+///
+/// # Use Cases
+/// - Max throughput tracking
+/// - BBR-style bandwidth estimation
+/// - Peak detection within a time window
+#[derive(Debug, Clone)]
+pub struct WindowedMaxF64 {
+    window: u64,
+    samples: [Sample<f64>; 3],
+    count: u64,
 }
 
-macro_rules! impl_windowed_max_raw_int {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// Streaming windowed maximum over a sliding time window (Nichols' algorithm).
-        ///
-        /// Tracks the maximum value within a `u64` timestamp window using only
-        /// 3 stored samples. O(1) amortized per update, `no_std` compatible.
-        ///
-        /// # Use Cases
-        /// - Max throughput tracking
-        /// - BBR-style bandwidth estimation
-        /// - Peak detection within a time window
-        /// - Deterministic replay with raw tick counters
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            window: u64,
-            samples: [Sample<$ty>; 3],
-            count: u64,
+impl WindowedMaxF64 {
+    /// Creates a new windowed max tracker.
+    ///
+    /// `window` is in the same units as the timestamps you will pass
+    /// to [`update`](Self::update). Must be positive.
+    #[inline]
+    pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: f64::MIN,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample at the given timestamp. Returns current window max.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the value is NaN, or
+    /// `DataError::Infinite` if the value is infinite.
+    #[inline]
+    pub fn update(&mut self, timestamp: u64, value: f64) -> Result<f64, crate::DataError> {
+        check_finite!(value);
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value >= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return Ok(s[0].value);
         }
 
-        impl $name {
-            /// Creates a new windowed max tracker.
-            ///
-            /// `window` is in the same units as the timestamps you will pass
-            /// to [`update`](Self::update). Must be positive.
-            #[inline]
-            pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("window must be positive"));
-                }
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                Ok(Self {
-                    window,
-                    samples: [init; 3],
-                    count: 0,
-                })
-            }
-
-            /// Feeds a sample at the given timestamp. Returns current window max.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, timestamp: u64, value: $ty) -> $ty {
-                self.count += 1;
-                let win = self.window;
-                let s = &mut self.samples;
-
-                if value >= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
-                    s[0] = Sample { timestamp, value };
-                    s[1] = s[0];
-                    s[2] = s[0];
-                    return s[0].value;
-                }
-
-                if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if value >= s[1].value {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if value >= s[2].value {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if timestamp.wrapping_sub(s[0].timestamp) > win {
-                    s[0] = s[1];
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                }
-
-                s[0].value
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            #[must_use]
-            pub fn update_i64(&mut self, timestamp: i64, value: $ty) -> $ty {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, value)
-            }
-
-            /// Current window maximum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn max(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.samples[0].value)
-                }
-            }
-
-            /// Window size in raw units.
-            #[inline]
-            #[must_use]
-            pub fn window(&self) -> u64 {
-                self.window
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to empty state. Window size is preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                self.samples = [init; 3];
-                self.count = 0;
-            }
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
         }
-    };
+
+        if value >= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value >= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        Ok(s[0].value)
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    pub fn update_i64(&mut self, timestamp: i64, value: f64) -> Result<f64, crate::DataError> {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, value)
+    }
+
+    /// Current window maximum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn max(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    /// Window size in raw units.
+    #[inline]
+    #[must_use]
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to empty state. Window size is preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: f64::MIN,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
 }
 
-macro_rules! impl_windowed_min_raw_float {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// Streaming windowed minimum over a sliding time window (Nichols' algorithm).
-        ///
-        /// Tracks the minimum value within a `u64` timestamp window using only
-        /// 3 stored samples. O(1) amortized per update, `no_std` compatible.
-        ///
-        /// # Use Cases
-        /// - Min RTT tracking (BBR)
-        /// - Minimum price in a window
-        /// - Best-case latency estimation
-        /// - Deterministic replay with raw tick counters
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            window: u64,
-            samples: [Sample<$ty>; 3],
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new windowed min tracker.
-            ///
-            /// `window` is in the same units as the timestamps you will pass
-            /// to [`update`](Self::update). Must be positive.
-            #[inline]
-            pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("window must be positive"));
-                }
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                Ok(Self {
-                    window,
-                    samples: [init; 3],
-                    count: 0,
-                })
-            }
-
-            /// Feeds a sample at the given timestamp. Returns current window min.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the value is NaN, or
-            /// `DataError::Infinite` if the value is infinite.
-            #[inline]
-            pub fn update(&mut self, timestamp: u64, value: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(value);
-                self.count += 1;
-                let win = self.window;
-                let s = &mut self.samples;
-
-                if value <= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
-                    s[0] = Sample { timestamp, value };
-                    s[1] = s[0];
-                    s[2] = s[0];
-                    return Ok(s[0].value);
-                }
-
-                if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if value <= s[1].value {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if value <= s[2].value {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if timestamp.wrapping_sub(s[0].timestamp) > win {
-                    s[0] = s[1];
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                }
-
-                Ok(s[0].value)
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            pub fn update_i64(
-                &mut self,
-                timestamp: i64,
-                value: $ty,
-            ) -> Result<$ty, crate::DataError> {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, value)
-            }
-
-            /// Current window minimum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.samples[0].value)
-                }
-            }
-
-            /// Window size in raw units.
-            #[inline]
-            #[must_use]
-            pub fn window(&self) -> u64 {
-                self.window
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to empty state. Window size is preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                self.samples = [init; 3];
-                self.count = 0;
-            }
-        }
-    };
+/// Streaming windowed maximum over a sliding time window (Nichols' algorithm).
+///
+/// Tracks the maximum value within a `u64` timestamp window using only
+/// 3 stored samples. O(1) amortized per update, `no_std` compatible.
+///
+/// # Use Cases
+/// - Max throughput tracking
+/// - BBR-style bandwidth estimation
+/// - Peak detection within a time window
+/// - Deterministic replay with raw tick counters
+#[derive(Debug, Clone)]
+pub struct WindowedMaxI64 {
+    window: u64,
+    samples: [Sample<i64>; 3],
+    count: u64,
 }
 
-macro_rules! impl_windowed_min_raw_int {
-    ($name:ident, $ty:ty, $init:expr) => {
-        /// Streaming windowed minimum over a sliding time window (Nichols' algorithm).
-        ///
-        /// Tracks the minimum value within a `u64` timestamp window using only
-        /// 3 stored samples. O(1) amortized per update, `no_std` compatible.
-        ///
-        /// # Use Cases
-        /// - Min RTT tracking (BBR)
-        /// - Minimum price in a window
-        /// - Best-case latency estimation
-        /// - Deterministic replay with raw tick counters
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            window: u64,
-            samples: [Sample<$ty>; 3],
-            count: u64,
+impl WindowedMaxI64 {
+    /// Creates a new windowed max tracker.
+    ///
+    /// `window` is in the same units as the timestamps you will pass
+    /// to [`update`](Self::update). Must be positive.
+    #[inline]
+    pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: i64::MIN,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample at the given timestamp. Returns current window max.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, timestamp: u64, value: i64) -> i64 {
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value >= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return s[0].value;
         }
 
-        impl $name {
-            /// Creates a new windowed min tracker.
-            ///
-            /// `window` is in the same units as the timestamps you will pass
-            /// to [`update`](Self::update). Must be positive.
-            #[inline]
-            pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
-                if window == 0 {
-                    return Err(crate::ConfigError::Invalid("window must be positive"));
-                }
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                Ok(Self {
-                    window,
-                    samples: [init; 3],
-                    count: 0,
-                })
-            }
-
-            /// Feeds a sample at the given timestamp. Returns current window min.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, timestamp: u64, value: $ty) -> $ty {
-                self.count += 1;
-                let win = self.window;
-                let s = &mut self.samples;
-
-                if value <= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
-                    s[0] = Sample { timestamp, value };
-                    s[1] = s[0];
-                    s[2] = s[0];
-                    return s[0].value;
-                }
-
-                if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if value <= s[1].value {
-                    s[1] = Sample { timestamp, value };
-                    s[2] = s[1];
-                } else if value <= s[2].value {
-                    s[2] = Sample { timestamp, value };
-                }
-
-                if timestamp.wrapping_sub(s[0].timestamp) > win {
-                    s[0] = s[1];
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
-                    s[1] = s[2];
-                    s[2] = Sample { timestamp, value };
-                }
-
-                s[0].value
-            }
-
-            /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
-            ///
-            /// Timestamps must be non-negative. Negative values wrap to large
-            /// `u64` values and will produce incorrect window expiration.
-            #[inline]
-            #[must_use]
-            pub fn update_i64(&mut self, timestamp: i64, value: $ty) -> $ty {
-                debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
-                self.update(timestamp as u64, value)
-            }
-
-            /// Current window minimum, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn min(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.samples[0].value)
-                }
-            }
-
-            /// Window size in raw units.
-            #[inline]
-            #[must_use]
-            pub fn window(&self) -> u64 {
-                self.window
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to empty state. Window size is preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                let init = Sample {
-                    timestamp: 0,
-                    value: $init,
-                };
-                self.samples = [init; 3];
-                self.count = 0;
-            }
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
         }
-    };
+
+        if value >= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value >= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        s[0].value
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    #[must_use]
+    pub fn update_i64(&mut self, timestamp: i64, value: i64) -> i64 {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, value)
+    }
+
+    /// Current window maximum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn max(&self) -> Option<i64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    /// Window size in raw units.
+    #[inline]
+    #[must_use]
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to empty state. Window size is preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: i64::MIN,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
 }
 
-impl_windowed_max_raw_float!(WindowedMaxF64, f64, f64::MIN);
-impl_windowed_max_raw_float!(WindowedMaxF32, f32, f32::MIN);
-impl_windowed_max_raw_int!(WindowedMaxI64, i64, i64::MIN);
-impl_windowed_max_raw_int!(WindowedMaxI32, i32, i32::MIN);
-impl_windowed_max_raw_int!(WindowedMaxI128, i128, i128::MIN);
+/// Streaming windowed minimum over a sliding time window (Nichols' algorithm).
+///
+/// Tracks the minimum value within a `u64` timestamp window using only
+/// 3 stored samples. O(1) amortized per update, `no_std` compatible.
+///
+/// # Use Cases
+/// - Min RTT tracking (BBR)
+/// - Minimum price in a window
+/// - Best-case latency estimation
+/// - Deterministic replay with raw tick counters
+#[derive(Debug, Clone)]
+pub struct WindowedMinF64 {
+    window: u64,
+    samples: [Sample<f64>; 3],
+    count: u64,
+}
 
-impl_windowed_min_raw_float!(WindowedMinF64, f64, f64::MAX);
-impl_windowed_min_raw_float!(WindowedMinF32, f32, f32::MAX);
-impl_windowed_min_raw_int!(WindowedMinI64, i64, i64::MAX);
-impl_windowed_min_raw_int!(WindowedMinI32, i32, i32::MAX);
-impl_windowed_min_raw_int!(WindowedMinI128, i128, i128::MAX);
+impl WindowedMinF64 {
+    /// Creates a new windowed min tracker.
+    ///
+    /// `window` is in the same units as the timestamps you will pass
+    /// to [`update`](Self::update). Must be positive.
+    #[inline]
+    pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: f64::MAX,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample at the given timestamp. Returns current window min.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the value is NaN, or
+    /// `DataError::Infinite` if the value is infinite.
+    #[inline]
+    pub fn update(&mut self, timestamp: u64, value: f64) -> Result<f64, crate::DataError> {
+        check_finite!(value);
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value <= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return Ok(s[0].value);
+        }
+
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if value <= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value <= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        Ok(s[0].value)
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    pub fn update_i64(&mut self, timestamp: i64, value: f64) -> Result<f64, crate::DataError> {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, value)
+    }
+
+    /// Current window minimum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    /// Window size in raw units.
+    #[inline]
+    #[must_use]
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to empty state. Window size is preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: f64::MAX,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
+}
+
+/// Streaming windowed minimum over a sliding time window (Nichols' algorithm).
+///
+/// Tracks the minimum value within a `u64` timestamp window using only
+/// 3 stored samples. O(1) amortized per update, `no_std` compatible.
+///
+/// # Use Cases
+/// - Min RTT tracking (BBR)
+/// - Minimum price in a window
+/// - Best-case latency estimation
+/// - Deterministic replay with raw tick counters
+#[derive(Debug, Clone)]
+pub struct WindowedMinI64 {
+    window: u64,
+    samples: [Sample<i64>; 3],
+    count: u64,
+}
+
+impl WindowedMinI64 {
+    /// Creates a new windowed min tracker.
+    ///
+    /// `window` is in the same units as the timestamps you will pass
+    /// to [`update`](Self::update). Must be positive.
+    #[inline]
+    pub fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: i64::MAX,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample at the given timestamp. Returns current window min.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, timestamp: u64, value: i64) -> i64 {
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value <= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return s[0].value;
+        }
+
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if value <= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value <= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        s[0].value
+    }
+
+    /// Convenience for `i64` timestamps (e.g., wire protocol epoch nanos).
+    ///
+    /// Timestamps must be non-negative. Negative values wrap to large
+    /// `u64` values and will produce incorrect window expiration.
+    #[inline]
+    #[must_use]
+    pub fn update_i64(&mut self, timestamp: i64, value: i64) -> i64 {
+        debug_assert!(timestamp >= 0, "negative timestamp: {timestamp}");
+        self.update(timestamp as u64, value)
+    }
+
+    /// Current window minimum, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn min(&self) -> Option<i64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    /// Window size in raw units.
+    #[inline]
+    #[must_use]
+    pub fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to empty state. Window size is preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: i64::MAX,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
+}
+
+// --- pub(crate) f32 variants for normalizers ---
+
+#[derive(Debug, Clone)]
+pub(crate) struct WindowedMaxF32 {
+    window: u64,
+    samples: [Sample<f32>; 3],
+    count: u64,
+}
+
+impl WindowedMaxF32 {
+    #[inline]
+    pub(crate) fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: f32::MIN,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    #[inline]
+    pub(crate) fn update(&mut self, timestamp: u64, value: f32) -> Result<f32, crate::DataError> {
+        check_finite!(value);
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value >= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return Ok(s[0].value);
+        }
+
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if value >= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value >= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        Ok(s[0].value)
+    }
+
+    #[inline]
+    pub(crate) fn max(&self) -> Option<f32> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn count(&self) -> u64 {
+        self.count
+    }
+
+    #[inline]
+    pub(crate) fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: f32::MIN,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WindowedMinF32 {
+    window: u64,
+    samples: [Sample<f32>; 3],
+    count: u64,
+}
+
+impl WindowedMinF32 {
+    #[inline]
+    pub(crate) fn new(window: u64) -> Result<Self, crate::ConfigError> {
+        if window == 0 {
+            return Err(crate::ConfigError::Invalid("window must be positive"));
+        }
+        let init = Sample {
+            timestamp: 0,
+            value: f32::MAX,
+        };
+        Ok(Self {
+            window,
+            samples: [init; 3],
+            count: 0,
+        })
+    }
+
+    #[inline]
+    pub(crate) fn update(&mut self, timestamp: u64, value: f32) -> Result<f32, crate::DataError> {
+        check_finite!(value);
+        self.count += 1;
+        let win = self.window;
+        let s = &mut self.samples;
+
+        if value <= s[0].value || timestamp.wrapping_sub(s[2].timestamp) > win {
+            s[0] = Sample { timestamp, value };
+            s[1] = s[0];
+            s[2] = s[0];
+            return Ok(s[0].value);
+        }
+
+        if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if timestamp.wrapping_sub(s[2].timestamp) > win / 3 {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if value <= s[1].value {
+            s[1] = Sample { timestamp, value };
+            s[2] = s[1];
+        } else if value <= s[2].value {
+            s[2] = Sample { timestamp, value };
+        }
+
+        if timestamp.wrapping_sub(s[0].timestamp) > win {
+            s[0] = s[1];
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        } else if timestamp.wrapping_sub(s[1].timestamp) > win / 3 {
+            s[1] = s[2];
+            s[2] = Sample { timestamp, value };
+        }
+
+        Ok(s[0].value)
+    }
+
+    #[inline]
+    pub(crate) fn min(&self) -> Option<f32> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.samples[0].value)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn count(&self) -> u64 {
+        self.count
+    }
+
+    #[inline]
+    pub(crate) fn reset(&mut self) {
+        let init = Sample {
+            timestamp: 0,
+            value: f32::MAX,
+        };
+        self.samples = [init; 3];
+        self.count = 0;
+    }
+}
 
 #[cfg(test)]
 mod raw_tests {

--- a/nexus-stats-core/src/normalization/minmax.rs
+++ b/nexus-stats-core/src/normalization/minmax.rs
@@ -1,4 +1,5 @@
-use crate::monitoring::{WindowedMaxF32, WindowedMaxF64, WindowedMinF32, WindowedMinF64};
+use crate::monitoring::windowed::{WindowedMaxF32, WindowedMinF32};
+use crate::monitoring::{WindowedMaxF64, WindowedMinF64};
 
 macro_rules! impl_minmax_norm {
     ($name:ident, $builder:ident, $ty:ty, $windowed_min:ident, $windowed_max:ident) => {
@@ -241,7 +242,7 @@ mod tests {
         let v = mm.update(0, 42.0).unwrap().unwrap();
         assert!(
             (v - 0.5).abs() < 1e-10,
-            "single sample: range=0 → 0.5, got {v}"
+            "single sample: range=0 -> 0.5, got {v}"
         );
     }
 

--- a/nexus-stats-core/src/smoothing/asym_ema.rs
+++ b/nexus-stats-core/src/smoothing/asym_ema.rs
@@ -1,379 +1,185 @@
 use crate::math::MulAdd;
-macro_rules! impl_asym_ema_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Asymmetric EMA — different smoothing factors for rising vs falling.
-        ///
-        /// Uses `alpha_up` when the new sample exceeds the current value,
-        /// `alpha_down` when it's below. This allows fast attack / slow decay
-        /// or vice versa.
-        ///
-        /// # Use Cases
-        /// - Fast attack / slow decay for peak tracking
-        /// - Slow attack / fast decay for trough tracking
-        /// - Asymmetric noise filtering
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha_up: $ty,
-            alpha_down: $ty,
-            // Precomputed `1.0 - alpha_*` for the `update` hot path; saves a
-            // subtraction per sample at the cost of two `$ty` fields per
-            // instance. Set in `build()` and held constant for the
-            // instance's lifetime.
-            one_minus_alpha_up: $ty,
-            one_minus_alpha_down: $ty,
-            value: $ty,
-            count: u64,
-            min_samples: u64,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha_up: Option<$ty>,
-            alpha_down: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha_up: Option::None,
-                    alpha_down: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed value once primed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.value = sample;
-                } else {
-                    let (alpha, one_minus) = if sample > self.value {
-                        (self.alpha_up, self.one_minus_alpha_up)
-                    } else {
-                        (self.alpha_down, self.one_minus_alpha_down)
-                    };
-                    self.value = alpha.fma(sample, one_minus * self.value);
-                }
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some(self.value))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Current smoothed value, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.value)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the EMA has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Smoothing factor when sample > current value.
-            #[inline]
-            #[must_use]
-            pub fn alpha_up(mut self, alpha: $ty) -> Self {
-                self.alpha_up = Option::Some(alpha);
-                self
-            }
-
-            /// Smoothing factor when sample <= current value.
-            #[inline]
-            #[must_use]
-            pub fn alpha_down(mut self, alpha: $ty) -> Self {
-                self.alpha_down = Option::Some(alpha);
-                self
-            }
-
-            /// Span for rising smoothing (alpha_up = 2/(n+1)).
-            #[inline]
-            #[must_use]
-            pub fn span_up(mut self, n: u64) -> Self {
-                self.alpha_up = Option::Some(2.0 as $ty / (n as $ty + 1.0 as $ty));
-                self
-            }
-
-            /// Span for falling smoothing (alpha_down = 2/(n+1)).
-            #[inline]
-            #[must_use]
-            pub fn span_down(mut self, n: u64) -> Self {
-                self.alpha_down = Option::Some(2.0 as $ty / (n as $ty + 1.0 as $ty));
-                self
-            }
-
-            /// Minimum samples before value is valid. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the asymmetric EMA.
-            ///
-            /// # Errors
-            ///
-            /// - Both alpha_up and alpha_down must have been set.
-            /// - Both must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha_up = self
-                    .alpha_up
-                    .ok_or(crate::ConfigError::Missing("alpha_up"))?;
-                let alpha_down = self
-                    .alpha_down
-                    .ok_or(crate::ConfigError::Missing("alpha_down"))?;
-                if !(alpha_up > 0.0 as $ty && alpha_up < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("alpha_up must be in (0, 1)"));
-                }
-                if !(alpha_down > 0.0 as $ty && alpha_down < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("alpha_down must be in (0, 1)"));
-                }
-
-                Ok($name {
-                    alpha_up,
-                    alpha_down,
-                    one_minus_alpha_up: 1.0 as $ty - alpha_up,
-                    one_minus_alpha_down: 1.0 as $ty - alpha_down,
-                    value: 0.0 as $ty,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Asymmetric EMA — different smoothing factors for rising vs falling.
+///
+/// Uses `alpha_up` when the new sample exceeds the current value,
+/// `alpha_down` when it's below. This allows fast attack / slow decay
+/// or vice versa.
+///
+/// # Use Cases
+/// - Fast attack / slow decay for peak tracking
+/// - Slow attack / fast decay for trough tracking
+/// - Asymmetric noise filtering
+#[derive(Debug, Clone)]
+pub struct AsymEmaF64 {
+    alpha_up: f64,
+    alpha_down: f64,
+    // Precomputed `1.0 - alpha_*` for the `update` hot path; saves a
+    // subtraction per sample at the cost of two f64 fields per
+    // instance. Set in `build()` and held constant for the
+    // instance's lifetime.
+    one_minus_alpha_up: f64,
+    one_minus_alpha_down: f64,
+    value: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-macro_rules! impl_asym_ema_int {
-    ($name:ident, $builder:ident, $ty:ty, $acc_ty:ty) => {
-        /// Asymmetric EMA (integer) — different shift factors for rising vs falling.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            acc: $acc_ty,
-            shift_up: u32,
-            shift_down: u32,
-            span_up: u64,
-            span_down: u64,
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            span_up: Option<u64>,
-            span_down: Option<u64>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    span_up: Option::None,
-                    span_down: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed value once primed.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                self.count += 1;
-
-                if !self.initialized {
-                    // Use the larger shift for initial accumulator
-                    let shift = self.shift_up.max(self.shift_down);
-                    self.acc = (sample as $acc_ty) << shift;
-                    self.initialized = true;
-                } else {
-                    let current = (self.acc >> self.shift_up.max(self.shift_down)) as $ty;
-                    let shift = if sample > current {
-                        self.shift_up
-                    } else {
-                        self.shift_down
-                    };
-                    let sample_shifted = (sample as $acc_ty) << shift;
-                    // Normalize accumulator to the active shift
-                    let acc_at_shift = if shift == self.shift_up {
-                        self.acc >> (self.shift_up.max(self.shift_down) - shift)
-                    } else {
-                        self.acc >> (self.shift_up.max(self.shift_down) - shift)
-                    };
-                    let new_acc = acc_at_shift + ((sample_shifted - acc_at_shift) >> shift);
-                    self.acc = new_acc << (self.shift_up.max(self.shift_down) - shift);
-                }
-
-                if self.count >= self.min_samples {
-                    let shift = self.shift_up.max(self.shift_down);
-                    Option::Some((self.acc >> shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Current smoothed value, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> Option<$ty> {
-                if self.count >= self.min_samples && self.initialized {
-                    let shift = self.shift_up.max(self.shift_down);
-                    Option::Some((self.acc >> shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Effective spans after rounding.
-            #[inline]
-            #[must_use]
-            pub fn effective_span_up(&self) -> u64 {
-                self.span_up
-            }
-
-            /// Effective span for falling direction.
-            #[inline]
-            #[must_use]
-            pub fn effective_span_down(&self) -> u64 {
-                self.span_down
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the EMA has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.acc = 0;
-                self.count = 0;
-                self.initialized = false;
-            }
-        }
-
-        impl $builder {
-            /// Span for rising direction. Rounded up to next `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn span_up(mut self, n: u64) -> Self {
-                self.span_up = Option::Some(n);
-                self
-            }
-
-            /// Span for falling direction. Rounded up to next `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn span_down(mut self, n: u64) -> Self {
-                self.span_down = Option::Some(n);
-                self
-            }
-
-            /// Minimum samples before value is valid. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the asymmetric EMA.
-            ///
-            /// # Errors
-            ///
-            /// - Both span_up and span_down must have been set and >= 1.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let req_up = self.span_up.ok_or(crate::ConfigError::Missing("span_up"))?;
-                let req_down = self
-                    .span_down
-                    .ok_or(crate::ConfigError::Missing("span_down"))?;
-                if req_up < 1 {
-                    return Err(crate::ConfigError::Invalid("span_up must be >= 1"));
-                }
-                if req_down < 1 {
-                    return Err(crate::ConfigError::Invalid("span_down must be >= 1"));
-                }
-
-                let eff_up = crate::smoothing::ema::next_power_of_two_minus_one(req_up);
-                let eff_down = crate::smoothing::ema::next_power_of_two_minus_one(req_down);
-
-                Ok($name {
-                    acc: 0,
-                    shift_up: crate::smoothing::ema::log2_of_span_plus_one(eff_up),
-                    shift_down: crate::smoothing::ema::log2_of_span_plus_one(eff_down),
-                    span_up: eff_up,
-                    span_down: eff_down,
-                    count: 0,
-                    min_samples: self.min_samples,
-                    initialized: false,
-                })
-            }
-        }
-    };
+/// Builder for [`AsymEmaF64`].
+#[derive(Debug, Clone)]
+pub struct AsymEmaF64Builder {
+    alpha_up: Option<f64>,
+    alpha_down: Option<f64>,
+    min_samples: u64,
 }
 
-impl_asym_ema_float!(AsymEmaF64, AsymEmaF64Builder, f64);
-impl_asym_ema_float!(AsymEmaF32, AsymEmaF32Builder, f32);
-impl_asym_ema_int!(AsymEmaI64, AsymEmaI64Builder, i64, i128);
-impl_asym_ema_int!(AsymEmaI32, AsymEmaI32Builder, i32, i64);
+impl AsymEmaF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> AsymEmaF64Builder {
+        AsymEmaF64Builder {
+            alpha_up: None,
+            alpha_down: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Feeds a sample. Returns smoothed value once primed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.value = sample;
+        } else {
+            let (alpha, one_minus) = if sample > self.value {
+                (self.alpha_up, self.one_minus_alpha_up)
+            } else {
+                (self.alpha_down, self.one_minus_alpha_down)
+            };
+            self.value = alpha.fma(sample, one_minus * self.value);
+        }
+
+        if self.count >= self.min_samples {
+            Ok(Some(self.value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current smoothed value, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the EMA has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.count = 0;
+    }
+}
+
+impl AsymEmaF64Builder {
+    /// Smoothing factor when sample > current value.
+    #[inline]
+    #[must_use]
+    pub fn alpha_up(mut self, alpha: f64) -> Self {
+        self.alpha_up = Some(alpha);
+        self
+    }
+
+    /// Smoothing factor when sample <= current value.
+    #[inline]
+    #[must_use]
+    pub fn alpha_down(mut self, alpha: f64) -> Self {
+        self.alpha_down = Some(alpha);
+        self
+    }
+
+    /// Span for rising smoothing (alpha_up = 2/(n+1)).
+    #[inline]
+    #[must_use]
+    pub fn span_up(mut self, n: u64) -> Self {
+        self.alpha_up = Some(2.0 / (n as f64 + 1.0));
+        self
+    }
+
+    /// Span for falling smoothing (alpha_down = 2/(n+1)).
+    #[inline]
+    #[must_use]
+    pub fn span_down(mut self, n: u64) -> Self {
+        self.alpha_down = Some(2.0 / (n as f64 + 1.0));
+        self
+    }
+
+    /// Minimum samples before value is valid. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the asymmetric EMA.
+    ///
+    /// # Errors
+    ///
+    /// - Both alpha_up and alpha_down must have been set.
+    /// - Both must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<AsymEmaF64, crate::ConfigError> {
+        let alpha_up = self
+            .alpha_up
+            .ok_or(crate::ConfigError::Missing("alpha_up"))?;
+        let alpha_down = self
+            .alpha_down
+            .ok_or(crate::ConfigError::Missing("alpha_down"))?;
+        if !(alpha_up > 0.0 && alpha_up < 1.0) {
+            return Err(crate::ConfigError::Invalid("alpha_up must be in (0, 1)"));
+        }
+        if !(alpha_down > 0.0 && alpha_down < 1.0) {
+            return Err(crate::ConfigError::Invalid("alpha_down must be in (0, 1)"));
+        }
+
+        Ok(AsymEmaF64 {
+            alpha_up,
+            alpha_down,
+            one_minus_alpha_up: 1.0 - alpha_up,
+            one_minus_alpha_down: 1.0 - alpha_down,
+            value: 0.0,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -454,30 +260,6 @@ mod tests {
         ema.reset();
         assert_eq!(ema.count(), 0);
         assert!(ema.value().is_none());
-    }
-
-    #[test]
-    fn i64_basic() {
-        let mut ema = AsymEmaI64::builder()
-            .span_up(3)
-            .span_down(7)
-            .build()
-            .unwrap();
-
-        let _ = ema.update(100);
-        let _ = ema.update(200);
-        assert!(ema.value().is_some());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut ema = AsymEmaF32::builder()
-            .alpha_up(0.5)
-            .alpha_down(0.3)
-            .build()
-            .unwrap();
-
-        assert!(ema.update(100.0).unwrap().is_some());
     }
 
     #[test]

--- a/nexus-stats-core/src/smoothing/ema.rs
+++ b/nexus-stats-core/src/smoothing/ema.rs
@@ -1,231 +1,8 @@
 use crate::math::MulAdd;
-// =============================================================================
-// Float EMA
-// =============================================================================
-
-macro_rules! impl_ema_float {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// EMA — Exponential Moving Average.
-        ///
-        /// Smooths a streaming signal with exponential decay. Recent samples
-        /// weighted more heavily. Equivalent to a first-order IIR low-pass filter.
-        ///
-        /// # Construction
-        ///
-        /// Three ways to configure the smoothing factor:
-        /// - `alpha(a)` — direct, a ∈ (0, 1). Higher = more reactive.
-        /// - `halflife(h)` — samples for weight to decay by half.
-        /// - `span(n)` — pandas/finance convention, alpha = 2/(n+1).
-        ///
-        /// # Use Cases
-        /// - Smoothing noisy latency measurements
-        /// - Tracking moving average of throughput
-        /// - Baseline estimation for anomaly detection
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            value: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            min_samples: u64,
-            seed: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    min_samples: 1,
-                    seed: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed value once primed.
-            ///
-            /// First sample initializes the EMA directly (no smoothing).
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.value = sample;
-                } else {
-                    self.value = self.alpha.fma(sample, self.one_minus_alpha * self.value);
-                }
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some(self.value))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Current smoothed value, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.value)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// The smoothing factor alpha.
-            #[inline]
-            #[must_use]
-            pub fn alpha(&self) -> $ty {
-                self.alpha
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the EMA has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.count = 0;
-            }
-
-            /// Updates the smoothing factor without resetting state.
-            ///
-            /// # Errors
-            ///
-            /// Alpha must be in (0, 1) exclusive.
-            #[inline]
-            pub fn reconfigure_alpha(&mut self, alpha: $ty) -> Result<(), crate::ConfigError> {
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("EMA alpha must be in (0, 1)"));
-                }
-                self.alpha = alpha;
-                self.one_minus_alpha = 1.0 as $ty - alpha;
-                Ok(())
-            }
-        }
-
-        impl $builder {
-            /// Direct smoothing factor. Must be in (0, 1) exclusive.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Samples for weight to decay by half.
-            ///
-            /// Computes: `alpha = 1 - exp(-ln(2) / halflife)`
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn halflife(mut self, halflife: $ty) -> Self {
-                let ln2 = core::f64::consts::LN_2 as $ty;
-                let alpha = 1.0 as $ty - crate::math::exp((-ln2 / halflife) as f64) as $ty;
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Number of samples for center of mass (pandas convention).
-            ///
-            /// Computes: `alpha = 2 / (n + 1)`
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                let alpha = 2.0 as $ty / (n as $ty + 1.0 as $ty);
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Minimum samples before value is considered valid. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-loads the smoothed value from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately and
-            /// the first `update()` applies smoothing (no raw initialization).
-            #[inline]
-            #[must_use]
-            pub fn seed(mut self, value: $ty) -> Self {
-                self.seed = Option::Some(value);
-                self
-            }
-
-            /// Builds the EMA.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha must have been set (via `alpha`, `halflife`, or `span`).
-            /// - Alpha must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("EMA alpha must be in (0, 1)"));
-                }
-
-                let (value, count) = if let Some(seed_val) = self.seed {
-                    (seed_val, self.min_samples)
-                } else {
-                    (0.0 as $ty, 0)
-                };
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    value,
-                    count,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
-}
-
-impl_ema_float!(EmaF64, EmaF64Builder, f64);
-impl_ema_float!(EmaF32, EmaF32Builder, f32);
-
-// =============================================================================
-// Integer EMA (kernel-style fixed-point)
-// =============================================================================
 
 /// Rounds `n` up to the next value of the form `2^k - 1`.
 ///
-/// Examples: 1→1, 2→3, 3→3, 4→7, 5→7, 10→15, 20→31.
+/// Examples: 1->1, 2->3, 3->3, 4->7, 5->7, 10->15, 20->31.
 #[inline]
 pub(crate) const fn next_power_of_two_minus_one(n: u64) -> u64 {
     if n == 0 {
@@ -245,232 +22,214 @@ pub(crate) const fn log2_of_span_plus_one(span: u64) -> u32 {
     (span + 1).trailing_zeros()
 }
 
-macro_rules! impl_ema_int {
-    ($name:ident, $builder:ident, $ty:ty, $acc_ty:ty) => {
-        /// EMA — Exponential Moving Average (integer fixed-point variant).
-        ///
-        /// Uses the Linux kernel pattern: bit-shift arithmetic with integer-only
-        /// operations. No floating point. Weight is derived from span, rounded
-        /// up to the next valid value (`2^k - 1`) for shift optimization.
-        ///
-        /// The weight reciprocal is `span + 1` (a power of 2), so division
-        /// becomes a right-shift by `k` bits.
-        ///
-        /// # Use Cases
-        /// - Smoothing nanosecond latency measurements without float
-        /// - Kernel-style EWMA for counters and durations
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            /// Accumulator — stores value << shift for precision
-            acc: $acc_ty,
-            /// Bit shift amount: log2(span + 1)
-            shift: u32,
-            /// Effective span (2^k - 1)
-            span: u64,
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            span: Option<u64>,
-            min_samples: u64,
-            seed: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    span: Option::None,
-                    min_samples: 1,
-                    seed: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns smoothed value once primed.
-            ///
-            /// First sample initializes the accumulator directly.
-            ///
-            /// Update formula (kernel pattern):
-            /// ```text
-            /// acc += (sample << shift) - acc) >> shift
-            /// ```
-            /// This is equivalent to: `value = value + (sample - value) / (span + 1)`
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<$ty> {
-                self.count += 1;
-
-                if !self.initialized {
-                    self.acc = (sample as $acc_ty) << self.shift;
-                    self.initialized = true;
-                } else {
-                    let sample_shifted = (sample as $acc_ty) << self.shift;
-                    self.acc += (sample_shifted - self.acc) >> self.shift;
-                }
-
-                if self.count >= self.min_samples {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Current smoothed value, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> Option<$ty> {
-                if self.count >= self.min_samples && self.initialized {
-                    Option::Some((self.acc >> self.shift) as $ty)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// The actual span after rounding up to `2^k - 1`.
-            #[inline]
-            #[must_use]
-            pub fn effective_span(&self) -> u64 {
-                self.span
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the EMA has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.acc = 0;
-                self.count = 0;
-                self.initialized = false;
-            }
-
-            /// Updates the span without resetting state.
-            ///
-            /// Unshifts the accumulator with the old shift and reshifts with the
-            /// new one, preserving the smoothed value.
-            ///
-            /// # Errors
-            ///
-            /// Span must be >= 1.
-            #[inline]
-            pub fn reconfigure_span(&mut self, span: u64) -> Result<(), crate::ConfigError> {
-                if span < 1 {
-                    return Err(crate::ConfigError::Invalid("EMA span must be >= 1"));
-                }
-                let effective = next_power_of_two_minus_one(span);
-                let new_shift = log2_of_span_plus_one(effective);
-
-                // Rescale accumulator directly to preserve fixed-point precision.
-                // Only loses bits when shifting down (smaller span), which is unavoidable.
-                if self.initialized {
-                    if new_shift > self.shift {
-                        self.acc <<= new_shift - self.shift;
-                    } else {
-                        self.acc >>= self.shift - new_shift;
-                    }
-                }
-
-                self.shift = new_shift;
-                self.span = effective;
-                Ok(())
-            }
-        }
-
-        impl $builder {
-            /// Minimum span. Rounded up to next `2^k - 1`.
-            ///
-            /// Call [`
-            #[doc = stringify!($name)]
-            /// ::effective_span()`] after build to see the actual value.
-            #[inline]
-            #[must_use]
-            pub fn span(mut self, n: u64) -> Self {
-                self.span = Option::Some(n);
-                self
-            }
-
-            /// Minimum samples before value is valid. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-loads the smoothed value from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately.
-            #[inline]
-            #[must_use]
-            pub fn seed(mut self, value: $ty) -> Self {
-                self.seed = Option::Some(value);
-                self
-            }
-
-            /// Builds the EMA.
-            ///
-            /// # Errors
-            ///
-            /// - Span must have been set.
-            /// - Span must be >= 1.
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
-                if requested < 1 {
-                    return Err(crate::ConfigError::Invalid("EMA span must be >= 1"));
-                }
-
-                let effective = next_power_of_two_minus_one(requested);
-                let shift = log2_of_span_plus_one(effective);
-
-                let (acc, count, initialized) = if let Some(seed_val) = self.seed {
-                    ((seed_val as $acc_ty) << shift, self.min_samples, true)
-                } else {
-                    (0, 0, false)
-                };
-
-                Ok($name {
-                    acc,
-                    shift,
-                    span: effective,
-                    count,
-                    min_samples: self.min_samples,
-                    initialized,
-                })
-            }
-        }
-    };
+/// EMA — Exponential Moving Average.
+///
+/// Smooths a streaming signal with exponential decay. Recent samples
+/// weighted more heavily. Equivalent to a first-order IIR low-pass filter.
+///
+/// # Construction
+///
+/// Three ways to configure the smoothing factor:
+/// - `alpha(a)` — direct, a ∈ (0, 1). Higher = more reactive.
+/// - `halflife(h)` — samples for weight to decay by half.
+/// - `span(n)` — pandas/finance convention, alpha = 2/(n+1).
+///
+/// # Use Cases
+/// - Smoothing noisy latency measurements
+/// - Tracking moving average of throughput
+/// - Baseline estimation for anomaly detection
+#[derive(Debug, Clone)]
+pub struct EmaF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    value: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_ema_int!(EmaI64, EmaI64Builder, i64, i128);
-impl_ema_int!(EmaI32, EmaI32Builder, i32, i64);
+/// Builder for [`EmaF64`].
+#[derive(Debug, Clone)]
+pub struct EmaF64Builder {
+    alpha: Option<f64>,
+    min_samples: u64,
+    seed: Option<f64>,
+}
+
+impl EmaF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EmaF64Builder {
+        EmaF64Builder {
+            alpha: None,
+            min_samples: 1,
+            seed: None,
+        }
+    }
+
+    /// Feeds a sample. Returns smoothed value once primed.
+    ///
+    /// First sample initializes the EMA directly (no smoothing).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.value = sample;
+        } else {
+            self.value = self.alpha.fma(sample, self.one_minus_alpha * self.value);
+        }
+
+        if self.count >= self.min_samples {
+            Ok(Some(self.value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current smoothed value, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// The smoothing factor alpha.
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the EMA has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.count = 0;
+    }
+
+    /// Updates the smoothing factor without resetting state.
+    ///
+    /// # Errors
+    ///
+    /// Alpha must be in (0, 1) exclusive.
+    #[inline]
+    pub fn reconfigure_alpha(&mut self, alpha: f64) -> Result<(), crate::ConfigError> {
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid("EMA alpha must be in (0, 1)"));
+        }
+        self.alpha = alpha;
+        self.one_minus_alpha = 1.0 - alpha;
+        Ok(())
+    }
+}
+
+impl EmaF64Builder {
+    /// Direct smoothing factor. Must be in (0, 1) exclusive.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Samples for weight to decay by half.
+    ///
+    /// Computes: `alpha = 1 - exp(-ln(2) / halflife)`
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn halflife(mut self, halflife: f64) -> Self {
+        let ln2 = core::f64::consts::LN_2;
+        let alpha = 1.0 - crate::math::exp(-ln2 / halflife);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Number of samples for center of mass (pandas convention).
+    ///
+    /// Computes: `alpha = 2 / (n + 1)`
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        let alpha = 2.0 / (n as f64 + 1.0);
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Minimum samples before value is considered valid. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Pre-loads the smoothed value from calibration data.
+    ///
+    /// When seeded, `is_primed()` returns true immediately and
+    /// the first `update()` applies smoothing (no raw initialization).
+    #[inline]
+    #[must_use]
+    pub fn seed(mut self, value: f64) -> Self {
+        self.seed = Some(value);
+        self
+    }
+
+    /// Builds the EMA.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha must have been set (via `alpha`, `halflife`, or `span`).
+    /// - Alpha must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<EmaF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid("EMA alpha must be in (0, 1)"));
+        }
+
+        let (value, count) = self
+            .seed
+            .map_or((0.0, 0), |seed_val| (seed_val, self.min_samples));
+
+        Ok(EmaF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            value,
+            count,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // =========================================================================
-    // Float EMA
-    // =========================================================================
 
     #[test]
     fn first_sample_initializes() {
@@ -581,117 +340,6 @@ mod tests {
         assert!(matches!(result, Err(crate::ConfigError::Invalid(_))));
     }
 
-    #[test]
-    fn f32_basic() {
-        let mut ema = EmaF32::builder().alpha(0.5).build().unwrap();
-        assert_eq!(ema.update(100.0).unwrap(), Some(100.0));
-        let v = ema.update(200.0).unwrap().unwrap();
-        assert!((v - 150.0).abs() < 0.01);
-    }
-
-    // =========================================================================
-    // Integer EMA
-    // =========================================================================
-
-    #[test]
-    fn span_rounding() {
-        // 1 → 1 (2^1 - 1)
-        let ema = EmaI64::builder().span(1).build().unwrap();
-        assert_eq!(ema.effective_span(), 1);
-
-        // 2 → 3 (2^2 - 1)
-        let ema = EmaI64::builder().span(2).build().unwrap();
-        assert_eq!(ema.effective_span(), 3);
-
-        // 3 → 3
-        let ema = EmaI64::builder().span(3).build().unwrap();
-        assert_eq!(ema.effective_span(), 3);
-
-        // 7 → 7 (2^3 - 1, exact)
-        let ema = EmaI64::builder().span(7).build().unwrap();
-        assert_eq!(ema.effective_span(), 7);
-
-        // 10 → 15 (2^4 - 1)
-        let ema = EmaI64::builder().span(10).build().unwrap();
-        assert_eq!(ema.effective_span(), 15);
-
-        // 20 → 31 (2^5 - 1)
-        let ema = EmaI64::builder().span(20).build().unwrap();
-        assert_eq!(ema.effective_span(), 31);
-    }
-
-    #[test]
-    fn int_first_sample_initializes() {
-        let mut ema = EmaI64::builder().span(7).build().unwrap();
-        assert_eq!(ema.update(1000), Some(1000));
-    }
-
-    #[test]
-    fn int_convergence() {
-        let mut ema = EmaI64::builder().span(7).build().unwrap();
-
-        let _ = ema.update(0);
-        for _ in 0..10_000 {
-            let _ = ema.update(1000);
-        }
-
-        let val = ema.value().unwrap();
-        // Should converge close to 1000 (integer precision may be off by 1)
-        assert!(
-            (val - 1000).abs() <= 1,
-            "should converge to ~1000, got {val}"
-        );
-    }
-
-    #[test]
-    fn int_no_drift_over_many_samples() {
-        let mut ema = EmaI64::builder().span(15).build().unwrap();
-
-        // Feed constant value — should not drift
-        for _ in 0..100_000 {
-            let _ = ema.update(500);
-        }
-
-        let val = ema.value().unwrap();
-        assert_eq!(
-            val, 500,
-            "constant input should produce exact output, got {val}"
-        );
-    }
-
-    #[test]
-    fn int_priming() {
-        let mut ema = EmaI64::builder().span(7).min_samples(5).build().unwrap();
-
-        for _ in 0..4 {
-            assert_eq!(ema.update(100), None);
-        }
-        assert!(ema.update(100).is_some());
-    }
-
-    #[test]
-    fn int_reset() {
-        let mut ema = EmaI64::builder().span(7).build().unwrap();
-        let _ = ema.update(1000);
-        let _ = ema.update(2000);
-
-        ema.reset();
-        assert_eq!(ema.count(), 0);
-        assert_eq!(ema.value(), None);
-    }
-
-    #[test]
-    fn i32_basic() {
-        let mut ema = EmaI32::builder().span(3).build().unwrap();
-        assert_eq!(ema.update(100), Some(100));
-    }
-
-    #[test]
-    fn int_errors_without_span() {
-        let result = EmaI64::builder().build();
-        assert!(matches!(result, Err(crate::ConfigError::Missing("span"))));
-    }
-
     // =========================================================================
     // Reconfigure
     // =========================================================================
@@ -718,52 +366,6 @@ mod tests {
         assert!(ema.reconfigure_alpha(0.0).is_err());
         assert!(ema.reconfigure_alpha(1.0).is_err());
         assert!(ema.reconfigure_alpha(-0.1).is_err());
-    }
-
-    #[test]
-    fn int_reconfigure_span_preserves_value() {
-        let mut ema = EmaI64::builder().span(7).build().unwrap();
-        for _ in 0..100 {
-            let _ = ema.update(500);
-        }
-        let val_before = ema.value().unwrap();
-        let count_before = ema.count();
-
-        ema.reconfigure_span(15).unwrap();
-
-        assert_eq!(ema.effective_span(), 15);
-        assert_eq!(ema.value().unwrap(), val_before);
-        assert_eq!(ema.count(), count_before);
-    }
-
-    #[test]
-    fn int_reconfigure_span_validates() {
-        let mut ema = EmaI64::builder().span(7).build().unwrap();
-        assert!(ema.reconfigure_span(0).is_err());
-    }
-
-    #[test]
-    fn int_vs_float_comparison() {
-        // Both should produce similar results on the same input
-        let mut int_ema = EmaI64::builder().span(15).build().unwrap();
-        let mut float_ema = EmaF64::builder().span(15).build().unwrap();
-
-        let samples = [100, 110, 95, 105, 120, 90, 100, 115, 85, 100];
-
-        for &s in &samples {
-            let _ = int_ema.update(s);
-            float_ema.update(s as f64).unwrap();
-        }
-
-        let int_val = int_ema.value().unwrap();
-        let float_val = float_ema.value().unwrap();
-
-        // Should be within a few units of each other
-        let diff = (int_val as f64 - float_val).abs();
-        assert!(
-            diff < 5.0,
-            "int ({int_val}) and float ({float_val}) should be close, diff={diff}"
-        );
     }
 
     #[test]

--- a/nexus-stats-core/src/smoothing/slew.rs
+++ b/nexus-stats-core/src/smoothing/slew.rs
@@ -1,141 +1,126 @@
-macro_rules! impl_slew_float {
-    ($name:ident, $ty:ty) => {
-        /// Slew rate limiter — clamps output change per sample.
-        ///
-        /// Limits how fast the output can change between consecutive samples.
-        /// Useful for preventing sudden jumps from propagating through a system.
-        ///
-        /// # Use Cases
-        /// - Smoothing control signals
-        /// - Preventing sudden parameter changes from destabilizing a system
-        /// - Rate-limiting position updates
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max_rate: $ty,
-            value: $ty,
-            initialized: bool,
-        }
-
-        impl $name {
-            /// Creates a new slew limiter with the given maximum change per sample.
-            #[inline]
-            pub fn new(max_rate: $ty) -> Result<Self, crate::ConfigError> {
-                #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                if !(max_rate > 0.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid("max_rate must be positive"));
-                }
-                Ok(Self {
-                    max_rate,
-                    value: 0.0 as $ty,
-                    initialized: false,
-                })
-            }
-
-            /// Feeds a sample. Returns the rate-limited output.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<$ty, crate::DataError> {
-                check_finite!(sample);
-                if !self.initialized {
-                    self.value = sample;
-                    self.initialized = true;
-                    return Ok(sample);
-                }
-
-                self.value = sample.clamp(self.value - self.max_rate, self.value + self.max_rate);
-                Ok(self.value)
-            }
-
-            /// Current output value.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> $ty {
-                self.value
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.initialized = false;
-            }
-        }
-    };
+/// Slew rate limiter — clamps output change per sample.
+///
+/// Limits how fast the output can change between consecutive samples.
+/// Useful for preventing sudden jumps from propagating through a system.
+///
+/// # Use Cases
+/// - Smoothing control signals
+/// - Preventing sudden parameter changes from destabilizing a system
+/// - Rate-limiting position updates
+#[derive(Debug, Clone)]
+pub struct SlewF64 {
+    max_rate: f64,
+    value: f64,
+    initialized: bool,
 }
 
-macro_rules! impl_slew_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Slew rate limiter — clamps output change per sample.
-        ///
-        /// Limits how fast the output can change between consecutive samples.
-        /// Useful for preventing sudden jumps from propagating through a system.
-        ///
-        /// # Use Cases
-        /// - Smoothing control signals
-        /// - Preventing sudden parameter changes from destabilizing a system
-        /// - Rate-limiting position updates
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            max_rate: $ty,
-            value: $ty,
-            initialized: bool,
+impl SlewF64 {
+    /// Creates a new slew limiter with the given maximum change per sample.
+    #[inline]
+    pub fn new(max_rate: f64) -> Result<Self, crate::ConfigError> {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(max_rate > 0.0) {
+            return Err(crate::ConfigError::Invalid("max_rate must be positive"));
+        }
+        Ok(Self {
+            max_rate,
+            value: 0.0,
+            initialized: false,
+        })
+    }
+
+    /// Feeds a sample. Returns the rate-limited output.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<f64, crate::DataError> {
+        check_finite!(sample);
+        if !self.initialized {
+            self.value = sample;
+            self.initialized = true;
+            return Ok(sample);
         }
 
-        impl $name {
-            /// Creates a new slew limiter with the given maximum change per sample.
-            #[inline]
-            pub fn new(max_rate: $ty) -> Result<Self, crate::ConfigError> {
-                #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                if !(max_rate > $zero) {
-                    return Err(crate::ConfigError::Invalid("max_rate must be positive"));
-                }
-                Ok(Self {
-                    max_rate,
-                    value: $zero,
-                    initialized: false,
-                })
-            }
+        self.value = sample.clamp(self.value - self.max_rate, self.value + self.max_rate);
+        Ok(self.value)
+    }
 
-            /// Feeds a sample. Returns the rate-limited output.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> $ty {
-                if !self.initialized {
-                    self.value = sample;
-                    self.initialized = true;
-                    return sample;
-                }
+    /// Current output value.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> f64 {
+        self.value
+    }
 
-                self.value = sample.clamp(self.value - self.max_rate, self.value + self.max_rate);
-                self.value
-            }
-
-            /// Current output value.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> $ty {
-                self.value
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = $zero;
-                self.initialized = false;
-            }
-        }
-    };
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.initialized = false;
+    }
 }
 
-impl_slew_float!(SlewF64, f64);
-impl_slew_float!(SlewF32, f32);
-impl_slew_int!(SlewI64, i64, 0);
-impl_slew_int!(SlewI32, i32, 0);
-impl_slew_int!(SlewI128, i128, 0);
+/// Slew rate limiter — clamps output change per sample.
+///
+/// Limits how fast the output can change between consecutive samples.
+/// Useful for preventing sudden jumps from propagating through a system.
+///
+/// # Use Cases
+/// - Smoothing control signals
+/// - Preventing sudden parameter changes from destabilizing a system
+/// - Rate-limiting position updates
+#[derive(Debug, Clone)]
+pub struct SlewI64 {
+    max_rate: i64,
+    value: i64,
+    initialized: bool,
+}
+
+impl SlewI64 {
+    /// Creates a new slew limiter with the given maximum change per sample.
+    #[inline]
+    pub fn new(max_rate: i64) -> Result<Self, crate::ConfigError> {
+        if max_rate <= 0 {
+            return Err(crate::ConfigError::Invalid("max_rate must be positive"));
+        }
+        Ok(Self {
+            max_rate,
+            value: 0,
+            initialized: false,
+        })
+    }
+
+    /// Feeds a sample. Returns the rate-limited output.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> i64 {
+        if !self.initialized {
+            self.value = sample;
+            self.initialized = true;
+            return sample;
+        }
+
+        self.value = sample.clamp(self.value - self.max_rate, self.value + self.max_rate);
+        self.value
+    }
+
+    /// Current output value.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> i64 {
+        self.value
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0;
+        self.initialized = false;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -192,13 +177,6 @@ mod tests {
             SlewI64::new(0),
             Err(crate::ConfigError::Invalid(_))
         ));
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut s = SlewI128::new(5).unwrap();
-        assert_eq!(s.update(100), 100);
-        assert_eq!(s.update(200), 105);
     }
 
     #[test]

--- a/nexus-stats-core/src/statistics/bipower.rs
+++ b/nexus-stats-core/src/statistics/bipower.rs
@@ -1,218 +1,195 @@
-macro_rules! impl_bipower {
-    ($name:ident, $builder:ident, $ty:ty, $pi_over_2:expr) => {
-        /// Bipower variation — jump-robust volatility estimator.
-        ///
-        /// Estimates the continuous component of quadratic variation
-        /// using products of consecutive absolute returns. Difference
-        /// with realized variance isolates the jump component.
-        ///
-        /// Barndorff-Nielsen & Shephard (2004).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_core::statistics::BipowerVariationF64;
-        ///
-        /// let mut bv = BipowerVariationF64::new();
-        /// for i in 0..100 {
-        ///     bv.update(100.0 + (i as f64) * 0.01).unwrap();
-        /// }
-        /// assert!(bv.bipower_variation().is_some());
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_bv: $ty,
-            sum_rv: $ty,
-            prev_abs_diff: $ty,
-            prev_price: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a new bipower variation tracker with default min_samples (30).
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    sum_bv: 0.0 as $ty,
-                    sum_rv: 0.0 as $ty,
-                    prev_abs_diff: 0.0 as $ty,
-                    prev_price: 0.0 as $ty,
-                    count: 0,
-                    min_samples: 30,
-                }
-            }
-
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder { min_samples: 30 }
-            }
-
-            /// Feeds a trade price.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the price is NaN, or
-            /// `DataError::Infinite` if the price is infinite.
-            #[inline]
-            pub fn update(&mut self, price: $ty) -> Result<(), crate::DataError> {
-                check_finite!(price);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.prev_price = price;
-                    return Ok(());
-                }
-
-                let diff = price - self.prev_price;
-                let abs_diff = if diff < 0.0 as $ty { -diff } else { diff };
-
-                self.sum_rv += diff * diff;
-
-                if self.count >= 3 {
-                    self.sum_bv += abs_diff * self.prev_abs_diff;
-                }
-
-                self.prev_abs_diff = abs_diff;
-                self.prev_price = price;
-                Ok(())
-            }
-
-            /// Bipower variation: `(π/2) · Σ|Δp_t|·|Δp_{t-1}| / n`.
-            ///
-            /// Returns `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn bipower_variation(&self) -> Option<$ty> {
-                if !self.is_primed() || self.count < 3 {
-                    return Option::None;
-                }
-                let n = (self.count - 2) as $ty;
-                Option::Some($pi_over_2 * self.sum_bv / n)
-            }
-
-            /// Realized variance: `Σ(Δp_t)² / n`.
-            ///
-            /// Returns `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn realized_variance(&self) -> Option<$ty> {
-                if !self.is_primed() || self.count < 2 {
-                    return Option::None;
-                }
-                let n = (self.count - 1) as $ty;
-                Option::Some(self.sum_rv / n)
-            }
-
-            /// Jump variation: `max(RV - BV, 0)`.
-            ///
-            /// Returns `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn jump_variation(&self) -> Option<$ty> {
-                let rv = self.realized_variance()?;
-                let bv = self.bipower_variation()?;
-                let jv = rv - bv;
-                if jv > 0.0 as $ty {
-                    Option::Some(jv)
-                } else {
-                    Option::Some(0.0 as $ty)
-                }
-            }
-
-            /// Jump ratio: `max(RV - BV, 0) / RV`. Range [0, 1].
-            ///
-            /// Returns `None` if not primed or RV is zero.
-            #[inline]
-            #[must_use]
-            pub fn jump_ratio(&self) -> Option<$ty> {
-                let rv = self.realized_variance()?;
-                if rv <= 0.0 as $ty {
-                    return Option::None;
-                }
-                let jv = self.jump_variation()?;
-                Option::Some(jv / rv)
-            }
-
-            /// Number of prices seen.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough samples have been observed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_bv = 0.0 as $ty;
-                self.sum_rv = 0.0 as $ty;
-                self.prev_abs_diff = 0.0 as $ty;
-                self.prev_price = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl $builder {
-            /// Minimum prices before results are valid. Default: 30.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the bipower variation tracker.
-            #[inline]
-            pub fn build(self) -> $name {
-                $name {
-                    sum_bv: 0.0 as $ty,
-                    sum_rv: 0.0 as $ty,
-                    prev_abs_diff: 0.0 as $ty,
-                    prev_price: 0.0 as $ty,
-                    count: 0,
-                    min_samples: self.min_samples,
-                }
-            }
-        }
-    };
+/// Bipower variation — jump-robust volatility estimator.
+///
+/// Estimates the continuous component of quadratic variation
+/// using products of consecutive absolute returns. Difference
+/// with realized variance isolates the jump component.
+///
+/// Barndorff-Nielsen & Shephard (2004).
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::BipowerVariationF64;
+///
+/// let mut bv = BipowerVariationF64::new();
+/// for i in 0..100 {
+///     bv.update(100.0 + (i as f64) * 0.01).unwrap();
+/// }
+/// assert!(bv.bipower_variation().is_some());
+/// ```
+#[derive(Debug, Clone)]
+pub struct BipowerVariationF64 {
+    sum_bv: f64,
+    sum_rv: f64,
+    prev_abs_diff: f64,
+    prev_price: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_bipower!(
-    BipowerVariationF64,
-    BipowerVariationF64Builder,
-    f64,
-    core::f64::consts::FRAC_PI_2
-);
-impl_bipower!(
-    BipowerVariationF32,
-    BipowerVariationF32Builder,
-    f32,
-    core::f32::consts::FRAC_PI_2
-);
+/// Builder for [`BipowerVariationF64`].
+#[derive(Debug, Clone)]
+pub struct BipowerVariationF64Builder {
+    min_samples: u64,
+}
+
+impl BipowerVariationF64 {
+    /// Creates a new bipower variation tracker with default min_samples (30).
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sum_bv: 0.0,
+            sum_rv: 0.0,
+            prev_abs_diff: 0.0,
+            prev_price: 0.0,
+            count: 0,
+            min_samples: 30,
+        }
+    }
+
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> BipowerVariationF64Builder {
+        BipowerVariationF64Builder { min_samples: 30 }
+    }
+
+    /// Feeds a trade price.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the price is NaN, or
+    /// `DataError::Infinite` if the price is infinite.
+    #[inline]
+    pub fn update(&mut self, price: f64) -> Result<(), crate::DataError> {
+        check_finite!(price);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.prev_price = price;
+            return Ok(());
+        }
+
+        let diff = price - self.prev_price;
+        let abs_diff = diff.abs();
+
+        self.sum_rv += diff * diff;
+
+        if self.count >= 3 {
+            self.sum_bv += abs_diff * self.prev_abs_diff;
+        }
+
+        self.prev_abs_diff = abs_diff;
+        self.prev_price = price;
+        Ok(())
+    }
+
+    /// Bipower variation: `(pi/2) * sum(|dp_t| * |dp_{t-1}|) / n`.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn bipower_variation(&self) -> Option<f64> {
+        if !self.is_primed() || self.count < 3 {
+            return None;
+        }
+        let n = (self.count - 2) as f64;
+        Some(core::f64::consts::FRAC_PI_2 * self.sum_bv / n)
+    }
+
+    /// Realized variance: `sum(dp_t^2) / n`.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn realized_variance(&self) -> Option<f64> {
+        if !self.is_primed() || self.count < 2 {
+            return None;
+        }
+        let n = (self.count - 1) as f64;
+        Some(self.sum_rv / n)
+    }
+
+    /// Jump variation: `max(RV - BV, 0)`.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn jump_variation(&self) -> Option<f64> {
+        let rv = self.realized_variance()?;
+        let bv = self.bipower_variation()?;
+        let jv = rv - bv;
+        if jv > 0.0 { Some(jv) } else { Some(0.0) }
+    }
+
+    /// Jump ratio: `max(RV - BV, 0) / RV`. Range [0, 1].
+    ///
+    /// Returns `None` if not primed or RV is zero.
+    #[inline]
+    #[must_use]
+    pub fn jump_ratio(&self) -> Option<f64> {
+        let rv = self.realized_variance()?;
+        if rv <= 0.0 {
+            return None;
+        }
+        let jv = self.jump_variation()?;
+        Some(jv / rv)
+    }
+
+    /// Number of prices seen.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough samples have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_bv = 0.0;
+        self.sum_rv = 0.0;
+        self.prev_abs_diff = 0.0;
+        self.prev_price = 0.0;
+        self.count = 0;
+    }
+}
+
+impl Default for BipowerVariationF64 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BipowerVariationF64Builder {
+    /// Minimum prices before results are valid. Default: 30.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the bipower variation tracker.
+    #[inline]
+    pub fn build(self) -> BipowerVariationF64 {
+        BipowerVariationF64 {
+            sum_bv: 0.0,
+            sum_rv: 0.0,
+            prev_abs_diff: 0.0,
+            prev_price: 0.0,
+            count: 0,
+            min_samples: self.min_samples,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -271,7 +248,7 @@ mod tests {
         for &p in &prices {
             bv.update(p).unwrap();
         }
-        // diffs: 1, -2, 3 → sum_sq = 1+4+9 = 14, n = 3 → RV = 14/3
+        // diffs: 1, -2, 3 -> sum_sq = 1+4+9 = 14, n = 3 -> RV = 14/3
         let min_bv = BipowerVariationF64::builder().min_samples(2).build();
         let mut bv2 = min_bv;
         for &p in &prices {
@@ -294,7 +271,7 @@ mod tests {
         }
         let bipower = bv.bipower_variation().unwrap();
         // sum_bv: |1|*|-2| + |-2|*|3| + |3|*|-2| = 2+6+6 = 14, n_bv = 3
-        // BV = (π/2) * 14/3
+        // BV = (pi/2) * 14/3
         let expected = core::f64::consts::FRAC_PI_2 * 14.0 / 3.0;
         assert!(
             (bipower - expected).abs() < 1e-10,

--- a/nexus-stats-core/src/statistics/covariance.rs
+++ b/nexus-stats-core/src/statistics/covariance.rs
@@ -1,176 +1,168 @@
 use crate::math::MulAdd;
-macro_rules! impl_covariance {
-    ($name:ident, $ty:ty) => {
-        /// Online covariance and Pearson correlation between two signals.
-        ///
-        /// Uses Welford-style numerically stable single-pass computation.
-        /// Supports Chan's merge for parallel aggregation.
-        ///
-        /// # Use Cases
-        /// - "Are these two signals moving together?"
-        /// - Latency correlation across venues
-        /// - Co-movement detection
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            count: u64,
-            mean_x: $ty,
-            mean_y: $ty,
-            m2_x: $ty,
-            m2_y: $ty,
-            co_moment: $ty,
-        }
 
-        impl $name {
-            /// Creates a new empty accumulator.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    count: 0,
-                    mean_x: 0.0 as $ty,
-                    mean_y: 0.0 as $ty,
-                    m2_x: 0.0 as $ty,
-                    m2_y: 0.0 as $ty,
-                    co_moment: 0.0 as $ty,
-                }
-            }
-
-            /// Feeds a paired sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if either input is NaN, or
-            /// `DataError::Infinite` if either input is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), crate::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                self.count += 1;
-                let inv_n = 1.0 as $ty / self.count as $ty;
-
-                let dx = x - self.mean_x;
-                let dy = y - self.mean_y;
-
-                self.mean_x += dx * inv_n;
-                self.mean_y += dy * inv_n;
-
-                // Use the NEW mean_x but OLD mean_y for the co-moment update
-                let dx2 = x - self.mean_x;
-                self.co_moment += dx * (y - self.mean_y);
-
-                // Welford M2 updates
-                self.m2_x += dx * dx2;
-                let dy2 = y - self.mean_y;
-                self.m2_y += dy * dy2;
-                Ok(())
-            }
-
-            /// Number of paired samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Mean of X, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean_x(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.mean_x)
-                }
-            }
-
-            /// Mean of Y, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean_y(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.mean_y)
-                }
-            }
-
-            /// Sample covariance (N-1 denominator), or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            pub fn covariance(&self) -> Option<$ty> {
-                if self.count < 2 {
-                    Option::None
-                } else {
-                    Option::Some(self.co_moment / (self.count - 1) as $ty)
-                }
-            }
-
-            /// Pearson correlation coefficient, or `None` if < 2 samples.
-            ///
-            /// Returns a value in [-1, 1]. Returns `None` if either variable
-            /// has zero variance (undefined correlation).
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn correlation(&self) -> Option<$ty> {
-                if self.count < 2 {
-                    return Option::None;
-                }
-                let var_product = self.m2_x * self.m2_y;
-                if var_product <= 0.0 as $ty {
-                    return Option::None;
-                }
-                let r = self.co_moment / crate::math::sqrt(var_product as f64) as $ty;
-                Option::Some(r)
-            }
-
-            /// Merges another accumulator into this one (Chan's algorithm).
-            #[inline]
-            pub fn merge(&mut self, other: &Self) {
-                if other.count == 0 {
-                    return;
-                }
-                if self.count == 0 {
-                    *self = other.clone();
-                    return;
-                }
-
-                let combined = self.count + other.count;
-                let dx = other.mean_x - self.mean_x;
-                let dy = other.mean_y - self.mean_y;
-                let weight = self.count as $ty * other.count as $ty / combined as $ty;
-
-                let new_mean_x =
-                    (dx * other.count as $ty).fma(1.0 as $ty / combined as $ty, self.mean_x);
-                let new_mean_y =
-                    (dy * other.count as $ty).fma(1.0 as $ty / combined as $ty, self.mean_y);
-
-                self.co_moment += (dx * dy).fma(weight, other.co_moment);
-                self.m2_x += (dx * dx).fma(weight, other.m2_x);
-                self.m2_y += (dy * dy).fma(weight, other.m2_y);
-                self.mean_x = new_mean_x;
-                self.mean_y = new_mean_y;
-                self.count = combined;
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                *self = Self::new();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online covariance and Pearson correlation between two signals.
+///
+/// Uses Welford-style numerically stable single-pass computation.
+/// Supports Chan's merge for parallel aggregation.
+///
+/// # Use Cases
+/// - "Are these two signals moving together?"
+/// - Latency correlation across venues
+/// - Co-movement detection
+#[derive(Debug, Clone)]
+pub struct CovarianceF64 {
+    count: u64,
+    mean_x: f64,
+    mean_y: f64,
+    m2_x: f64,
+    m2_y: f64,
+    co_moment: f64,
 }
 
-impl_covariance!(CovarianceF64, f64);
-impl_covariance!(CovarianceF32, f32);
+impl CovarianceF64 {
+    /// Creates a new empty accumulator.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            mean_x: 0.0,
+            mean_y: 0.0,
+            m2_x: 0.0,
+            m2_y: 0.0,
+            co_moment: 0.0,
+        }
+    }
+
+    /// Feeds a paired sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either input is NaN, or
+    /// `DataError::Infinite` if either input is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), crate::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        self.count += 1;
+        let inv_n = 1.0 / self.count as f64;
+
+        let dx = x - self.mean_x;
+        let dy = y - self.mean_y;
+
+        self.mean_x += dx * inv_n;
+        self.mean_y += dy * inv_n;
+
+        // Use the NEW mean_x but OLD mean_y for the co-moment update
+        let dx2 = x - self.mean_x;
+        self.co_moment += dx * (y - self.mean_y);
+
+        // Welford M2 updates
+        self.m2_x += dx * dx2;
+        let dy2 = y - self.mean_y;
+        self.m2_y += dy * dy2;
+        Ok(())
+    }
+
+    /// Number of paired samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Mean of X, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mean_x(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.mean_x)
+        }
+    }
+
+    /// Mean of Y, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mean_y(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.mean_y)
+        }
+    }
+
+    /// Sample covariance (N-1 denominator), or `None` if < 2 samples.
+    #[inline]
+    #[must_use]
+    pub fn covariance(&self) -> Option<f64> {
+        if self.count < 2 {
+            None
+        } else {
+            Some(self.co_moment / (self.count - 1) as f64)
+        }
+    }
+
+    /// Pearson correlation coefficient, or `None` if < 2 samples.
+    ///
+    /// Returns a value in [-1, 1]. Returns `None` if either variable
+    /// has zero variance (undefined correlation).
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[inline]
+    #[must_use]
+    pub fn correlation(&self) -> Option<f64> {
+        if self.count < 2 {
+            return None;
+        }
+        let var_product = self.m2_x * self.m2_y;
+        if var_product <= 0.0 {
+            return None;
+        }
+        let r = self.co_moment / crate::math::sqrt(var_product);
+        Some(r)
+    }
+
+    /// Merges another accumulator into this one (Chan's algorithm).
+    #[inline]
+    pub fn merge(&mut self, other: &Self) {
+        if other.count == 0 {
+            return;
+        }
+        if self.count == 0 {
+            *self = other.clone();
+            return;
+        }
+
+        let combined = self.count + other.count;
+        let dx = other.mean_x - self.mean_x;
+        let dy = other.mean_y - self.mean_y;
+        let weight = self.count as f64 * other.count as f64 / combined as f64;
+
+        let new_mean_x = (dx * other.count as f64).fma(1.0 / combined as f64, self.mean_x);
+        let new_mean_y = (dy * other.count as f64).fma(1.0 / combined as f64, self.mean_y);
+
+        self.co_moment += (dx * dy).fma(weight, other.co_moment);
+        self.m2_x += (dx * dx).fma(weight, other.m2_x);
+        self.m2_y += (dy * dy).fma(weight, other.m2_y);
+        self.mean_x = new_mean_x;
+        self.mean_y = new_mean_y;
+        self.count = combined;
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+}
+
+impl Default for CovarianceF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -258,14 +250,6 @@ mod tests {
         c.update(3.0, 4.0).unwrap();
         c.reset();
         assert_eq!(c.count(), 0);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut c = CovarianceF32::new();
-        c.update(1.0, 2.0).unwrap();
-        c.update(2.0, 4.0).unwrap();
-        assert!(c.covariance().is_some());
     }
 
     #[test]

--- a/nexus-stats-core/src/statistics/cvar.rs
+++ b/nexus-stats-core/src/statistics/cvar.rs
@@ -1,189 +1,175 @@
-use super::{PercentileF32, PercentileF64};
+use super::PercentileF64;
 
-macro_rules! impl_cvar {
-    ($name:ident, $builder:ident, $ty:ty, $percentile_name:ident) => {
-        /// Conditional Value at Risk (Expected Shortfall).
-        ///
-        /// Streaming CVaR at confidence level alpha. CVaR_α is the expected
-        /// value of outcomes in the worst α fraction:
-        ///
-        /// CVaR_α = E[X | X <= VaR_α]
-        ///
-        /// Composes a P² percentile estimator internally for VaR estimation.
-        /// Tail samples (those at or below the estimated VaR) are accumulated
-        /// for the conditional mean.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_core::statistics::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut cvar = ", stringify!($name), "::builder().alpha(0.05).build().unwrap();")]
-        /// // Cycling input so tail samples accumulate after P² converges
-        /// for i in 0..5000u64 {
-        #[doc = concat!("    cvar.update((i % 1000 + 1) as ", stringify!($ty), ").unwrap();")]
-        /// }
-        /// let cv = cvar.cvar().unwrap();
-        /// let var = cvar.var().unwrap();
-        /// assert!(cv < 500.0 && cv > 0.0);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            percentile: $percentile_name,
-            tail_sum: $ty,
-            tail_count: u64,
-            count: u64,
-            alpha: $ty,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                }
-            }
-
-            /// Feeds a sample.
-            ///
-            /// Samples below the current VaR estimate contribute to the
-            /// CVaR (conditional tail mean). The VaR estimate is updated
-            /// via the internal P² percentile tracker.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                self.percentile.update(sample)?;
-                self.count += 1;
-
-                if self.percentile.is_primed() {
-                    if let Option::Some(var) = self.percentile.percentile() {
-                        if sample <= var {
-                            self.tail_sum += sample;
-                            self.tail_count += 1;
-                        }
-                    }
-                }
-
-                Ok(())
-            }
-
-            /// CVaR (Expected Shortfall): mean of tail observations.
-            ///
-            /// Returns `None` if not primed or no tail observations.
-            #[inline]
-            #[must_use]
-            pub fn cvar(&self) -> Option<$ty> {
-                if !self.is_primed() || self.tail_count == 0 {
-                    return Option::None;
-                }
-                Option::Some(self.tail_sum / self.tail_count as $ty)
-            }
-
-            /// VaR (Value at Risk): the alpha-quantile.
-            ///
-            /// Delegates to the internal P² percentile estimator.
-            #[inline]
-            #[must_use]
-            pub fn var(&self) -> Option<$ty> {
-                self.percentile.percentile()
-            }
-
-            /// Confidence level.
-            #[inline]
-            #[must_use]
-            pub fn alpha(&self) -> $ty {
-                self.alpha
-            }
-
-            /// Number of samples classified into the tail.
-            #[inline]
-            #[must_use]
-            pub fn tail_count(&self) -> u64 {
-                self.tail_count
-            }
-
-            /// Total samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the VaR estimate is primed and at least one tail
-            /// observation has been recorded.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.percentile.is_primed() && self.tail_count >= 1
-            }
-
-            /// Resets all state. Alpha is preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.percentile.reset();
-                self.tail_sum = 0.0 as $ty;
-                self.tail_count = 0;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Confidence level in (0, 1) exclusive.
-            ///
-            /// For 5% CVaR (worst 5%): `alpha(0.05)`.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Builds the CVaR tracker.
-            ///
-            /// # Errors
-            ///
-            /// Returns `ConfigError` if alpha is missing or not in (0, 1).
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(crate::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(crate::ConfigError::Invalid(
-                        "alpha must be in (0, 1) exclusive",
-                    ));
-                }
-
-                let percentile = $percentile_name::new(alpha)?;
-
-                Ok($name {
-                    percentile,
-                    tail_sum: 0.0 as $ty,
-                    tail_count: 0,
-                    count: 0,
-                    alpha,
-                })
-            }
-        }
-    };
+/// Conditional Value at Risk (Expected Shortfall).
+///
+/// Streaming CVaR at confidence level alpha. CVaR_α is the expected
+/// value of outcomes in the worst α fraction:
+///
+/// CVaR_α = E[X | X <= VaR_α]
+///
+/// Composes a P² percentile estimator internally for VaR estimation.
+/// Tail samples (those at or below the estimated VaR) are accumulated
+/// for the conditional mean.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::CvarF64;
+///
+/// let mut cvar = CvarF64::builder().alpha(0.05).build().unwrap();
+/// // Cycling input so tail samples accumulate after P² converges
+/// for i in 0..5000u64 {
+///     cvar.update((i % 1000 + 1) as f64).unwrap();
+/// }
+/// let cv = cvar.cvar().unwrap();
+/// let var = cvar.var().unwrap();
+/// assert!(cv < 500.0 && cv > 0.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct CvarF64 {
+    percentile: PercentileF64,
+    tail_sum: f64,
+    tail_count: u64,
+    count: u64,
+    alpha: f64,
 }
 
-impl_cvar!(CvarF64, CvarF64Builder, f64, PercentileF64);
-impl_cvar!(CvarF32, CvarF32Builder, f32, PercentileF32);
+/// Builder for [`CvarF64`].
+#[derive(Debug, Clone)]
+pub struct CvarF64Builder {
+    alpha: Option<f64>,
+}
+
+impl CvarF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> CvarF64Builder {
+        CvarF64Builder { alpha: None }
+    }
+
+    /// Feeds a sample.
+    ///
+    /// Samples below the current VaR estimate contribute to the
+    /// CVaR (conditional tail mean). The VaR estimate is updated
+    /// via the internal P² percentile tracker.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        self.percentile.update(sample)?;
+        self.count += 1;
+
+        if self.percentile.is_primed()
+            && let Some(var) = self.percentile.percentile()
+            && sample <= var
+        {
+            self.tail_sum += sample;
+            self.tail_count += 1;
+        }
+
+        Ok(())
+    }
+
+    /// CVaR (Expected Shortfall): mean of tail observations.
+    ///
+    /// Returns `None` if not primed or no tail observations.
+    #[inline]
+    #[must_use]
+    pub fn cvar(&self) -> Option<f64> {
+        if !self.is_primed() || self.tail_count == 0 {
+            return None;
+        }
+        Some(self.tail_sum / self.tail_count as f64)
+    }
+
+    /// VaR (Value at Risk): the alpha-quantile.
+    ///
+    /// Delegates to the internal P² percentile estimator.
+    #[inline]
+    #[must_use]
+    pub fn var(&self) -> Option<f64> {
+        self.percentile.percentile()
+    }
+
+    /// Confidence level.
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// Number of samples classified into the tail.
+    #[inline]
+    #[must_use]
+    pub fn tail_count(&self) -> u64 {
+        self.tail_count
+    }
+
+    /// Total samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the VaR estimate is primed and at least one tail
+    /// observation has been recorded.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.percentile.is_primed() && self.tail_count >= 1
+    }
+
+    /// Resets all state. Alpha is preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.percentile.reset();
+        self.tail_sum = 0.0;
+        self.tail_count = 0;
+        self.count = 0;
+    }
+}
+
+impl CvarF64Builder {
+    /// Confidence level in (0, 1) exclusive.
+    ///
+    /// For 5% CVaR (worst 5%): `alpha(0.05)`.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Builds the CVaR tracker.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError` if alpha is missing or not in (0, 1).
+    pub fn build(self) -> Result<CvarF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(crate::ConfigError::Invalid(
+                "alpha must be in (0, 1) exclusive",
+            ));
+        }
+
+        let percentile = PercentileF64::new(alpha)?;
+
+        Ok(CvarF64 {
+            percentile,
+            tail_sum: 0.0,
+            tail_count: 0,
+            count: 0,
+            alpha,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-core/src/statistics/ewma_var.rs
+++ b/nexus-stats-core/src/statistics/ewma_var.rs
@@ -1,6 +1,6 @@
 use crate::math::MulAdd;
 macro_rules! impl_ewma_var {
-    ($name:ident, $builder:ident, $ty:ty) => {
+    ($(#[$struct_meta:meta])* $vis:vis $name:ident, $(#[$builder_meta:meta])* $bvis:vis $builder:ident, $ty:ty) => {
         /// EWMA Variance — Exponentially Weighted Moving Average with variance tracking.
         ///
         /// Tracks both the exponentially smoothed mean and variance of a streaming
@@ -11,7 +11,8 @@ macro_rules! impl_ewma_var {
         /// - Adaptive thresholds (mean ± k * std_dev)
         /// - Regime detection (variance spike = regime change)
         #[derive(Debug, Clone)]
-        pub struct $name {
+        $(#[$struct_meta])*
+        $vis struct $name {
             alpha: $ty,
             one_minus_alpha: $ty,
             mean: $ty,
@@ -24,13 +25,15 @@ macro_rules! impl_ewma_var {
         #[doc = stringify!($name)]
         /// `].
         #[derive(Debug, Clone)]
-        pub struct $builder {
+        $(#[$builder_meta])*
+        $bvis struct $builder {
             alpha: Option<$ty>,
             min_samples: u64,
             seed_mean: Option<$ty>,
             seed_variance: Option<$ty>,
         }
 
+        $(#[$struct_meta])*
         impl $name {
             /// Creates a builder.
             #[inline]
@@ -139,6 +142,7 @@ macro_rules! impl_ewma_var {
             }
         }
 
+        $(#[$builder_meta])*
         impl $builder {
             /// Direct smoothing factor. Must be in (0, 1) exclusive.
             #[inline]
@@ -220,8 +224,8 @@ macro_rules! impl_ewma_var {
     };
 }
 
-impl_ewma_var!(EwmaVarF64, EwmaVarF64Builder, f64);
-impl_ewma_var!(EwmaVarF32, EwmaVarF32Builder, f32);
+impl_ewma_var!(pub EwmaVarF64, pub EwmaVarF64Builder, f64);
+impl_ewma_var!(#[allow(dead_code)] pub(crate) EwmaVarF32, #[allow(dead_code)] pub(crate) EwmaVarF32Builder, f32);
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-core/src/statistics/harmonic_mean.rs
+++ b/nexus-stats-core/src/statistics/harmonic_mean.rs
@@ -1,98 +1,88 @@
-macro_rules! impl_harmonic_mean {
-    ($name:ident, $ty:ty) => {
-        /// Online harmonic mean.
-        ///
-        /// Tracks the sum of reciprocals for computing the harmonic mean
-        /// incrementally. Useful for averaging rates (e.g., throughput in
-        /// requests/second across multiple servers).
-        ///
-        /// # Use Cases
-        /// - Average throughput across heterogeneous servers
-        /// - Mean speed over equal-distance segments
-        /// - Any rate where arithmetic mean would be misleading
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            reciprocal_sum: $ty,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new empty accumulator.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    reciprocal_sum: 0.0 as $ty,
-                    count: 0,
-                }
-            }
-
-            /// Feeds a sample. Must be positive and non-zero.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            ///
-            /// # Panics
-            ///
-            /// Panics if sample is zero or negative.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                assert!(
-                    sample > 0.0 as $ty,
-                    "harmonic mean requires positive values"
-                );
-                self.count += 1;
-                self.reciprocal_sum += 1.0 as $ty / sample;
-                Ok(())
-            }
-
-            /// Harmonic mean, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.count as $ty / self.reciprocal_sum)
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether at least one sample has been recorded.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.reciprocal_sum = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online harmonic mean.
+///
+/// Tracks the sum of reciprocals for computing the harmonic mean
+/// incrementally. Useful for averaging rates (e.g., throughput in
+/// requests/second across multiple servers).
+///
+/// # Use Cases
+/// - Average throughput across heterogeneous servers
+/// - Mean speed over equal-distance segments
+/// - Any rate where arithmetic mean would be misleading
+#[derive(Debug, Clone)]
+pub struct HarmonicMeanF64 {
+    reciprocal_sum: f64,
+    count: u64,
 }
 
-impl_harmonic_mean!(HarmonicMeanF64, f64);
-impl_harmonic_mean!(HarmonicMeanF32, f32);
+impl HarmonicMeanF64 {
+    /// Creates a new empty accumulator.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            reciprocal_sum: 0.0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample. Must be positive and non-zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    ///
+    /// # Panics
+    ///
+    /// Panics if sample is zero or negative.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        assert!(sample > 0.0, "harmonic mean requires positive values");
+        self.count += 1;
+        self.reciprocal_sum += 1.0 / sample;
+        Ok(())
+    }
+
+    /// Harmonic mean, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mean(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.count as f64 / self.reciprocal_sum)
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether at least one sample has been recorded.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.reciprocal_sum = 0.0;
+        self.count = 0;
+    }
+}
+
+impl Default for HarmonicMeanF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -151,14 +141,6 @@ mod tests {
         hm.reset();
         assert_eq!(hm.count(), 0);
         assert!(hm.mean().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut hm = HarmonicMeanF32::new();
-        hm.update(2.0).unwrap();
-        hm.update(4.0).unwrap();
-        assert!(hm.mean().is_some());
     }
 
     #[test]

--- a/nexus-stats-core/src/statistics/lpm.rs
+++ b/nexus-stats-core/src/statistics/lpm.rs
@@ -1,198 +1,185 @@
-macro_rules! impl_lpm {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Lower Partial Moments — streaming downside risk.
-        ///
-        /// Measures deviations below a target threshold, raised to a
-        /// configurable integer order:
-        ///
-        /// - Order 0: shortfall probability (fraction below target)
-        /// - Order 1: expected shortfall (mean distance below target)
-        /// - Order 2: semivariance (variance of downside deviations)
-        ///
-        /// Fishburn (1977), Sortino & van der Meer (1991).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_core::statistics::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut lpm = ", stringify!($name), "::semivariance(0.0).unwrap();")]
-        /// for &v in &[-3.0, -1.0, 0.0, 2.0, 5.0] {
-        #[doc = concat!("    lpm.update(v as ", stringify!($ty), ").unwrap();")]
-        /// }
-        /// let sv = lpm.lpm().unwrap();
-        #[doc = concat!("assert!((sv - 2.0 as ", stringify!($ty), ").abs() < 0.01 as ", stringify!($ty), ");")]
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_lpm: $ty,
-            count: u64,
-            target: $ty,
-            order: u32,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            target: Option<$ty>,
-            order: Option<u32>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    target: Option::None,
-                    order: Option::None,
-                    min_samples: 1,
-                }
-            }
-
-            /// Convenience constructor for semivariance (order = 2).
-            #[inline]
-            pub fn semivariance(target: $ty) -> Result<Self, crate::ConfigError> {
-                Self::builder().target(target).order(2).build()
-            }
-
-            /// Feeds a sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                let shortfall = self.target - sample;
-                if shortfall > 0.0 as $ty {
-                    match self.order {
-                        0 => self.sum_lpm += 1.0 as $ty,
-                        1 => self.sum_lpm += shortfall,
-                        2 => self.sum_lpm += shortfall * shortfall,
-                        d => {
-                            let mut power = shortfall;
-                            for _ in 1..d {
-                                power *= shortfall;
-                            }
-                            self.sum_lpm += power;
-                        }
-                    }
-                }
-                self.count += 1;
-                Ok(())
-            }
-
-            /// Lower partial moment: average downside deviation^order.
-            ///
-            /// Returns `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn lpm(&self) -> Option<$ty> {
-                if self.count < self.min_samples {
-                    Option::None
-                } else {
-                    Option::Some(self.sum_lpm / self.count as $ty)
-                }
-            }
-
-            /// The target threshold.
-            #[inline]
-            #[must_use]
-            pub fn target(&self) -> $ty {
-                self.target
-            }
-
-            /// The moment order.
-            #[inline]
-            #[must_use]
-            pub fn order(&self) -> u32 {
-                self.order
-            }
-
-            /// Total samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough samples have been observed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets accumulated state. Target and order are preserved.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_lpm = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the target threshold (required).
-            #[inline]
-            #[must_use]
-            pub fn target(mut self, target: $ty) -> Self {
-                self.target = Option::Some(target);
-                self
-            }
-
-            /// Sets the moment order (required).
-            #[inline]
-            #[must_use]
-            pub fn order(mut self, order: u32) -> Self {
-                self.order = Option::Some(order);
-                self
-            }
-
-            /// Sets the minimum samples before `lpm()` returns a value.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = n;
-                self
-            }
-
-            /// Builds the LPM tracker.
-            ///
-            /// # Errors
-            ///
-            /// Returns `ConfigError` if target is missing/non-finite or
-            /// order is missing.
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let target = self
-                    .target
-                    .ok_or(crate::ConfigError::Missing("target"))?;
-                if !target.is_finite() {
-                    return Err(crate::ConfigError::Invalid("target must be finite"));
-                }
-                let order = self
-                    .order
-                    .ok_or(crate::ConfigError::Missing("order"))?;
-
-                Ok($name {
-                    sum_lpm: 0.0 as $ty,
-                    count: 0,
-                    target,
-                    order,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Lower Partial Moments — streaming downside risk.
+///
+/// Measures deviations below a target threshold, raised to a
+/// configurable integer order:
+///
+/// - Order 0: shortfall probability (fraction below target)
+/// - Order 1: expected shortfall (mean distance below target)
+/// - Order 2: semivariance (variance of downside deviations)
+///
+/// Fishburn (1977), Sortino & van der Meer (1991).
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::LpmF64;
+///
+/// let mut lpm = LpmF64::semivariance(0.0).unwrap();
+/// for &v in &[-3.0, -1.0, 0.0, 2.0, 5.0] {
+///     lpm.update(v).unwrap();
+/// }
+/// let sv = lpm.lpm().unwrap();
+/// assert!((sv - 2.0).abs() < 0.01);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LpmF64 {
+    sum_lpm: f64,
+    count: u64,
+    target: f64,
+    order: u32,
+    min_samples: u64,
 }
 
-impl_lpm!(LpmF64, LpmF64Builder, f64);
-impl_lpm!(LpmF32, LpmF32Builder, f32);
+/// Builder for [`LpmF64`].
+#[derive(Debug, Clone)]
+pub struct LpmF64Builder {
+    target: Option<f64>,
+    order: Option<u32>,
+    min_samples: u64,
+}
+
+impl LpmF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LpmF64Builder {
+        LpmF64Builder {
+            target: None,
+            order: None,
+            min_samples: 1,
+        }
+    }
+
+    /// Convenience constructor for semivariance (order = 2).
+    #[inline]
+    pub fn semivariance(target: f64) -> Result<Self, crate::ConfigError> {
+        Self::builder().target(target).order(2).build()
+    }
+
+    /// Feeds a sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        let shortfall = self.target - sample;
+        if shortfall > 0.0 {
+            match self.order {
+                0 => self.sum_lpm += 1.0,
+                1 => self.sum_lpm += shortfall,
+                2 => self.sum_lpm += shortfall * shortfall,
+                d => {
+                    let mut power = shortfall;
+                    for _ in 1..d {
+                        power *= shortfall;
+                    }
+                    self.sum_lpm += power;
+                }
+            }
+        }
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Lower partial moment: average downside deviation^order.
+    ///
+    /// Returns `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn lpm(&self) -> Option<f64> {
+        if self.count < self.min_samples {
+            None
+        } else {
+            Some(self.sum_lpm / self.count as f64)
+        }
+    }
+
+    /// The target threshold.
+    #[inline]
+    #[must_use]
+    pub fn target(&self) -> f64 {
+        self.target
+    }
+
+    /// The moment order.
+    #[inline]
+    #[must_use]
+    pub fn order(&self) -> u32 {
+        self.order
+    }
+
+    /// Total samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough samples have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets accumulated state. Target and order are preserved.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_lpm = 0.0;
+        self.count = 0;
+    }
+}
+
+impl LpmF64Builder {
+    /// Sets the target threshold (required).
+    #[inline]
+    #[must_use]
+    pub fn target(mut self, target: f64) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    /// Sets the moment order (required).
+    #[inline]
+    #[must_use]
+    pub fn order(mut self, order: u32) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    /// Sets the minimum samples before `lpm()` returns a value.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = n;
+        self
+    }
+
+    /// Builds the LPM tracker.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError` if target is missing/non-finite or
+    /// order is missing.
+    pub fn build(self) -> Result<LpmF64, crate::ConfigError> {
+        let target = self.target.ok_or(crate::ConfigError::Missing("target"))?;
+        if !target.is_finite() {
+            return Err(crate::ConfigError::Invalid("target must be finite"));
+        }
+        let order = self.order.ok_or(crate::ConfigError::Missing("order"))?;
+
+        Ok(LpmF64 {
+            sum_lpm: 0.0,
+            count: 0,
+            target,
+            order,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-core/src/statistics/moments.rs
+++ b/nexus-stats-core/src/statistics/moments.rs
@@ -4,510 +4,249 @@
 // no_std without libm.
 #![allow(clippy::suboptimal_flops, clippy::float_cmp)]
 
-// Pébay Moments — Online Skewness & Kurtosis
-//
-// Extension of Welford's algorithm to 3rd and 4th central moments.
-// "Formulas for Robust, One-Pass Parallel Computation of Covariances
-// and Arbitrary-Order Statistical Moments" (Pébay, 2008).
-//
-// Update order matters: M4 before M3 before M2 (each uses the
-// previous iteration's lower moments).
-
-macro_rules! impl_moments_float {
-    ($name:ident, $ty:ty) => {
-        /// Online skewness and kurtosis via Pébay's higher-moment extension
-        /// of Welford's algorithm (Pébay, 2008).
-        ///
-        /// Numerically stable single-pass computation of mean, variance,
-        /// skewness, and excess kurtosis. Supports merging partial results
-        /// via Pébay's parallel aggregation formulas.
-        ///
-        /// # Use Cases
-        /// - Distribution shape monitoring (is latency becoming skewed?)
-        /// - Fat-tail detection (kurtosis spike → regime change)
-        /// - Quality control (symmetric vs asymmetric error distributions)
-        ///
-        /// Computes population (not sample-corrected) skewness and kurtosis.
-        /// For streaming use cases with n > 100, population and sample estimators
-        /// are indistinguishable. For small-sample inference (n < 30), use a
-        /// batch estimator with Bessel's correction instead.
-        ///
-        /// # Complexity
-        /// - O(1) per update, 40 bytes state (f64), zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_core::statistics::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut m = ", stringify!($name), "::new();")]
-        #[doc = concat!("for i in 1..=1000u64 { m.update(i as ", stringify!($ty), ").unwrap(); }")]
-        /// // Uniform distribution: skewness ≈ 0, kurtosis ≈ -1.2
-        /// let skew = m.skewness().unwrap();
-        /// assert!(skew.abs() < 0.1);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            count: u64,
-            mean: $ty,
-            m2: $ty,
-            m3: $ty,
-            m4: $ty,
-        }
-
-        impl $name {
-            /// Creates a new empty accumulator.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    count: 0,
-                    mean: 0.0 as $ty,
-                    m2: 0.0 as $ty,
-                    m3: 0.0 as $ty,
-                    m4: 0.0 as $ty,
-                }
-            }
-
-            /// Feeds a sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-                let n = self.count as $ty;
-                let delta = sample - self.mean;
-                let delta_n = delta / n;
-                let delta_n2 = delta_n * delta_n;
-                let term1 = delta * delta_n * (n - 1.0 as $ty);
-
-                // M4 before M3 before M2 — each uses previous iteration's lower moments
-                self.m4 += term1 * delta_n2 * (n * n - 3.0 as $ty * n + 3.0 as $ty)
-                    + 6.0 as $ty * delta_n2 * self.m2
-                    - 4.0 as $ty * delta_n * self.m3;
-                self.m3 += term1 * delta_n * (n - 2.0 as $ty) - 3.0 as $ty * delta_n * self.m2;
-                self.m2 += term1;
-                self.mean += delta_n;
-                Ok(())
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Running mean, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.mean)
-                }
-            }
-
-            /// Sample variance (N-1 denominator), or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            pub fn variance(&self) -> Option<$ty> {
-                if self.count < 2 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / (self.count - 1) as $ty)
-                }
-            }
-
-            /// Population variance (N denominator), or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn population_variance(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / self.count as $ty)
-                }
-            }
-
-            /// Sample standard deviation, or `None` if < 2 samples.
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn std_dev(&self) -> Option<$ty> {
-                self.variance().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        crate::math::sqrt(v as f64) as $ty
-                    }
-                })
-            }
-
-            /// Population skewness (Fisher's definition), or `None` if < 3
-            /// samples or variance is zero.
-            ///
-            /// Positive = right-skewed (tail extends right).
-            /// Negative = left-skewed (tail extends left).
-            /// Zero = symmetric.
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn skewness(&self) -> Option<$ty> {
-                if self.count < 3 {
-                    return Option::None;
-                }
-                if self.m2 == 0.0 as $ty {
-                    return Option::None;
-                }
-                let n = self.count as f64;
-                let m2 = self.m2 as f64;
-                let m3 = self.m3 as f64;
-                #[allow(clippy::cast_possible_truncation)]
-                {
-                    Option::Some((crate::math::sqrt(n) * m3 / (m2 * crate::math::sqrt(m2))) as $ty)
-                }
-            }
-
-            /// Population excess kurtosis, or `None` if < 4 samples or
-            /// variance is zero.
-            ///
-            /// Normal distribution = 0. Positive = heavy tails (leptokurtic).
-            /// Negative = light tails (platykurtic). This is the most common
-            /// convention (numpy, scipy, most finance).
-            #[inline]
-            #[must_use]
-            pub fn excess_kurtosis(&self) -> Option<$ty> {
-                if self.count < 4 {
-                    return Option::None;
-                }
-                let m2 = self.m2;
-                if m2 == 0.0 as $ty {
-                    return Option::None;
-                }
-                let n = self.count as $ty;
-                Option::Some(n * self.m4 / (m2 * m2) - 3.0 as $ty)
-            }
-
-            /// Population kurtosis (non-excess), or `None` if < 4 samples or
-            /// variance is zero.
-            ///
-            /// Normal distribution = 3. This is `excess_kurtosis() + 3`.
-            #[inline]
-            #[must_use]
-            pub fn kurtosis(&self) -> Option<$ty> {
-                self.excess_kurtosis().map(|k| k + 3.0 as $ty)
-            }
-
-            /// Whether enough data has been collected for all queries (>= 4).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= 4
-            }
-
-            /// Merges another accumulator into this one (Pébay's parallel algorithm).
-            ///
-            /// After merging, `self` contains the statistics of the combined
-            /// dataset. The other accumulator is unchanged.
-            #[inline]
-            pub fn merge(&mut self, other: &Self) {
-                if other.count == 0 {
-                    return;
-                }
-                if self.count == 0 {
-                    *self = other.clone();
-                    return;
-                }
-
-                let n_a = self.count as $ty;
-                let n_b = other.count as $ty;
-                let n = n_a + n_b;
-                let delta = other.mean - self.mean;
-                let delta2 = delta * delta;
-                let delta3 = delta2 * delta;
-                let delta4 = delta2 * delta2;
-
-                let new_m4 = self.m4
-                    + other.m4
-                    + delta4 * n_a * n_b * (n_a * n_a - n_a * n_b + n_b * n_b) / (n * n * n)
-                    + 6.0 as $ty * delta2 * (n_a * n_a * other.m2 + n_b * n_b * self.m2) / (n * n)
-                    + 4.0 as $ty * delta * (n_a * other.m3 - n_b * self.m3) / n;
-
-                let new_m3 = self.m3
-                    + other.m3
-                    + delta3 * n_a * n_b * (n_a - n_b) / (n * n)
-                    + 3.0 as $ty * delta * (n_a * other.m2 - n_b * self.m2) / n;
-
-                let new_m2 = self.m2 + other.m2 + delta2 * n_a * n_b / n;
-
-                self.mean += delta * n_b / n;
-                self.count += other.count;
-                self.m2 = new_m2;
-                self.m3 = new_m3;
-                self.m4 = new_m4;
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                *self = Self::new();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online skewness and kurtosis via Pébay's higher-moment extension
+/// of Welford's algorithm (Pébay, 2008).
+///
+/// Numerically stable single-pass computation of mean, variance,
+/// skewness, and excess kurtosis. Supports merging partial results
+/// via Pébay's parallel aggregation formulas.
+///
+/// # Use Cases
+/// - Distribution shape monitoring (is latency becoming skewed?)
+/// - Fat-tail detection (kurtosis spike → regime change)
+/// - Quality control (symmetric vs asymmetric error distributions)
+///
+/// Computes population (not sample-corrected) skewness and kurtosis.
+/// For streaming use cases with n > 100, population and sample estimators
+/// are indistinguishable. For small-sample inference (n < 30), use a
+/// batch estimator with Bessel's correction instead.
+///
+/// # Complexity
+/// - O(1) per update, 40 bytes state, zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::MomentsF64;
+///
+/// let mut m = MomentsF64::new();
+/// for i in 1..=1000u64 { m.update(i as f64).unwrap(); }
+/// // Uniform distribution: skewness ≈ 0, kurtosis ≈ -1.2
+/// let skew = m.skewness().unwrap();
+/// assert!(skew.abs() < 0.1);
+/// ```
+#[derive(Debug, Clone)]
+pub struct MomentsF64 {
+    count: u64,
+    mean: f64,
+    m2: f64,
+    m3: f64,
+    m4: f64,
 }
 
-macro_rules! impl_moments_int {
-    ($name:ident, $input:ty) => {
-        /// Online skewness and kurtosis via Pébay's higher-moment extension
-        /// of Welford's algorithm (Pébay, 2008).
-        ///
-        /// Integer input variant — accepts integer samples, accumulates
-        /// internally in f64 for numerical stability. All query methods
-        /// return f64 since skewness and kurtosis are inherently fractional.
-        ///
-        /// # Use Cases
-        /// - Distribution shape of integer measurements (latency in nanos, counts)
-        /// - Detecting skew or heavy tails in discrete data
-        ///
-        /// Computes population (not sample-corrected) skewness and kurtosis.
-        /// For streaming use cases with n > 100, population and sample estimators
-        /// are indistinguishable. For small-sample inference (n < 30), use a
-        /// batch estimator with Bessel's correction instead.
-        ///
-        /// # Complexity
-        /// - O(1) per update, 40 bytes state, zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_core::statistics::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut m = ", stringify!($name), "::new();")]
-        #[doc = concat!("for i in 1..=1000 { m.update(i as ", stringify!($input), "); }")]
-        /// let skew = m.skewness().unwrap();
-        /// assert!(skew.abs() < 0.1);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            count: u64,
-            mean: f64,
-            m2: f64,
-            m3: f64,
-            m4: f64,
+impl MomentsF64 {
+    /// Creates a new empty accumulator.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            mean: 0.0,
+            m2: 0.0,
+            m3: 0.0,
+            m4: 0.0,
+        }
+    }
+
+    /// Feeds a sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+        let n = self.count as f64;
+        let delta = sample - self.mean;
+        let delta_n = delta / n;
+        let delta_n2 = delta_n * delta_n;
+        let term1 = delta * delta_n * (n - 1.0);
+
+        // M4 before M3 before M2 — each uses previous iteration's lower moments
+        self.m4 += term1 * delta_n2 * (n * n - 3.0 * n + 3.0) + 6.0 * delta_n2 * self.m2
+            - 4.0 * delta_n * self.m3;
+        self.m3 += term1 * delta_n * (n - 2.0) - 3.0 * delta_n * self.m2;
+        self.m2 += term1;
+        self.mean += delta_n;
+        Ok(())
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Running mean, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mean(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.mean)
+        }
+    }
+
+    /// Sample variance (N-1 denominator), or `None` if < 2 samples.
+    #[inline]
+    #[must_use]
+    pub fn variance(&self) -> Option<f64> {
+        if self.count < 2 {
+            None
+        } else {
+            Some(self.m2 / (self.count - 1) as f64)
+        }
+    }
+
+    /// Population variance (N denominator), or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn population_variance(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.m2 / self.count as f64)
+        }
+    }
+
+    /// Sample standard deviation, or `None` if < 2 samples.
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[inline]
+    #[must_use]
+    pub fn std_dev(&self) -> Option<f64> {
+        self.variance().map(crate::math::sqrt)
+    }
+
+    /// Population skewness (Fisher's definition), or `None` if < 3
+    /// samples or variance is zero.
+    ///
+    /// Positive = right-skewed (tail extends right).
+    /// Negative = left-skewed (tail extends left).
+    /// Zero = symmetric.
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[inline]
+    #[must_use]
+    pub fn skewness(&self) -> Option<f64> {
+        if self.count < 3 {
+            return None;
+        }
+        if self.m2 == 0.0 {
+            return None;
+        }
+        let n = self.count as f64;
+        Some(crate::math::sqrt(n) * self.m3 / (self.m2 * crate::math::sqrt(self.m2)))
+    }
+
+    /// Population excess kurtosis, or `None` if < 4 samples or
+    /// variance is zero.
+    ///
+    /// Normal distribution = 0. Positive = heavy tails (leptokurtic).
+    /// Negative = light tails (platykurtic). This is the most common
+    /// convention (numpy, scipy, most finance).
+    #[inline]
+    #[must_use]
+    pub fn excess_kurtosis(&self) -> Option<f64> {
+        if self.count < 4 {
+            return None;
+        }
+        if self.m2 == 0.0 {
+            return None;
+        }
+        let n = self.count as f64;
+        Some(n * self.m4 / (self.m2 * self.m2) - 3.0)
+    }
+
+    /// Population kurtosis (non-excess), or `None` if < 4 samples or
+    /// variance is zero.
+    ///
+    /// Normal distribution = 3. This is `excess_kurtosis() + 3`.
+    #[inline]
+    #[must_use]
+    pub fn kurtosis(&self) -> Option<f64> {
+        self.excess_kurtosis().map(|k| k + 3.0)
+    }
+
+    /// Whether enough data has been collected for all queries (>= 4).
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= 4
+    }
+
+    /// Merges another accumulator into this one (Pébay's parallel algorithm).
+    ///
+    /// After merging, `self` contains the statistics of the combined
+    /// dataset. The other accumulator is unchanged.
+    #[inline]
+    #[allow(clippy::suspicious_operation_groupings)]
+    pub fn merge(&mut self, other: &Self) {
+        if other.count == 0 {
+            return;
+        }
+        if self.count == 0 {
+            *self = other.clone();
+            return;
         }
 
-        impl $name {
-            /// Creates a new empty accumulator.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    count: 0,
-                    mean: 0.0,
-                    m2: 0.0,
-                    m3: 0.0,
-                    m4: 0.0,
-                }
-            }
+        let n_a = self.count as f64;
+        let n_b = other.count as f64;
+        let n = n_a + n_b;
+        let delta = other.mean - self.mean;
+        let delta2 = delta * delta;
+        let delta3 = delta2 * delta;
+        let delta4 = delta2 * delta2;
 
-            /// Feeds a sample.
-            #[inline]
-            pub fn update(&mut self, sample: $input) {
-                #[allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
-                let x = sample as f64;
-                self.count += 1;
-                let n = self.count as f64;
-                let delta = x - self.mean;
-                let delta_n = delta / n;
-                let delta_n2 = delta_n * delta_n;
-                let term1 = delta * delta_n * (n - 1.0);
+        let new_m4 = self.m4
+            + other.m4
+            + delta4 * n_a * n_b * (n_a * n_a - n_a * n_b + n_b * n_b) / (n * n * n)
+            + 6.0 * delta2 * (n_a * n_a * other.m2 + n_b * n_b * self.m2) / (n * n)
+            + 4.0 * delta * (n_a * other.m3 - n_b * self.m3) / n;
 
-                self.m4 += term1 * delta_n2 * (n * n - 3.0 * n + 3.0) + 6.0 * delta_n2 * self.m2
-                    - 4.0 * delta_n * self.m3;
-                self.m3 += term1 * delta_n * (n - 2.0) - 3.0 * delta_n * self.m2;
-                self.m2 += term1;
-                self.mean += delta_n;
-            }
+        let new_m3 = self.m3
+            + other.m3
+            + delta3 * n_a * n_b * (n_a - n_b) / (n * n)
+            + 3.0 * delta * (n_a * other.m2 - n_b * self.m2) / n;
 
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
+        let new_m2 = self.m2 + other.m2 + delta2 * n_a * n_b / n;
 
-            /// Running mean, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean(&self) -> Option<f64> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.mean)
-                }
-            }
+        self.mean += delta * n_b / n;
+        self.count += other.count;
+        self.m2 = new_m2;
+        self.m3 = new_m3;
+        self.m4 = new_m4;
+    }
 
-            /// Sample variance (N-1 denominator), or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            pub fn variance(&self) -> Option<f64> {
-                if self.count < 2 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / (self.count - 1) as f64)
-                }
-            }
-
-            /// Population variance (N denominator), or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn population_variance(&self) -> Option<f64> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / self.count as f64)
-                }
-            }
-
-            /// Sample standard deviation, or `None` if < 2 samples.
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn std_dev(&self) -> Option<f64> {
-                self.variance().map(crate::math::sqrt)
-            }
-
-            /// Population skewness (Fisher's definition), or `None` if < 3
-            /// samples or variance is zero.
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn skewness(&self) -> Option<f64> {
-                if self.count < 3 {
-                    return Option::None;
-                }
-                if self.m2 == 0.0 {
-                    return Option::None;
-                }
-                let n = self.count as f64;
-                Option::Some(
-                    crate::math::sqrt(n) * self.m3 / (self.m2 * crate::math::sqrt(self.m2)),
-                )
-            }
-
-            /// Population excess kurtosis, or `None` if < 4 samples or
-            /// variance is zero.
-            ///
-            /// Normal distribution = 0. Positive = heavy tails.
-            #[inline]
-            #[must_use]
-            pub fn excess_kurtosis(&self) -> Option<f64> {
-                if self.count < 4 {
-                    return Option::None;
-                }
-                if self.m2 == 0.0 {
-                    return Option::None;
-                }
-                let n = self.count as f64;
-                Option::Some(n * self.m4 / (self.m2 * self.m2) - 3.0)
-            }
-
-            /// Population kurtosis (non-excess), or `None` if < 4 samples or
-            /// variance is zero.
-            ///
-            /// Normal distribution = 3. This is `excess_kurtosis() + 3`.
-            #[inline]
-            #[must_use]
-            pub fn kurtosis(&self) -> Option<f64> {
-                self.excess_kurtosis().map(|k| k + 3.0)
-            }
-
-            /// Whether enough data has been collected for all queries (>= 4).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= 4
-            }
-
-            /// Merges another accumulator into this one (Pébay's parallel algorithm).
-            #[inline]
-            pub fn merge(&mut self, other: &Self) {
-                if other.count == 0 {
-                    return;
-                }
-                if self.count == 0 {
-                    *self = other.clone();
-                    return;
-                }
-
-                let n_a = self.count as f64;
-                let n_b = other.count as f64;
-                let n = n_a + n_b;
-                let delta = other.mean - self.mean;
-                let delta2 = delta * delta;
-                let delta3 = delta2 * delta;
-                let delta4 = delta2 * delta2;
-
-                let new_m4 = self.m4
-                    + other.m4
-                    + delta4 * n_a * n_b * (n_a * n_a - n_a * n_b + n_b * n_b) / (n * n * n)
-                    + 6.0 * delta2 * (n_a * n_a * other.m2 + n_b * n_b * self.m2) / (n * n)
-                    + 4.0 * delta * (n_a * other.m3 - n_b * self.m3) / n;
-
-                let new_m3 = self.m3
-                    + other.m3
-                    + delta3 * n_a * n_b * (n_a - n_b) / (n * n)
-                    + 3.0 * delta * (n_a * other.m2 - n_b * self.m2) / n;
-
-                let new_m2 = self.m2 + other.m2 + delta2 * n_a * n_b / n;
-
-                self.mean += delta * n_b / n;
-                self.count += other.count;
-                self.m2 = new_m2;
-                self.m3 = new_m3;
-                self.m4 = new_m4;
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                *self = Self::new();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
 }
 
-impl_moments_float!(MomentsF64, f64);
-impl_moments_float!(MomentsF32, f32);
-impl_moments_int!(MomentsI64, i64);
-impl_moments_int!(MomentsI32, i32);
+impl Default for MomentsF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // =========================================================================
-    // Basic correctness — known distribution
-    // =========================================================================
 
     #[test]
     fn uniform_1_to_100() {
@@ -518,15 +257,12 @@ mod tests {
 
         assert_eq!(m.count(), 100);
 
-        // Mean = 50.5
         let mean = m.mean().unwrap();
         assert!((mean - 50.5).abs() < 1e-10, "mean = {mean}");
 
-        // Population variance = (100²-1)/12 = 833.25
         let pop_var = m.population_variance().unwrap();
         assert!((pop_var - 833.25).abs() < 1e-6, "pop variance = {pop_var}");
 
-        // Sample variance = 100*(100²-1)/12/99 = 841.666...
         let var = m.variance().unwrap();
         assert!((var - 841.6667).abs() < 0.01, "variance = {var}");
     }
@@ -537,7 +273,6 @@ mod tests {
         for i in 1..=10000u64 {
             m.update(i as f64).unwrap();
         }
-        // Symmetric distribution → skewness ≈ 0
         let skew = m.skewness().unwrap();
         assert!(skew.abs() < 0.01, "skewness = {skew}, expected ≈ 0");
     }
@@ -548,17 +283,12 @@ mod tests {
         for i in 1..=10000u64 {
             m.update(i as f64).unwrap();
         }
-        // Uniform excess kurtosis = -6/5 = -1.2
         let kurt = m.excess_kurtosis().unwrap();
         assert!(
             (kurt - (-1.2)).abs() < 0.01,
             "kurtosis = {kurt}, expected ≈ -1.2"
         );
     }
-
-    // =========================================================================
-    // Edge cases
-    // =========================================================================
 
     #[test]
     fn empty() {
@@ -586,13 +316,13 @@ mod tests {
     fn priming_thresholds() {
         let mut m = MomentsF64::new();
         m.update(1.0).unwrap();
-        assert!(m.mean().is_some()); // 1 sample
+        assert!(m.mean().is_some());
         m.update(2.0).unwrap();
-        assert!(m.variance().is_some()); // 2 samples
+        assert!(m.variance().is_some());
         m.update(3.0).unwrap();
-        assert!(m.skewness().is_some()); // 3 samples
+        assert!(m.skewness().is_some());
         m.update(4.0).unwrap();
-        assert!(m.excess_kurtosis().is_some()); // 4 samples
+        assert!(m.excess_kurtosis().is_some());
         assert!(m.is_primed());
     }
 
@@ -605,7 +335,6 @@ mod tests {
         }
         assert_eq!(m.mean(), Some(42.0));
         assert_eq!(m.variance(), Some(0.0));
-        // Zero variance → skewness and kurtosis undefined
         assert!(m.skewness().is_none());
         assert!(m.excess_kurtosis().is_none());
     }
@@ -613,7 +342,6 @@ mod tests {
     #[test]
     fn right_skewed_distribution() {
         let mut m = MomentsF64::new();
-        // Exponential-like: lots of small values, few large
         for _ in 0..900 {
             m.update(1.0).unwrap();
         }
@@ -623,10 +351,6 @@ mod tests {
         let skew = m.skewness().unwrap();
         assert!(skew > 0.0, "right-skewed should be positive, got {skew}");
     }
-
-    // =========================================================================
-    // Reset
-    // =========================================================================
 
     #[test]
     fn reset_clears_state() {
@@ -639,10 +363,6 @@ mod tests {
         assert!(m.mean().is_none());
         assert!(m.excess_kurtosis().is_none());
     }
-
-    // =========================================================================
-    // Merge (Pébay's parallel algorithm)
-    // =========================================================================
 
     #[test]
     fn merge_empty_into_empty() {
@@ -689,68 +409,6 @@ mod tests {
         assert!((first.skewness().unwrap() - single.skewness().unwrap()).abs() < 1e-6);
         assert!((first.kurtosis().unwrap() - single.kurtosis().unwrap()).abs() < 1e-4);
     }
-
-    // =========================================================================
-    // Integer variants
-    // =========================================================================
-
-    #[test]
-    fn i64_basic() {
-        let mut m = MomentsI64::new();
-        for i in 1..=1000i64 {
-            m.update(i);
-        }
-        assert_eq!(m.count(), 1000);
-        assert!((m.mean().unwrap() - 500.5).abs() < 1e-10);
-        assert!(m.skewness().unwrap().abs() < 0.01);
-    }
-
-    #[test]
-    fn i32_basic() {
-        let mut m = MomentsI32::new();
-        for i in 1..=100i32 {
-            m.update(i);
-        }
-        assert_eq!(m.count(), 100);
-        assert!((m.mean().unwrap() - 50.5).abs() < 1e-10);
-    }
-
-    #[test]
-    fn i64_merge() {
-        let mut a = MomentsI64::new();
-        let mut b = MomentsI64::new();
-        let mut single = MomentsI64::new();
-        for i in 1..=100i64 {
-            single.update(i);
-            if i <= 40 {
-                a.update(i);
-            } else {
-                b.update(i);
-            }
-        }
-        a.merge(&b);
-        assert_eq!(a.count(), single.count());
-        assert!((a.mean().unwrap() - single.mean().unwrap()).abs() < 1e-10);
-    }
-
-    // =========================================================================
-    // f32 variant
-    // =========================================================================
-
-    #[test]
-    fn f32_basic() {
-        let mut m = MomentsF32::new();
-        for i in 1..=100u32 {
-            m.update(i as f32).unwrap();
-        }
-        assert_eq!(m.count(), 100);
-        assert!(m.mean().is_some());
-        assert!(m.excess_kurtosis().is_some());
-    }
-
-    // =========================================================================
-    // Default
-    // =========================================================================
 
     #[test]
     fn default_is_empty() {

--- a/nexus-stats-core/src/statistics/percentile.rs
+++ b/nexus-stats-core/src/statistics/percentile.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::suboptimal_flops)]
 
 macro_rules! impl_percentile {
-    ($name:ident, $builder:ident, $ty:ty) => {
+    ($(#[$struct_meta:meta])* $vis:vis $name:ident, $(#[$builder_meta:meta])* $bvis:vis $builder:ident, $ty:ty) => {
         /// P² streaming percentile estimator.
         ///
         /// Tracks a single percentile using 5 markers that converge via
@@ -22,24 +22,9 @@ macro_rules! impl_percentile {
         /// - p99 latency monitoring on the hot path
         /// - Streaming median estimation
         /// - Tail latency tracking without histograms
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_core::statistics::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut p = ", stringify!($name), "::new(0.99).unwrap();")]
-        #[doc = concat!("for i in 1..=1000u64 { p.update(i as ", stringify!($ty), ").unwrap(); }")]
-        /// let est = p.percentile().unwrap();
-        #[doc = concat!("assert!((est - 990.0 as ", stringify!($ty), ").abs() < 50.0 as ", stringify!($ty), ");")]
-        /// ```
-        /// Marker positions are stored as the same float type as values.
-        /// For `PercentileF64`, precision degrades after 2^53 observations
-        /// (~9 quadrillion, ~285 years at 1M/s). For `PercentileF32`,
-        /// precision degrades after 2^24 observations (~16 million, ~16s at
-        /// 1M/s). Use `PercentileF64` unless memory is extremely constrained.
         #[derive(Debug, Clone)]
-        pub struct $name {
+        $(#[$struct_meta])*
+        $vis struct $name {
             /// Marker heights (value estimates).
             q: [$ty; 5],
             /// Marker positions (observation count, f64 for interpolation math).
@@ -60,10 +45,12 @@ macro_rules! impl_percentile {
         #[doc = stringify!($name)]
         /// `].
         #[derive(Debug, Clone)]
-        pub struct $builder {
+        $(#[$builder_meta])*
+        $bvis struct $builder {
             p: Option<$ty>,
         }
 
+        $(#[$struct_meta])*
         impl $name {
             /// Creates a builder.
             #[inline]
@@ -286,6 +273,7 @@ macro_rules! impl_percentile {
             }
         }
 
+        $(#[$builder_meta])*
         impl $builder {
             /// Target percentile in (0.0, 1.0). Required.
             #[inline]
@@ -334,8 +322,8 @@ macro_rules! impl_percentile {
     };
 }
 
-impl_percentile!(PercentileF64, PercentileF64Builder, f64);
-impl_percentile!(PercentileF32, PercentileF32Builder, f32);
+impl_percentile!(pub PercentileF64, pub PercentileF64Builder, f64);
+impl_percentile!(#[allow(dead_code)] pub(crate) PercentileF32, #[allow(dead_code)] pub(crate) PercentileF32Builder, f32);
 
 #[cfg(test)]
 mod tests {
@@ -435,7 +423,6 @@ mod tests {
     #[test]
     fn skewed_distribution() {
         let mut p = PercentileF64::new(0.99).unwrap();
-        // Interleave: 99 values of 10.0 for every 1 value of 1000.0
         for i in 0..10000u64 {
             if i % 100 == 99 {
                 p.update(1000.0).unwrap();
@@ -444,7 +431,6 @@ mod tests {
             }
         }
         let est = p.percentile().unwrap();
-        // p99 should be near the transition, not at 1000
         assert!(est < 500.0, "p99 = {est}, expected well below 1000");
     }
 

--- a/nexus-stats-core/src/statistics/roll_spread.rs
+++ b/nexus-stats-core/src/statistics/roll_spread.rs
@@ -1,229 +1,218 @@
 use crate::math::MulAdd;
 
-macro_rules! impl_roll_spread {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Roll's implicit spread estimator.
-        ///
-        /// Estimates effective bid-ask spread from the autocovariance of
-        /// consecutive price changes: `spread = 2·√(-Cov(Δp_t, Δp_{t-1}))`.
-        ///
-        /// When autocovariance is non-negative (trending market), spread
-        /// is undefined and `spread()` returns `None`.
-        ///
-        /// Hasbrouck (2009) adjustment uses autocorrelation:
-        /// `spread_h = spread · √(1 + ρ)`.
-        ///
-        /// Roll (1984).
-        ///
-        /// # Parameters
-        ///
-        /// - `alpha` — EW decay factor for the autocovariance estimator.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_core::statistics::RollSpreadF64;
-        ///
-        /// let mut rs = RollSpreadF64::builder()
-        ///     .alpha(0.05)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// // Feed alternating prices (mean-reverting → negative autocov)
-        /// for i in 0..200 {
-        ///     let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
-        ///     rs.update(price).unwrap();
-        /// }
-        /// assert!(rs.spread().is_some());
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            ew_cov: $ty,
-            ew_var: $ty,
-            prev_price: $ty,
-            prev_diff: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    min_samples: 30,
-                }
-            }
-
-            /// Feeds a trade price.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the price is NaN, or
-            /// `DataError::Infinite` if the price is infinite.
-            #[inline]
-            pub fn update(&mut self, price: $ty) -> Result<(), crate::DataError> {
-                check_finite!(price);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.prev_price = price;
-                    return Ok(());
-                }
-
-                let diff = price - self.prev_price;
-                self.prev_price = price;
-
-                if self.count == 2 {
-                    self.prev_diff = diff;
-                    return Ok(());
-                }
-
-                self.ew_cov = self
-                    .alpha
-                    .fma(diff * self.prev_diff, self.one_minus_alpha * self.ew_cov);
-                self.ew_var = self
-                    .alpha
-                    .fma(diff * diff, self.one_minus_alpha * self.ew_var);
-                self.prev_diff = diff;
-                Ok(())
-            }
-
-            /// Roll's spread: `2·√(-cov)`.
-            ///
-            /// Returns `None` if not primed or autocovariance is non-negative
-            /// (trending market — spread undefined).
-            #[inline]
-            #[must_use]
-            pub fn spread(&self) -> Option<$ty> {
-                if !self.is_primed() {
-                    return Option::None;
-                }
-                if self.ew_cov >= 0.0 as $ty {
-                    return Option::None;
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                Option::Some(2.0 as $ty * crate::math::sqrt((-self.ew_cov) as f64) as $ty)
-            }
-
-            /// Hasbrouck's adjusted spread: `spread · √(1 + ρ)` where
-            /// `ρ = cov / var` is the first-order autocorrelation.
-            ///
-            /// Returns `None` if Roll spread is `None`, variance is zero,
-            /// or `1 + ρ <= 0` (extreme mean-reversion).
-            #[inline]
-            #[must_use]
-            pub fn hasbrouck_spread(&self) -> Option<$ty> {
-                let s = self.spread()?;
-                if self.ew_var <= 0.0 as $ty {
-                    return Option::None;
-                }
-                let rho = self.ew_cov / self.ew_var;
-                let factor = 1.0 as $ty + rho;
-                if factor <= 0.0 as $ty {
-                    return Option::None;
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                Option::Some(s * crate::math::sqrt(factor as f64) as $ty)
-            }
-
-            /// Raw exponentially weighted autocovariance, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn autocovariance(&self) -> Option<$ty> {
-                if self.is_primed() {
-                    Option::Some(self.ew_cov)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of prices seen.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough samples have been observed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.ew_cov = 0.0 as $ty;
-                self.ew_var = 0.0 as $ty;
-                self.prev_price = 0.0 as $ty;
-                self.prev_diff = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// EW decay factor (required, in (0, 1)).
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Minimum prices before results are valid. Default: 30.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the Roll spread estimator.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha must have been set and be in (0, 1).
-            #[inline]
-            pub fn build(self) -> Result<$name, crate::ConfigError> {
-                let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-                if alpha <= 0.0 as $ty || alpha >= 1.0 as $ty || !alpha.is_finite() {
-                    return Err(crate::ConfigError::Invalid(
-                        "RollSpread alpha must be in (0, 1)",
-                    ));
-                }
-
-                Ok($name {
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    ew_cov: 0.0 as $ty,
-                    ew_var: 0.0 as $ty,
-                    prev_price: 0.0 as $ty,
-                    prev_diff: 0.0 as $ty,
-                    count: 0,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Roll's implicit spread estimator.
+///
+/// Estimates effective bid-ask spread from the autocovariance of
+/// consecutive price changes: `spread = 2·sqrt(-Cov(dp_t, dp_{t-1}))`.
+///
+/// When autocovariance is non-negative (trending market), spread
+/// is undefined and `spread()` returns `None`.
+///
+/// Hasbrouck (2009) adjustment uses autocorrelation:
+/// `spread_h = spread · sqrt(1 + rho)`.
+///
+/// Roll (1984).
+///
+/// # Parameters
+///
+/// - `alpha` — EW decay factor for the autocovariance estimator.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_core::statistics::RollSpreadF64;
+///
+/// let mut rs = RollSpreadF64::builder()
+///     .alpha(0.05)
+///     .build()
+///     .unwrap();
+///
+/// // Feed alternating prices (mean-reverting -> negative autocov)
+/// for i in 0..200 {
+///     let price = 100.0 + if i % 2 == 0 { 0.5 } else { -0.5 };
+///     rs.update(price).unwrap();
+/// }
+/// assert!(rs.spread().is_some());
+/// ```
+#[derive(Debug, Clone)]
+pub struct RollSpreadF64 {
+    alpha: f64,
+    one_minus_alpha: f64,
+    ew_cov: f64,
+    ew_var: f64,
+    prev_price: f64,
+    prev_diff: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_roll_spread!(RollSpreadF64, RollSpreadF64Builder, f64);
-impl_roll_spread!(RollSpreadF32, RollSpreadF32Builder, f32);
+/// Builder for [`RollSpreadF64`].
+#[derive(Debug, Clone)]
+pub struct RollSpreadF64Builder {
+    alpha: Option<f64>,
+    min_samples: u64,
+}
+
+impl RollSpreadF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> RollSpreadF64Builder {
+        RollSpreadF64Builder {
+            alpha: None,
+            min_samples: 30,
+        }
+    }
+
+    /// Feeds a trade price.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the price is NaN, or
+    /// `DataError::Infinite` if the price is infinite.
+    #[inline]
+    pub fn update(&mut self, price: f64) -> Result<(), crate::DataError> {
+        check_finite!(price);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.prev_price = price;
+            return Ok(());
+        }
+
+        let diff = price - self.prev_price;
+        self.prev_price = price;
+
+        if self.count == 2 {
+            self.prev_diff = diff;
+            return Ok(());
+        }
+
+        self.ew_cov = self
+            .alpha
+            .fma(diff * self.prev_diff, self.one_minus_alpha * self.ew_cov);
+        self.ew_var = self
+            .alpha
+            .fma(diff * diff, self.one_minus_alpha * self.ew_var);
+        self.prev_diff = diff;
+        Ok(())
+    }
+
+    /// Roll's spread: `2 * sqrt(-cov)`.
+    ///
+    /// Returns `None` if not primed or autocovariance is non-negative
+    /// (trending market — spread undefined).
+    #[inline]
+    #[must_use]
+    pub fn spread(&self) -> Option<f64> {
+        if !self.is_primed() {
+            return None;
+        }
+        if self.ew_cov >= 0.0 {
+            return None;
+        }
+        Some(2.0 * crate::math::sqrt(-self.ew_cov))
+    }
+
+    /// Hasbrouck's adjusted spread: `spread * sqrt(1 + rho)` where
+    /// `rho = cov / var` is the first-order autocorrelation.
+    ///
+    /// Returns `None` if Roll spread is `None`, variance is zero,
+    /// or `1 + rho <= 0` (extreme mean-reversion).
+    #[inline]
+    #[must_use]
+    pub fn hasbrouck_spread(&self) -> Option<f64> {
+        let s = self.spread()?;
+        if self.ew_var <= 0.0 {
+            return None;
+        }
+        let rho = self.ew_cov / self.ew_var;
+        let factor = 1.0 + rho;
+        if factor <= 0.0 {
+            return None;
+        }
+        Some(s * crate::math::sqrt(factor))
+    }
+
+    /// Raw exponentially weighted autocovariance, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn autocovariance(&self) -> Option<f64> {
+        if self.is_primed() {
+            Some(self.ew_cov)
+        } else {
+            None
+        }
+    }
+
+    /// Number of prices seen.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough samples have been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.ew_cov = 0.0;
+        self.ew_var = 0.0;
+        self.prev_price = 0.0;
+        self.prev_diff = 0.0;
+        self.count = 0;
+    }
+}
+
+impl RollSpreadF64Builder {
+    /// EW decay factor (required, in (0, 1)).
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Minimum prices before results are valid. Default: 30.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the Roll spread estimator.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha must have been set and be in (0, 1).
+    #[inline]
+    pub fn build(self) -> Result<RollSpreadF64, crate::ConfigError> {
+        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
+        if alpha <= 0.0 || alpha >= 1.0 || !alpha.is_finite() {
+            return Err(crate::ConfigError::Invalid(
+                "RollSpread alpha must be in (0, 1)",
+            ));
+        }
+
+        Ok(RollSpreadF64 {
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            ew_cov: 0.0,
+            ew_var: 0.0,
+            prev_price: 0.0,
+            prev_diff: 0.0,
+            count: 0,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -273,7 +262,7 @@ mod tests {
             .build()
             .unwrap();
 
-        // Trend + bounce: negative autocov but ρ > -1
+        // Trend + bounce: negative autocov but rho > -1
         for i in 0..200 {
             let bounce = if i % 2 == 0 { 0.2 } else { -0.2 };
             rs.update(100.0 + (i as f64) * 0.1 + bounce).unwrap();

--- a/nexus-stats-core/src/statistics/welford.rs
+++ b/nexus-stats-core/src/statistics/welford.rs
@@ -1,178 +1,163 @@
 use crate::math::MulAdd;
-macro_rules! impl_welford {
-    ($name:ident, $ty:ty) => {
-        /// Welford — Online mean, variance, and standard deviation.
-        ///
-        /// Numerically stable single-pass computation using Welford's algorithm.
-        /// No catastrophic cancellation. Supports merging partial results via
-        /// Chan's algorithm for parallel aggregation.
-        ///
-        /// # Use Cases
-        /// - Running statistics on latency, throughput, PnL
-        /// - Z-score computation (combine with EMA for baseline)
-        /// - Input to adaptive thresholds
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            count: u64,
-            mean: $ty,
-            m2: $ty,
-        }
 
-        impl $name {
-            /// Creates a new empty accumulator.
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    count: 0,
-                    mean: 0.0 as $ty,
-                    m2: 0.0 as $ty,
-                }
-            }
-
-            /// Creates an accumulator pre-loaded from known statistics.
-            ///
-            /// `m2` is the sum of squared deviations from the mean
-            /// (`variance * (count - 1)` for sample variance).
-            #[inline]
-            #[must_use]
-            pub const fn from_parts(count: u64, mean: $ty, m2: $ty) -> Self {
-                Self { count, mean, m2 }
-            }
-
-            /// Feeds a sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), crate::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-                let delta = sample - self.mean;
-                self.mean += delta / self.count as $ty;
-                let delta2 = sample - self.mean;
-                self.m2 += delta * delta2;
-                Ok(())
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data for variance/std_dev queries (>= 2 samples).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= 2
-            }
-
-            /// Running mean, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mean(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.mean)
-                }
-            }
-
-            /// Sample variance (N-1 denominator), or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            pub fn variance(&self) -> Option<$ty> {
-                if self.count < 2 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / (self.count - 1) as $ty)
-                }
-            }
-
-            /// Population variance (N denominator), or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn population_variance(&self) -> Option<$ty> {
-                if self.count == 0 {
-                    Option::None
-                } else {
-                    Option::Some(self.m2 / self.count as $ty)
-                }
-            }
-
-            /// Sample standard deviation, or `None` if < 2 samples.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn std_dev(&self) -> Option<$ty> {
-                self.variance().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        crate::math::sqrt(v as f64) as $ty
-                    }
-                })
-            }
-
-            /// Merges another accumulator into this one (Chan's algorithm).
-            ///
-            /// After merging, `self` contains the statistics of the combined
-            /// dataset. The other accumulator is unchanged.
-            #[inline]
-            pub fn merge(&mut self, other: &Self) {
-                if other.count == 0 {
-                    return;
-                }
-                if self.count == 0 {
-                    self.count = other.count;
-                    self.mean = other.mean;
-                    self.m2 = other.m2;
-                    return;
-                }
-
-                let combined_count = self.count + other.count;
-                let delta = other.mean - self.mean;
-                let weight = other.count as $ty / combined_count as $ty;
-                let new_mean = delta.fma(weight, self.mean);
-                let cross = self.count as $ty * other.count as $ty / combined_count as $ty;
-                let new_m2 = delta.fma(delta * cross, self.m2 + other.m2);
-
-                self.count = combined_count;
-                self.mean = new_mean;
-                self.m2 = new_m2;
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.count = 0;
-                self.mean = 0.0 as $ty;
-                self.m2 = 0.0 as $ty;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Welford — Online mean, variance, and standard deviation.
+///
+/// Numerically stable single-pass computation using Welford's algorithm.
+/// No catastrophic cancellation. Supports merging partial results via
+/// Chan's algorithm for parallel aggregation.
+///
+/// # Use Cases
+/// - Running statistics on latency, throughput, PnL
+/// - Z-score computation (combine with EMA for baseline)
+/// - Input to adaptive thresholds
+#[derive(Debug, Clone)]
+pub struct WelfordF64 {
+    count: u64,
+    mean: f64,
+    m2: f64,
 }
 
-impl_welford!(WelfordF64, f64);
-impl_welford!(WelfordF32, f32);
+impl WelfordF64 {
+    /// Creates a new empty accumulator.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            mean: 0.0,
+            m2: 0.0,
+        }
+    }
+
+    /// Creates an accumulator pre-loaded from known statistics.
+    ///
+    /// `m2` is the sum of squared deviations from the mean
+    /// (`variance * (count - 1)` for sample variance).
+    #[inline]
+    #[must_use]
+    pub const fn from_parts(count: u64, mean: f64, m2: f64) -> Self {
+        Self { count, mean, m2 }
+    }
+
+    /// Feeds a sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), crate::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+        let delta = sample - self.mean;
+        self.mean += delta / self.count as f64;
+        let delta2 = sample - self.mean;
+        self.m2 += delta * delta2;
+        Ok(())
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data for variance/std_dev queries (>= 2 samples).
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= 2
+    }
+
+    /// Running mean, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mean(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.mean)
+        }
+    }
+
+    /// Sample variance (N-1 denominator), or `None` if < 2 samples.
+    #[inline]
+    #[must_use]
+    pub fn variance(&self) -> Option<f64> {
+        if self.count < 2 {
+            None
+        } else {
+            Some(self.m2 / (self.count - 1) as f64)
+        }
+    }
+
+    /// Population variance (N denominator), or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn population_variance(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.m2 / self.count as f64)
+        }
+    }
+
+    /// Sample standard deviation, or `None` if < 2 samples.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn std_dev(&self) -> Option<f64> {
+        self.variance().map(crate::math::sqrt)
+    }
+
+    /// Merges another accumulator into this one (Chan's algorithm).
+    ///
+    /// After merging, `self` contains the statistics of the combined
+    /// dataset. The other accumulator is unchanged.
+    #[inline]
+    pub fn merge(&mut self, other: &Self) {
+        if other.count == 0 {
+            return;
+        }
+        if self.count == 0 {
+            self.count = other.count;
+            self.mean = other.mean;
+            self.m2 = other.m2;
+            return;
+        }
+
+        let combined_count = self.count + other.count;
+        let delta = other.mean - self.mean;
+        let weight = other.count as f64 / combined_count as f64;
+        let new_mean = delta.fma(weight, self.mean);
+        let cross = self.count as f64 * other.count as f64 / combined_count as f64;
+        let new_m2 = delta.fma(delta * cross, self.m2 + other.m2);
+
+        self.count = combined_count;
+        self.mean = new_mean;
+        self.m2 = new_m2;
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.count = 0;
+        self.mean = 0.0;
+        self.m2 = 0.0;
+    }
+}
+
+impl Default for WelfordF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // =========================================================================
-    // Basic correctness
-    // =========================================================================
 
     #[test]
     fn empty_returns_none() {
@@ -191,9 +176,7 @@ mod tests {
 
         assert_eq!(w.count(), 1);
         assert_eq!(w.mean(), Some(42.0));
-        // Variance needs at least 2 samples
         assert!(w.variance().is_none());
-        // Population variance with 1 sample is 0
         assert_eq!(w.population_variance(), Some(0.0));
     }
 
@@ -201,32 +184,27 @@ mod tests {
     fn known_values() {
         let mut w = WelfordF64::new();
 
-        // Dataset: [2, 4, 4, 4, 5, 5, 7, 9]
         for &x in &[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
             w.update(x).unwrap();
         }
 
         assert_eq!(w.count(), 8);
 
-        // Mean = 40/8 = 5.0
         let mean = w.mean().unwrap();
         assert!((mean - 5.0).abs() < 1e-10, "mean should be 5.0, got {mean}");
 
-        // Population variance = 4.0
         let pop_var = w.population_variance().unwrap();
         assert!(
             (pop_var - 4.0).abs() < 1e-10,
             "pop variance should be 4.0, got {pop_var}"
         );
 
-        // Sample variance = 32/7 ≈ 4.571428
         let var = w.variance().unwrap();
         assert!(
             (var - 32.0 / 7.0).abs() < 1e-10,
             "sample variance should be 32/7, got {var}"
         );
 
-        // Std dev = sqrt(32/7) ≈ 2.138
         let sd = w.std_dev().unwrap();
         assert!(
             (sd - (32.0_f64 / 7.0).sqrt()).abs() < 1e-6,
@@ -242,19 +220,12 @@ mod tests {
 
         assert_eq!(w.count(), 2);
         assert!((w.mean().unwrap() - 15.0).abs() < 1e-10);
-        // Sample variance of [10, 20] = 50.0
         assert!((w.variance().unwrap() - 50.0).abs() < 1e-10);
-        // Pop variance = 25.0
         assert!((w.population_variance().unwrap() - 25.0).abs() < 1e-10);
     }
 
-    // =========================================================================
-    // Numerical stability
-    // =========================================================================
-
     #[test]
     fn numerical_stability_large_offset() {
-        // Classic failure case for naive variance: large mean, small deltas
         let mut w = WelfordF64::new();
         let base = 1e8;
 
@@ -263,15 +234,9 @@ mod tests {
         }
 
         let var = w.variance().unwrap();
-        // Variance of 0, 0.001, 0.002, ..., 0.999 ≈ 0.08341...
-        // (doesn't matter exactly — just check it's positive and reasonable)
         assert!(var > 0.0, "variance should be positive, got {var}");
         assert!(var < 1.0, "variance should be small, got {var}");
     }
-
-    // =========================================================================
-    // Merge (Chan's algorithm)
-    // =========================================================================
 
     #[test]
     fn merge_empty_into_empty() {
@@ -310,13 +275,11 @@ mod tests {
     fn merge_matches_single_accumulator() {
         let data = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
 
-        // Single accumulator
         let mut single = WelfordF64::new();
         for &x in &data {
             single.update(x).unwrap();
         }
 
-        // Split into two halves and merge
         let mut first = WelfordF64::new();
         let mut second = WelfordF64::new();
         for &x in &data[..4] {
@@ -354,10 +317,6 @@ mod tests {
         assert!((a.variance().unwrap() - single.variance().unwrap()).abs() < 1e-6);
     }
 
-    // =========================================================================
-    // Reset
-    // =========================================================================
-
     #[test]
     fn reset_clears_state() {
         let mut w = WelfordF64::new();
@@ -371,23 +330,11 @@ mod tests {
         assert!(w.variance().is_none());
     }
 
-    // =========================================================================
-    // Default
-    // =========================================================================
-
     #[test]
     fn default_is_empty() {
         let w = WelfordF64::default();
         assert_eq!(w.count(), 0);
     }
-
-    // =========================================================================
-    // f32 variant
-    // =========================================================================
-
-    // =========================================================================
-    // from_parts
-    // =========================================================================
 
     #[test]
     fn from_parts_round_trip() {
@@ -398,29 +345,12 @@ mod tests {
 
         let count = w.count();
         let mean = w.mean().unwrap();
-        // m2 = variance * (count - 1)
         let m2 = w.variance().unwrap() * (count - 1) as f64;
 
         let w2 = WelfordF64::from_parts(count, mean, m2);
         assert_eq!(w2.count(), count);
         assert!((w2.mean().unwrap() - mean).abs() < 1e-10);
         assert!((w2.variance().unwrap() - w.variance().unwrap()).abs() < 1e-10);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut w = WelfordF32::new();
-        w.update(10.0).unwrap();
-        w.update(20.0).unwrap();
-
-        assert_eq!(w.count(), 2);
-        assert!((w.mean().unwrap() - 15.0).abs() < 1e-5);
-    }
-
-    #[test]
-    fn f32_default() {
-        let w = WelfordF32::default();
-        assert_eq!(w.count(), 0);
     }
 
     #[test]

--- a/nexus-stats-detection/src/adaptive_threshold.rs
+++ b/nexus-stats-detection/src/adaptive_threshold.rs
@@ -1,6 +1,6 @@
 use nexus_stats_core::Direction;
-use nexus_stats_core::smoothing::{EmaF32, EmaF64};
-use nexus_stats_core::statistics::{WelfordF32, WelfordF64};
+use nexus_stats_core::smoothing::EmaF64;
+use nexus_stats_core::statistics::WelfordF64;
 
 macro_rules! impl_adaptive_threshold {
     ($name:ident, $builder:ident, $ty:ty, $ema:ty, $ema_builder:ident, $welford:ty) => {
@@ -282,14 +282,6 @@ impl_adaptive_threshold!(
     EmaF64Builder,
     WelfordF64
 );
-impl_adaptive_threshold!(
-    AdaptiveThresholdF32,
-    AdaptiveThresholdF32Builder,
-    f32,
-    EmaF32,
-    EmaF32Builder,
-    WelfordF32
-);
 
 #[cfg(test)]
 mod tests {
@@ -408,20 +400,6 @@ mod tests {
         at.reset();
         assert_eq!(at.count(), 0);
         assert!(!at.is_primed());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut at = AdaptiveThresholdF32::builder()
-            .alpha(0.1)
-            .min_samples(5)
-            .build()
-            .unwrap();
-
-        for _ in 0..10 {
-            let _ = at.update(100.0);
-        }
-        assert!(at.is_primed());
     }
 
     #[test]

--- a/nexus-stats/examples/perf_stats.rs
+++ b/nexus-stats/examples/perf_stats.rs
@@ -10,7 +10,7 @@ use std::hint::black_box;
 
 use nexus_stats::{
     control::{BoolWindow, HysteresisF64},
-    detection::{CusumF64, CusumI64, MosumF64, MultiGateF64, RobustZScoreF64, ShiryaevRobertsF64},
+    detection::{CusumF64, MosumF64, MultiGateF64, RobustZScoreF64, ShiryaevRobertsF64},
     frequency::TopK,
     learning::{EpsilonGreedyF64, Exp3F64, ThompsonBetaF64, ThompsonGammaF64, Ucb1F64},
     monitoring::{
@@ -19,7 +19,7 @@ use nexus_stats::{
     },
     signal::{AutocorrelationF64, CrossCorrelationF64, EntropyF64, TransferEntropyF64},
     smoothing::{
-        AsymEmaF64, EmaF64, EmaI64, HoltF64, Kalman1dF64, KamaF64, SlewF64, SpringF64,
+        AsymEmaF64, EmaF64, HoltF64, Kalman1dF64, KamaF64, SlewF64, SpringF64,
         WindowedMedianF64,
     },
     statistics::{CovarianceF64, EwmaVarF64, MomentsF64, WelfordF64},
@@ -122,27 +122,6 @@ fn bench_cusum_f64(samples: &mut [u64]) {
     }
 }
 
-fn bench_cusum_i64(samples: &mut [u64]) {
-    let mut cusum = CusumI64::builder(1000)
-        .slack(50)
-        .threshold(i64::MAX)
-        .build()
-        .unwrap();
-    let mut rng = 12345u64;
-    for _ in 0..WARMUP {
-        let _ = cusum.update(990 + (next_val(&mut rng) % 20) as i64);
-    }
-    for s in samples.iter_mut() {
-        let start = rdtsc_start();
-        for _ in 0..BATCH {
-            let v = 990 + (next_val(&mut rng) % 20) as i64;
-            black_box(cusum.update(black_box(v)));
-        }
-        let end = rdtsc_end();
-        *s = (end - start) / BATCH;
-    }
-}
-
 fn bench_ema_f64(samples: &mut [u64]) {
     let mut ema = EmaF64::builder().alpha(0.1).build().unwrap();
     let mut rng = 12345u64;
@@ -154,24 +133,6 @@ fn bench_ema_f64(samples: &mut [u64]) {
         let start = rdtsc_start();
         for _ in 0..BATCH {
             let _ = ema.update(90.0 + (next_val(&mut rng) % 20) as f64);
-        }
-        let end = rdtsc_end();
-        black_box(ema.value());
-        *s = (end - start) / BATCH;
-    }
-}
-
-fn bench_ema_i64(samples: &mut [u64]) {
-    let mut ema = EmaI64::builder().span(15).build().unwrap();
-    let mut rng = 12345u64;
-    let _ = ema.update(1000);
-    for _ in 0..WARMUP {
-        let _ = ema.update(990 + (next_val(&mut rng) % 20) as i64);
-    }
-    for s in samples.iter_mut() {
-        let start = rdtsc_start();
-        for _ in 0..BATCH {
-            let _ = ema.update(990 + (next_val(&mut rng) % 20) as i64);
         }
         let end = rdtsc_end();
         black_box(ema.value());
@@ -994,8 +955,6 @@ fn main() {
     print_header();
     bench_cusum_f64(&mut buf);
     print_row("CusumF64::update", &mut buf);
-    bench_cusum_i64(&mut buf);
-    print_row("CusumI64::update", &mut buf);
     bench_mosum_f64(&mut buf);
     print_row("MosumF64(64)::update", &mut buf);
     bench_shiryaev_roberts(&mut buf);
@@ -1005,8 +964,6 @@ fn main() {
     print_header();
     bench_ema_f64(&mut buf);
     print_row("EmaF64::update", &mut buf);
-    bench_ema_i64(&mut buf);
-    print_row("EmaI64::update", &mut buf);
     bench_holt_f64(&mut buf);
     print_row("HoltF64::update", &mut buf);
 


### PR DESCRIPTION
## Summary

Type-variant audit for `nexus-stats-core` (#377, part of #366).

Reduces public API surface by removing type variants that don't have concrete callers. Three regimes govern what stays:

- **Regime A** (accumulating/transcendental): f64 only — f32 is a precision footgun, integers don't apply
- **Regime B** (comparison/extremum/timing): f64 + i64 — integers are useful for tick counters, timestamps, raw wire values
- **Regime C** (normalizers): f64 + f32 public, with f32 dependencies kept as `pub(crate)` internally

### What changed

- **34 files in nexus-stats-core** modified across statistics/, smoothing/, monitoring/, control/, detection/, normalization/
- **~1,850 lines net deleted** (36 files total including 2 downstream fixes)
- Macros inlined to plain structs wherever only one variant survives
- Macros with `$vis:vis` visibility parameter retained for ewma_var and percentile (pub f64 + pub(crate) f32)
- 6 `pub(crate)` types retained for normalizer internal use: `EwmaVarF32`, `PercentileF32`, `WindowedMaxF32`, `WindowedMinF32` + builders
- `DeadBandI64` threshold changed from `i64` to `u64` with `abs_diff()` to prevent overflow on `i64::MIN` delta
- `HysteresisF64::new` uses negated comparison `!(low < high)` for NaN-safe validation
- All clippy lints from macro inlining resolved (unnecessary casts, manual abs, boolean simplifications, etc.)

### Downstream fixes

- `nexus-stats-detection`: removed `AdaptiveThresholdF32` (depended on deleted `EmaF32`)
- `nexus-stats/examples/perf_stats.rs`: removed `CusumI64`/`EmaI64` benchmarks

### Modules affected

| Module | Types cut |
|--------|-----------|
| statistics/ | F32 from Welford, Moments, Covariance, HarmonicMean, Bipower, Lpm, Cvar, RollSpread. Int variants from Moments. |
| smoothing/ | F32/I64/I32 from EMA, AsymEma. I128 from Slew. |
| monitoring/ | F32/I32/I128 from all. F32/I64/I32 from EventRate. F32 from ErrorRate, Saturation, Hawkes. |
| control/ | F32/I32/I128 from DeadBand, Hysteresis, LevelCrossing, Diff. U32 from Debounce. |
| detection/ | F32/I64/I32/I128 from Cusum. |
| normalization/ | No public API changes (F32 normalizers retained per regime C). |

## Test plan

- [x] `cargo test -p nexus-stats-core --all-features` — 394 unit + 24 doc tests pass
- [x] `cargo clippy -p nexus-stats-core --all-features -- -D warnings` — clean
- [x] `cargo fmt -p nexus-stats-core -- --check` — clean
- [x] `cargo test -p nexus-stats --all-features` — umbrella crate tests pass
- [x] `cargo check -p nexus-stats-detection --all-features` — downstream compiles
- [ ] Version bump to 3.0.0 (deferred to umbrella PR or final merge)

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)