### PR TITLE
stripping unnecessary types from nexus-stats-smoothing

### DIFF
--- a/nexus-stats-detection/CHANGELOG.md
+++ b/nexus-stats-detection/CHANGELOG.md
@@ -10,6 +10,14 @@ contained.
 
 ## [Unreleased]
 
+### Removed
+
+- `TrendAlertF32`, `TrendAlertF32Builder` — use `TrendAlertF64` (dependency `HoltF32` removed from smoothing crate)
+
+### Changed
+
+- `TrendAlertF64Builder::build` now rejects negative and non-finite trend thresholds
+
 ## [1.2.0] — 2026-05-26
 
 ## [1.2.0] — 2026-05-26

--- a/nexus-stats-detection/src/trend_alert.rs
+++ b/nexus-stats-detection/src/trend_alert.rs
@@ -204,6 +204,20 @@ impl TrendAlertF64Builder {
                 "TrendAlert requires a trend threshold",
             ));
         }
+        if let Some(t) = self.trend_threshold_abs
+            && (!t.is_finite() || t < 0.0)
+        {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "absolute trend threshold must be finite and non-negative",
+            ));
+        }
+        if let Some(t) = self.trend_threshold_rel
+            && (!t.is_finite() || t < 0.0)
+        {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "relative trend threshold must be finite and non-negative",
+            ));
+        }
 
         let holt = HoltF64::builder()
             .alpha(alpha)

--- a/nexus-stats-detection/src/trend_alert.rs
+++ b/nexus-stats-detection/src/trend_alert.rs
@@ -1,233 +1,224 @@
 use nexus_stats_core::Direction;
-use nexus_stats_smoothing::{HoltF32, HoltF64};
+use nexus_stats_smoothing::HoltF64;
 
-macro_rules! impl_trend_alert {
-    ($name:ident, $builder:ident, $ty:ty, $holt:ty) => {
-        /// Trend alert — Holt's double exponential with threshold on the trend component.
-        ///
-        /// Detects not just "value is high" but "value is getting worse over time."
-        /// Supports both absolute and relative trend thresholds.
-        ///
-        /// # Use Cases
-        /// - "Latency is increasing linearly"
-        /// - Capacity planning — detect degradation trends
-        /// - Drift detection in stationary processes
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            holt: $holt,
-            trend_threshold_abs: Option<$ty>,
-            trend_threshold_rel: Option<$ty>,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            beta: Option<$ty>,
-            trend_threshold_abs: Option<$ty>,
-            trend_threshold_rel: Option<$ty>,
-            min_samples: u64,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    beta: Option::None,
-                    trend_threshold_abs: Option::None,
-                    trend_threshold_rel: Option::None,
-                    min_samples: 2,
-                }
-            }
-
-            /// Feeds a sample. Returns trend direction once primed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                sample: $ty,
-            ) -> Result<Option<Direction>, nexus_stats_core::DataError> {
-                check_finite!(sample);
-                // Holt already validated by check_finite above
-                let result = self.holt.update(sample)?;
-
-                if self.holt.count() < self.min_samples {
-                    return Ok(Option::None);
-                }
-
-                let Some((level, trend)) = result else {
-                    return Ok(Option::None);
-                };
-
-                // Check absolute threshold
-                if let Some(abs_thresh) = self.trend_threshold_abs {
-                    if trend > abs_thresh {
-                        return Ok(Option::Some(Direction::Rising));
-                    } else if trend < -abs_thresh {
-                        return Ok(Option::Some(Direction::Falling));
-                    }
-                }
-
-                // Check relative threshold
-                if let Some(rel_thresh) = self.trend_threshold_rel {
-                    #[allow(clippy::float_cmp)]
-                    if level != (0.0 as $ty) {
-                        let ratio = trend / level;
-                        if ratio > rel_thresh {
-                            return Ok(Option::Some(Direction::Rising));
-                        } else if ratio < -rel_thresh {
-                            return Ok(Option::Some(Direction::Falling));
-                        }
-                    }
-                }
-
-                Ok(Option::Some(Direction::Neutral))
-            }
-
-            /// Current smoothed level, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn level(&self) -> Option<$ty> {
-                self.holt.level()
-            }
-
-            /// Current trend (rate of change), or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn trend(&self) -> Option<$ty> {
-                self.holt.trend()
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.holt.count()
-            }
-
-            /// Whether enough data has been collected.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.holt.count() >= self.min_samples
-            }
-
-            /// Resets to empty state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.holt.reset();
-            }
-
-            /// Updates the absolute trend threshold without resetting state.
-            ///
-            /// # Errors
-            ///
-            /// Threshold must be >= 0.
-            #[inline]
-            pub fn reconfigure_threshold(
-                &mut self,
-                threshold: $ty,
-            ) -> Result<(), nexus_stats_core::ConfigError> {
-                if threshold < (0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "threshold must be non-negative",
-                    ));
-                }
-                self.trend_threshold_abs = Option::Some(threshold);
-                Ok(())
-            }
-        }
-
-        impl $builder {
-            /// Level smoothing factor (Holt's alpha).
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Trend smoothing factor (Holt's beta).
-            #[inline]
-            #[must_use]
-            pub fn beta(mut self, beta: $ty) -> Self {
-                self.beta = Option::Some(beta);
-                self
-            }
-
-            /// Absolute trend threshold. Alert when `|trend| > threshold`.
-            #[inline]
-            #[must_use]
-            pub fn trend_threshold(mut self, threshold: $ty) -> Self {
-                self.trend_threshold_abs = Option::Some(threshold);
-                self
-            }
-
-            /// Relative trend threshold. Alert when `|trend / level| > fraction`.
-            #[inline]
-            #[must_use]
-            pub fn trend_threshold_relative(mut self, fraction: $ty) -> Self {
-                self.trend_threshold_rel = Option::Some(fraction);
-                self
-            }
-
-            /// Minimum samples before detection activates. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Builds the trend alert detector.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha and beta must have been set.
-            /// - At least one threshold (absolute or relative) must be set.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                let beta = self
-                    .beta
-                    .ok_or(nexus_stats_core::ConfigError::Missing("beta"))?;
-                if self.trend_threshold_abs.is_none() && self.trend_threshold_rel.is_none() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "TrendAlert requires a trend threshold",
-                    ));
-                }
-
-                let holt = <$holt>::builder()
-                    .alpha(alpha)
-                    .beta(beta)
-                    .min_samples(self.min_samples)
-                    .build()?;
-
-                Ok($name {
-                    holt,
-                    trend_threshold_abs: self.trend_threshold_abs,
-                    trend_threshold_rel: self.trend_threshold_rel,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Trend alert — Holt's double exponential with threshold on the trend component.
+///
+/// Detects not just "value is high" but "value is getting worse over time."
+/// Supports both absolute and relative trend thresholds.
+///
+/// # Use Cases
+/// - "Latency is increasing linearly"
+/// - Capacity planning — detect degradation trends
+/// - Drift detection in stationary processes
+#[derive(Debug, Clone)]
+pub struct TrendAlertF64 {
+    holt: HoltF64,
+    trend_threshold_abs: Option<f64>,
+    trend_threshold_rel: Option<f64>,
+    min_samples: u64,
 }
 
-impl_trend_alert!(TrendAlertF64, TrendAlertF64Builder, f64, HoltF64);
-impl_trend_alert!(TrendAlertF32, TrendAlertF32Builder, f32, HoltF32);
+/// Builder for [`TrendAlertF64`].
+#[derive(Debug, Clone)]
+pub struct TrendAlertF64Builder {
+    alpha: Option<f64>,
+    beta: Option<f64>,
+    trend_threshold_abs: Option<f64>,
+    trend_threshold_rel: Option<f64>,
+    min_samples: u64,
+}
+
+impl TrendAlertF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> TrendAlertF64Builder {
+        TrendAlertF64Builder {
+            alpha: None,
+            beta: None,
+            trend_threshold_abs: None,
+            trend_threshold_rel: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Feeds a sample. Returns trend direction once primed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        sample: f64,
+    ) -> Result<Option<Direction>, nexus_stats_core::DataError> {
+        check_finite!(sample);
+        // Holt already validated by check_finite above
+        let result = self.holt.update(sample)?;
+
+        if self.holt.count() < self.min_samples {
+            return Ok(None);
+        }
+
+        let Some((level, trend)) = result else {
+            return Ok(None);
+        };
+
+        // Check absolute threshold
+        if let Some(abs_thresh) = self.trend_threshold_abs {
+            if trend > abs_thresh {
+                return Ok(Some(Direction::Rising));
+            } else if trend < -abs_thresh {
+                return Ok(Some(Direction::Falling));
+            }
+        }
+
+        // Check relative threshold
+        if let Some(rel_thresh) = self.trend_threshold_rel {
+            #[allow(clippy::float_cmp)]
+            if level != 0.0 {
+                let ratio = trend / level;
+                if ratio > rel_thresh {
+                    return Ok(Some(Direction::Rising));
+                } else if ratio < -rel_thresh {
+                    return Ok(Some(Direction::Falling));
+                }
+            }
+        }
+
+        Ok(Some(Direction::Neutral))
+    }
+
+    /// Current smoothed level, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn level(&self) -> Option<f64> {
+        self.holt.level()
+    }
+
+    /// Current trend (rate of change), or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn trend(&self) -> Option<f64> {
+        self.holt.trend()
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.holt.count()
+    }
+
+    /// Whether enough data has been collected.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.holt.count() >= self.min_samples
+    }
+
+    /// Resets to empty state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.holt.reset();
+    }
+
+    /// Updates the absolute trend threshold without resetting state.
+    ///
+    /// # Errors
+    ///
+    /// Threshold must be >= 0.
+    #[inline]
+    pub fn reconfigure_threshold(
+        &mut self,
+        threshold: f64,
+    ) -> Result<(), nexus_stats_core::ConfigError> {
+        if threshold < 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "threshold must be non-negative",
+            ));
+        }
+        self.trend_threshold_abs = Some(threshold);
+        Ok(())
+    }
+}
+
+impl TrendAlertF64Builder {
+    /// Level smoothing factor (Holt's alpha).
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Trend smoothing factor (Holt's beta).
+    #[inline]
+    #[must_use]
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.beta = Some(beta);
+        self
+    }
+
+    /// Absolute trend threshold. Alert when `|trend| > threshold`.
+    #[inline]
+    #[must_use]
+    pub fn trend_threshold(mut self, threshold: f64) -> Self {
+        self.trend_threshold_abs = Some(threshold);
+        self
+    }
+
+    /// Relative trend threshold. Alert when `|trend / level| > fraction`.
+    #[inline]
+    #[must_use]
+    pub fn trend_threshold_relative(mut self, fraction: f64) -> Self {
+        self.trend_threshold_rel = Some(fraction);
+        self
+    }
+
+    /// Minimum samples before detection activates. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the trend alert detector.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha and beta must have been set.
+    /// - At least one threshold (absolute or relative) must be set.
+    #[inline]
+    pub fn build(self) -> Result<TrendAlertF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        let beta = self
+            .beta
+            .ok_or(nexus_stats_core::ConfigError::Missing("beta"))?;
+        if self.trend_threshold_abs.is_none() && self.trend_threshold_rel.is_none() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "TrendAlert requires a trend threshold",
+            ));
+        }
+
+        let holt = HoltF64::builder()
+            .alpha(alpha)
+            .beta(beta)
+            .min_samples(self.min_samples)
+            .build()?;
+
+        Ok(TrendAlertF64 {
+            holt,
+            trend_threshold_abs: self.trend_threshold_abs,
+            trend_threshold_rel: self.trend_threshold_rel,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -327,20 +318,6 @@ mod tests {
         }
         ta.reset();
         assert_eq!(ta.count(), 0);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut ta = TrendAlertF32::builder()
-            .alpha(0.3)
-            .beta(0.1)
-            .trend_threshold(1.0)
-            .build()
-            .unwrap();
-
-        let _ = ta.update(10.0);
-        let _ = ta.update(20.0);
-        assert!(ta.is_primed());
     }
 
     #[test]

--- a/nexus-stats-smoothing/CHANGELOG.md
+++ b/nexus-stats-smoothing/CHANGELOG.md
@@ -10,6 +10,20 @@ contained.
 
 ## [Unreleased]
 
+### Removed
+
+- `HoltF32`, `HoltF32Builder` — use `HoltF64` (f32 is a precision footgun for accumulating smoothers)
+- `SpringF32` — use `SpringF64`
+- `Kalman1dF32`, `Kalman1dF32Builder` — use `Kalman1dF64`
+- `KamaF32`, `KamaF32Builder` — use `KamaF64`
+- `WindowedMedianF32` — use `WindowedMedianF64`
+- `WindowedMedianI32` — use `WindowedMedianI64`
+
+### Changed
+
+- `WindowedMedianI64::modified_z_score` now returns `Option<f64>` (was `Option<i64>`) to include the 0.6745 scale factor
+- `Kalman1dF64Builder::build` now rejects NaN/infinite process and measurement noise
+
 ## [1.2.3] — 2026-05-26
 
 ## [1.2.1] and earlier

--- a/nexus-stats-smoothing/src/holt.rs
+++ b/nexus-stats-smoothing/src/holt.rs
@@ -1,235 +1,227 @@
 use nexus_stats_core::math::MulAdd;
-macro_rules! impl_holt {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Holt's Double Exponential Smoothing — level + trend tracking.
-        ///
-        /// Separates the signal into level (current smoothed value) and trend
-        /// (rate of change). Detects not just "value is high" but "value is
-        /// getting worse over time."
-        ///
-        /// # Use Cases
-        /// - Trend detection ("latency is increasing linearly")
-        /// - Capacity planning and degradation forecasting
-        /// - Adaptive baselines that track drift
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            beta: $ty,
-            one_minus_alpha: $ty,
-            one_minus_beta: $ty,
-            level: $ty,
-            trend: $ty,
-            count: u64,
-            min_samples: u64,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            beta: Option<$ty>,
-            min_samples: u64,
-            seed_level: Option<$ty>,
-            seed_trend: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    beta: Option::None,
-                    min_samples: 2,
-                    seed_level: Option::None,
-                    seed_trend: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns `(level, trend)` once primed.
-            ///
-            /// First sample sets the level. Second sample initializes the trend.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                sample: $ty,
-            ) -> Result<Option<($ty, $ty)>, nexus_stats_core::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.level = sample;
-                    self.trend = 0.0 as $ty;
-                } else if self.count == 2 {
-                    let prev_level = self.level;
-                    self.level = sample;
-                    self.trend = sample - prev_level;
-                } else {
-                    let prev_level = self.level;
-                    // Level: alpha * sample + (1 - alpha) * (prev_level + prev_trend)
-                    self.level = self
-                        .alpha
-                        .fma(sample, self.one_minus_alpha * (prev_level + self.trend));
-                    // Trend: beta * (level - prev_level) + (1 - beta) * prev_trend
-                    self.trend = self
-                        .beta
-                        .fma(self.level - prev_level, self.one_minus_beta * self.trend);
-                }
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some((self.level, self.trend)))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Current smoothed level, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn level(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.level)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Current trend (rate of change), or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn trend(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.trend)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Forecast: `level + steps * trend`. Or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn forecast(&self, steps: u64) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.trend.fma(steps as $ty, self.level))
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether Holt's has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state. Parameters unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.level = 0.0 as $ty;
-                self.trend = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Level smoothing factor. Must be in (0, 1) exclusive.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Trend smoothing factor. Must be in (0, 1) exclusive.
-            #[inline]
-            #[must_use]
-            pub fn beta(mut self, beta: $ty) -> Self {
-                self.beta = Option::Some(beta);
-                self
-            }
-
-            /// Minimum samples before values are valid. Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-loads the level and trend from calibration data.
-            ///
-            /// When seeded, `is_primed()` returns true immediately.
-            #[inline]
-            #[must_use]
-            pub fn seed(mut self, level: $ty, trend: $ty) -> Self {
-                self.seed_level = Option::Some(level);
-                self.seed_trend = Option::Some(trend);
-                self
-            }
-
-            /// Builds the Holt's smoother.
-            ///
-            /// # Errors
-            ///
-            /// - Alpha and beta must have been set.
-            /// - Both must be in (0, 1) exclusive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                let beta = self
-                    .beta
-                    .ok_or(nexus_stats_core::ConfigError::Missing("beta"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "Holt alpha must be in (0, 1)",
-                    ));
-                }
-                if !(beta > 0.0 as $ty && beta < 1.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "Holt beta must be in (0, 1)",
-                    ));
-                }
-
-                let (level, trend, count) = match (self.seed_level, self.seed_trend) {
-                    (Some(l), Some(t)) => (l, t, self.min_samples),
-                    _ => (0.0 as $ty, 0.0 as $ty, 0),
-                };
-
-                Ok($name {
-                    alpha,
-                    beta,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    one_minus_beta: 1.0 as $ty - beta,
-                    level,
-                    trend,
-                    count,
-                    min_samples: self.min_samples,
-                })
-            }
-        }
-    };
+/// Holt's Double Exponential Smoothing — level + trend tracking.
+///
+/// Separates the signal into level (current smoothed value) and trend
+/// (rate of change). Detects not just "value is high" but "value is
+/// getting worse over time."
+///
+/// # Use Cases
+/// - Trend detection ("latency is increasing linearly")
+/// - Capacity planning and degradation forecasting
+/// - Adaptive baselines that track drift
+#[derive(Debug, Clone)]
+pub struct HoltF64 {
+    alpha: f64,
+    beta: f64,
+    one_minus_alpha: f64,
+    one_minus_beta: f64,
+    level: f64,
+    trend: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_holt!(HoltF64, HoltF64Builder, f64);
-impl_holt!(HoltF32, HoltF32Builder, f32);
+/// Builder for [`HoltF64`].
+#[derive(Debug, Clone)]
+pub struct HoltF64Builder {
+    alpha: Option<f64>,
+    beta: Option<f64>,
+    min_samples: u64,
+    seed_level: Option<f64>,
+    seed_trend: Option<f64>,
+}
+
+impl HoltF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> HoltF64Builder {
+        HoltF64Builder {
+            alpha: None,
+            beta: None,
+            min_samples: 2,
+            seed_level: None,
+            seed_trend: None,
+        }
+    }
+
+    /// Feeds a sample. Returns `(level, trend)` once primed.
+    ///
+    /// First sample sets the level. Second sample initializes the trend.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        sample: f64,
+    ) -> Result<Option<(f64, f64)>, nexus_stats_core::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.level = sample;
+            self.trend = 0.0;
+        } else if self.count == 2 {
+            let prev_level = self.level;
+            self.level = sample;
+            self.trend = sample - prev_level;
+        } else {
+            let prev_level = self.level;
+            // Level: alpha * sample + (1 - alpha) * (prev_level + prev_trend)
+            self.level = self
+                .alpha
+                .fma(sample, self.one_minus_alpha * (prev_level + self.trend));
+            // Trend: beta * (level - prev_level) + (1 - beta) * prev_trend
+            self.trend = self
+                .beta
+                .fma(self.level - prev_level, self.one_minus_beta * self.trend);
+        }
+
+        if self.count >= self.min_samples {
+            Ok(Some((self.level, self.trend)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current smoothed level, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn level(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.level)
+        } else {
+            None
+        }
+    }
+
+    /// Current trend (rate of change), or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn trend(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.trend)
+        } else {
+            None
+        }
+    }
+
+    /// Forecast: `level + steps * trend`. Or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn forecast(&self, steps: u64) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.trend.fma(steps as f64, self.level))
+        } else {
+            None
+        }
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether Holt's has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state. Parameters unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.level = 0.0;
+        self.trend = 0.0;
+        self.count = 0;
+    }
+}
+
+impl HoltF64Builder {
+    /// Level smoothing factor. Must be in (0, 1) exclusive.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Trend smoothing factor. Must be in (0, 1) exclusive.
+    #[inline]
+    #[must_use]
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.beta = Some(beta);
+        self
+    }
+
+    /// Minimum samples before values are valid. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Pre-loads the level and trend from calibration data.
+    ///
+    /// When seeded, `is_primed()` returns true immediately.
+    #[inline]
+    #[must_use]
+    pub fn seed(mut self, level: f64, trend: f64) -> Self {
+        self.seed_level = Some(level);
+        self.seed_trend = Some(trend);
+        self
+    }
+
+    /// Builds the Holt's smoother.
+    ///
+    /// # Errors
+    ///
+    /// - Alpha and beta must have been set.
+    /// - Both must be in (0, 1) exclusive.
+    #[inline]
+    pub fn build(self) -> Result<HoltF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        let beta = self
+            .beta
+            .ok_or(nexus_stats_core::ConfigError::Missing("beta"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "Holt alpha must be in (0, 1)",
+            ));
+        }
+        if !(beta > 0.0 && beta < 1.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "Holt beta must be in (0, 1)",
+            ));
+        }
+
+        let (level, trend, count) = match (self.seed_level, self.seed_trend) {
+            (Some(l), Some(t)) => (l, t, self.min_samples),
+            _ => (0.0, 0.0, 0),
+        };
+
+        Ok(HoltF64 {
+            alpha,
+            beta,
+            one_minus_alpha: 1.0 - alpha,
+            one_minus_beta: 1.0 - beta,
+            level,
+            trend,
+            count,
+            min_samples: self.min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -302,14 +294,6 @@ mod tests {
         assert_eq!(h.count(), 0);
         assert!(h.level().is_none());
         assert!(h.trend().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut h = HoltF32::builder().alpha(0.3).beta(0.1).build().unwrap();
-        h.update(10.0).unwrap();
-        let result = h.update(20.0).unwrap();
-        assert!(result.is_some());
     }
 
     #[test]

--- a/nexus-stats-smoothing/src/kalman1d.rs
+++ b/nexus-stats-smoothing/src/kalman1d.rs
@@ -1,281 +1,273 @@
 use nexus_stats_core::math::MulAdd;
-macro_rules! impl_kalman1d {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// 1D Kalman filter with constant-velocity model.
-        ///
-        /// Tracks position and velocity from noisy measurements.
-        /// Automatically balances process noise (system uncertainty) against
-        /// measurement noise (sensor uncertainty).
-        ///
-        /// # Timing assumption
-        ///
-        /// This filter assumes **dt = 1** between consecutive measurements.
-        /// For variable-interval data, either:
-        /// - Scale `process_noise` proportionally to the actual interval
-        /// - Pre-normalize timestamps so samples arrive at uniform intervals
-        ///
-        /// # Use Cases
-        /// - Smoothing noisy position/latency measurements
-        /// - Estimating rate of change (velocity) from noisy data
-        /// - Predictive filtering (forecast next value)
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            // State: [position, velocity]
-            x0: $ty,
-            x1: $ty,
-            // Covariance: symmetric 2x2 → 3 values (P00, P01, P11)
-            p00: $ty,
-            p01: $ty,
-            p11: $ty,
-            // Noise parameters
-            q: $ty, // process noise
-            r: $ty, // measurement noise
-            count: u64,
-            min_samples: u64,
-            initialized: bool,
-        }
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            q: Option<$ty>,
-            r: Option<$ty>,
-            min_samples: u64,
-            seed_pos: Option<$ty>,
-            seed_vel: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    q: Option::None,
-                    r: Option::None,
-                    min_samples: 1,
-                    seed_pos: Option::None,
-                    seed_vel: Option::None,
-                }
-            }
-
-            /// Feeds a measurement. Returns `(position, velocity)` once primed.
-            ///
-            /// Assumes dt = 1 between measurements. For variable dt, scale
-            /// the process noise or pre-process timestamps.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the measurement is NaN, or
-            /// `DataError::Infinite` if the measurement is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                measurement: $ty,
-            ) -> Result<Option<($ty, $ty)>, nexus_stats_core::DataError> {
-                check_finite!(measurement);
-                self.count += 1;
-
-                if !self.initialized {
-                    // Initialize from first measurement
-                    self.x0 = measurement;
-                    self.x1 = 0.0 as $ty;
-                    self.p00 = self.r;
-                    self.p01 = 0.0 as $ty;
-                    self.p11 = 1.0 as $ty;
-                    self.initialized = true;
-
-                    return if self.count >= self.min_samples {
-                        Ok(Option::Some((self.x0, self.x1)))
-                    } else {
-                        Ok(Option::None)
-                    };
-                }
-
-                // Predict step (constant velocity model, dt=1)
-                // x_pred = F * x = [x0 + x1, x1]
-                let pred_x0 = self.x0 + self.x1;
-                let pred_x1 = self.x1;
-
-                // P_pred = F * P * F' + Q
-                let pred_p00 = (2.0 as $ty).fma(self.p01, self.p00) + self.p11 + self.q;
-                let pred_p01 = self.p01 + self.p11;
-                let pred_p11 = self.p11 + self.q;
-
-                // Update step
-                // Innovation: y = z - H * x_pred (H = [1, 0])
-                let y = measurement - pred_x0;
-
-                // Innovation covariance: S = H * P_pred * H' + R = P00 + R
-                let s_inv = (1.0 as $ty) / (pred_p00 + self.r).max(<$ty>::EPSILON);
-
-                // Kalman gain: K = P_pred * H' / S = [P00/S, P01/S]
-                let k0 = pred_p00 * s_inv;
-                let k1 = pred_p01 * s_inv;
-
-                // State update: x = x_pred + K * y
-                self.x0 = k0.fma(y, pred_x0);
-                self.x1 = k1.fma(y, pred_x1);
-
-                // Covariance update: P = (I - K*H) * P_pred
-                let one_minus_k0 = 1.0 as $ty - k0;
-                self.p00 = one_minus_k0 * pred_p00;
-                self.p01 = one_minus_k0 * pred_p01;
-                self.p11 = pred_p11 - k1 * pred_p01;
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some((self.x0, self.x1)))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Estimated position, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn position(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.x0)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Estimated velocity, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn velocity(&self) -> Option<$ty> {
-                if self.count >= self.min_samples {
-                    Option::Some(self.x1)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Position uncertainty (P00).
-            #[inline]
-            #[must_use]
-            pub fn uncertainty(&self) -> $ty {
-                self.p00
-            }
-
-            /// Number of measurements processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether the filter has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count >= self.min_samples
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.x0 = 0.0 as $ty;
-                self.x1 = 0.0 as $ty;
-                self.p00 = 1.0 as $ty;
-                self.p01 = 0.0 as $ty;
-                self.p11 = 1.0 as $ty;
-                self.count = 0;
-                self.initialized = false;
-            }
-        }
-
-        impl $builder {
-            /// Process noise variance. Higher = more reactive to changes.
-            ///
-            /// The filter assumes dt=1 between samples. For variable-interval
-            /// data, scale this value proportionally to the actual interval.
-            #[inline]
-            #[must_use]
-            pub fn process_noise(mut self, q: $ty) -> Self {
-                self.q = Option::Some(q);
-                self
-            }
-
-            /// Measurement noise variance. Higher = smoother output.
-            #[inline]
-            #[must_use]
-            pub fn measurement_noise(mut self, r: $ty) -> Self {
-                self.r = Option::Some(r);
-                self
-            }
-
-            /// Minimum measurements before output is valid. Default: 1.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = min;
-                self
-            }
-
-            /// Pre-load position and velocity from calibration.
-            #[inline]
-            #[must_use]
-            pub fn seed(mut self, position: $ty, velocity: $ty) -> Self {
-                self.seed_pos = Option::Some(position);
-                self.seed_vel = Option::Some(velocity);
-                self
-            }
-
-            /// Builds the Kalman filter.
-            ///
-            /// # Errors
-            ///
-            /// - process_noise and measurement_noise must have been set.
-            /// - Both must be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let q = self
-                    .q
-                    .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
-                let r = self
-                    .r
-                    .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
-                if q <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "process_noise must be positive",
-                    ));
-                }
-                if r <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "measurement_noise must be positive",
-                    ));
-                }
-
-                let (x0, x1, count, initialized) =
-                    if let (Some(pos), Some(vel)) = (self.seed_pos, self.seed_vel) {
-                        (pos, vel, self.min_samples, true)
-                    } else {
-                        (0.0 as $ty, 0.0 as $ty, 0, false)
-                    };
-
-                Ok($name {
-                    x0,
-                    x1,
-                    p00: 1.0 as $ty,
-                    p01: 0.0 as $ty,
-                    p11: 1.0 as $ty,
-                    q,
-                    r,
-                    count,
-                    min_samples: self.min_samples,
-                    initialized,
-                })
-            }
-        }
-    };
+/// 1D Kalman filter with constant-velocity model.
+///
+/// Tracks position and velocity from noisy measurements.
+/// Automatically balances process noise (system uncertainty) against
+/// measurement noise (sensor uncertainty).
+///
+/// # Timing assumption
+///
+/// This filter assumes **dt = 1** between consecutive measurements.
+/// For variable-interval data, either:
+/// - Scale `process_noise` proportionally to the actual interval
+/// - Pre-normalize timestamps so samples arrive at uniform intervals
+///
+/// # Use Cases
+/// - Smoothing noisy position/latency measurements
+/// - Estimating rate of change (velocity) from noisy data
+/// - Predictive filtering (forecast next value)
+#[derive(Debug, Clone)]
+pub struct Kalman1dF64 {
+    // State: [position, velocity]
+    x0: f64,
+    x1: f64,
+    // Covariance: symmetric 2x2 -> 3 values (P00, P01, P11)
+    p00: f64,
+    p01: f64,
+    p11: f64,
+    // Noise parameters
+    q: f64, // process noise
+    r: f64, // measurement noise
+    count: u64,
+    min_samples: u64,
+    initialized: bool,
 }
 
-impl_kalman1d!(Kalman1dF64, Kalman1dF64Builder, f64);
-impl_kalman1d!(Kalman1dF32, Kalman1dF32Builder, f32);
+/// Builder for [`Kalman1dF64`].
+#[derive(Debug, Clone)]
+pub struct Kalman1dF64Builder {
+    q: Option<f64>,
+    r: Option<f64>,
+    min_samples: u64,
+    seed_pos: Option<f64>,
+    seed_vel: Option<f64>,
+}
+
+impl Kalman1dF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> Kalman1dF64Builder {
+        Kalman1dF64Builder {
+            q: None,
+            r: None,
+            min_samples: 1,
+            seed_pos: None,
+            seed_vel: None,
+        }
+    }
+
+    /// Feeds a measurement. Returns `(position, velocity)` once primed.
+    ///
+    /// Assumes dt = 1 between measurements. For variable dt, scale
+    /// the process noise or pre-process timestamps.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the measurement is NaN, or
+    /// `DataError::Infinite` if the measurement is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        measurement: f64,
+    ) -> Result<Option<(f64, f64)>, nexus_stats_core::DataError> {
+        check_finite!(measurement);
+        self.count += 1;
+
+        if !self.initialized {
+            // Initialize from first measurement
+            self.x0 = measurement;
+            self.x1 = 0.0;
+            self.p00 = self.r;
+            self.p01 = 0.0;
+            self.p11 = 1.0;
+            self.initialized = true;
+
+            return if self.count >= self.min_samples {
+                Ok(Some((self.x0, self.x1)))
+            } else {
+                Ok(None)
+            };
+        }
+
+        // Predict step (constant velocity model, dt=1)
+        // x_pred = F * x = [x0 + x1, x1]
+        let pred_x0 = self.x0 + self.x1;
+        let pred_x1 = self.x1;
+
+        // P_pred = F * P * F' + Q
+        let pred_p00 = 2.0f64.fma(self.p01, self.p00) + self.p11 + self.q;
+        let pred_p01 = self.p01 + self.p11;
+        let pred_p11 = self.p11 + self.q;
+
+        // Update step
+        // Innovation: y = z - H * x_pred (H = [1, 0])
+        let y = measurement - pred_x0;
+
+        // Innovation covariance: S = H * P_pred * H' + R = P00 + R
+        let s_inv = 1.0 / (pred_p00 + self.r).max(f64::EPSILON);
+
+        // Kalman gain: K = P_pred * H' / S = [P00/S, P01/S]
+        let k0 = pred_p00 * s_inv;
+        let k1 = pred_p01 * s_inv;
+
+        // State update: x = x_pred + K * y
+        self.x0 = k0.fma(y, pred_x0);
+        self.x1 = k1.fma(y, pred_x1);
+
+        // Covariance update: P = (I - K*H) * P_pred
+        let one_minus_k0 = 1.0 - k0;
+        self.p00 = one_minus_k0 * pred_p00;
+        self.p01 = one_minus_k0 * pred_p01;
+        self.p11 = pred_p11 - k1 * pred_p01;
+
+        if self.count >= self.min_samples {
+            Ok(Some((self.x0, self.x1)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Estimated position, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn position(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.x0)
+        } else {
+            None
+        }
+    }
+
+    /// Estimated velocity, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn velocity(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.x1)
+        } else {
+            None
+        }
+    }
+
+    /// Position uncertainty (P00).
+    #[inline]
+    #[must_use]
+    pub fn uncertainty(&self) -> f64 {
+        self.p00
+    }
+
+    /// Number of measurements processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the filter has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.x0 = 0.0;
+        self.x1 = 0.0;
+        self.p00 = 1.0;
+        self.p01 = 0.0;
+        self.p11 = 1.0;
+        self.count = 0;
+        self.initialized = false;
+    }
+}
+
+impl Kalman1dF64Builder {
+    /// Process noise variance. Higher = more reactive to changes.
+    ///
+    /// The filter assumes dt=1 between samples. For variable-interval
+    /// data, scale this value proportionally to the actual interval.
+    #[inline]
+    #[must_use]
+    pub fn process_noise(mut self, q: f64) -> Self {
+        self.q = Some(q);
+        self
+    }
+
+    /// Measurement noise variance. Higher = smoother output.
+    #[inline]
+    #[must_use]
+    pub fn measurement_noise(mut self, r: f64) -> Self {
+        self.r = Some(r);
+        self
+    }
+
+    /// Minimum measurements before output is valid. Default: 1.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Pre-load position and velocity from calibration.
+    #[inline]
+    #[must_use]
+    pub fn seed(mut self, position: f64, velocity: f64) -> Self {
+        self.seed_pos = Some(position);
+        self.seed_vel = Some(velocity);
+        self
+    }
+
+    /// Builds the Kalman filter.
+    ///
+    /// # Errors
+    ///
+    /// - process_noise and measurement_noise must have been set.
+    /// - Both must be positive.
+    #[inline]
+    pub fn build(self) -> Result<Kalman1dF64, nexus_stats_core::ConfigError> {
+        let q = self
+            .q
+            .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
+        let r = self
+            .r
+            .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
+        if q <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "process_noise must be positive",
+            ));
+        }
+        if r <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "measurement_noise must be positive",
+            ));
+        }
+
+        let (x0, x1, count, initialized) =
+            if let (Some(pos), Some(vel)) = (self.seed_pos, self.seed_vel) {
+                (pos, vel, self.min_samples, true)
+            } else {
+                (0.0, 0.0, 0, false)
+            };
+
+        Ok(Kalman1dF64 {
+            x0,
+            x1,
+            p00: 1.0,
+            p01: 0.0,
+            p11: 1.0,
+            q,
+            r,
+            count,
+            min_samples: self.min_samples,
+            initialized,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -394,18 +386,6 @@ mod tests {
         }
         kf.reset();
         assert_eq!(kf.count(), 0);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut kf = Kalman1dF32::builder()
-            .process_noise(0.1)
-            .measurement_noise(1.0)
-            .build()
-            .unwrap();
-
-        kf.update(50.0).unwrap();
-        assert!(kf.position().is_some());
     }
 
     #[test]

--- a/nexus-stats-smoothing/src/kalman1d.rs
+++ b/nexus-stats-smoothing/src/kalman1d.rs
@@ -236,14 +236,14 @@ impl Kalman1dF64Builder {
         let r = self
             .r
             .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
-        if q <= 0.0 {
+        if !q.is_finite() || q <= 0.0 {
             return Err(nexus_stats_core::ConfigError::Invalid(
-                "process_noise must be positive",
+                "process_noise must be finite and positive",
             ));
         }
-        if r <= 0.0 {
+        if !r.is_finite() || r <= 0.0 {
             return Err(nexus_stats_core::ConfigError::Invalid(
-                "measurement_noise must be positive",
+                "measurement_noise must be finite and positive",
             ));
         }
 

--- a/nexus-stats-smoothing/src/kama.rs
+++ b/nexus-stats-smoothing/src/kama.rs
@@ -1,327 +1,346 @@
 use nexus_stats_core::math::MulAdd;
 
-macro_rules! impl_kama {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// KAMA — Kaufman Adaptive Moving Average.
-        ///
-        /// EMA with an efficiency-ratio-driven alpha. In trending markets,
-        /// the alpha increases (fast response). In noisy/choppy markets,
-        /// the alpha decreases (slow response).
-        ///
-        /// The efficiency ratio = |direction| / volatility, where:
-        /// - direction = price_now - price_N_ago
-        /// - volatility = sum of |price_i - price_{i-1}| over N periods
-        ///
-        /// The window size is specified at runtime via the builder. The ring
-        /// buffer is heap-allocated once during `build()` — no allocation
-        /// after construction.
-        ///
-        /// # Use Cases
-        /// - Adaptive smoothing that auto-tunes to market conditions
-        /// - Noise-resistant trend following
-        /// - Signal processing with variable noise levels
-        pub struct $name {
-            ring: *mut $ty,
-            window: usize,
-            head: usize,
-            value: $ty,
-            fast_sc: $ty,
-            slow_sc: $ty,
-            sc_range: $ty,
-            volatility_sum: $ty,
-            count: u64,
-            min_samples: u64,
-        }
-
-        // SAFETY: buffer is exclusively owned, T is Copy + Send
-        unsafe impl Send for $name {}
-
-        impl $name {
-            #[inline]
-            fn ring(&self) -> &[$ty] {
-                // SAFETY: buffer allocated with capacity `window`, all elements initialized
-                unsafe { core::slice::from_raw_parts(self.ring, self.window) }
-            }
-
-            #[inline]
-            fn ring_mut(&mut self) -> &mut [$ty] {
-                // SAFETY: buffer exclusively owned, all elements initialized
-                unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
-            }
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            window: Option<usize>,
-            fast_span: u64,
-            slow_span: u64,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    window: Option::None,
-                    fast_span: 2,
-                    slow_span: 30,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Feeds a sample. Returns the adaptive smoothed value once primed.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<Option<$ty>, nexus_stats_core::DataError> {
-                check_finite!(sample);
-                let n = self.window;
-                let idx = (self.count as usize) % n;
-                // SAFETY: idx is in [0, window), buffer exclusively owned
-                unsafe { *self.ring.add(idx) = sample; }
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.value = sample;
-                    return if self.count >= self.min_samples { Ok(Option::Some(self.value)) } else { Ok(Option::None) };
-                }
-
-                if self.count <= n as u64 {
-                    self.value = sample;
-                    return if self.count >= self.min_samples { Ok(Option::Some(self.value)) } else { Ok(Option::None) };
-                }
-
-                // Window is full — compute ER from the ring buffer
-                // SAFETY: buffer allocated with capacity `window`, all initialized
-                let ring = unsafe { core::slice::from_raw_parts(self.ring, n) };
-
-                // The ring is ordered: oldest at (idx+1)%n, newest at idx.
-                // Split into two contiguous slices to avoid modular indexing
-                // per iteration, enabling SIMD vectorization.
-                let oldest = (idx + 1) % n;
-
-                // Compute volatility: sum of |consecutive differences| in ring order
-                let mut volatility = 0.0 as $ty;
-
-                // Slice 1: oldest..end of buffer
-                let s1 = &ring[oldest..];
-                for w in s1.windows(2) {
-                    volatility += (w[1] - w[0]).abs();
-                }
-
-                // Bridge: last element of s1 to first element of s2
-                if oldest > 0 && !s1.is_empty() {
-                    volatility += (ring[0] - s1[s1.len() - 1]).abs();
-                }
-
-                // Slice 2: start..oldest (the wrap-around portion)
-                let s2 = &ring[..oldest];
-                for w in s2.windows(2) {
-                    volatility += (w[1] - w[0]).abs();
-                }
-
-                // Direction: |newest - oldest|
-                let direction = (sample - ring[oldest]).abs();
-                self.volatility_sum = volatility;
-                let er = if volatility > 0.0 as $ty {
-                    direction / volatility
-                } else {
-                    0.0 as $ty
-                };
-
-                // Smoothing constant: sc = (er * sc_range + slow)^2
-                let sc = er * self.sc_range + self.slow_sc;
-                let alpha = sc * sc;
-
-                self.value = alpha.fma(sample - self.value, self.value);
-
-                if self.count >= self.min_samples {
-                    Ok(Option::Some(self.value))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Current adaptive smoothed value, or `None` if not primed.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> Option<$ty> {
-                if self.count >= self.min_samples { Option::Some(self.value) } else { Option::None }
-            }
-
-            /// Current efficiency ratio (0 to 1), or `None` if < window samples.
-            #[inline]
-            #[must_use]
-            pub fn efficiency_ratio(&self) -> Option<$ty> {
-                let n = self.window;
-                if self.count <= n as u64 {
-                    return Option::None;
-                }
-                let newest_idx = ((self.count - 1) as usize) % n;
-                let oldest_idx = (self.count as usize) % n;
-                let ring = self.ring();
-                let direction = (ring[newest_idx] - ring[oldest_idx]).abs();
-                if self.volatility_sum > 0.0 as $ty {
-                    Option::Some(direction / self.volatility_sum)
-                } else {
-                    Option::Some(0.0 as $ty)
-                }
-            }
-
-            /// Window size.
-            #[inline]
-            #[must_use]
-            pub fn window_size(&self) -> usize { self.window }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 { self.count }
-
-            /// Whether the KAMA has reached `min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool { self.count >= self.min_samples }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.ring_mut().fill(0.0 as $ty);
-                self.head = 0;
-                self.value = 0.0 as $ty;
-                self.volatility_sum = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Window size (number of samples in the ring buffer).
-            #[inline]
-            #[must_use]
-            pub fn window_size(mut self, n: usize) -> Self {
-                self.window = Option::Some(n);
-                self
-            }
-
-            /// Fast EMA span (most reactive). Default: 2.
-            #[inline]
-            #[must_use]
-            pub fn fast_span(mut self, n: u64) -> Self {
-                self.fast_span = n;
-                self
-            }
-
-            /// Slow EMA span (least reactive). Default: 30.
-            #[inline]
-            #[must_use]
-            pub fn slow_span(mut self, n: u64) -> Self {
-                self.slow_span = n;
-                self
-            }
-
-            /// Minimum samples before value is valid. Default: window size.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, min: u64) -> Self {
-                self.min_samples = Option::Some(min);
-                self
-            }
-
-            /// Builds the KAMA.
-            ///
-            /// # Errors
-            ///
-            /// - Window size must have been set and > 0.
-            /// - `fast_span` must be >= 1.
-            /// - `slow_span` must be > `fast_span`.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let window = self.window.ok_or(nexus_stats_core::ConfigError::Missing("window_size"))?;
-                if window == 0 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("window_size must be > 0"));
-                }
-                if self.fast_span < 1 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("fast_span must be >= 1"));
-                }
-                if self.slow_span <= self.fast_span {
-                    return Err(nexus_stats_core::ConfigError::Invalid("slow_span must be > fast_span"));
-                }
-                let min_samples = self.min_samples.unwrap_or(window as u64);
-
-                let mut vec = core::mem::ManuallyDrop::new(alloc::vec![0.0 as $ty; window]);
-                let ring = vec.as_mut_ptr();
-
-                let fast_sc = 2.0 as $ty / (self.fast_span as $ty + 1.0 as $ty);
-                let slow_sc = 2.0 as $ty / (self.slow_span as $ty + 1.0 as $ty);
-
-                Ok($name {
-                    ring,
-                    window,
-                    head: 0,
-                    value: 0.0 as $ty,
-                    fast_sc,
-                    slow_sc,
-                    sc_range: fast_sc - slow_sc,
-                    volatility_sum: 0.0 as $ty,
-                    count: 0,
-                    min_samples,
-                })
-            }
-        }
-
-        impl Drop for $name {
-            fn drop(&mut self) {
-                // SAFETY: buffer was allocated by Vec with capacity `window`.
-                // T is Copy so no element drops needed. Reclaim the allocation.
-                unsafe {
-                    let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
-                }
-            }
-        }
-
-        impl Clone for $name {
-            fn clone(&self) -> Self {
-                let mut vec = alloc::vec![0.0 as $ty; self.window];
-                vec.copy_from_slice(self.ring());
-                let mut cloned = core::mem::ManuallyDrop::new(vec);
-                let ring = cloned.as_mut_ptr();
-                Self {
-                    ring,
-                    window: self.window,
-                    head: self.head,
-                    value: self.value,
-                    fast_sc: self.fast_sc,
-                    slow_sc: self.slow_sc,
-                    sc_range: self.sc_range,
-                    volatility_sum: self.volatility_sum,
-                    count: self.count,
-                    min_samples: self.min_samples,
-                }
-            }
-        }
-
-        impl core::fmt::Debug for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                f.debug_struct(stringify!($name))
-                    .field("window", &self.window)
-                    .field("count", &self.count)
-                    .field("value", &self.value)
-                    .finish()
-            }
-        }
-    };
+/// KAMA — Kaufman Adaptive Moving Average.
+///
+/// EMA with an efficiency-ratio-driven alpha. In trending markets,
+/// the alpha increases (fast response). In noisy/choppy markets,
+/// the alpha decreases (slow response).
+///
+/// The efficiency ratio = |direction| / volatility, where:
+/// - direction = price_now - price_N_ago
+/// - volatility = sum of |price_i - price_{i-1}| over N periods
+///
+/// The window size is specified at runtime via the builder. The ring
+/// buffer is heap-allocated once during `build()` — no allocation
+/// after construction.
+///
+/// # Use Cases
+/// - Adaptive smoothing that auto-tunes to market conditions
+/// - Noise-resistant trend following
+/// - Signal processing with variable noise levels
+pub struct KamaF64 {
+    ring: *mut f64,
+    window: usize,
+    head: usize,
+    value: f64,
+    fast_sc: f64,
+    slow_sc: f64,
+    sc_range: f64,
+    volatility_sum: f64,
+    count: u64,
+    min_samples: u64,
 }
 
-impl_kama!(KamaF64, KamaF64Builder, f64);
-impl_kama!(KamaF32, KamaF32Builder, f32);
+// SAFETY: buffer is exclusively owned, f64 is Copy + Send
+unsafe impl Send for KamaF64 {}
+
+impl KamaF64 {
+    #[inline]
+    fn ring(&self) -> &[f64] {
+        // SAFETY: buffer allocated with capacity `window`, all elements initialized
+        unsafe { core::slice::from_raw_parts(self.ring, self.window) }
+    }
+
+    #[inline]
+    fn ring_mut(&mut self) -> &mut [f64] {
+        // SAFETY: buffer exclusively owned, all elements initialized
+        unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
+    }
+}
+
+/// Builder for [`KamaF64`].
+#[derive(Debug, Clone)]
+pub struct KamaF64Builder {
+    window: Option<usize>,
+    fast_span: u64,
+    slow_span: u64,
+    min_samples: Option<u64>,
+}
+
+impl KamaF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> KamaF64Builder {
+        KamaF64Builder {
+            window: None,
+            fast_span: 2,
+            slow_span: 30,
+            min_samples: None,
+        }
+    }
+
+    /// Feeds a sample. Returns the adaptive smoothed value once primed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<Option<f64>, nexus_stats_core::DataError> {
+        check_finite!(sample);
+        let n = self.window;
+        let idx = (self.count as usize) % n;
+        // SAFETY: idx is in [0, window), buffer exclusively owned
+        unsafe {
+            *self.ring.add(idx) = sample;
+        }
+        self.count += 1;
+
+        if self.count == 1 {
+            self.value = sample;
+            return if self.count >= self.min_samples {
+                Ok(Some(self.value))
+            } else {
+                Ok(None)
+            };
+        }
+
+        if self.count <= n as u64 {
+            self.value = sample;
+            return if self.count >= self.min_samples {
+                Ok(Some(self.value))
+            } else {
+                Ok(None)
+            };
+        }
+
+        // Window is full — compute ER from the ring buffer
+        // SAFETY: buffer allocated with capacity `window`, all initialized
+        let ring = unsafe { core::slice::from_raw_parts(self.ring, n) };
+
+        // The ring is ordered: oldest at (idx+1)%n, newest at idx.
+        // Split into two contiguous slices to avoid modular indexing
+        // per iteration, enabling SIMD vectorization.
+        let oldest = (idx + 1) % n;
+
+        // Compute volatility: sum of |consecutive differences| in ring order
+        let mut volatility = 0.0;
+
+        // Slice 1: oldest..end of buffer
+        let s1 = &ring[oldest..];
+        for w in s1.windows(2) {
+            volatility += (w[1] - w[0]).abs();
+        }
+
+        // Bridge: last element of s1 to first element of s2
+        if oldest > 0 && !s1.is_empty() {
+            volatility += (ring[0] - s1[s1.len() - 1]).abs();
+        }
+
+        // Slice 2: start..oldest (the wrap-around portion)
+        let s2 = &ring[..oldest];
+        for w in s2.windows(2) {
+            volatility += (w[1] - w[0]).abs();
+        }
+
+        // Direction: |newest - oldest|
+        let direction = (sample - ring[oldest]).abs();
+        self.volatility_sum = volatility;
+        let er = if volatility > 0.0 {
+            direction / volatility
+        } else {
+            0.0
+        };
+
+        // Smoothing constant: sc = (er * sc_range + slow)^2
+        let sc = er * self.sc_range + self.slow_sc;
+        let alpha = sc * sc;
+
+        self.value = alpha.fma(sample - self.value, self.value);
+
+        if self.count >= self.min_samples {
+            Ok(Some(self.value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current adaptive smoothed value, or `None` if not primed.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> Option<f64> {
+        if self.count >= self.min_samples {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// Current efficiency ratio (0 to 1), or `None` if < window samples.
+    #[inline]
+    #[must_use]
+    pub fn efficiency_ratio(&self) -> Option<f64> {
+        let n = self.window;
+        if self.count <= n as u64 {
+            return None;
+        }
+        let newest_idx = ((self.count - 1) as usize) % n;
+        let oldest_idx = (self.count as usize) % n;
+        let ring = self.ring();
+        let direction = (ring[newest_idx] - ring[oldest_idx]).abs();
+        if self.volatility_sum > 0.0 {
+            Some(direction / self.volatility_sum)
+        } else {
+            Some(0.0)
+        }
+    }
+
+    /// Window size.
+    #[inline]
+    #[must_use]
+    pub fn window_size(&self) -> usize {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the KAMA has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.ring_mut().fill(0.0);
+        self.head = 0;
+        self.value = 0.0;
+        self.volatility_sum = 0.0;
+        self.count = 0;
+    }
+}
+
+impl KamaF64Builder {
+    /// Window size (number of samples in the ring buffer).
+    #[inline]
+    #[must_use]
+    pub fn window_size(mut self, n: usize) -> Self {
+        self.window = Some(n);
+        self
+    }
+
+    /// Fast EMA span (most reactive). Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn fast_span(mut self, n: u64) -> Self {
+        self.fast_span = n;
+        self
+    }
+
+    /// Slow EMA span (least reactive). Default: 30.
+    #[inline]
+    #[must_use]
+    pub fn slow_span(mut self, n: u64) -> Self {
+        self.slow_span = n;
+        self
+    }
+
+    /// Minimum samples before value is valid. Default: window size.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = Some(min);
+        self
+    }
+
+    /// Builds the KAMA.
+    ///
+    /// # Errors
+    ///
+    /// - Window size must have been set and > 0.
+    /// - `fast_span` must be >= 1.
+    /// - `slow_span` must be > `fast_span`.
+    #[inline]
+    pub fn build(self) -> Result<KamaF64, nexus_stats_core::ConfigError> {
+        let window = self
+            .window
+            .ok_or(nexus_stats_core::ConfigError::Missing("window_size"))?;
+        if window == 0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "window_size must be > 0",
+            ));
+        }
+        if self.fast_span < 1 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "fast_span must be >= 1",
+            ));
+        }
+        if self.slow_span <= self.fast_span {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "slow_span must be > fast_span",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(window as u64);
+
+        let mut vec = core::mem::ManuallyDrop::new(alloc::vec![0.0f64; window]);
+        let ring = vec.as_mut_ptr();
+
+        let fast_sc = 2.0 / (self.fast_span as f64 + 1.0);
+        let slow_sc = 2.0 / (self.slow_span as f64 + 1.0);
+
+        Ok(KamaF64 {
+            ring,
+            window,
+            head: 0,
+            value: 0.0,
+            fast_sc,
+            slow_sc,
+            sc_range: fast_sc - slow_sc,
+            volatility_sum: 0.0,
+            count: 0,
+            min_samples,
+        })
+    }
+}
+
+impl Drop for KamaF64 {
+    fn drop(&mut self) {
+        // SAFETY: buffer was allocated by Vec with capacity `window`.
+        // f64 is Copy so no element drops needed. Reclaim the allocation.
+        unsafe {
+            let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
+        }
+    }
+}
+
+impl Clone for KamaF64 {
+    fn clone(&self) -> Self {
+        let mut vec = alloc::vec![0.0f64; self.window];
+        vec.copy_from_slice(self.ring());
+        let mut cloned = core::mem::ManuallyDrop::new(vec);
+        let ring = cloned.as_mut_ptr();
+        Self {
+            ring,
+            window: self.window,
+            head: self.head,
+            value: self.value,
+            fast_sc: self.fast_sc,
+            slow_sc: self.slow_sc,
+            sc_range: self.sc_range,
+            volatility_sum: self.volatility_sum,
+            count: self.count,
+            min_samples: self.min_samples,
+        }
+    }
+}
+
+impl core::fmt::Debug for KamaF64 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KamaF64")
+            .field("window", &self.window)
+            .field("count", &self.count)
+            .field("value", &self.value)
+            .finish()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -384,15 +403,6 @@ mod tests {
         }
         kama.reset();
         assert_eq!(kama.count(), 0);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut kama = KamaF32::builder().window_size(5).build().unwrap();
-        for i in 0..10 {
-            kama.update(i as f32).unwrap();
-        }
-        assert!(kama.value().is_some());
     }
 
     #[test]

--- a/nexus-stats-smoothing/src/lib.rs
+++ b/nexus-stats-smoothing/src/lib.rs
@@ -11,13 +11,14 @@
 //!
 //! | Type | Description | Feature |
 //! |------|-------------|---------|
-//! | [`HoltF64`] / [`HoltF32`] | Double exponential smoothing (level + trend) | — |
-//! | [`SpringF64`] / [`SpringF32`] | Critically damped spring (chase without overshoot) | — |
-//! | [`Kalman1dF64`] / [`Kalman1dF32`] | 1D Kalman filter (position + velocity) | — |
+//! | [`HoltF64`] | Double exponential smoothing (level + trend) | — |
+//! | [`SpringF64`] | Critically damped spring (chase without overshoot) | — |
+//! | [`Kalman1dF64`] | 1D Kalman filter (position + velocity) | — |
 //! | [`HuberEmaF64`] | Outlier-robust EMA (bounded step per observation) | — |
-//! | [`KamaF64`] / [`KamaF32`] | Kaufman Adaptive Moving Average | `alloc` |
+//! | [`KamaF64`] | Kaufman Adaptive Moving Average | `alloc` |
 //! | [`HampelF64`] | Three-zone outlier filter (pass / Winsorize / reject) | `alloc` |
-//! | [`WindowedMedianF64`] / [`WindowedMedianF32`] | Running median over a sliding window | `alloc` |
+//! | [`WindowedMedianF64`] | Running median over a sliding window (f64) | `alloc` |
+//! | [`WindowedMedianI64`] | Running median over a sliding window (i64) | `alloc` |
 //!
 //! # Re-export
 //!

--- a/nexus-stats-smoothing/src/spring.rs
+++ b/nexus-stats-smoothing/src/spring.rs
@@ -1,124 +1,114 @@
 use nexus_stats_core::math::MulAdd;
-macro_rules! impl_spring {
-    ($name:ident, $ty:ty) => {
-        /// Critically damped spring — chase a target without overshoot.
-        ///
-        /// Uses a Padé approximant for stable behavior with variable dt.
-        /// The output smoothly approaches the target with no ringing.
-        ///
-        /// # Use Cases
-        /// - Camera smoothing in games
-        /// - Smooth parameter transitions
-        /// - Any "chase this value" without PID complexity
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            smooth_time: $ty,
-            omega: $ty,
-            value: $ty,
-            velocity: $ty,
-            initialized: bool,
-        }
 
-        impl $name {
-            /// Creates a new spring with the given smooth time.
-            ///
-            /// `smooth_time` controls how quickly the spring converges.
-            /// Larger = slower, smoother. Smaller = faster, more reactive.
-            #[inline]
-            pub fn new(smooth_time: $ty) -> Result<Self, nexus_stats_core::ConfigError> {
-                #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                if !(smooth_time > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "smooth_time must be positive",
-                    ));
-                }
-                Ok(Self {
-                    smooth_time,
-                    omega: 2.0 as $ty / smooth_time,
-                    value: 0.0 as $ty,
-                    velocity: 0.0 as $ty,
-                    initialized: false,
-                })
-            }
-
-            /// Updates toward the target. Returns the new value.
-            ///
-            /// `dt` is the time since the last update, in the same units as `smooth_time`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if target or dt is NaN, or
-            /// `DataError::Infinite` if either is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                target: $ty,
-                dt: $ty,
-            ) -> Result<$ty, nexus_stats_core::DataError> {
-                check_finite!(target);
-                check_finite!(dt);
-                if !self.initialized {
-                    self.value = target;
-                    self.initialized = true;
-                    return Ok(target);
-                }
-
-                // Critically damped spring using Padé approximant
-                let x = self.omega * dt;
-                // Padé(2,2) approximant to exp(-x): (1 - x/2 + x²/12) / (1 + x/2 + x²/12)
-                // Simplified: use exact exp(-x) via (1 + x + x²/2)⁻¹ approximation
-                let exp_neg = 1.0 as $ty / (x.fma(x.fma(0.5 as $ty, 1.0 as $ty), 1.0 as $ty));
-
-                let delta = self.value - target;
-                let temp = self.omega.fma(delta, self.velocity) * dt;
-                self.velocity = self.omega.fma(-temp, self.velocity) * exp_neg;
-                self.value = (delta + temp).fma(exp_neg, target);
-
-                Ok(self.value)
-            }
-
-            /// The configured smooth time.
-            #[inline]
-            #[must_use]
-            pub fn smooth_time(&self) -> $ty {
-                self.smooth_time
-            }
-
-            /// Current output value.
-            #[inline]
-            #[must_use]
-            pub fn value(&self) -> $ty {
-                self.value
-            }
-
-            /// Current velocity.
-            #[inline]
-            #[must_use]
-            pub fn velocity(&self) -> $ty {
-                self.velocity
-            }
-
-            /// Resets to uninitialized state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.value = 0.0 as $ty;
-                self.velocity = 0.0 as $ty;
-                self.initialized = false;
-            }
-
-            /// Resets to a specific value with zero velocity.
-            #[inline]
-            pub fn reset_to(&mut self, value: $ty) {
-                self.value = value;
-                self.velocity = 0.0 as $ty;
-                self.initialized = true;
-            }
-        }
-    };
+/// Critically damped spring — chase a target without overshoot.
+///
+/// Uses a Pade approximant for stable behavior with variable dt.
+/// The output smoothly approaches the target with no ringing.
+///
+/// # Use Cases
+/// - Camera smoothing in games
+/// - Smooth parameter transitions
+/// - Any "chase this value" without PID complexity
+#[derive(Debug, Clone)]
+pub struct SpringF64 {
+    smooth_time: f64,
+    omega: f64,
+    value: f64,
+    velocity: f64,
+    initialized: bool,
 }
 
-impl_spring!(SpringF64, f64);
-impl_spring!(SpringF32, f32);
+impl SpringF64 {
+    /// Creates a new spring with the given smooth time.
+    ///
+    /// `smooth_time` controls how quickly the spring converges.
+    /// Larger = slower, smoother. Smaller = faster, more reactive.
+    #[inline]
+    pub fn new(smooth_time: f64) -> Result<Self, nexus_stats_core::ConfigError> {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(smooth_time > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "smooth_time must be positive",
+            ));
+        }
+        Ok(Self {
+            smooth_time,
+            omega: 2.0 / smooth_time,
+            value: 0.0,
+            velocity: 0.0,
+            initialized: false,
+        })
+    }
+
+    /// Updates toward the target. Returns the new value.
+    ///
+    /// `dt` is the time since the last update, in the same units as `smooth_time`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if target or dt is NaN, or
+    /// `DataError::Infinite` if either is infinite.
+    #[inline]
+    pub fn update(&mut self, target: f64, dt: f64) -> Result<f64, nexus_stats_core::DataError> {
+        check_finite!(target);
+        check_finite!(dt);
+        if !self.initialized {
+            self.value = target;
+            self.initialized = true;
+            return Ok(target);
+        }
+
+        // Critically damped spring using Pade approximant
+        let x = self.omega * dt;
+        // Pade(2,2) approximant to exp(-x): (1 - x/2 + x^2/12) / (1 + x/2 + x^2/12)
+        // Simplified: use exact exp(-x) via (1 + x + x^2/2)^-1 approximation
+        let exp_neg = 1.0 / x.fma(x.fma(0.5, 1.0), 1.0);
+
+        let delta = self.value - target;
+        let temp = self.omega.fma(delta, self.velocity) * dt;
+        self.velocity = self.omega.fma(-temp, self.velocity) * exp_neg;
+        self.value = (delta + temp).fma(exp_neg, target);
+
+        Ok(self.value)
+    }
+
+    /// The configured smooth time.
+    #[inline]
+    #[must_use]
+    pub fn smooth_time(&self) -> f64 {
+        self.smooth_time
+    }
+
+    /// Current output value.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    /// Current velocity.
+    #[inline]
+    #[must_use]
+    pub fn velocity(&self) -> f64 {
+        self.velocity
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.value = 0.0;
+        self.velocity = 0.0;
+        self.initialized = false;
+    }
+
+    /// Resets to a specific value with zero velocity.
+    #[inline]
+    pub fn reset_to(&mut self, value: f64) {
+        self.value = value;
+        self.velocity = 0.0;
+        self.initialized = true;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -183,13 +173,6 @@ mod tests {
         s.reset_to(50.0);
         assert_eq!(s.value(), 50.0);
         assert_eq!(s.velocity(), 0.0);
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut s = SpringF32::new(0.5).unwrap();
-        let v = s.update(100.0, 0.016).unwrap();
-        assert!((v - 100.0).abs() < 0.01);
     }
 
     #[test]

--- a/nexus-stats-smoothing/src/windowed_median.rs
+++ b/nexus-stats-smoothing/src/windowed_median.rs
@@ -641,15 +641,17 @@ impl WindowedMedianI64 {
     }
 
     /// Modified z-score: `0.6745 * (x - median) / MAD`.
+    ///
+    /// Returns `f64` because the `0.6745` scale factor is fractional.
     #[inline]
     #[must_use]
-    pub fn modified_z_score(&self, sample: i64) -> Option<i64> {
+    pub fn modified_z_score(&self, sample: i64) -> Option<f64> {
         let median = self.median()?;
         let mad = self.mad()?;
         if mad == 0 {
             return None;
         }
-        Some((sample - median) / mad)
+        Some(0.6745 * (sample - median) as f64 / mad as f64)
     }
 
     /// Window size.

--- a/nexus-stats-smoothing/src/windowed_median.rs
+++ b/nexus-stats-smoothing/src/windowed_median.rs
@@ -1,667 +1,729 @@
-#[inline]
-fn abs_f64(x: f64) -> f64 {
-    x.abs()
+/// Windowed median with runtime-configured window size (requires `alloc` feature).
+///
+/// Maintains a ring buffer and an insertion-sorted shadow array
+/// for O(N) update with O(1) median/quartile queries.
+///
+/// # Use Cases
+/// - Robust central tendency (median is outlier-resistant)
+/// - IQR-based anomaly detection
+/// - Modified z-score for non-normal distributions
+pub struct WindowedMedianF64 {
+    ring: *mut f64,
+    sorted: *mut f64,
+    window: usize,
+    head: usize,
+    count: u64,
 }
 
-#[inline]
-fn abs_f32(x: f32) -> f32 {
-    x.abs()
-}
+// SAFETY: both buffers are exclusively owned, f64 is Copy + Send
+unsafe impl Send for WindowedMedianF64 {}
 
-#[inline]
-fn abs_i64(x: i64) -> i64 {
-    x.abs()
-}
+impl WindowedMedianF64 {
+    #[inline]
+    fn ring(&self) -> &[f64] {
+        // SAFETY: buffer allocated with capacity `window`, all elements initialized
+        unsafe { core::slice::from_raw_parts(self.ring, self.window) }
+    }
 
-#[inline]
-fn abs_i32(x: i32) -> i32 {
-    x.abs()
-}
+    #[inline]
+    fn ring_mut(&mut self) -> &mut [f64] {
+        // SAFETY: buffer exclusively owned, all elements initialized
+        unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
+    }
 
-macro_rules! impl_windowed_median_float {
-    ($name:ident, $ty:ty, $abs_fn:expr) => {
-        /// Windowed median with runtime-configured window size (requires `alloc` feature).
-        ///
-        /// Maintains a ring buffer and an insertion-sorted shadow array
-        /// for O(N) update with O(1) median/quartile queries.
-        ///
-        /// # Use Cases
-        /// - Robust central tendency (median is outlier-resistant)
-        /// - IQR-based anomaly detection
-        /// - Modified z-score for non-normal distributions
-        pub struct $name {
-            ring: *mut $ty,
-            sorted: *mut $ty,
-            window: usize,
-            head: usize,
-            count: u64,
+    #[inline]
+    fn sorted(&self) -> &[f64] {
+        // SAFETY: buffer allocated with capacity `window`, all elements initialized
+        unsafe { core::slice::from_raw_parts(self.sorted, self.window) }
+    }
+
+    #[inline]
+    fn sorted_mut(&mut self) -> &mut [f64] {
+        // SAFETY: buffer exclusively owned, all elements initialized
+        unsafe { core::slice::from_raw_parts_mut(self.sorted, self.window) }
+    }
+
+    /// Creates a new windowed median tracker with the given window size.
+    ///
+    /// # Panics
+    ///
+    /// Window size must be > 0.
+    #[inline]
+    #[must_use]
+    pub fn new(window_size: usize) -> Self {
+        assert!(window_size > 0, "window size must be > 0");
+        let mut ring_vec = core::mem::ManuallyDrop::new(alloc::vec![0.0f64; window_size]);
+        let ring = ring_vec.as_mut_ptr();
+        let mut sorted_vec = core::mem::ManuallyDrop::new(alloc::vec![0.0f64; window_size]);
+        let sorted = sorted_vec.as_mut_ptr();
+        Self {
+            ring,
+            sorted,
+            window: window_size,
+            head: 0,
+            count: 0,
         }
+    }
 
-        // SAFETY: both buffers are exclusively owned, T is Copy + Send
-        unsafe impl Send for $name {}
+    /// Feeds a sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(&mut self, sample: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(sample);
+        let len = (self.count as usize).min(self.window);
+        let head = self.head;
+        let window = self.window;
+        // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
+        // exclusively owned. We need both slices simultaneously plus scalar fields.
+        let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
+        let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
 
-        impl $name {
-            #[inline]
-            fn ring(&self) -> &[$ty] {
-                // SAFETY: buffer allocated with capacity `window`, all elements initialized
-                unsafe { core::slice::from_raw_parts(self.ring, self.window) }
-            }
+        if self.count >= window as u64 {
+            let evicted = ring[head];
+            ring[head] = sample;
 
-            #[inline]
-            fn ring_mut(&mut self) -> &mut [$ty] {
-                // SAFETY: buffer exclusively owned, all elements initialized
-                unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
-            }
-
-            #[inline]
-            fn sorted(&self) -> &[$ty] {
-                // SAFETY: buffer allocated with capacity `window`, all elements initialized
-                unsafe { core::slice::from_raw_parts(self.sorted, self.window) }
-            }
-
-            #[inline]
-            fn sorted_mut(&mut self) -> &mut [$ty] {
-                // SAFETY: buffer exclusively owned, all elements initialized
-                unsafe { core::slice::from_raw_parts_mut(self.sorted, self.window) }
-            }
-
-            /// Creates a new windowed median tracker with the given window size.
-            ///
-            /// # Panics
-            ///
-            /// Window size must be > 0.
-            #[inline]
-            #[must_use]
-            pub fn new(window_size: usize) -> Self {
-                assert!(window_size > 0, "window size must be > 0");
-                let mut ring_vec = core::mem::ManuallyDrop::new(alloc::vec![0.0 as $ty; window_size]);
-                let ring = ring_vec.as_mut_ptr();
-                let mut sorted_vec = core::mem::ManuallyDrop::new(alloc::vec![0.0 as $ty; window_size]);
-                let sorted = sorted_vec.as_mut_ptr();
-                Self { ring, sorted, window: window_size, head: 0, count: 0 }
-            }
-
-            /// Feeds a sample.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(sample);
-                let len = (self.count as usize).min(self.window);
-                let head = self.head;
-                let window = self.window;
-                // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
-                // exclusively owned. We need both slices simultaneously plus scalar fields.
-                let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
-                let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
-
-                if self.count >= window as u64 {
-                    let evicted = ring[head];
-                    ring[head] = sample;
-
-                    // Find removal position (where the evicted value is)
-                    let remove_pos = {
-                        let mut lo = 0;
-                        let mut hi = len;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] < evicted { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-
-                    // Find insertion position for new sample in the (len-1) array
-                    // that would exist after removal. Adjust search range based on
-                    // removal position to search the correct virtual array.
-                    let insert_pos = if sample <= evicted {
-                        // New value goes left of or at remove position
-                        let mut lo = 0;
-                        let mut hi = remove_pos;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
+            // Find removal position (where the evicted value is)
+            let remove_pos = {
+                let mut lo = 0;
+                let mut hi = len;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] < evicted {
+                        lo = mid + 1;
                     } else {
-                        // New value goes right of remove position — search in
-                        // the portion after remove_pos (these shift left by 1)
-                        let mut lo = remove_pos;
-                        let mut hi = len - 1;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            // After removal, sorted[mid] becomes sorted[mid+1]
-                            if sorted[mid + 1] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-
-                    // Single-pass shift using ptr::copy (memmove)
-                    let ptr = sorted.as_mut_ptr();
-                    if remove_pos < insert_pos {
-                        // Shift left: elements between remove_pos and insert_pos
-                        // SAFETY: remove_pos < insert_pos < len, all in bounds
-                        unsafe {
-                            core::ptr::copy(
-                                ptr.add(remove_pos + 1),
-                                ptr.add(remove_pos),
-                                insert_pos - remove_pos,
-                            );
-                        }
-                        sorted[insert_pos] = sample;
-                    } else if remove_pos > insert_pos {
-                        // Shift right: elements between insert_pos and remove_pos
-                        // SAFETY: insert_pos < remove_pos < len, all in bounds
-                        unsafe {
-                            core::ptr::copy(
-                                ptr.add(insert_pos),
-                                ptr.add(insert_pos + 1),
-                                remove_pos - insert_pos,
-                            );
-                        }
-                        sorted[insert_pos] = sample;
-                    } else {
-                        // Same position — just overwrite
-                        sorted[remove_pos] = sample;
+                        hi = mid;
                     }
-                } else {
-                    ring[head] = sample;
+                }
+                lo
+            };
 
-                    let insert_pos = {
-                        let mut lo = 0;
-                        let mut hi = len;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-                    for i in (insert_pos..len).rev() {
-                        sorted[i + 1] = sorted[i];
+            // Find insertion position for new sample in the (len-1) array
+            // that would exist after removal. Adjust search range based on
+            // removal position to search the correct virtual array.
+            let insert_pos = if sample <= evicted {
+                // New value goes left of or at remove position
+                let mut lo = 0;
+                let mut hi = remove_pos;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            } else {
+                // New value goes right of remove position — search in
+                // the portion after remove_pos (these shift left by 1)
+                let mut lo = remove_pos;
+                let mut hi = len - 1;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    // After removal, sorted[mid] becomes sorted[mid+1]
+                    if sorted[mid + 1] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            };
+
+            // Single-pass shift using ptr::copy (memmove)
+            let ptr = sorted.as_mut_ptr();
+            match remove_pos.cmp(&insert_pos) {
+                core::cmp::Ordering::Less => {
+                    // Shift left: elements between remove_pos and insert_pos
+                    // SAFETY: remove_pos < insert_pos < len, all in bounds
+                    unsafe {
+                        core::ptr::copy(
+                            ptr.add(remove_pos + 1),
+                            ptr.add(remove_pos),
+                            insert_pos - remove_pos,
+                        );
                     }
                     sorted[insert_pos] = sample;
                 }
-
-                self.head = (head + 1) % window;
-                self.count += 1;
-                Ok(())
-            }
-
-            #[inline]
-            fn current_len(&self) -> usize { (self.count as usize).min(self.window) }
-
-            /// Median value, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn median(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len == 0 { return Option::None; }
-                let sorted = self.sorted();
-                if len % 2 == 1 {
-                    Option::Some(sorted[len / 2])
-                } else {
-                    Option::Some((sorted[len / 2 - 1] + sorted[len / 2]) / (2 as $ty))
-                }
-            }
-
-            /// Returns the q-th quantile of the current window.
-            ///
-            /// `q = 0.0` returns the minimum, `q = 1.0` returns the maximum,
-            /// `q = 0.5` matches [`median()`](Self::median) for odd window sizes.
-            ///
-            /// Returns `None` if the window is empty.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `q` is not in `[0.0, 1.0]`.
-            #[inline]
-            #[must_use]
-            pub fn quantile(&self, q: $ty) -> Option<$ty> {
-                assert!(q >= (0.0 as $ty) && q <= (1.0 as $ty), "quantile must be in [0.0, 1.0]");
-                let len = self.current_len();
-                if len == 0 { return Option::None; }
-                let sorted = &self.sorted()[..len];
-                let idx = ((len - 1) as $ty * q) as usize;
-                Option::Some(sorted[idx])
-            }
-
-            /// Median Absolute Deviation (MAD), or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mad(&self) -> Option<$ty> {
-                let median = self.median()?;
-                let len = self.current_len();
-                let sorted = self.sorted();
-                let mut deviations = alloc::vec![0.0 as $ty; self.window];
-                for i in 0..len {
-                    deviations[i] = $abs_fn(sorted[i] - median);
-                }
-                deviations[..len].sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
-                if len % 2 == 1 {
-                    Option::Some(deviations[len / 2])
-                } else {
-                    Option::Some((deviations[len / 2 - 1] + deviations[len / 2]) / (2 as $ty))
-                }
-            }
-
-            /// First quartile (Q1), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn q1(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len < 4 { Option::None } else { Option::Some(self.sorted()[len / 4]) }
-            }
-
-            /// Third quartile (Q3), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn q3(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len < 4 { Option::None } else { Option::Some(self.sorted()[3 * len / 4]) }
-            }
-
-            /// Interquartile range (Q3 - Q1), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn iqr(&self) -> Option<$ty> {
-                match (self.q1(), self.q3()) {
-                    (Some(q1), Some(q3)) => Option::Some(q3 - q1),
-                    _ => Option::None,
-                }
-            }
-
-            /// Modified z-score: `0.6745 * (x - median) / MAD`.
-            #[inline]
-            #[must_use]
-            #[allow(clippy::float_cmp)]
-            pub fn modified_z_score(&self, sample: $ty) -> Option<$ty> {
-                let median = self.median()?;
-                let mad = self.mad()?;
-                if mad == (0.0 as $ty) { return Option::None; }
-                Option::Some(0.6745 as $ty * (sample - median) / mad)
-            }
-
-            /// Window size.
-            #[inline]
-            #[must_use]
-            pub fn window_size(&self) -> usize { self.window }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 { self.count }
-
-            /// Whether the window is full.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool { self.count >= self.window as u64 }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.ring_mut().fill(0.0 as $ty);
-                self.sorted_mut().fill(0.0 as $ty);
-                self.head = 0;
-                self.count = 0;
-            }
-        }
-
-        impl Drop for $name {
-            fn drop(&mut self) {
-                // SAFETY: both buffers were allocated by Vec with capacity `window`.
-                // T is Copy so no element drops needed. Reclaim the allocations.
-                unsafe {
-                    let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
-                    let _ = alloc::vec::Vec::from_raw_parts(self.sorted, 0, self.window);
-                }
-            }
-        }
-
-        impl Clone for $name {
-            fn clone(&self) -> Self {
-                let mut ring_vec = alloc::vec![0.0 as $ty; self.window];
-                ring_vec.copy_from_slice(self.ring());
-                let mut ring_md = core::mem::ManuallyDrop::new(ring_vec);
-                let ring = ring_md.as_mut_ptr();
-
-                let mut sorted_vec = alloc::vec![0.0 as $ty; self.window];
-                sorted_vec.copy_from_slice(self.sorted());
-                let mut sorted_md = core::mem::ManuallyDrop::new(sorted_vec);
-                let sorted = sorted_md.as_mut_ptr();
-
-                Self {
-                    ring,
-                    sorted,
-                    window: self.window,
-                    head: self.head,
-                    count: self.count,
-                }
-            }
-        }
-
-        impl core::fmt::Debug for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                f.debug_struct(stringify!($name))
-                    .field("window", &self.window)
-                    .field("count", &self.count)
-                    .finish()
-            }
-        }
-    };
-}
-
-macro_rules! impl_windowed_median_int {
-    ($name:ident, $ty:ty, $zero:expr, $abs_fn:expr) => {
-        /// Windowed median with runtime-configured window size (requires `alloc` feature).
-        ///
-        /// Maintains a ring buffer and an insertion-sorted shadow array
-        /// for O(N) update with O(1) median/quartile queries.
-        ///
-        /// # Use Cases
-        /// - Robust central tendency (median is outlier-resistant)
-        /// - IQR-based anomaly detection
-        /// - Modified z-score for non-normal distributions
-        pub struct $name {
-            ring: *mut $ty,
-            sorted: *mut $ty,
-            window: usize,
-            head: usize,
-            count: u64,
-        }
-
-        // SAFETY: both buffers are exclusively owned, T is Copy + Send
-        unsafe impl Send for $name {}
-
-        impl $name {
-            #[inline]
-            fn ring(&self) -> &[$ty] {
-                // SAFETY: buffer allocated with capacity `window`, all elements initialized
-                unsafe { core::slice::from_raw_parts(self.ring, self.window) }
-            }
-
-            #[inline]
-            fn ring_mut(&mut self) -> &mut [$ty] {
-                // SAFETY: buffer exclusively owned, all elements initialized
-                unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
-            }
-
-            #[inline]
-            fn sorted(&self) -> &[$ty] {
-                // SAFETY: buffer allocated with capacity `window`, all elements initialized
-                unsafe { core::slice::from_raw_parts(self.sorted, self.window) }
-            }
-
-            #[inline]
-            fn sorted_mut(&mut self) -> &mut [$ty] {
-                // SAFETY: buffer exclusively owned, all elements initialized
-                unsafe { core::slice::from_raw_parts_mut(self.sorted, self.window) }
-            }
-
-            /// Creates a new windowed median tracker with the given window size.
-            ///
-            /// # Panics
-            ///
-            /// Window size must be > 0.
-            #[inline]
-            #[must_use]
-            pub fn new(window_size: usize) -> Self {
-                assert!(window_size > 0, "window size must be > 0");
-                let mut ring_vec = core::mem::ManuallyDrop::new(alloc::vec![$zero; window_size]);
-                let ring = ring_vec.as_mut_ptr();
-                let mut sorted_vec = core::mem::ManuallyDrop::new(alloc::vec![$zero; window_size]);
-                let sorted = sorted_vec.as_mut_ptr();
-                Self { ring, sorted, window: window_size, head: 0, count: 0 }
-            }
-
-            /// Feeds a sample.
-            #[inline]
-            pub fn update(&mut self, sample: $ty) {
-                let len = (self.count as usize).min(self.window);
-                let head = self.head;
-                let window = self.window;
-                // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
-                // exclusively owned. We need both slices simultaneously plus scalar fields.
-                let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
-                let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
-
-                if self.count >= window as u64 {
-                    let evicted = ring[head];
-                    ring[head] = sample;
-
-                    // Find removal position (where the evicted value is)
-                    let remove_pos = {
-                        let mut lo = 0;
-                        let mut hi = len;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] < evicted { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-
-                    // Find insertion position for new sample in the (len-1) array
-                    // that would exist after removal. Adjust search range based on
-                    // removal position to search the correct virtual array.
-                    let insert_pos = if sample <= evicted {
-                        // New value goes left of or at remove position
-                        let mut lo = 0;
-                        let mut hi = remove_pos;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    } else {
-                        // New value goes right of remove position — search in
-                        // the portion after remove_pos (these shift left by 1)
-                        let mut lo = remove_pos;
-                        let mut hi = len - 1;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            // After removal, sorted[mid] becomes sorted[mid+1]
-                            if sorted[mid + 1] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-
-                    // Single-pass shift using ptr::copy (memmove)
-                    let ptr = sorted.as_mut_ptr();
-                    if remove_pos < insert_pos {
-                        // Shift left: elements between remove_pos and insert_pos
-                        // SAFETY: remove_pos < insert_pos < len, all in bounds
-                        unsafe {
-                            core::ptr::copy(
-                                ptr.add(remove_pos + 1),
-                                ptr.add(remove_pos),
-                                insert_pos - remove_pos,
-                            );
-                        }
-                        sorted[insert_pos] = sample;
-                    } else if remove_pos > insert_pos {
-                        // Shift right: elements between insert_pos and remove_pos
-                        // SAFETY: insert_pos < remove_pos < len, all in bounds
-                        unsafe {
-                            core::ptr::copy(
-                                ptr.add(insert_pos),
-                                ptr.add(insert_pos + 1),
-                                remove_pos - insert_pos,
-                            );
-                        }
-                        sorted[insert_pos] = sample;
-                    } else {
-                        // Same position — just overwrite
-                        sorted[remove_pos] = sample;
-                    }
-                } else {
-                    ring[head] = sample;
-
-                    let insert_pos = {
-                        let mut lo = 0;
-                        let mut hi = len;
-                        while lo < hi {
-                            let mid = lo + (hi - lo) / 2;
-                            if sorted[mid] <= sample { lo = mid + 1; } else { hi = mid; }
-                        }
-                        lo
-                    };
-                    for i in (insert_pos..len).rev() {
-                        sorted[i + 1] = sorted[i];
+                core::cmp::Ordering::Greater => {
+                    // Shift right: elements between insert_pos and remove_pos
+                    // SAFETY: insert_pos < remove_pos < len, all in bounds
+                    unsafe {
+                        core::ptr::copy(
+                            ptr.add(insert_pos),
+                            ptr.add(insert_pos + 1),
+                            remove_pos - insert_pos,
+                        );
                     }
                     sorted[insert_pos] = sample;
                 }
-
-                self.head = (head + 1) % window;
-                self.count += 1;
-            }
-
-            #[inline]
-            fn current_len(&self) -> usize { (self.count as usize).min(self.window) }
-
-            /// Median value, or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn median(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len == 0 { return Option::None; }
-                let sorted = self.sorted();
-                if len % 2 == 1 {
-                    Option::Some(sorted[len / 2])
-                } else {
-                    Option::Some((sorted[len / 2 - 1] + sorted[len / 2]) / (2 as $ty))
+                core::cmp::Ordering::Equal => {
+                    // Same position — just overwrite
+                    sorted[remove_pos] = sample;
                 }
             }
+        } else {
+            ring[head] = sample;
 
-            /// Median Absolute Deviation (MAD), or `None` if empty.
-            #[inline]
-            #[must_use]
-            pub fn mad(&self) -> Option<$ty> {
-                let median = self.median()?;
-                let len = self.current_len();
-                let sorted = self.sorted();
-                let mut deviations = alloc::vec![$zero; self.window];
-                for i in 0..len {
-                    deviations[i] = $abs_fn(sorted[i] - median);
+            let insert_pos = {
+                let mut lo = 0;
+                let mut hi = len;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
                 }
-                deviations[..len].sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
-                if len % 2 == 1 {
-                    Option::Some(deviations[len / 2])
-                } else {
-                    Option::Some((deviations[len / 2 - 1] + deviations[len / 2]) / (2 as $ty))
-                }
+                lo
+            };
+            for i in (insert_pos..len).rev() {
+                sorted[i + 1] = sorted[i];
             }
-
-            /// First quartile (Q1), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn q1(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len < 4 { Option::None } else { Option::Some(self.sorted()[len / 4]) }
-            }
-
-            /// Third quartile (Q3), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn q3(&self) -> Option<$ty> {
-                let len = self.current_len();
-                if len < 4 { Option::None } else { Option::Some(self.sorted()[3 * len / 4]) }
-            }
-
-            /// Interquartile range (Q3 - Q1), or `None` if < 4 samples.
-            #[inline]
-            #[must_use]
-            pub fn iqr(&self) -> Option<$ty> {
-                match (self.q1(), self.q3()) {
-                    (Some(q1), Some(q3)) => Option::Some(q3 - q1),
-                    _ => Option::None,
-                }
-            }
-
-            /// Modified z-score: `0.6745 * (x - median) / MAD`.
-            #[inline]
-            #[must_use]
-            #[allow(clippy::float_cmp)]
-            pub fn modified_z_score(&self, sample: $ty) -> Option<$ty> {
-                let median = self.median()?;
-                let mad = self.mad()?;
-                if mad == ($zero) { return Option::None; }
-                Option::Some(0.6745 as $ty * (sample - median) / mad)
-            }
-
-            /// Window size.
-            #[inline]
-            #[must_use]
-            pub fn window_size(&self) -> usize { self.window }
-
-            /// Number of samples processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 { self.count }
-
-            /// Whether the window is full.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool { self.count >= self.window as u64 }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.ring_mut().fill($zero);
-                self.sorted_mut().fill($zero);
-                self.head = 0;
-                self.count = 0;
-            }
+            sorted[insert_pos] = sample;
         }
 
-        impl Drop for $name {
-            fn drop(&mut self) {
-                // SAFETY: both buffers were allocated by Vec with capacity `window`.
-                // T is Copy so no element drops needed. Reclaim the allocations.
-                unsafe {
-                    let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
-                    let _ = alloc::vec::Vec::from_raw_parts(self.sorted, 0, self.window);
-                }
-            }
+        self.head = (head + 1) % window;
+        self.count += 1;
+        Ok(())
+    }
+
+    #[inline]
+    fn current_len(&self) -> usize {
+        (self.count as usize).min(self.window)
+    }
+
+    /// Median value, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn median(&self) -> Option<f64> {
+        let len = self.current_len();
+        if len == 0 {
+            return None;
         }
-
-        impl Clone for $name {
-            fn clone(&self) -> Self {
-                let mut ring_vec = alloc::vec![$zero; self.window];
-                ring_vec.copy_from_slice(self.ring());
-                let mut ring_md = core::mem::ManuallyDrop::new(ring_vec);
-                let ring = ring_md.as_mut_ptr();
-
-                let mut sorted_vec = alloc::vec![$zero; self.window];
-                sorted_vec.copy_from_slice(self.sorted());
-                let mut sorted_md = core::mem::ManuallyDrop::new(sorted_vec);
-                let sorted = sorted_md.as_mut_ptr();
-
-                Self {
-                    ring,
-                    sorted,
-                    window: self.window,
-                    head: self.head,
-                    count: self.count,
-                }
-            }
+        let sorted = self.sorted();
+        if len % 2 == 1 {
+            Some(sorted[len / 2])
+        } else {
+            Some(f64::midpoint(sorted[len / 2 - 1], sorted[len / 2]))
         }
+    }
 
-        impl core::fmt::Debug for $name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                f.debug_struct(stringify!($name))
-                    .field("window", &self.window)
-                    .field("count", &self.count)
-                    .finish()
-            }
+    /// Returns the q-th quantile of the current window.
+    ///
+    /// `q = 0.0` returns the minimum, `q = 1.0` returns the maximum,
+    /// `q = 0.5` matches [`median()`](Self::median) for odd window sizes.
+    ///
+    /// Returns `None` if the window is empty.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `q` is not in `[0.0, 1.0]`.
+    #[inline]
+    #[must_use]
+    pub fn quantile(&self, q: f64) -> Option<f64> {
+        assert!(q >= 0.0 && q <= 1.0, "quantile must be in [0.0, 1.0]");
+        let len = self.current_len();
+        if len == 0 {
+            return None;
         }
-    };
+        let sorted = &self.sorted()[..len];
+        let idx = ((len - 1) as f64 * q) as usize;
+        Some(sorted[idx])
+    }
+
+    /// Median Absolute Deviation (MAD), or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mad(&self) -> Option<f64> {
+        let median = self.median()?;
+        let len = self.current_len();
+        let sorted = self.sorted();
+        let mut deviations = alloc::vec![0.0f64; self.window];
+        for i in 0..len {
+            deviations[i] = (sorted[i] - median).abs();
+        }
+        deviations[..len]
+            .sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+        if len % 2 == 1 {
+            Some(deviations[len / 2])
+        } else {
+            Some(f64::midpoint(deviations[len / 2 - 1], deviations[len / 2]))
+        }
+    }
+
+    /// First quartile (Q1), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn q1(&self) -> Option<f64> {
+        let len = self.current_len();
+        if len < 4 {
+            None
+        } else {
+            Some(self.sorted()[len / 4])
+        }
+    }
+
+    /// Third quartile (Q3), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn q3(&self) -> Option<f64> {
+        let len = self.current_len();
+        if len < 4 {
+            None
+        } else {
+            Some(self.sorted()[3 * len / 4])
+        }
+    }
+
+    /// Interquartile range (Q3 - Q1), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn iqr(&self) -> Option<f64> {
+        match (self.q1(), self.q3()) {
+            (Some(q1), Some(q3)) => Some(q3 - q1),
+            _ => None,
+        }
+    }
+
+    /// Modified z-score: `0.6745 * (x - median) / MAD`.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn modified_z_score(&self, sample: f64) -> Option<f64> {
+        let median = self.median()?;
+        let mad = self.mad()?;
+        if mad == 0.0 {
+            return None;
+        }
+        Some(0.6745 * (sample - median) / mad)
+    }
+
+    /// Window size.
+    #[inline]
+    #[must_use]
+    pub fn window_size(&self) -> usize {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the window is full.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.window as u64
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.ring_mut().fill(0.0);
+        self.sorted_mut().fill(0.0);
+        self.head = 0;
+        self.count = 0;
+    }
 }
 
-impl_windowed_median_float!(WindowedMedianF64, f64, abs_f64);
-impl_windowed_median_float!(WindowedMedianF32, f32, abs_f32);
-impl_windowed_median_int!(WindowedMedianI64, i64, 0, abs_i64);
-impl_windowed_median_int!(WindowedMedianI32, i32, 0, abs_i32);
+impl Drop for WindowedMedianF64 {
+    fn drop(&mut self) {
+        // SAFETY: both buffers were allocated by Vec with capacity `window`.
+        // f64 is Copy so no element drops needed. Reclaim the allocations.
+        unsafe {
+            let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
+            let _ = alloc::vec::Vec::from_raw_parts(self.sorted, 0, self.window);
+        }
+    }
+}
+
+impl Clone for WindowedMedianF64 {
+    fn clone(&self) -> Self {
+        let mut ring_vec = alloc::vec![0.0f64; self.window];
+        ring_vec.copy_from_slice(self.ring());
+        let mut ring_md = core::mem::ManuallyDrop::new(ring_vec);
+        let ring = ring_md.as_mut_ptr();
+
+        let mut sorted_vec = alloc::vec![0.0f64; self.window];
+        sorted_vec.copy_from_slice(self.sorted());
+        let mut sorted_md = core::mem::ManuallyDrop::new(sorted_vec);
+        let sorted = sorted_md.as_mut_ptr();
+
+        Self {
+            ring,
+            sorted,
+            window: self.window,
+            head: self.head,
+            count: self.count,
+        }
+    }
+}
+
+impl core::fmt::Debug for WindowedMedianF64 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WindowedMedianF64")
+            .field("window", &self.window)
+            .field("count", &self.count)
+            .finish()
+    }
+}
+
+/// Windowed median with runtime-configured window size (requires `alloc` feature).
+///
+/// Maintains a ring buffer and an insertion-sorted shadow array
+/// for O(N) update with O(1) median/quartile queries.
+///
+/// # Use Cases
+/// - Robust central tendency (median is outlier-resistant)
+/// - IQR-based anomaly detection
+/// - Modified z-score for non-normal distributions
+pub struct WindowedMedianI64 {
+    ring: *mut i64,
+    sorted: *mut i64,
+    window: usize,
+    head: usize,
+    count: u64,
+}
+
+// SAFETY: both buffers are exclusively owned, i64 is Copy + Send
+unsafe impl Send for WindowedMedianI64 {}
+
+impl WindowedMedianI64 {
+    #[inline]
+    fn ring(&self) -> &[i64] {
+        // SAFETY: buffer allocated with capacity `window`, all elements initialized
+        unsafe { core::slice::from_raw_parts(self.ring, self.window) }
+    }
+
+    #[inline]
+    fn ring_mut(&mut self) -> &mut [i64] {
+        // SAFETY: buffer exclusively owned, all elements initialized
+        unsafe { core::slice::from_raw_parts_mut(self.ring, self.window) }
+    }
+
+    #[inline]
+    fn sorted(&self) -> &[i64] {
+        // SAFETY: buffer allocated with capacity `window`, all elements initialized
+        unsafe { core::slice::from_raw_parts(self.sorted, self.window) }
+    }
+
+    #[inline]
+    fn sorted_mut(&mut self) -> &mut [i64] {
+        // SAFETY: buffer exclusively owned, all elements initialized
+        unsafe { core::slice::from_raw_parts_mut(self.sorted, self.window) }
+    }
+
+    /// Creates a new windowed median tracker with the given window size.
+    ///
+    /// # Panics
+    ///
+    /// Window size must be > 0.
+    #[inline]
+    #[must_use]
+    pub fn new(window_size: usize) -> Self {
+        assert!(window_size > 0, "window size must be > 0");
+        let mut ring_vec = core::mem::ManuallyDrop::new(alloc::vec![0i64; window_size]);
+        let ring = ring_vec.as_mut_ptr();
+        let mut sorted_vec = core::mem::ManuallyDrop::new(alloc::vec![0i64; window_size]);
+        let sorted = sorted_vec.as_mut_ptr();
+        Self {
+            ring,
+            sorted,
+            window: window_size,
+            head: 0,
+            count: 0,
+        }
+    }
+
+    /// Feeds a sample.
+    #[inline]
+    pub fn update(&mut self, sample: i64) {
+        let len = (self.count as usize).min(self.window);
+        let head = self.head;
+        let window = self.window;
+        // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
+        // exclusively owned. We need both slices simultaneously plus scalar fields.
+        let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
+        let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
+
+        if self.count >= window as u64 {
+            let evicted = ring[head];
+            ring[head] = sample;
+
+            // Find removal position (where the evicted value is)
+            let remove_pos = {
+                let mut lo = 0;
+                let mut hi = len;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] < evicted {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            };
+
+            // Find insertion position for new sample in the (len-1) array
+            // that would exist after removal. Adjust search range based on
+            // removal position to search the correct virtual array.
+            let insert_pos = if sample <= evicted {
+                // New value goes left of or at remove position
+                let mut lo = 0;
+                let mut hi = remove_pos;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            } else {
+                // New value goes right of remove position — search in
+                // the portion after remove_pos (these shift left by 1)
+                let mut lo = remove_pos;
+                let mut hi = len - 1;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    // After removal, sorted[mid] becomes sorted[mid+1]
+                    if sorted[mid + 1] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            };
+
+            // Single-pass shift using ptr::copy (memmove)
+            let ptr = sorted.as_mut_ptr();
+            match remove_pos.cmp(&insert_pos) {
+                core::cmp::Ordering::Less => {
+                    // Shift left: elements between remove_pos and insert_pos
+                    // SAFETY: remove_pos < insert_pos < len, all in bounds
+                    unsafe {
+                        core::ptr::copy(
+                            ptr.add(remove_pos + 1),
+                            ptr.add(remove_pos),
+                            insert_pos - remove_pos,
+                        );
+                    }
+                    sorted[insert_pos] = sample;
+                }
+                core::cmp::Ordering::Greater => {
+                    // Shift right: elements between insert_pos and remove_pos
+                    // SAFETY: insert_pos < remove_pos < len, all in bounds
+                    unsafe {
+                        core::ptr::copy(
+                            ptr.add(insert_pos),
+                            ptr.add(insert_pos + 1),
+                            remove_pos - insert_pos,
+                        );
+                    }
+                    sorted[insert_pos] = sample;
+                }
+                core::cmp::Ordering::Equal => {
+                    // Same position — just overwrite
+                    sorted[remove_pos] = sample;
+                }
+            }
+        } else {
+            ring[head] = sample;
+
+            let insert_pos = {
+                let mut lo = 0;
+                let mut hi = len;
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    if sorted[mid] <= sample {
+                        lo = mid + 1;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                lo
+            };
+            for i in (insert_pos..len).rev() {
+                sorted[i + 1] = sorted[i];
+            }
+            sorted[insert_pos] = sample;
+        }
+
+        self.head = (head + 1) % window;
+        self.count += 1;
+    }
+
+    #[inline]
+    fn current_len(&self) -> usize {
+        (self.count as usize).min(self.window)
+    }
+
+    /// Median value, or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn median(&self) -> Option<i64> {
+        let len = self.current_len();
+        if len == 0 {
+            return None;
+        }
+        let sorted = self.sorted();
+        if len % 2 == 1 {
+            Some(sorted[len / 2])
+        } else {
+            Some(i64::midpoint(sorted[len / 2 - 1], sorted[len / 2]))
+        }
+    }
+
+    /// Median Absolute Deviation (MAD), or `None` if empty.
+    #[inline]
+    #[must_use]
+    pub fn mad(&self) -> Option<i64> {
+        let median = self.median()?;
+        let len = self.current_len();
+        let sorted = self.sorted();
+        let mut deviations = alloc::vec![0i64; self.window];
+        for i in 0..len {
+            deviations[i] = (sorted[i] - median).abs();
+        }
+        deviations[..len]
+            .sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+        if len % 2 == 1 {
+            Some(deviations[len / 2])
+        } else {
+            Some(i64::midpoint(deviations[len / 2 - 1], deviations[len / 2]))
+        }
+    }
+
+    /// First quartile (Q1), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn q1(&self) -> Option<i64> {
+        let len = self.current_len();
+        if len < 4 {
+            None
+        } else {
+            Some(self.sorted()[len / 4])
+        }
+    }
+
+    /// Third quartile (Q3), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn q3(&self) -> Option<i64> {
+        let len = self.current_len();
+        if len < 4 {
+            None
+        } else {
+            Some(self.sorted()[3 * len / 4])
+        }
+    }
+
+    /// Interquartile range (Q3 - Q1), or `None` if < 4 samples.
+    #[inline]
+    #[must_use]
+    pub fn iqr(&self) -> Option<i64> {
+        match (self.q1(), self.q3()) {
+            (Some(q1), Some(q3)) => Some(q3 - q1),
+            _ => None,
+        }
+    }
+
+    /// Modified z-score: `0.6745 * (x - median) / MAD`.
+    #[inline]
+    #[must_use]
+    pub fn modified_z_score(&self, sample: i64) -> Option<i64> {
+        let median = self.median()?;
+        let mad = self.mad()?;
+        if mad == 0 {
+            return None;
+        }
+        Some((sample - median) / mad)
+    }
+
+    /// Window size.
+    #[inline]
+    #[must_use]
+    pub fn window_size(&self) -> usize {
+        self.window
+    }
+
+    /// Number of samples processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the window is full.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.window as u64
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.ring_mut().fill(0);
+        self.sorted_mut().fill(0);
+        self.head = 0;
+        self.count = 0;
+    }
+}
+
+impl Drop for WindowedMedianI64 {
+    fn drop(&mut self) {
+        // SAFETY: both buffers were allocated by Vec with capacity `window`.
+        // i64 is Copy so no element drops needed. Reclaim the allocations.
+        unsafe {
+            let _ = alloc::vec::Vec::from_raw_parts(self.ring, 0, self.window);
+            let _ = alloc::vec::Vec::from_raw_parts(self.sorted, 0, self.window);
+        }
+    }
+}
+
+impl Clone for WindowedMedianI64 {
+    fn clone(&self) -> Self {
+        let mut ring_vec = alloc::vec![0i64; self.window];
+        ring_vec.copy_from_slice(self.ring());
+        let mut ring_md = core::mem::ManuallyDrop::new(ring_vec);
+        let ring = ring_md.as_mut_ptr();
+
+        let mut sorted_vec = alloc::vec![0i64; self.window];
+        sorted_vec.copy_from_slice(self.sorted());
+        let mut sorted_md = core::mem::ManuallyDrop::new(sorted_vec);
+        let sorted = sorted_md.as_mut_ptr();
+
+        Self {
+            ring,
+            sorted,
+            window: self.window,
+            head: self.head,
+            count: self.count,
+        }
+    }
+}
+
+impl core::fmt::Debug for WindowedMedianI64 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WindowedMedianI64")
+            .field("window", &self.window)
+            .field("count", &self.count)
+            .finish()
+    }
+}
 
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
@@ -780,24 +842,6 @@ mod tests {
     }
 
     #[test]
-    fn i32_basic() {
-        let mut wm = WindowedMedianI32::new(3);
-        wm.update(10);
-        wm.update(20);
-        wm.update(30);
-        assert_eq!(wm.median(), Some(20));
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut wm = WindowedMedianF32::new(3);
-        wm.update(1.0).unwrap();
-        wm.update(3.0).unwrap();
-        wm.update(2.0).unwrap();
-        assert_eq!(wm.median(), Some(2.0));
-    }
-
-    #[test]
     fn priming() {
         let mut wm = WindowedMedianF64::new(5);
         for _ in 0..4 {
@@ -854,7 +898,7 @@ mod tests {
             wm.update(v).unwrap();
         }
         // sorted: [10, 20, 30, 40, 50]
-        // idx = (4) * 0.75 = 3.0 → sorted[3] = 40.0
+        // idx = (4) * 0.75 = 3.0 -> sorted[3] = 40.0
         assert_eq!(wm.quantile(0.75).unwrap(), 40.0);
     }
 


### PR DESCRIPTION
## Summary

Type-variant audit for `nexus-stats-smoothing` (#378, part of #366).

Removes F32/I32 type variants with no concrete callers. All macros inlined to plain structs since only one variant survives per type (except `WindowedMedian` which keeps F64 + I64).

### Types removed

| Type | Cut | Reason |
|------|-----|--------|
| `HoltF32` / `HoltF32Builder` | F32 | Accumulating smoother — f32 precision footgun |
| `SpringF32` | F32 | Damping/stiffness coefficients are fractional |
| `Kalman1dF32` / `Kalman1dF32Builder` | F32 | Kalman gain division degrades in f32 |
| `KamaF32` / `KamaF32Builder` | F32 | Adaptive smoothing constant is fractional |
| `WindowedMedianF32` | F32 | Selection, not accumulation — f64 covers the float case |
| `WindowedMedianI32` | I32 | Redundant with I64 |

### Downstream fix

- `nexus-stats-detection`: `TrendAlertF32` / `TrendAlertF32Builder` removed (depended on `HoltF32`)

### Bug fixes from review

- **`WindowedMedianI64::modified_z_score`** now returns `Option<f64>` (was `Option<i64>`) and includes the 0.6745 scale factor. The integer return type was silently dropping the fractional multiplier.
- **`Kalman1dF64Builder::build`** now rejects NaN/infinite process and measurement noise values (`is_finite()` check before positivity check).
- **`TrendAlertF64Builder::build`** now validates that absolute and relative trend thresholds are finite and non-negative.

### Files changed

- 7 source files across smoothing + detection
- 2 CHANGELOG.md files updated
- All macros inlined to plain structs/impls

## Test plan

- [x] `cargo test -p nexus-stats-smoothing --all-features` — 70 unit + 1 doc test pass
- [x] `cargo test -p nexus-stats-detection --all-features` — 174 unit + 18 doc tests pass
- [x] `cargo clippy` clean for both crates
- [x] `cargo fmt --check` clean for both crates
- [x] `cargo test -p nexus-stats --all-features` — umbrella tests pass

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)