### PR TITLE
type-variant audit: nexus-stats-regression (#380)

### DIFF
--- a/nexus-stats-regression/CHANGELOG.md
+++ b/nexus-stats-regression/CHANGELOG.md
@@ -10,6 +10,29 @@ contained.
 
 ## [Unreleased]
 
+### Removed
+
+- `LinearRegressionF32`, `LinearRegressionF32Builder` — use `LinearRegressionF64`
+- `EwLinearRegressionF32`, `EwLinearRegressionF32Builder` — use `EwLinearRegressionF64`
+- `CoefficientsF32` — use `CoefficientsF64`
+- `PolynomialRegressionF32`, `PolynomialRegressionF32Builder` — use `PolynomialRegressionF64`
+- `EwPolynomialRegressionF32`, `EwPolynomialRegressionF32Builder` — use `EwPolynomialRegressionF64`
+- `ExponentialRegressionF32` — use `ExponentialRegressionF64`
+- `LogarithmicRegressionF32` — use `LogarithmicRegressionF64`
+- `PowerRegressionF32` — use `PowerRegressionF64`
+- `BetaBinomialF32`, `BetaBinomialF32Builder` — use `BetaBinomialF64`
+- `GammaPoissonF32`, `GammaPoissonF32Builder` — use `GammaPoissonF64`
+- `Kalman2dF32`, `Kalman2dF32Builder` — use `Kalman2dF64`
+- `Kalman3dF32`, `Kalman3dF32Builder` — use `Kalman3dF64`
+- `Ucb1F32`, `Ucb1F32Builder` — use `Ucb1F64`
+- `ThompsonBetaF32`, `ThompsonBetaF32Builder` — use `ThompsonBetaF64`
+- `ThompsonGammaF32`, `ThompsonGammaF32Builder` — use `ThompsonGammaF64`
+- `EpsilonGreedyF32`, `EpsilonGreedyF32Builder` — use `EpsilonGreedyF64`
+- `Exp3F32`, `Exp3F32Builder` — use `Exp3F64`
+- `RlsFilterF32`, `RlsFilterF32Builder` — use `RlsFilterF64`
+- `LmsFilterF32`, `LmsFilterF32Builder` — use `LmsFilterF64`
+- `NlmsFilterF32`, `NlmsFilterF32Builder` — use `NlmsFilterF64`
+
 ## [1.3.1] — 2026-05-26
 
 ## [1.3.0] — 2026-05-19

--- a/nexus-stats-regression/src/estimation/beta_binomial.rs
+++ b/nexus-stats-regression/src/estimation/beta_binomial.rs
@@ -1,294 +1,276 @@
 #![allow(
     clippy::suboptimal_flops,
     clippy::float_cmp,
-    clippy::neg_cmp_op_on_partial_ord
+    clippy::neg_cmp_op_on_partial_ord,
+    clippy::unreadable_literal
 )]
 
-macro_rules! impl_beta_binomial {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Bayesian success rate estimator using the Beta-Binomial conjugate prior.
-        ///
-        /// Maintains a Beta(alpha, beta) posterior updated by observing binary
-        /// outcomes. The posterior mean is a natural shrinkage estimator —
-        /// with few observations, it stays near the prior; with many, it
-        /// converges to the observed rate.
-        ///
-        /// # Use Cases
-        /// - Fill rate estimation (what fraction of orders fill?)
-        /// - Exchange reliability scoring
-        /// - A/B testing with early stopping
-        /// - Any binary outcome where you want uncertainty quantification
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            beta: $ty,
-            prior_alpha: $ty,
-            prior_beta: $ty,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: $ty,
-            beta: $ty,
-        }
-
-        impl $name {
-            /// Creates a new estimator with a uniform (uninformative) prior.
-            ///
-            /// Beta(1, 1) is the uniform distribution on [0, 1].
-            #[inline]
-            #[must_use]
-            pub const fn new() -> Self {
-                Self {
-                    alpha: 1.0 as $ty,
-                    beta: 1.0 as $ty,
-                    prior_alpha: 1.0 as $ty,
-                    prior_beta: 1.0 as $ty,
-                }
-            }
-
-            /// Creates an estimator with a specified prior.
-            ///
-            /// Higher alpha biases toward success, higher beta toward failure.
-            /// `Beta(10, 1)` expresses strong prior belief in ~91% success rate.
-            ///
-            /// # Errors
-            ///
-            /// Both alpha and beta must be positive.
-            #[inline]
-            pub fn with_prior(
-                alpha: $ty,
-                beta: $ty,
-            ) -> Result<Self, nexus_stats_core::ConfigError> {
-                if !(alpha > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "alpha must be positive",
-                    ));
-                }
-                if !(beta > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "beta must be positive",
-                    ));
-                }
-                Ok(Self {
-                    alpha,
-                    beta,
-                    prior_alpha: alpha,
-                    prior_beta: beta,
-                })
-            }
-
-            /// Creates a builder with defaults of alpha=1.0, beta=1.0.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: 1.0 as $ty,
-                    beta: 1.0 as $ty,
-                }
-            }
-
-            /// Updates with a single binary outcome.
-            #[inline]
-            pub fn update(&mut self, success: bool) {
-                if success {
-                    self.alpha += 1.0 as $ty;
-                } else {
-                    self.beta += 1.0 as $ty;
-                }
-            }
-
-            /// Updates with a batch of outcomes.
-            #[inline]
-            pub fn update_batch(&mut self, successes: u64, failures: u64) {
-                self.alpha += successes as $ty;
-                self.beta += failures as $ty;
-            }
-
-            /// Posterior mean: the expected success rate.
-            ///
-            /// This is the Bayes estimator under squared error loss.
-            #[inline]
-            #[must_use]
-            pub fn mean(&self) -> $ty {
-                self.alpha / (self.alpha + self.beta)
-            }
-
-            /// Posterior variance.
-            #[inline]
-            #[must_use]
-            pub fn variance(&self) -> $ty {
-                let sum = self.alpha + self.beta;
-                (self.alpha * self.beta) / (sum * sum * (sum + 1.0 as $ty))
-            }
-
-            /// Posterior mode, or `None` if alpha <= 1 or beta <= 1.
-            ///
-            /// The mode is undefined for the uniform prior (1, 1) and
-            /// degenerate when either parameter is at or below 1.
-            #[inline]
-            #[must_use]
-            pub fn mode(&self) -> Option<$ty> {
-                if self.alpha <= 1.0 as $ty || self.beta <= 1.0 as $ty {
-                    Option::None
-                } else {
-                    Option::Some((self.alpha - 1.0 as $ty) / (self.alpha + self.beta - 2.0 as $ty))
-                }
-            }
-
-            /// Approximate credible interval using normal approximation.
-            ///
-            /// Returns `(lower, upper)` bounds for the given confidence level
-            /// (e.g., 0.95 for a 95% interval). Uses the Abramowitz & Stegun
-            /// rational approximation (26.2.23) for the inverse normal CDF.
-            ///
-            /// Returns `None` if no observations have been made.
-            #[inline]
-            #[must_use]
-            #[cfg(any(feature = "std", feature = "libm"))]
-            pub fn credible_interval(&self, confidence: $ty) -> Option<($ty, $ty)> {
-                if self.total() == 0.0 as $ty {
-                    return Option::None;
-                }
-                if !(confidence > 0.0 as $ty && confidence < 1.0 as $ty) {
-                    return Option::None;
-                }
-
-                let tail = (1.0 as $ty - confidence) / 2.0 as $ty;
-
-                // Abramowitz & Stegun 26.2.23 rational approximation
-                #[allow(clippy::cast_possible_truncation)]
-                let t = nexus_stats_core::math::sqrt(
-                    (-2.0 as f64) * nexus_stats_core::math::ln(tail as f64),
-                ) as $ty;
-                let z = t
-                    - (2.515517 as $ty + 0.802853 as $ty * t + 0.010328 as $ty * t * t)
-                        / (1.0 as $ty
-                            + 1.432788 as $ty * t
-                            + 0.189269 as $ty * t * t
-                            + 0.001308 as $ty * t * t * t);
-
-                let mean = self.mean();
-                #[allow(clippy::cast_possible_truncation)]
-                let std_dev = nexus_stats_core::math::sqrt(self.variance() as f64) as $ty;
-                let half_width = z * std_dev;
-
-                // Clamp to [0, 1] since we're estimating a probability.
-                let lower = if mean - half_width < 0.0 as $ty {
-                    0.0 as $ty
-                } else {
-                    mean - half_width
-                };
-                let upper = if mean + half_width > 1.0 as $ty {
-                    1.0 as $ty
-                } else {
-                    mean + half_width
-                };
-
-                Option::Some((lower, upper))
-            }
-
-            /// Number of observed successes (excluding prior).
-            #[inline]
-            #[must_use]
-            pub fn successes(&self) -> $ty {
-                self.alpha - self.prior_alpha
-            }
-
-            /// Number of observed failures (excluding prior).
-            #[inline]
-            #[must_use]
-            pub fn failures(&self) -> $ty {
-                self.beta - self.prior_beta
-            }
-
-            /// Total number of observations (excluding prior).
-            #[inline]
-            #[must_use]
-            pub fn total(&self) -> $ty {
-                self.successes() + self.failures()
-            }
-
-            /// Total observations as an integer.
-            #[inline]
-            #[must_use]
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            pub fn count(&self) -> u64 {
-                self.total() as u64
-            }
-
-            /// Whether any observations have been made.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total() > 0.0 as $ty
-            }
-
-            /// Resets to the original prior, discarding all observations.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.alpha = self.prior_alpha;
-                self.beta = self.prior_beta;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl $builder {
-            /// Sets the alpha (success) prior parameter.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = alpha;
-                self
-            }
-
-            /// Sets the beta (failure) prior parameter.
-            #[inline]
-            #[must_use]
-            pub fn beta(mut self, beta: $ty) -> Self {
-                self.beta = beta;
-                self
-            }
-
-            /// Builds the estimator.
-            ///
-            /// # Errors
-            ///
-            /// Both alpha and beta must be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                if !(self.alpha > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "alpha must be positive",
-                    ));
-                }
-                if !(self.beta > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "beta must be positive",
-                    ));
-                }
-                Ok($name {
-                    alpha: self.alpha,
-                    beta: self.beta,
-                    prior_alpha: self.alpha,
-                    prior_beta: self.beta,
-                })
-            }
-        }
-    };
+/// Bayesian success rate estimator using the Beta-Binomial conjugate prior.
+///
+/// Maintains a Beta(alpha, beta) posterior updated by observing binary
+/// outcomes. The posterior mean is a natural shrinkage estimator —
+/// with few observations, it stays near the prior; with many, it
+/// converges to the observed rate.
+///
+/// # Use Cases
+/// - Fill rate estimation (what fraction of orders fill?)
+/// - Exchange reliability scoring
+/// - A/B testing with early stopping
+/// - Any binary outcome where you want uncertainty quantification
+#[derive(Debug, Clone)]
+pub struct BetaBinomialF64 {
+    alpha: f64,
+    beta: f64,
+    prior_alpha: f64,
+    prior_beta: f64,
 }
 
-impl_beta_binomial!(BetaBinomialF64, BetaBinomialF64Builder, f64);
-impl_beta_binomial!(BetaBinomialF32, BetaBinomialF32Builder, f32);
+/// Builder for [`BetaBinomialF64`].
+#[derive(Debug, Clone)]
+pub struct BetaBinomialF64Builder {
+    alpha: f64,
+    beta: f64,
+}
+
+impl BetaBinomialF64 {
+    /// Creates a new estimator with a uniform (uninformative) prior.
+    ///
+    /// Beta(1, 1) is the uniform distribution on [0, 1].
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            alpha: 1.0,
+            beta: 1.0,
+            prior_alpha: 1.0,
+            prior_beta: 1.0,
+        }
+    }
+
+    /// Creates an estimator with a specified prior.
+    ///
+    /// Higher alpha biases toward success, higher beta toward failure.
+    /// `Beta(10, 1)` expresses strong prior belief in ~91% success rate.
+    ///
+    /// # Errors
+    ///
+    /// Both alpha and beta must be positive.
+    #[inline]
+    pub fn with_prior(alpha: f64, beta: f64) -> Result<Self, nexus_stats_core::ConfigError> {
+        if !(alpha > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "alpha must be positive",
+            ));
+        }
+        if !(beta > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "beta must be positive",
+            ));
+        }
+        Ok(Self {
+            alpha,
+            beta,
+            prior_alpha: alpha,
+            prior_beta: beta,
+        })
+    }
+
+    /// Creates a builder with defaults of alpha=1.0, beta=1.0.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> BetaBinomialF64Builder {
+        BetaBinomialF64Builder {
+            alpha: 1.0,
+            beta: 1.0,
+        }
+    }
+
+    /// Updates with a single binary outcome.
+    #[inline]
+    pub fn update(&mut self, success: bool) {
+        if success {
+            self.alpha += 1.0;
+        } else {
+            self.beta += 1.0;
+        }
+    }
+
+    /// Updates with a batch of outcomes.
+    #[inline]
+    pub fn update_batch(&mut self, successes: u64, failures: u64) {
+        self.alpha += successes as f64;
+        self.beta += failures as f64;
+    }
+
+    /// Posterior mean: the expected success rate.
+    ///
+    /// This is the Bayes estimator under squared error loss.
+    #[inline]
+    #[must_use]
+    pub fn mean(&self) -> f64 {
+        self.alpha / (self.alpha + self.beta)
+    }
+
+    /// Posterior variance.
+    #[inline]
+    #[must_use]
+    pub fn variance(&self) -> f64 {
+        let sum = self.alpha + self.beta;
+        (self.alpha * self.beta) / (sum * sum * (sum + 1.0))
+    }
+
+    /// Posterior mode, or `None` if alpha <= 1 or beta <= 1.
+    ///
+    /// The mode is undefined for the uniform prior (1, 1) and
+    /// degenerate when either parameter is at or below 1.
+    #[inline]
+    #[must_use]
+    pub fn mode(&self) -> Option<f64> {
+        if self.alpha <= 1.0 || self.beta <= 1.0 {
+            None
+        } else {
+            Some((self.alpha - 1.0) / (self.alpha + self.beta - 2.0))
+        }
+    }
+
+    /// Approximate credible interval using normal approximation.
+    ///
+    /// Returns `(lower, upper)` bounds for the given confidence level
+    /// (e.g., 0.95 for a 95% interval). Uses the Abramowitz & Stegun
+    /// rational approximation (26.2.23) for the inverse normal CDF.
+    ///
+    /// Returns `None` if no observations have been made.
+    #[inline]
+    #[must_use]
+    #[cfg(any(feature = "std", feature = "libm"))]
+    pub fn credible_interval(&self, confidence: f64) -> Option<(f64, f64)> {
+        if self.total() == 0.0 {
+            return None;
+        }
+        if !(confidence > 0.0 && confidence < 1.0) {
+            return None;
+        }
+
+        let tail = (1.0 - confidence) / 2.0;
+
+        // Abramowitz & Stegun 26.2.23 rational approximation
+        let t = nexus_stats_core::math::sqrt(-2.0 * nexus_stats_core::math::ln(tail));
+        let z = t
+            - (2.515517 + 0.802853 * t + 0.010328 * t * t)
+                / (1.0 + 1.432788 * t + 0.189269 * t * t + 0.001308 * t * t * t);
+
+        let mean = self.mean();
+        let std_dev = nexus_stats_core::math::sqrt(self.variance());
+        let half_width = z * std_dev;
+
+        // Clamp to [0, 1] since we're estimating a probability.
+        let lower = if mean - half_width < 0.0 {
+            0.0
+        } else {
+            mean - half_width
+        };
+        let upper = if mean + half_width > 1.0 {
+            1.0
+        } else {
+            mean + half_width
+        };
+
+        Some((lower, upper))
+    }
+
+    /// Number of observed successes (excluding prior).
+    #[inline]
+    #[must_use]
+    pub fn successes(&self) -> f64 {
+        self.alpha - self.prior_alpha
+    }
+
+    /// Number of observed failures (excluding prior).
+    #[inline]
+    #[must_use]
+    pub fn failures(&self) -> f64 {
+        self.beta - self.prior_beta
+    }
+
+    /// Total number of observations (excluding prior).
+    #[inline]
+    #[must_use]
+    pub fn total(&self) -> f64 {
+        self.successes() + self.failures()
+    }
+
+    /// Total observations as an integer.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn count(&self) -> u64 {
+        self.total() as u64
+    }
+
+    /// Whether any observations have been made.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total() > 0.0
+    }
+
+    /// Resets to the original prior, discarding all observations.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.alpha = self.prior_alpha;
+        self.beta = self.prior_beta;
+    }
+}
+
+impl Default for BetaBinomialF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BetaBinomialF64Builder {
+    /// Sets the alpha (success) prior parameter.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = alpha;
+        self
+    }
+
+    /// Sets the beta (failure) prior parameter.
+    #[inline]
+    #[must_use]
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.beta = beta;
+        self
+    }
+
+    /// Builds the estimator.
+    ///
+    /// # Errors
+    ///
+    /// Both alpha and beta must be positive.
+    #[inline]
+    pub fn build(self) -> Result<BetaBinomialF64, nexus_stats_core::ConfigError> {
+        if !(self.alpha > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "alpha must be positive",
+            ));
+        }
+        if !(self.beta > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "beta must be positive",
+            ));
+        }
+        Ok(BetaBinomialF64 {
+            alpha: self.alpha,
+            beta: self.beta,
+            prior_alpha: self.alpha,
+            prior_beta: self.beta,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -408,16 +390,6 @@ mod tests {
         );
         assert_eq!(bb.count(), 0);
         assert!(!bb.is_primed());
-    }
-
-    #[test]
-    fn f32_variant() {
-        let mut bb = BetaBinomialF32::new();
-        bb.update(true);
-        bb.update(false);
-        // Beta(2, 2) → mean = 0.5
-        let mean = bb.mean();
-        assert!((mean - 0.5).abs() < 1e-5, "expected ~0.5, got {mean}");
     }
 
     #[test]

--- a/nexus-stats-regression/src/estimation/beta_binomial.rs
+++ b/nexus-stats-regression/src/estimation/beta_binomial.rs
@@ -1,8 +1,7 @@
 #![allow(
     clippy::suboptimal_flops,
     clippy::float_cmp,
-    clippy::neg_cmp_op_on_partial_ord,
-    clippy::unreadable_literal
+    clippy::neg_cmp_op_on_partial_ord
 )]
 
 /// Bayesian success rate estimator using the Beta-Binomial conjugate prior.
@@ -156,8 +155,8 @@ impl BetaBinomialF64 {
         // Abramowitz & Stegun 26.2.23 rational approximation
         let t = nexus_stats_core::math::sqrt(-2.0 * nexus_stats_core::math::ln(tail));
         let z = t
-            - (2.515517 + 0.802853 * t + 0.010328 * t * t)
-                / (1.0 + 1.432788 * t + 0.189269 * t * t + 0.001308 * t * t * t);
+            - (2.515_517 + 0.802_853 * t + 0.010_328 * t * t)
+                / (1.0 + 1.432_788 * t + 0.189_269 * t * t + 0.001_308 * t * t * t);
 
         let mean = self.mean();
         let std_dev = nexus_stats_core::math::sqrt(self.variance());

--- a/nexus-stats-regression/src/estimation/gamma_poisson.rs
+++ b/nexus-stats-regression/src/estimation/gamma_poisson.rs
@@ -9,254 +9,239 @@
 #![allow(
     clippy::suboptimal_flops,
     clippy::float_cmp,
-    clippy::neg_cmp_op_on_partial_ord
+    clippy::neg_cmp_op_on_partial_ord,
+    clippy::unreadable_literal
 )]
 
-macro_rules! impl_gamma_poisson {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Bayesian event rate estimator using the Gamma-Poisson conjugate prior.
-        ///
-        /// Maintains a Gamma posterior over the Poisson rate parameter.
-        /// Each observation adds event counts and exposure time, updating the
-        /// posterior analytically — no sampling, no iteration.
-        ///
-        /// # Use Cases
-        /// - "What's the expected message arrival rate given what we've seen?"
-        /// - Estimating fill rates, error rates, or tick rates with uncertainty
-        /// - Credible intervals on event rates from limited data
-        ///
-        /// # Complexity
-        /// - O(1) per observation, O(1) per query.
-        /// - 32 bytes state (f64), 16 bytes (f32). Zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::estimation::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut gp = ", stringify!($name), "::new();")]
-        /// gp.update(100, 10.0);  // 100 events in 10 seconds
-        /// let rate = gp.rate();
-        /// // With weak prior (1,1), rate ≈ 101/11 ≈ 9.18
-        #[doc = concat!("assert!((rate - 9.18 as ", stringify!($ty), ").abs() < 0.01 as ", stringify!($ty), ");")]
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alpha: $ty,
-            beta: $ty,
-            prior_alpha: $ty,
-            prior_beta: $ty,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: $ty,
-            beta: $ty,
-        }
-
-        impl $name {
-            /// Creates a builder with default prior (alpha=1, beta=1).
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: 1.0 as $ty,
-                    beta: 1.0 as $ty,
-                }
-            }
-
-            /// Creates an estimator with a weakly informative prior (alpha=1, beta=1).
-            #[inline]
-            #[must_use]
-            pub fn new() -> Self {
-                Self {
-                    alpha: 1.0 as $ty,
-                    beta: 1.0 as $ty,
-                    prior_alpha: 1.0 as $ty,
-                    prior_beta: 1.0 as $ty,
-                }
-            }
-
-            /// Creates an estimator with a specific Gamma prior.
-            ///
-            /// # Errors
-            ///
-            /// Returns `ConfigError::Invalid` if `alpha <= 0` or `beta <= 0`.
-            #[inline]
-            pub fn with_prior(alpha: $ty, beta: $ty) -> Result<Self, nexus_stats_core::ConfigError> {
-                if !(alpha > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid("alpha must be > 0"));
-                }
-                if !(beta > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid("beta must be > 0"));
-                }
-                Ok(Self {
-                    alpha,
-                    beta,
-                    prior_alpha: alpha,
-                    prior_beta: beta,
-                })
-            }
-
-            /// Updates with an observation: `count` events observed over `exposure` time.
-            ///
-            /// Updates the posterior: alpha += count, beta += exposure.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the exposure is NaN, or
-            /// `DataError::Infinite` if the exposure is infinite.
-            #[inline]
-            pub fn update(&mut self, count: u64, exposure: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(exposure);
-                self.alpha += count as $ty;
-                self.beta += exposure;
-                Ok(())
-            }
-
-            /// Posterior mean rate (alpha / beta).
-            #[inline]
-            #[must_use]
-            pub fn rate(&self) -> $ty {
-                self.alpha / self.beta
-            }
-
-            /// Posterior variance (alpha / beta²).
-            #[inline]
-            #[must_use]
-            pub fn variance(&self) -> $ty {
-                self.alpha / (self.beta * self.beta)
-            }
-
-            /// Approximate credible interval using normal approximation.
-            ///
-            /// Returns `(lower, upper)` bounds for the given confidence level,
-            /// or `None` if no exposure has been observed or confidence is not in (0, 1).
-            ///
-            /// Uses the Abramowitz & Stegun rational approximation for the
-            /// inverse normal CDF.
-            #[cfg(any(feature = "std", feature = "libm"))]
-            #[inline]
-            #[must_use]
-            pub fn credible_interval(&self, confidence: $ty) -> Option<($ty, $ty)> {
-                if self.total_exposure() <= 0.0 as $ty {
-                    return Option::None;
-                }
-                if !(confidence > 0.0 as $ty && confidence < 1.0 as $ty) {
-                    return Option::None;
-                }
-
-                let tail = (1.0 as $ty - confidence) / 2.0 as $ty;
-
-                // Abramowitz & Stegun rational approximation for inverse normal
-                #[allow(clippy::cast_possible_truncation)]
-                let t = nexus_stats_core::math::sqrt(
-                    -2.0 * nexus_stats_core::math::ln(tail as f64),
-                ) as $ty;
-                let z = t
-                    - (2.515517 as $ty + 0.802853 as $ty * t + 0.010328 as $ty * t * t)
-                        / (1.0 as $ty
-                            + 1.432788 as $ty * t
-                            + 0.189269 as $ty * t * t
-                            + 0.001308 as $ty * t * t * t);
-
-                #[allow(clippy::cast_possible_truncation)]
-                let std_dev = nexus_stats_core::math::sqrt(self.variance() as f64) as $ty;
-                let mean = self.rate();
-
-                let lower = (mean - z * std_dev).max(0.0 as $ty);
-                Option::Some((lower, mean + z * std_dev))
-            }
-
-            /// Total event count observed (excluding prior).
-            #[inline]
-            #[must_use]
-            pub fn total_count(&self) -> $ty {
-                self.alpha - self.prior_alpha
-            }
-
-            /// Total exposure time observed (excluding prior).
-            #[inline]
-            #[must_use]
-            pub fn total_exposure(&self) -> $ty {
-                self.beta - self.prior_beta
-            }
-
-            /// Total event count as integer.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_count() as u64
-            }
-
-            /// Whether any exposure has been observed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_exposure() > 0.0 as $ty
-            }
-
-            /// Resets to the original prior, discarding all observations.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.alpha = self.prior_alpha;
-                self.beta = self.prior_beta;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl $builder {
-            /// Sets the shape parameter (prior alpha). Must be > 0.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = alpha;
-                self
-            }
-
-            /// Sets the rate parameter (prior beta). Must be > 0.
-            #[inline]
-            #[must_use]
-            pub fn beta(mut self, beta: $ty) -> Self {
-                self.beta = beta;
-                self
-            }
-
-            /// Builds the estimator, validating parameters.
-            ///
-            /// # Errors
-            ///
-            /// Returns `ConfigError::Invalid` if alpha or beta are not positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                if !(self.alpha > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid("alpha must be > 0"));
-                }
-                if !(self.beta > 0.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid("beta must be > 0"));
-                }
-                Ok($name {
-                    alpha: self.alpha,
-                    beta: self.beta,
-                    prior_alpha: self.alpha,
-                    prior_beta: self.beta,
-                })
-            }
-        }
-    };
+/// Bayesian event rate estimator using the Gamma-Poisson conjugate prior.
+///
+/// Maintains a Gamma posterior over the Poisson rate parameter.
+/// Each observation adds event counts and exposure time, updating the
+/// posterior analytically — no sampling, no iteration.
+///
+/// # Use Cases
+/// - "What's the expected message arrival rate given what we've seen?"
+/// - Estimating fill rates, error rates, or tick rates with uncertainty
+/// - Credible intervals on event rates from limited data
+///
+/// # Complexity
+/// - O(1) per observation, O(1) per query.
+/// - 32 bytes state. Zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::estimation::GammaPoissonF64;
+///
+/// let mut gp = GammaPoissonF64::new();
+/// gp.update(100, 10.0);  // 100 events in 10 seconds
+/// let rate = gp.rate();
+/// // With weak prior (1,1), rate ≈ 101/11 ≈ 9.18
+/// assert!((rate - 9.18).abs() < 0.01);
+/// ```
+#[derive(Debug, Clone)]
+pub struct GammaPoissonF64 {
+    alpha: f64,
+    beta: f64,
+    prior_alpha: f64,
+    prior_beta: f64,
 }
 
-impl_gamma_poisson!(GammaPoissonF64, GammaPoissonF64Builder, f64);
-impl_gamma_poisson!(GammaPoissonF32, GammaPoissonF32Builder, f32);
+/// Builder for [`GammaPoissonF64`].
+#[derive(Debug, Clone)]
+pub struct GammaPoissonF64Builder {
+    alpha: f64,
+    beta: f64,
+}
+
+impl GammaPoissonF64 {
+    /// Creates a builder with default prior (alpha=1, beta=1).
+    #[inline]
+    #[must_use]
+    pub fn builder() -> GammaPoissonF64Builder {
+        GammaPoissonF64Builder {
+            alpha: 1.0,
+            beta: 1.0,
+        }
+    }
+
+    /// Creates an estimator with a weakly informative prior (alpha=1, beta=1).
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            alpha: 1.0,
+            beta: 1.0,
+            prior_alpha: 1.0,
+            prior_beta: 1.0,
+        }
+    }
+
+    /// Creates an estimator with a specific Gamma prior.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Invalid` if `alpha <= 0` or `beta <= 0`.
+    #[inline]
+    pub fn with_prior(alpha: f64, beta: f64) -> Result<Self, nexus_stats_core::ConfigError> {
+        if !(alpha > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid("alpha must be > 0"));
+        }
+        if !(beta > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid("beta must be > 0"));
+        }
+        Ok(Self {
+            alpha,
+            beta,
+            prior_alpha: alpha,
+            prior_beta: beta,
+        })
+    }
+
+    /// Updates with an observation: `count` events observed over `exposure` time.
+    ///
+    /// Updates the posterior: alpha += count, beta += exposure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the exposure is NaN, or
+    /// `DataError::Infinite` if the exposure is infinite.
+    #[inline]
+    pub fn update(&mut self, count: u64, exposure: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(exposure);
+        self.alpha += count as f64;
+        self.beta += exposure;
+        Ok(())
+    }
+
+    /// Posterior mean rate (alpha / beta).
+    #[inline]
+    #[must_use]
+    pub fn rate(&self) -> f64 {
+        self.alpha / self.beta
+    }
+
+    /// Posterior variance (alpha / beta²).
+    #[inline]
+    #[must_use]
+    pub fn variance(&self) -> f64 {
+        self.alpha / (self.beta * self.beta)
+    }
+
+    /// Approximate credible interval using normal approximation.
+    ///
+    /// Returns `(lower, upper)` bounds for the given confidence level,
+    /// or `None` if no exposure has been observed or confidence is not in (0, 1).
+    ///
+    /// Uses the Abramowitz & Stegun rational approximation for the
+    /// inverse normal CDF.
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[inline]
+    #[must_use]
+    pub fn credible_interval(&self, confidence: f64) -> Option<(f64, f64)> {
+        if self.total_exposure() <= 0.0 {
+            return None;
+        }
+        if !(confidence > 0.0 && confidence < 1.0) {
+            return None;
+        }
+
+        let tail = (1.0 - confidence) / 2.0;
+
+        // Abramowitz & Stegun rational approximation for inverse normal
+        let t = nexus_stats_core::math::sqrt(-2.0 * nexus_stats_core::math::ln(tail));
+        let z = t
+            - (2.515517 + 0.802853 * t + 0.010328 * t * t)
+                / (1.0 + 1.432788 * t + 0.189269 * t * t + 0.001308 * t * t * t);
+
+        let std_dev = nexus_stats_core::math::sqrt(self.variance());
+        let mean = self.rate();
+
+        let lower = (mean - z * std_dev).max(0.0);
+        Some((lower, mean + z * std_dev))
+    }
+
+    /// Total event count observed (excluding prior).
+    #[inline]
+    #[must_use]
+    pub fn total_count(&self) -> f64 {
+        self.alpha - self.prior_alpha
+    }
+
+    /// Total exposure time observed (excluding prior).
+    #[inline]
+    #[must_use]
+    pub fn total_exposure(&self) -> f64 {
+        self.beta - self.prior_beta
+    }
+
+    /// Total event count as integer.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_count() as u64
+    }
+
+    /// Whether any exposure has been observed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_exposure() > 0.0
+    }
+
+    /// Resets to the original prior, discarding all observations.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.alpha = self.prior_alpha;
+        self.beta = self.prior_beta;
+    }
+}
+
+impl Default for GammaPoissonF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GammaPoissonF64Builder {
+    /// Sets the shape parameter (prior alpha). Must be > 0.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = alpha;
+        self
+    }
+
+    /// Sets the rate parameter (prior beta). Must be > 0.
+    #[inline]
+    #[must_use]
+    pub fn beta(mut self, beta: f64) -> Self {
+        self.beta = beta;
+        self
+    }
+
+    /// Builds the estimator, validating parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Invalid` if alpha or beta are not positive.
+    #[inline]
+    pub fn build(self) -> Result<GammaPoissonF64, nexus_stats_core::ConfigError> {
+        if !(self.alpha > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid("alpha must be > 0"));
+        }
+        if !(self.beta > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid("beta must be > 0"));
+        }
+        Ok(GammaPoissonF64 {
+            alpha: self.alpha,
+            beta: self.beta,
+            prior_alpha: self.alpha,
+            prior_beta: self.beta,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -320,15 +305,6 @@ mod tests {
         assert!(GammaPoissonF64::with_prior(f64::NAN, 1.0).is_err());
         assert!(GammaPoissonF64::with_prior(1.0, f64::NAN).is_err());
         assert!(GammaPoissonF64::with_prior(1.0, 1.0).is_ok());
-    }
-
-    #[test]
-    fn f32_variant() {
-        let mut gp = GammaPoissonF32::new();
-        gp.update(50, 5.0).unwrap();
-        let rate = gp.rate();
-        // Gamma(51, 6) → 51/6 = 8.5
-        assert!((rate - 8.5_f32).abs() < 0.01);
     }
 
     #[test]

--- a/nexus-stats-regression/src/estimation/gamma_poisson.rs
+++ b/nexus-stats-regression/src/estimation/gamma_poisson.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::suboptimal_flops,
     clippy::float_cmp,
-    clippy::neg_cmp_op_on_partial_ord,
-    clippy::unreadable_literal
+    clippy::neg_cmp_op_on_partial_ord
 )]
 
 /// Bayesian event rate estimator using the Gamma-Poisson conjugate prior.
@@ -151,8 +150,8 @@ impl GammaPoissonF64 {
         // Abramowitz & Stegun rational approximation for inverse normal
         let t = nexus_stats_core::math::sqrt(-2.0 * nexus_stats_core::math::ln(tail));
         let z = t
-            - (2.515517 + 0.802853 * t + 0.010328 * t * t)
-                / (1.0 + 1.432788 * t + 0.189269 * t * t + 0.001308 * t * t * t);
+            - (2.515_517 + 0.802_853 * t + 0.010_328 * t * t)
+                / (1.0 + 1.432_788 * t + 0.189_269 * t * t + 0.001_308 * t * t * t);
 
         let std_dev = nexus_stats_core::math::sqrt(self.variance());
         let mean = self.rate();

--- a/nexus-stats-regression/src/estimation/kalman2d.rs
+++ b/nexus-stats-regression/src/estimation/kalman2d.rs
@@ -1,320 +1,311 @@
 #![allow(clippy::suboptimal_flops, clippy::float_cmp)]
 
-macro_rules! impl_kalman2d {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// 2-state Kalman filter with configurable observation model.
-        ///
-        /// Tracks a 2-element state vector from noisy scalar measurements.
-        /// The observation model H is provided at each update, allowing
-        /// the measurement to be any linear combination of the state.
-        ///
-        /// The predict step adds process noise Q to the covariance.
-        /// The update step applies the standard Kalman correction.
-        ///
-        /// # Use Cases
-        /// - Position + velocity tracking from noisy position measurements
-        /// - Level + trend estimation
-        /// - Any 2-state linear system
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            state: [$ty; 2],
-            p: [$ty; 4],
-            q: [$ty; 4],
-            r: $ty,
-            last_innovation: Option<$ty>,
-            last_innovation_var: Option<$ty>,
-            count: u64,
-            initial_state: [$ty; 2],
-            initial_p: [$ty; 4],
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            process_noise: Option<[[$ty; 2]; 2]>,
-            measurement_noise: Option<$ty>,
-            initial_state: [$ty; 2],
-            initial_covariance: [[$ty; 2]; 2],
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    process_noise: Option::None,
-                    measurement_noise: Option::None,
-                    initial_state: [0.0 as $ty; 2],
-                    initial_covariance: [[1.0 as $ty, 0.0 as $ty], [0.0 as $ty, 1.0 as $ty]],
-                }
-            }
-
-            /// Adds process noise to the covariance: P = P + Q.
-            ///
-            /// Call this before `update` to model the passage of time
-            /// and the associated uncertainty growth.
-            #[inline]
-            pub fn predict(&mut self) {
-                self.p[0] += self.q[0];
-                self.p[1] += self.q[1];
-                self.p[2] += self.q[2];
-                self.p[3] += self.q[3];
-            }
-
-            /// Predict with custom state transition matrix F.
-            ///
-            /// Propagates state as `x = F * x` and covariance as `P = F * P * F' + Q`.
-            /// The existing `predict()` uses identity dynamics (F = I).
-            pub fn predict_with_dynamics(&mut self, f: [[$ty; 2]; 2]) {
-                // x_new = F * x
-                let x0 = f[0][0] * self.state[0] + f[0][1] * self.state[1];
-                let x1 = f[1][0] * self.state[0] + f[1][1] * self.state[1];
-                self.state = [x0, x1];
-
-                // P_new = F * P * F' + Q
-                // FP[i][j] = Σ_k F[i][k] * P[k*2+j]
-                let fp00 = f[0][0] * self.p[0] + f[0][1] * self.p[2];
-                let fp01 = f[0][0] * self.p[1] + f[0][1] * self.p[3];
-                let fp10 = f[1][0] * self.p[0] + f[1][1] * self.p[2];
-                let fp11 = f[1][0] * self.p[1] + f[1][1] * self.p[3];
-
-                // (FP) * F' + Q
-                self.p[0] = fp00 * f[0][0] + fp01 * f[0][1] + self.q[0];
-                self.p[1] = fp00 * f[1][0] + fp01 * f[1][1] + self.q[1];
-                self.p[2] = fp10 * f[0][0] + fp11 * f[0][1] + self.q[2];
-                self.p[3] = fp10 * f[1][0] + fp11 * f[1][1] + self.q[3];
-            }
-
-            /// Incorporates a scalar observation with observation model H.
-            ///
-            /// The observation is modeled as: `z = h[0]*state[0] + h[1]*state[1] + noise`.
-            ///
-            /// # Arguments
-            /// - `observation` — the measured scalar value
-            /// - `h` — the 2-element observation vector [h0, h1]
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the observation is NaN, or
-            /// `DataError::Infinite` if the observation is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                observation: $ty,
-                h: [$ty; 2],
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(observation);
-                debug_assert!(h.iter().all(|v| v.is_finite()), "h must be finite");
-                // Innovation: y = obs - H*x
-                let y = observation - h[0] * self.state[0] - h[1] * self.state[1];
-
-                // Innovation covariance: S = H*P*H' + R
-                // Epsilon floor prevents NaN if P degrades numerically.
-                let s = (h[0] * h[0] * self.p[0]
-                    + h[0] * h[1] * self.p[1]
-                    + h[1] * h[0] * self.p[2]
-                    + h[1] * h[1] * self.p[3]
-                    + self.r)
-                    .max(<$ty>::EPSILON);
-
-                // Kalman gain: K = P*H' / S
-                let s_inv = (1.0 as $ty) / s;
-                let k0 = (self.p[0] * h[0] + self.p[1] * h[1]) * s_inv;
-                let k1 = (self.p[2] * h[0] + self.p[3] * h[1]) * s_inv;
-
-                // State update: x = x + K*y
-                self.state[0] += k0 * y;
-                self.state[1] += k1 * y;
-
-                // Covariance update: P = (I - K*H) * P
-                let old_p = self.p;
-                self.p[0] = (1.0 as $ty - k0 * h[0]) * old_p[0] + (-k0 * h[1]) * old_p[2];
-                self.p[1] = (1.0 as $ty - k0 * h[0]) * old_p[1] + (-k0 * h[1]) * old_p[3];
-                self.p[2] = (-k1 * h[0]) * old_p[0] + (1.0 as $ty - k1 * h[1]) * old_p[2];
-                self.p[3] = (-k1 * h[0]) * old_p[1] + (1.0 as $ty - k1 * h[1]) * old_p[3];
-
-                self.last_innovation = Option::Some(y);
-                self.last_innovation_var = Option::Some(s);
-                self.count += 1;
-                Ok(())
-            }
-
-            /// Returns the current state estimate [x0, x1].
-            #[inline]
-            #[must_use]
-            pub fn state(&self) -> [$ty; 2] {
-                self.state
-            }
-
-            /// Returns the current covariance as a 2x2 matrix.
-            #[inline]
-            #[must_use]
-            pub fn covariance(&self) -> [[$ty; 2]; 2] {
-                [[self.p[0], self.p[1]], [self.p[2], self.p[3]]]
-            }
-
-            /// Returns the last innovation (measurement residual), or `None`
-            /// if no updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn innovation(&self) -> Option<$ty> {
-                self.last_innovation
-            }
-
-            /// Returns the last innovation variance (S), or `None`
-            /// if no updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn innovation_variance(&self) -> Option<$ty> {
-                self.last_innovation_var
-            }
-
-            /// Override measurement noise (R) for subsequent updates.
-            ///
-            /// Use this to increase R when an observation looks like an outlier
-            /// (innovation > 3σ) — the Kalman will trust the observation less.
-            /// Set back to baseline when done.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `r` is negative, NaN, or infinite.
-            #[inline]
-            pub fn set_measurement_noise(&mut self, r: $ty) {
-                assert!(
-                    r > 0.0 && r.is_finite(),
-                    "measurement noise R must be positive and finite, got {r}"
-                );
-                self.r = r;
-            }
-
-            /// Override process noise (Q) for subsequent updates.
-            ///
-            /// Use this to increase Q when CUSUM detects a regime shift —
-            /// the Kalman will adapt faster to the new level.
-            ///
-            /// # Panics
-            ///
-            /// Panics if any element is NaN or infinite.
-            #[inline]
-            pub fn set_process_noise(&mut self, q: [[$ty; 2]; 2]) {
-                assert!(
-                    q.iter().flat_map(|r| r.iter()).all(|v| v.is_finite()),
-                    "process noise Q elements must be finite"
-                );
-                self.q = [q[0][0], q[0][1], q[1][0], q[1][1]];
-            }
-
-            /// Returns the current measurement noise (R).
-            #[inline]
-            #[must_use]
-            pub fn measurement_noise(&self) -> $ty {
-                self.r
-            }
-
-            /// Returns the current process noise (Q) as a 2x2 matrix.
-            #[inline]
-            #[must_use]
-            pub fn process_noise(&self) -> [[$ty; 2]; 2] {
-                [[self.q[0], self.q[1]], [self.q[2], self.q[3]]]
-            }
-
-            /// Number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to initial state and covariance.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.state = self.initial_state;
-                self.p = self.initial_p;
-                self.last_innovation = Option::None;
-                self.last_innovation_var = Option::None;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the 2x2 process noise matrix Q (required).
-            #[inline]
-            #[must_use]
-            pub fn process_noise(mut self, q: [[$ty; 2]; 2]) -> Self {
-                self.process_noise = Option::Some(q);
-                self
-            }
-
-            /// Sets the scalar measurement noise variance R (required, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn measurement_noise(mut self, r: $ty) -> Self {
-                self.measurement_noise = Option::Some(r);
-                self
-            }
-
-            /// Sets the initial state estimate. Default: [0, 0].
-            #[inline]
-            #[must_use]
-            pub fn initial_state(mut self, state: [$ty; 2]) -> Self {
-                self.initial_state = state;
-                self
-            }
-
-            /// Sets the initial covariance matrix. Default: identity.
-            #[inline]
-            #[must_use]
-            pub fn initial_covariance(mut self, p: [[$ty; 2]; 2]) -> Self {
-                self.initial_covariance = p;
-                self
-            }
-
-            /// Builds the filter.
-            ///
-            /// # Errors
-            ///
-            /// - `process_noise` and `measurement_noise` must be set.
-            /// - `measurement_noise` must be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let q_mat = self
-                    .process_noise
-                    .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
-                let r = self
-                    .measurement_noise
-                    .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
-
-                if r <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "measurement_noise must be positive",
-                    ));
-                }
-
-                let q = [q_mat[0][0], q_mat[0][1], q_mat[1][0], q_mat[1][1]];
-                let p0 = self.initial_covariance;
-                let p = [p0[0][0], p0[0][1], p0[1][0], p0[1][1]];
-
-                Ok($name {
-                    state: self.initial_state,
-                    p,
-                    q,
-                    r,
-                    last_innovation: Option::None,
-                    last_innovation_var: Option::None,
-                    count: 0,
-                    initial_state: self.initial_state,
-                    initial_p: p,
-                })
-            }
-        }
-    };
+/// 2-state Kalman filter with configurable observation model.
+///
+/// Tracks a 2-element state vector from noisy scalar measurements.
+/// The observation model H is provided at each update, allowing
+/// the measurement to be any linear combination of the state.
+///
+/// The predict step adds process noise Q to the covariance.
+/// The update step applies the standard Kalman correction.
+///
+/// # Use Cases
+/// - Position + velocity tracking from noisy position measurements
+/// - Level + trend estimation
+/// - Any 2-state linear system
+#[derive(Debug, Clone)]
+pub struct Kalman2dF64 {
+    state: [f64; 2],
+    p: [f64; 4],
+    q: [f64; 4],
+    r: f64,
+    last_innovation: Option<f64>,
+    last_innovation_var: Option<f64>,
+    count: u64,
+    initial_state: [f64; 2],
+    initial_p: [f64; 4],
 }
 
-impl_kalman2d!(Kalman2dF64, Kalman2dF64Builder, f64);
-impl_kalman2d!(Kalman2dF32, Kalman2dF32Builder, f32);
+/// Builder for [`Kalman2dF64`].
+#[derive(Debug, Clone)]
+pub struct Kalman2dF64Builder {
+    process_noise: Option<[[f64; 2]; 2]>,
+    measurement_noise: Option<f64>,
+    initial_state: [f64; 2],
+    initial_covariance: [[f64; 2]; 2],
+}
+
+impl Kalman2dF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> Kalman2dF64Builder {
+        Kalman2dF64Builder {
+            process_noise: None,
+            measurement_noise: None,
+            initial_state: [0.0; 2],
+            initial_covariance: [[1.0, 0.0], [0.0, 1.0]],
+        }
+    }
+
+    /// Adds process noise to the covariance: P = P + Q.
+    ///
+    /// Call this before `update` to model the passage of time
+    /// and the associated uncertainty growth.
+    #[inline]
+    pub fn predict(&mut self) {
+        self.p[0] += self.q[0];
+        self.p[1] += self.q[1];
+        self.p[2] += self.q[2];
+        self.p[3] += self.q[3];
+    }
+
+    /// Predict with custom state transition matrix F.
+    ///
+    /// Propagates state as `x = F * x` and covariance as `P = F * P * F' + Q`.
+    /// The existing `predict()` uses identity dynamics (F = I).
+    pub fn predict_with_dynamics(&mut self, f: [[f64; 2]; 2]) {
+        // x_new = F * x
+        let x0 = f[0][0] * self.state[0] + f[0][1] * self.state[1];
+        let x1 = f[1][0] * self.state[0] + f[1][1] * self.state[1];
+        self.state = [x0, x1];
+
+        // P_new = F * P * F' + Q
+        // FP[i][j] = Σ_k F[i][k] * P[k*2+j]
+        let fp00 = f[0][0] * self.p[0] + f[0][1] * self.p[2];
+        let fp01 = f[0][0] * self.p[1] + f[0][1] * self.p[3];
+        let fp10 = f[1][0] * self.p[0] + f[1][1] * self.p[2];
+        let fp11 = f[1][0] * self.p[1] + f[1][1] * self.p[3];
+
+        // (FP) * F' + Q
+        self.p[0] = fp00 * f[0][0] + fp01 * f[0][1] + self.q[0];
+        self.p[1] = fp00 * f[1][0] + fp01 * f[1][1] + self.q[1];
+        self.p[2] = fp10 * f[0][0] + fp11 * f[0][1] + self.q[2];
+        self.p[3] = fp10 * f[1][0] + fp11 * f[1][1] + self.q[3];
+    }
+
+    /// Incorporates a scalar observation with observation model H.
+    ///
+    /// The observation is modeled as: `z = h[0]*state[0] + h[1]*state[1] + noise`.
+    ///
+    /// # Arguments
+    /// - `observation` — the measured scalar value
+    /// - `h` — the 2-element observation vector [h0, h1]
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the observation is NaN, or
+    /// `DataError::Infinite` if the observation is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        observation: f64,
+        h: [f64; 2],
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(observation);
+        debug_assert!(h.iter().all(|v| v.is_finite()), "h must be finite");
+        // Innovation: y = obs - H*x
+        let y = observation - h[0] * self.state[0] - h[1] * self.state[1];
+
+        // Innovation covariance: S = H*P*H' + R
+        // Epsilon floor prevents NaN if P degrades numerically.
+        let s = (h[0] * h[0] * self.p[0]
+            + h[0] * h[1] * self.p[1]
+            + h[1] * h[0] * self.p[2]
+            + h[1] * h[1] * self.p[3]
+            + self.r)
+            .max(f64::EPSILON);
+
+        // Kalman gain: K = P*H' / S
+        let s_inv = 1.0 / s;
+        let k0 = (self.p[0] * h[0] + self.p[1] * h[1]) * s_inv;
+        let k1 = (self.p[2] * h[0] + self.p[3] * h[1]) * s_inv;
+
+        // State update: x = x + K*y
+        self.state[0] += k0 * y;
+        self.state[1] += k1 * y;
+
+        // Covariance update: P = (I - K*H) * P
+        let old_p = self.p;
+        self.p[0] = (1.0 - k0 * h[0]) * old_p[0] + (-k0 * h[1]) * old_p[2];
+        self.p[1] = (1.0 - k0 * h[0]) * old_p[1] + (-k0 * h[1]) * old_p[3];
+        self.p[2] = (-k1 * h[0]) * old_p[0] + (1.0 - k1 * h[1]) * old_p[2];
+        self.p[3] = (-k1 * h[0]) * old_p[1] + (1.0 - k1 * h[1]) * old_p[3];
+
+        self.last_innovation = Some(y);
+        self.last_innovation_var = Some(s);
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Returns the current state estimate [x0, x1].
+    #[inline]
+    #[must_use]
+    pub fn state(&self) -> [f64; 2] {
+        self.state
+    }
+
+    /// Returns the current covariance as a 2x2 matrix.
+    #[inline]
+    #[must_use]
+    pub fn covariance(&self) -> [[f64; 2]; 2] {
+        [[self.p[0], self.p[1]], [self.p[2], self.p[3]]]
+    }
+
+    /// Returns the last innovation (measurement residual), or `None`
+    /// if no updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn innovation(&self) -> Option<f64> {
+        self.last_innovation
+    }
+
+    /// Returns the last innovation variance (S), or `None`
+    /// if no updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn innovation_variance(&self) -> Option<f64> {
+        self.last_innovation_var
+    }
+
+    /// Override measurement noise (R) for subsequent updates.
+    ///
+    /// Use this to increase R when an observation looks like an outlier
+    /// (innovation > 3σ) — the Kalman will trust the observation less.
+    /// Set back to baseline when done.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `r` is negative, NaN, or infinite.
+    #[inline]
+    pub fn set_measurement_noise(&mut self, r: f64) {
+        assert!(
+            r > 0.0 && r.is_finite(),
+            "measurement noise R must be positive and finite, got {r}"
+        );
+        self.r = r;
+    }
+
+    /// Override process noise (Q) for subsequent updates.
+    ///
+    /// Use this to increase Q when CUSUM detects a regime shift —
+    /// the Kalman will adapt faster to the new level.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any element is NaN or infinite.
+    #[inline]
+    pub fn set_process_noise(&mut self, q: [[f64; 2]; 2]) {
+        assert!(
+            q.iter().flat_map(|r| r.iter()).all(|v| v.is_finite()),
+            "process noise Q elements must be finite"
+        );
+        self.q = [q[0][0], q[0][1], q[1][0], q[1][1]];
+    }
+
+    /// Returns the current measurement noise (R).
+    #[inline]
+    #[must_use]
+    pub fn measurement_noise(&self) -> f64 {
+        self.r
+    }
+
+    /// Returns the current process noise (Q) as a 2x2 matrix.
+    #[inline]
+    #[must_use]
+    pub fn process_noise(&self) -> [[f64; 2]; 2] {
+        [[self.q[0], self.q[1]], [self.q[2], self.q[3]]]
+    }
+
+    /// Number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to initial state and covariance.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.state = self.initial_state;
+        self.p = self.initial_p;
+        self.last_innovation = None;
+        self.last_innovation_var = None;
+        self.count = 0;
+    }
+}
+
+impl Kalman2dF64Builder {
+    /// Sets the 2x2 process noise matrix Q (required).
+    #[inline]
+    #[must_use]
+    pub fn process_noise(mut self, q: [[f64; 2]; 2]) -> Self {
+        self.process_noise = Some(q);
+        self
+    }
+
+    /// Sets the scalar measurement noise variance R (required, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn measurement_noise(mut self, r: f64) -> Self {
+        self.measurement_noise = Some(r);
+        self
+    }
+
+    /// Sets the initial state estimate. Default: [0, 0].
+    #[inline]
+    #[must_use]
+    pub fn initial_state(mut self, state: [f64; 2]) -> Self {
+        self.initial_state = state;
+        self
+    }
+
+    /// Sets the initial covariance matrix. Default: identity.
+    #[inline]
+    #[must_use]
+    pub fn initial_covariance(mut self, p: [[f64; 2]; 2]) -> Self {
+        self.initial_covariance = p;
+        self
+    }
+
+    /// Builds the filter.
+    ///
+    /// # Errors
+    ///
+    /// - `process_noise` and `measurement_noise` must be set.
+    /// - `measurement_noise` must be positive.
+    #[inline]
+    pub fn build(self) -> Result<Kalman2dF64, nexus_stats_core::ConfigError> {
+        let q_mat = self
+            .process_noise
+            .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
+        let r = self
+            .measurement_noise
+            .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
+
+        if r <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "measurement_noise must be positive",
+            ));
+        }
+
+        let q = [q_mat[0][0], q_mat[0][1], q_mat[1][0], q_mat[1][1]];
+        let p0 = self.initial_covariance;
+        let p = [p0[0][0], p0[0][1], p0[1][0], p0[1][1]];
+
+        Ok(Kalman2dF64 {
+            state: self.initial_state,
+            p,
+            q,
+            r,
+            last_innovation: None,
+            last_innovation_var: None,
+            count: 0,
+            initial_state: self.initial_state,
+            initial_p: p,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -406,27 +397,6 @@ mod tests {
         assert_eq!(kf.count(), 0);
         assert_eq!(kf.state(), [5.0, 3.0]);
         assert!(kf.innovation().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut kf = Kalman2dF32::builder()
-            .process_noise([[0.01, 0.0], [0.0, 0.01]])
-            .measurement_noise(1.0)
-            .build()
-            .unwrap();
-
-        for _ in 0..100 {
-            kf.predict();
-            kf.update(50.0, [1.0, 0.0]).unwrap();
-        }
-
-        let s = kf.state();
-        assert!(
-            (s[0] - 50.0).abs() < 2.0,
-            "state[0] = {}, expected ~50.0",
-            s[0]
-        );
     }
 
     #[test]

--- a/nexus-stats-regression/src/estimation/kalman3d.rs
+++ b/nexus-stats-regression/src/estimation/kalman3d.rs
@@ -1,372 +1,355 @@
 #![allow(clippy::suboptimal_flops, clippy::float_cmp)]
 
-macro_rules! impl_kalman3d {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// 3-state Kalman filter with configurable observation model.
-        ///
-        /// Tracks a 3-element state vector from noisy scalar measurements.
-        /// The observation model H is provided at each update, allowing
-        /// the measurement to be any linear combination of the state.
-        ///
-        /// The predict step adds process noise Q to the covariance.
-        /// The update step applies the standard Kalman correction.
-        ///
-        /// # Use Cases
-        /// - Position + velocity + acceleration tracking
-        /// - Level + trend + curvature estimation
-        /// - Any 3-state linear system
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            state: [$ty; 3],
-            p: [$ty; 9],
-            q: [$ty; 9],
-            r: $ty,
-            last_innovation: Option<$ty>,
-            last_innovation_var: Option<$ty>,
-            count: u64,
-            initial_state: [$ty; 3],
-            initial_p: [$ty; 9],
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            process_noise: Option<[[$ty; 3]; 3]>,
-            measurement_noise: Option<$ty>,
-            initial_state: [$ty; 3],
-            initial_covariance: [[$ty; 3]; 3],
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    process_noise: Option::None,
-                    measurement_noise: Option::None,
-                    initial_state: [0.0 as $ty; 3],
-                    initial_covariance: [
-                        [1.0 as $ty, 0.0 as $ty, 0.0 as $ty],
-                        [0.0 as $ty, 1.0 as $ty, 0.0 as $ty],
-                        [0.0 as $ty, 0.0 as $ty, 1.0 as $ty],
-                    ],
-                }
-            }
-
-            /// Adds process noise to the covariance: P = P + Q.
-            ///
-            /// Call this before `update` to model the passage of time
-            /// and the associated uncertainty growth.
-            #[inline]
-            pub fn predict(&mut self) {
-                for i in 0..3 {
-                    for j in 0..3 {
-                        self.p[i * 3 + j] += self.q[i * 3 + j];
-                    }
-                }
-            }
-
-            /// Predict with custom state transition matrix F.
-            pub fn predict_with_dynamics(&mut self, f: [[$ty; 3]; 3]) {
-                // x_new = F * x
-                let mut new_state = [0.0 as $ty; 3];
-                for i in 0..3 {
-                    for k in 0..3 {
-                        new_state[i] += f[i][k] * self.state[k];
-                    }
-                }
-                self.state = new_state;
-
-                // FP = F * P
-                let mut fp = [0.0 as $ty; 9];
-                for i in 0..3 {
-                    for j in 0..3 {
-                        for k in 0..3 {
-                            fp[i * 3 + j] += f[i][k] * self.p[k * 3 + j];
-                        }
-                    }
-                }
-
-                // P_new = FP * F' + Q
-                let mut new_p = [0.0 as $ty; 9];
-                for i in 0..3 {
-                    for j in 0..3 {
-                        for k in 0..3 {
-                            new_p[i * 3 + j] += fp[i * 3 + k] * f[j][k];
-                        }
-                        new_p[i * 3 + j] += self.q[i * 3 + j];
-                    }
-                }
-                self.p = new_p;
-            }
-
-            /// Incorporates a scalar observation with observation model H.
-            ///
-            /// The observation is modeled as:
-            /// `z = h[0]*state[0] + h[1]*state[1] + h[2]*state[2] + noise`.
-            ///
-            /// # Arguments
-            /// - `observation` — the measured scalar value
-            /// - `h` — the 3-element observation vector [h0, h1, h2]
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the observation is NaN, or
-            /// `DataError::Infinite` if the observation is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                observation: $ty,
-                h: [$ty; 3],
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(observation);
-                debug_assert!(h.iter().all(|v| v.is_finite()), "h must be finite");
-                // Innovation: y = obs - H*x
-                let mut hx = 0.0 as $ty;
-                for i in 0..3 {
-                    hx += h[i] * self.state[i];
-                }
-                let y = observation - hx;
-
-                // Innovation covariance: S = H*P*H' + R
-                // Epsilon floor prevents NaN if P degrades numerically.
-                let mut s = self.r;
-                for i in 0..3 {
-                    for j in 0..3 {
-                        s += h[i] * self.p[i * 3 + j] * h[j];
-                    }
-                }
-                s = s.max(<$ty>::EPSILON);
-
-                // Kalman gain: K = P*H' / S
-                let s_inv = (1.0 as $ty) / s;
-                let mut k = [0.0 as $ty; 3];
-                for i in 0..3 {
-                    let mut ph = 0.0 as $ty;
-                    for j in 0..3 {
-                        ph += self.p[i * 3 + j] * h[j];
-                    }
-                    k[i] = ph * s_inv;
-                }
-
-                // State update: x = x + K*y
-                for i in 0..3 {
-                    self.state[i] += k[i] * y;
-                }
-
-                // Covariance update: P = (I - K*H) * P
-                let old_p = self.p;
-                for i in 0..3 {
-                    for j in 0..3 {
-                        let mut sum = 0.0 as $ty;
-                        for m in 0..3 {
-                            let ikh = if i == m { 1.0 as $ty } else { 0.0 as $ty } - k[i] * h[m];
-                            sum += ikh * old_p[m * 3 + j];
-                        }
-                        self.p[i * 3 + j] = sum;
-                    }
-                }
-
-                self.last_innovation = Option::Some(y);
-                self.last_innovation_var = Option::Some(s);
-                self.count += 1;
-                Ok(())
-            }
-
-            /// Returns the current state estimate [x0, x1, x2].
-            #[inline]
-            #[must_use]
-            pub fn state(&self) -> [$ty; 3] {
-                self.state
-            }
-
-            /// Returns the current covariance as a 3x3 matrix.
-            #[inline]
-            #[must_use]
-            pub fn covariance(&self) -> [[$ty; 3]; 3] {
-                [
-                    [self.p[0], self.p[1], self.p[2]],
-                    [self.p[3], self.p[4], self.p[5]],
-                    [self.p[6], self.p[7], self.p[8]],
-                ]
-            }
-
-            /// Returns the last innovation (measurement residual), or `None`
-            /// if no updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn innovation(&self) -> Option<$ty> {
-                self.last_innovation
-            }
-
-            /// Returns the last innovation variance (S), or `None`
-            /// if no updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn innovation_variance(&self) -> Option<$ty> {
-                self.last_innovation_var
-            }
-
-            /// Override measurement noise (R) for subsequent updates.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `r` is negative, NaN, or infinite.
-            #[inline]
-            pub fn set_measurement_noise(&mut self, r: $ty) {
-                assert!(
-                    r > 0.0 && r.is_finite(),
-                    "measurement noise R must be positive and finite, got {r}"
-                );
-                self.r = r;
-            }
-
-            /// Override process noise (Q) for subsequent updates.
-            ///
-            /// # Panics
-            ///
-            /// Panics if any element is NaN or infinite.
-            #[inline]
-            pub fn set_process_noise(&mut self, q: [[$ty; 3]; 3]) {
-                assert!(
-                    q.iter().flat_map(|r| r.iter()).all(|v| v.is_finite()),
-                    "process noise Q elements must be finite"
-                );
-                self.q = [
-                    q[0][0], q[0][1], q[0][2], q[1][0], q[1][1], q[1][2], q[2][0], q[2][1], q[2][2],
-                ];
-            }
-
-            /// Returns the current measurement noise (R).
-            #[inline]
-            #[must_use]
-            pub fn measurement_noise(&self) -> $ty {
-                self.r
-            }
-
-            /// Returns the current process noise (Q) as a 3x3 matrix.
-            #[inline]
-            #[must_use]
-            pub fn process_noise(&self) -> [[$ty; 3]; 3] {
-                [
-                    [self.q[0], self.q[1], self.q[2]],
-                    [self.q[3], self.q[4], self.q[5]],
-                    [self.q[6], self.q[7], self.q[8]],
-                ]
-            }
-
-            /// Number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Resets to initial state and covariance.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.state = self.initial_state;
-                self.p = self.initial_p;
-                self.last_innovation = Option::None;
-                self.last_innovation_var = Option::None;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the 3x3 process noise matrix Q (required).
-            #[inline]
-            #[must_use]
-            pub fn process_noise(mut self, q: [[$ty; 3]; 3]) -> Self {
-                self.process_noise = Option::Some(q);
-                self
-            }
-
-            /// Sets the scalar measurement noise variance R (required, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn measurement_noise(mut self, r: $ty) -> Self {
-                self.measurement_noise = Option::Some(r);
-                self
-            }
-
-            /// Sets the initial state estimate. Default: [0, 0, 0].
-            #[inline]
-            #[must_use]
-            pub fn initial_state(mut self, state: [$ty; 3]) -> Self {
-                self.initial_state = state;
-                self
-            }
-
-            /// Sets the initial covariance matrix. Default: identity.
-            #[inline]
-            #[must_use]
-            pub fn initial_covariance(mut self, p: [[$ty; 3]; 3]) -> Self {
-                self.initial_covariance = p;
-                self
-            }
-
-            /// Builds the filter.
-            ///
-            /// # Errors
-            ///
-            /// - `process_noise` and `measurement_noise` must be set.
-            /// - `measurement_noise` must be positive.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let q_mat = self
-                    .process_noise
-                    .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
-                let r = self
-                    .measurement_noise
-                    .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
-
-                if r <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "measurement_noise must be positive",
-                    ));
-                }
-
-                let mut q = [0.0 as $ty; 9];
-                let mut p = [0.0 as $ty; 9];
-                for i in 0..3 {
-                    for j in 0..3 {
-                        q[i * 3 + j] = q_mat[i][j];
-                        p[i * 3 + j] = self.initial_covariance[i][j];
-                    }
-                }
-
-                Ok($name {
-                    state: self.initial_state,
-                    p,
-                    q,
-                    r,
-                    last_innovation: Option::None,
-                    last_innovation_var: Option::None,
-                    count: 0,
-                    initial_state: self.initial_state,
-                    initial_p: p,
-                })
-            }
-        }
-    };
+/// 3-state Kalman filter with configurable observation model.
+///
+/// Tracks a 3-element state vector from noisy scalar measurements.
+/// The observation model H is provided at each update, allowing
+/// the measurement to be any linear combination of the state.
+///
+/// The predict step adds process noise Q to the covariance.
+/// The update step applies the standard Kalman correction.
+///
+/// # Use Cases
+/// - Position + velocity + acceleration tracking
+/// - Level + trend + curvature estimation
+/// - Any 3-state linear system
+#[derive(Debug, Clone)]
+pub struct Kalman3dF64 {
+    state: [f64; 3],
+    p: [f64; 9],
+    q: [f64; 9],
+    r: f64,
+    last_innovation: Option<f64>,
+    last_innovation_var: Option<f64>,
+    count: u64,
+    initial_state: [f64; 3],
+    initial_p: [f64; 9],
 }
 
-impl_kalman3d!(Kalman3dF64, Kalman3dF64Builder, f64);
-impl_kalman3d!(Kalman3dF32, Kalman3dF32Builder, f32);
+/// Builder for [`Kalman3dF64`].
+#[derive(Debug, Clone)]
+pub struct Kalman3dF64Builder {
+    process_noise: Option<[[f64; 3]; 3]>,
+    measurement_noise: Option<f64>,
+    initial_state: [f64; 3],
+    initial_covariance: [[f64; 3]; 3],
+}
+
+impl Kalman3dF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> Kalman3dF64Builder {
+        Kalman3dF64Builder {
+            process_noise: None,
+            measurement_noise: None,
+            initial_state: [0.0; 3],
+            initial_covariance: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        }
+    }
+
+    /// Adds process noise to the covariance: P = P + Q.
+    ///
+    /// Call this before `update` to model the passage of time
+    /// and the associated uncertainty growth.
+    #[inline]
+    pub fn predict(&mut self) {
+        for i in 0..3 {
+            for j in 0..3 {
+                self.p[i * 3 + j] += self.q[i * 3 + j];
+            }
+        }
+    }
+
+    /// Predict with custom state transition matrix F.
+    pub fn predict_with_dynamics(&mut self, f: [[f64; 3]; 3]) {
+        // x_new = F * x
+        let mut new_state = [0.0; 3];
+        for i in 0..3 {
+            for k in 0..3 {
+                new_state[i] += f[i][k] * self.state[k];
+            }
+        }
+        self.state = new_state;
+
+        // FP = F * P
+        let mut fp = [0.0; 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                for k in 0..3 {
+                    fp[i * 3 + j] += f[i][k] * self.p[k * 3 + j];
+                }
+            }
+        }
+
+        // P_new = FP * F' + Q
+        let mut new_p = [0.0; 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                for k in 0..3 {
+                    new_p[i * 3 + j] += fp[i * 3 + k] * f[j][k];
+                }
+                new_p[i * 3 + j] += self.q[i * 3 + j];
+            }
+        }
+        self.p = new_p;
+    }
+
+    /// Incorporates a scalar observation with observation model H.
+    ///
+    /// The observation is modeled as:
+    /// `z = h[0]*state[0] + h[1]*state[1] + h[2]*state[2] + noise`.
+    ///
+    /// # Arguments
+    /// - `observation` — the measured scalar value
+    /// - `h` — the 3-element observation vector [h0, h1, h2]
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the observation is NaN, or
+    /// `DataError::Infinite` if the observation is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        observation: f64,
+        h: [f64; 3],
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(observation);
+        debug_assert!(h.iter().all(|v| v.is_finite()), "h must be finite");
+        // Innovation: y = obs - H*x
+        let mut hx = 0.0;
+        for i in 0..3 {
+            hx += h[i] * self.state[i];
+        }
+        let y = observation - hx;
+
+        // Innovation covariance: S = H*P*H' + R
+        // Epsilon floor prevents NaN if P degrades numerically.
+        let mut s = self.r;
+        for i in 0..3 {
+            for j in 0..3 {
+                s += h[i] * self.p[i * 3 + j] * h[j];
+            }
+        }
+        s = s.max(f64::EPSILON);
+
+        // Kalman gain: K = P*H' / S
+        let s_inv = 1.0 / s;
+        let mut k = [0.0; 3];
+        for i in 0..3 {
+            let mut ph = 0.0;
+            for j in 0..3 {
+                ph += self.p[i * 3 + j] * h[j];
+            }
+            k[i] = ph * s_inv;
+        }
+
+        // State update: x = x + K*y
+        for i in 0..3 {
+            self.state[i] += k[i] * y;
+        }
+
+        // Covariance update: P = (I - K*H) * P
+        let old_p = self.p;
+        for i in 0..3 {
+            for j in 0..3 {
+                let mut sum = 0.0;
+                for m in 0..3 {
+                    let ikh = if i == m { 1.0 } else { 0.0 } - k[i] * h[m];
+                    sum += ikh * old_p[m * 3 + j];
+                }
+                self.p[i * 3 + j] = sum;
+            }
+        }
+
+        self.last_innovation = Some(y);
+        self.last_innovation_var = Some(s);
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Returns the current state estimate [x0, x1, x2].
+    #[inline]
+    #[must_use]
+    pub fn state(&self) -> [f64; 3] {
+        self.state
+    }
+
+    /// Returns the current covariance as a 3x3 matrix.
+    #[inline]
+    #[must_use]
+    pub fn covariance(&self) -> [[f64; 3]; 3] {
+        [
+            [self.p[0], self.p[1], self.p[2]],
+            [self.p[3], self.p[4], self.p[5]],
+            [self.p[6], self.p[7], self.p[8]],
+        ]
+    }
+
+    /// Returns the last innovation (measurement residual), or `None`
+    /// if no updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn innovation(&self) -> Option<f64> {
+        self.last_innovation
+    }
+
+    /// Returns the last innovation variance (S), or `None`
+    /// if no updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn innovation_variance(&self) -> Option<f64> {
+        self.last_innovation_var
+    }
+
+    /// Override measurement noise (R) for subsequent updates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `r` is negative, NaN, or infinite.
+    #[inline]
+    pub fn set_measurement_noise(&mut self, r: f64) {
+        assert!(
+            r > 0.0 && r.is_finite(),
+            "measurement noise R must be positive and finite, got {r}"
+        );
+        self.r = r;
+    }
+
+    /// Override process noise (Q) for subsequent updates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any element is NaN or infinite.
+    #[inline]
+    pub fn set_process_noise(&mut self, q: [[f64; 3]; 3]) {
+        assert!(
+            q.iter().flat_map(|r| r.iter()).all(|v| v.is_finite()),
+            "process noise Q elements must be finite"
+        );
+        self.q = [
+            q[0][0], q[0][1], q[0][2], q[1][0], q[1][1], q[1][2], q[2][0], q[2][1], q[2][2],
+        ];
+    }
+
+    /// Returns the current measurement noise (R).
+    #[inline]
+    #[must_use]
+    pub fn measurement_noise(&self) -> f64 {
+        self.r
+    }
+
+    /// Returns the current process noise (Q) as a 3x3 matrix.
+    #[inline]
+    #[must_use]
+    pub fn process_noise(&self) -> [[f64; 3]; 3] {
+        [
+            [self.q[0], self.q[1], self.q[2]],
+            [self.q[3], self.q[4], self.q[5]],
+            [self.q[6], self.q[7], self.q[8]],
+        ]
+    }
+
+    /// Number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Resets to initial state and covariance.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.state = self.initial_state;
+        self.p = self.initial_p;
+        self.last_innovation = None;
+        self.last_innovation_var = None;
+        self.count = 0;
+    }
+}
+
+impl Kalman3dF64Builder {
+    /// Sets the 3x3 process noise matrix Q (required).
+    #[inline]
+    #[must_use]
+    pub fn process_noise(mut self, q: [[f64; 3]; 3]) -> Self {
+        self.process_noise = Some(q);
+        self
+    }
+
+    /// Sets the scalar measurement noise variance R (required, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn measurement_noise(mut self, r: f64) -> Self {
+        self.measurement_noise = Some(r);
+        self
+    }
+
+    /// Sets the initial state estimate. Default: [0, 0, 0].
+    #[inline]
+    #[must_use]
+    pub fn initial_state(mut self, state: [f64; 3]) -> Self {
+        self.initial_state = state;
+        self
+    }
+
+    /// Sets the initial covariance matrix. Default: identity.
+    #[inline]
+    #[must_use]
+    pub fn initial_covariance(mut self, p: [[f64; 3]; 3]) -> Self {
+        self.initial_covariance = p;
+        self
+    }
+
+    /// Builds the filter.
+    ///
+    /// # Errors
+    ///
+    /// - `process_noise` and `measurement_noise` must be set.
+    /// - `measurement_noise` must be positive.
+    #[inline]
+    pub fn build(self) -> Result<Kalman3dF64, nexus_stats_core::ConfigError> {
+        let q_mat = self
+            .process_noise
+            .ok_or(nexus_stats_core::ConfigError::Missing("process_noise"))?;
+        let r = self
+            .measurement_noise
+            .ok_or(nexus_stats_core::ConfigError::Missing("measurement_noise"))?;
+
+        if r <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "measurement_noise must be positive",
+            ));
+        }
+
+        let mut q = [0.0; 9];
+        let mut p = [0.0; 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                q[i * 3 + j] = q_mat[i][j];
+                p[i * 3 + j] = self.initial_covariance[i][j];
+            }
+        }
+
+        Ok(Kalman3dF64 {
+            state: self.initial_state,
+            p,
+            q,
+            r,
+            last_innovation: None,
+            last_innovation_var: None,
+            count: 0,
+            initial_state: self.initial_state,
+            initial_p: p,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn diagonal_q() -> [[f64; 3]; 3] {
-        [[0.01, 0.0, 0.0], [0.0, 0.01, 0.0], [0.0, 0.0, 0.01]]
-    }
-
-    fn diagonal_q_f32() -> [[f32; 3]; 3] {
         [[0.01, 0.0, 0.0], [0.0, 0.01, 0.0], [0.0, 0.0, 0.01]]
     }
 
@@ -461,27 +444,6 @@ mod tests {
         assert_eq!(kf.count(), 0);
         assert_eq!(kf.state(), [5.0, 3.0, 1.0]);
         assert!(kf.innovation().is_none());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut kf = Kalman3dF32::builder()
-            .process_noise(diagonal_q_f32())
-            .measurement_noise(1.0)
-            .build()
-            .unwrap();
-
-        for _ in 0..100 {
-            kf.predict();
-            kf.update(50.0, [1.0, 0.0, 0.0]).unwrap();
-        }
-
-        let s = kf.state();
-        assert!(
-            (s[0] - 50.0).abs() < 2.0,
-            "state[0] = {}, expected ~50.0",
-            s[0]
-        );
     }
 
     #[test]

--- a/nexus-stats-regression/src/learning/epsilon_greedy.rs
+++ b/nexus-stats-regression/src/learning/epsilon_greedy.rs
@@ -2,294 +2,281 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
 
-macro_rules! impl_epsilon_greedy {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Epsilon-greedy multi-armed bandit.
-        ///
-        /// With probability `epsilon`, selects a uniformly random arm
-        /// (explore). Otherwise selects the arm with the highest mean
-        /// reward (exploit). Ties broken by lowest index.
-        ///
-        /// Arms with zero pulls are selected first (round-robin, lowest
-        /// index priority) before the epsilon-greedy rule applies.
-        ///
-        /// The simplest bandit algorithm. Useful as a baseline and when
-        /// operational simplicity matters more than convergence speed.
-        ///
-        /// # Parameters
-        ///
-        /// - `arms` — number of arms (>= 2)
-        /// - `epsilon` — exploration probability, in (0, 1)
-        /// - `decay` — exponential discount on counts/rewards (default: 1.0)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_regression::learning::EpsilonGreedyF64;
-        ///
-        /// let mut bandit = EpsilonGreedyF64::builder()
-        ///     .arms(3)
-        ///     .epsilon(0.1)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// let mut s: u64 = 42;
-        /// let mut rng = || -> f64 {
-        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
-        ///     (s >> 33) as f64 / (1u64 << 31) as f64
-        /// };
-        /// let arm = bandit.select(&mut rng);
-        /// bandit.update(arm, 1.0).unwrap();
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            counts: Box<[$ty]>,
-            rewards: Box<[$ty]>,
-            epsilon: $ty,
-            decay: $ty,
-            total_pulls: u64,
-            num_arms: usize,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            arms: Option<usize>,
-            epsilon: Option<$ty>,
-            decay: $ty,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    arms: Option::None,
-                    epsilon: Option::None,
-                    decay: 1.0 as $ty,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Selects an arm: random with probability epsilon, best mean otherwise.
-            ///
-            /// Unpulled arms are selected first (lowest index priority).
-            /// `rng` must return a uniform sample in [0, 1).
-            #[must_use]
-            #[allow(clippy::float_cmp)]
-            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
-                // Round-robin unpulled arms first
-                for (i, &c) in self.counts.iter().enumerate() {
-                    if c == 0.0 as $ty {
-                        return i;
-                    }
-                }
-
-                let coin = rng();
-                if coin < self.epsilon {
-                    // Explore: uniform random arm
-                    let r = rng();
-                    let idx = (r * self.num_arms as $ty) as usize;
-                    // Clamp to valid range (r could be very close to 1.0)
-                    if idx >= self.num_arms {
-                        self.num_arms - 1
-                    } else {
-                        idx
-                    }
-                } else {
-                    // Exploit: best mean reward
-                    let mut best_arm = 0;
-                    let mut best_mean = -(1.0 as $ty / 0.0 as $ty);
-                    for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
-                        let mean = r / c;
-                        if mean > best_mean {
-                            best_mean = mean;
-                            best_arm = i;
-                        }
-                    }
-                    best_arm
-                }
-            }
-
-            /// Records a reward for an arm.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError` if reward is NaN or infinite.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `arm >= num_arms`.
-            #[inline]
-            pub fn update(
-                &mut self,
-                arm: usize,
-                reward: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(reward);
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-
-                if self.decay < 1.0 as $ty {
-                    let decay = self.decay;
-                    for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
-                        *c *= decay;
-                        *r *= decay;
-                    }
-                }
-
-                self.counts[arm] += 1.0 as $ty;
-                self.rewards[arm] += reward;
-                self.total_pulls += 1;
-                Ok(())
-            }
-
-            /// Mean reward for an arm, or `None` if never pulled.
-            #[inline]
-            #[must_use]
-            #[allow(clippy::float_cmp)]
-            pub fn mean_reward(&self, arm: usize) -> Option<$ty> {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                if self.counts[arm] == 0.0 as $ty {
-                    return Option::None;
-                }
-                Option::Some(self.rewards[arm] / self.counts[arm])
-            }
-
-            /// Effective pull count for an arm (decayed).
-            #[inline]
-            #[must_use]
-            pub fn pulls(&self, arm: usize) -> $ty {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                self.counts[arm]
-            }
-
-            /// Total pulls across all arms (un-decayed counter).
-            #[inline]
-            #[must_use]
-            pub fn total_pulls(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Number of arms.
-            #[inline]
-            #[must_use]
-            pub fn num_arms(&self) -> usize {
-                self.num_arms
-            }
-
-            /// Whether all arms have been pulled at least once
-            /// and `total_pulls >= min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0 as $ty)
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Resets all state, keeping configuration.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.counts.fill(0.0 as $ty);
-                self.rewards.fill(0.0 as $ty);
-                self.total_pulls = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of arms (required, >= 2).
-            #[inline]
-            #[must_use]
-            pub fn arms(mut self, n: usize) -> Self {
-                self.arms = Option::Some(n);
-                self
-            }
-
-            /// Sets the exploration probability (required, in (0, 1)).
-            #[inline]
-            #[must_use]
-            pub fn epsilon(mut self, e: $ty) -> Self {
-                self.epsilon = Option::Some(e);
-                self
-            }
-
-            /// Sets the decay factor (default: 1.0, in (0, 1]).
-            #[inline]
-            #[must_use]
-            pub fn decay(mut self, d: $ty) -> Self {
-                self.decay = d;
-                self
-            }
-
-            /// Sets the minimum samples before `is_primed()` returns true.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = Option::Some(n);
-                self
-            }
-
-            /// Builds the bandit.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let arms = self
-                    .arms
-                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
-                let epsilon = self
-                    .epsilon
-                    .ok_or(nexus_stats_core::ConfigError::Missing("epsilon"))?;
-                if arms < 2 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
-                }
-                if epsilon <= 0.0 as $ty || epsilon >= 1.0 as $ty || !epsilon.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "epsilon must be in (0, 1)",
-                    ));
-                }
-                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "decay must be in (0, 1]",
-                    ));
-                }
-                let min_samples = self.min_samples.unwrap_or(arms as u64);
-                Ok($name {
-                    counts: vec![0.0 as $ty; arms].into_boxed_slice(),
-                    rewards: vec![0.0 as $ty; arms].into_boxed_slice(),
-                    epsilon,
-                    decay: self.decay,
-                    total_pulls: 0,
-                    num_arms: arms,
-                    min_samples,
-                })
-            }
-        }
-    };
+/// Epsilon-greedy multi-armed bandit.
+///
+/// With probability `epsilon`, selects a uniformly random arm
+/// (explore). Otherwise selects the arm with the highest mean
+/// reward (exploit). Ties broken by lowest index.
+///
+/// Arms with zero pulls are selected first (round-robin, lowest
+/// index priority) before the epsilon-greedy rule applies.
+///
+/// The simplest bandit algorithm. Useful as a baseline and when
+/// operational simplicity matters more than convergence speed.
+///
+/// # Parameters
+///
+/// - `arms` — number of arms (>= 2)
+/// - `epsilon` — exploration probability, in (0, 1)
+/// - `decay` — exponential discount on counts/rewards (default: 1.0)
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::learning::EpsilonGreedyF64;
+///
+/// let mut bandit = EpsilonGreedyF64::builder()
+///     .arms(3)
+///     .epsilon(0.1)
+///     .build()
+///     .unwrap();
+///
+/// let mut s: u64 = 42;
+/// let mut rng = || -> f64 {
+///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+///     (s >> 33) as f64 / (1u64 << 31) as f64
+/// };
+/// let arm = bandit.select(&mut rng);
+/// bandit.update(arm, 1.0).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct EpsilonGreedyF64 {
+    counts: Box<[f64]>,
+    rewards: Box<[f64]>,
+    epsilon: f64,
+    decay: f64,
+    total_pulls: u64,
+    num_arms: usize,
+    min_samples: u64,
 }
 
-impl_epsilon_greedy!(EpsilonGreedyF64, EpsilonGreedyF64Builder, f64);
-impl_epsilon_greedy!(EpsilonGreedyF32, EpsilonGreedyF32Builder, f32);
+/// Builder for [`EpsilonGreedyF64`].
+#[derive(Debug, Clone)]
+pub struct EpsilonGreedyF64Builder {
+    arms: Option<usize>,
+    epsilon: Option<f64>,
+    decay: f64,
+    min_samples: Option<u64>,
+}
+
+impl EpsilonGreedyF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EpsilonGreedyF64Builder {
+        EpsilonGreedyF64Builder {
+            arms: None,
+            epsilon: None,
+            decay: 1.0,
+            min_samples: None,
+        }
+    }
+
+    /// Selects an arm: random with probability epsilon, best mean otherwise.
+    ///
+    /// Unpulled arms are selected first (lowest index priority).
+    /// `rng` must return a uniform sample in [0, 1).
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn select(&self, rng: &mut impl FnMut() -> f64) -> usize {
+        // Round-robin unpulled arms first
+        for (i, &c) in self.counts.iter().enumerate() {
+            if c == 0.0 {
+                return i;
+            }
+        }
+
+        let coin = rng();
+        if coin < self.epsilon {
+            // Explore: uniform random arm
+            let r = rng();
+            let idx = (r * self.num_arms as f64) as usize;
+            // Clamp to valid range (r could be very close to 1.0)
+            if idx >= self.num_arms {
+                self.num_arms - 1
+            } else {
+                idx
+            }
+        } else {
+            // Exploit: best mean reward
+            let mut best_arm = 0;
+            let mut best_mean = f64::NEG_INFINITY;
+            for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
+                let mean = r / c;
+                if mean > best_mean {
+                    best_mean = mean;
+                    best_arm = i;
+                }
+            }
+            best_arm
+        }
+    }
+
+    /// Records a reward for an arm.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError` if reward is NaN or infinite.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `arm >= num_arms`.
+    #[inline]
+    pub fn update(&mut self, arm: usize, reward: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(reward);
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+
+        if self.decay < 1.0 {
+            let decay = self.decay;
+            for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
+                *c *= decay;
+                *r *= decay;
+            }
+        }
+
+        self.counts[arm] += 1.0;
+        self.rewards[arm] += reward;
+        self.total_pulls += 1;
+        Ok(())
+    }
+
+    /// Mean reward for an arm, or `None` if never pulled.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn mean_reward(&self, arm: usize) -> Option<f64> {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        if self.counts[arm] == 0.0 {
+            return None;
+        }
+        Some(self.rewards[arm] / self.counts[arm])
+    }
+
+    /// Effective pull count for an arm (decayed).
+    #[inline]
+    #[must_use]
+    pub fn pulls(&self, arm: usize) -> f64 {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        self.counts[arm]
+    }
+
+    /// Total pulls across all arms (un-decayed counter).
+    #[inline]
+    #[must_use]
+    pub fn total_pulls(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Number of arms.
+    #[inline]
+    #[must_use]
+    pub fn num_arms(&self) -> usize {
+        self.num_arms
+    }
+
+    /// Whether all arms have been pulled at least once
+    /// and `total_pulls >= min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0)
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Resets all state, keeping configuration.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.counts.fill(0.0);
+        self.rewards.fill(0.0);
+        self.total_pulls = 0;
+    }
+}
+
+impl EpsilonGreedyF64Builder {
+    /// Sets the number of arms (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn arms(mut self, n: usize) -> Self {
+        self.arms = Some(n);
+        self
+    }
+
+    /// Sets the exploration probability (required, in (0, 1)).
+    #[inline]
+    #[must_use]
+    pub fn epsilon(mut self, e: f64) -> Self {
+        self.epsilon = Some(e);
+        self
+    }
+
+    /// Sets the decay factor (default: 1.0, in (0, 1]).
+    #[inline]
+    #[must_use]
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = d;
+        self
+    }
+
+    /// Sets the minimum samples before `is_primed()` returns true.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = Some(n);
+        self
+    }
+
+    /// Builds the bandit.
+    #[inline]
+    pub fn build(self) -> Result<EpsilonGreedyF64, nexus_stats_core::ConfigError> {
+        let arms = self
+            .arms
+            .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+        let epsilon = self
+            .epsilon
+            .ok_or(nexus_stats_core::ConfigError::Missing("epsilon"))?;
+        if arms < 2 {
+            return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+        }
+        if epsilon <= 0.0 || epsilon >= 1.0 || !epsilon.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "epsilon must be in (0, 1)",
+            ));
+        }
+        if self.decay <= 0.0 || self.decay > 1.0 || !self.decay.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "decay must be in (0, 1]",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(arms as u64);
+        Ok(EpsilonGreedyF64 {
+            counts: vec![0.0; arms].into_boxed_slice(),
+            rewards: vec![0.0; arms].into_boxed_slice(),
+            epsilon,
+            decay: self.decay,
+            total_pulls: 0,
+            num_arms: arms,
+            min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -431,7 +418,7 @@ mod tests {
         bandit.update(0, 1.0).unwrap();
         bandit.reset();
         assert_eq!(bandit.total_pulls(), 0);
-        assert_eq!(bandit.mean_reward(0), Option::None);
+        assert_eq!(bandit.mean_reward(0), None);
     }
 
     #[test]

--- a/nexus-stats-regression/src/learning/exp3.rs
+++ b/nexus-stats-regression/src/learning/exp3.rs
@@ -2,333 +2,326 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
 
-macro_rules! impl_exp3 {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// EXP3 adversarial bandit.
-        ///
-        /// Exponential-weight algorithm for Exploration and Exploitation.
-        /// Unlike UCB1/Thompson which assume stochastic rewards, EXP3
-        /// makes no assumptions about how rewards are generated — they
-        /// can be adversarial.
-        ///
-        /// Selection probability: `p_i = (1 - gamma) * w_i / sum(w) + gamma / K`
-        ///
-        /// Weight update (log-space): `ln(w_i) += eta * reward / (K * p_i)`
-        ///
-        /// Internally stores log-weights for numerical stability. No
-        /// overflow possible regardless of learning rate or horizon.
-        ///
-        /// Auer, Cesa-Bianchi, Freund, Schapire (2002).
-        ///
-        /// # Parameters
-        ///
-        /// - `arms` — number of arms K (>= 2)
-        /// - `gamma` — exploration mixing rate, in (0, 1]. Higher = more uniform.
-        /// - `eta` — learning rate (default: gamma)
-        ///
-        /// # Reward range
-        ///
-        /// Rewards must be in [0, 1]. Normalize before feeding.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_regression::learning::Exp3F64;
-        ///
-        /// let mut bandit = Exp3F64::builder()
-        ///     .arms(3)
-        ///     .gamma(0.1)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// let mut s: u64 = 42;
-        /// let mut rng = || -> f64 {
-        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
-        ///     (s >> 33) as f64 / (1u64 << 31) as f64
-        /// };
-        /// let (arm, prob) = bandit.select(&mut rng);
-        /// bandit.update(arm, 0.8, prob).unwrap();
-        /// ```
-        #[derive(Debug)]
-        pub struct $name {
-            log_weights: Box<[$ty]>,
-            scratch: core::cell::UnsafeCell<Box<[$ty]>>,
-            gamma: $ty,
-            eta: $ty,
-            total_pulls: u64,
-            num_arms: usize,
-            min_samples: u64,
-        }
-
-        impl Clone for $name {
-            fn clone(&self) -> Self {
-                Self {
-                    log_weights: self.log_weights.clone(),
-                    scratch: core::cell::UnsafeCell::new(
-                        vec![0.0 as $ty; self.num_arms].into_boxed_slice(),
-                    ),
-                    gamma: self.gamma,
-                    eta: self.eta,
-                    total_pulls: self.total_pulls,
-                    num_arms: self.num_arms,
-                    min_samples: self.min_samples,
-                }
-            }
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            arms: Option<usize>,
-            gamma: Option<$ty>,
-            eta: Option<$ty>,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    arms: Option::None,
-                    gamma: Option::None,
-                    eta: Option::None,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Samples an arm proportional to mixed weights.
-            ///
-            /// Returns `(arm_index, selection_probability)`. The caller
-            /// must pass the probability back to `update()`.
-            ///
-            /// Uses log-sum-exp with a cached scratch buffer to avoid
-            /// recomputing exp() values during CDF sampling.
-            #[must_use]
-            #[allow(clippy::suboptimal_flops, clippy::cast_possible_truncation)]
-            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> (usize, $ty) {
-                let k = self.num_arms as $ty;
-                let gamma = self.gamma;
-
-                // SAFETY: scratch is a write-only cache derived from log_weights.
-                // No reference escapes this method and select() is not reentrant.
-                let scratch = unsafe { &mut *self.scratch.get() };
-
-                let max_lw = self.log_weights.iter().copied()
-                    .fold(-(1.0 as $ty / 0.0 as $ty), |a, b| if a > b { a } else { b });
-
-                // Compute exp values into scratch, accumulate sum (K exp calls)
-                let mut sum_exp = 0.0 as $ty;
-                for (s, &lw) in scratch.iter_mut().zip(self.log_weights.iter()) {
-                    *s = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
-                    sum_exp += *s;
-                }
-
-                let scale = (1.0 as $ty - gamma) / sum_exp;
-                let gamma_over_k = gamma / k;
-                let u = rng();
-                let mut cumulative = 0.0 as $ty;
-
-                // CDF sampling from cached exp values — no exp() calls
-                for (i, &exp_w) in scratch.iter().enumerate() {
-                    let p_i = exp_w * scale + gamma_over_k;
-                    cumulative += p_i;
-                    if u < cumulative {
-                        return (i, p_i);
-                    }
-                }
-
-                let last = self.num_arms - 1;
-                let p_last = scratch[last] * scale + gamma_over_k;
-                (last, p_last)
-            }
-
-            /// Records a reward for the selected arm.
-            ///
-            /// `prob` is the selection probability returned by `select()`.
-            /// Log-weight update: `ln(w_arm) += eta * reward / (K * prob)`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1],
-            /// or if prob is NaN, infinite, or <= 0.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `arm >= num_arms`.
-            #[inline]
-            pub fn update(
-                &mut self,
-                arm: usize,
-                reward: $ty,
-                prob: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(reward);
-                if reward < 0.0 as $ty || reward > 1.0 as $ty {
-                    return Err(nexus_stats_core::DataError::Negative);
-                }
-                check_finite!(prob);
-                if prob <= 0.0 as $ty {
-                    return Err(nexus_stats_core::DataError::Negative);
-                }
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-
-                let k = self.num_arms as $ty;
-                self.log_weights[arm] += self.eta * reward / (k * prob);
-                self.total_pulls += 1;
-                Ok(())
-            }
-
-            /// Writes the current probability distribution into `out`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `out.len() != num_arms`.
-            #[allow(clippy::suboptimal_flops, clippy::cast_possible_truncation)]
-            pub fn probabilities(&self, out: &mut [$ty]) {
-                assert_eq!(
-                    out.len(),
-                    self.num_arms,
-                    "output length {} != num_arms {}",
-                    out.len(),
-                    self.num_arms,
-                );
-                let k = self.num_arms as $ty;
-                let gamma = self.gamma;
-
-                // Log-sum-exp: use output buffer as scratch for exp values
-                let max_lw = self.log_weights.iter().copied()
-                    .fold(-(1.0 as $ty / 0.0 as $ty), |a, b| if a > b { a } else { b });
-                let mut sum_exp = 0.0 as $ty;
-                for (o, &lw) in out.iter_mut().zip(self.log_weights.iter()) {
-                    *o = nexus_stats_core::math::exp((lw - max_lw) as f64) as $ty;
-                    sum_exp += *o;
-                }
-                let scale = (1.0 as $ty - gamma) / sum_exp;
-                let gamma_over_k = gamma / k;
-                for o in out.iter_mut() {
-                    *o = *o * scale + gamma_over_k;
-                }
-            }
-
-            /// Total pulls across all arms.
-            #[inline]
-            #[must_use]
-            pub fn total_pulls(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Number of arms.
-            #[inline]
-            #[must_use]
-            pub fn num_arms(&self) -> usize {
-                self.num_arms
-            }
-
-            /// Whether total pulls >= min_samples.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_pulls >= self.min_samples
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Resets log-weights to uniform (all zero = equal weight).
-            #[inline]
-            pub fn reset(&mut self) {
-                self.log_weights.fill(0.0 as $ty);
-                self.total_pulls = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of arms (required, >= 2).
-            #[inline]
-            #[must_use]
-            pub fn arms(mut self, n: usize) -> Self {
-                self.arms = Option::Some(n);
-                self
-            }
-
-            /// Sets the exploration mixing rate (required, in (0, 1]).
-            #[inline]
-            #[must_use]
-            pub fn gamma(mut self, g: $ty) -> Self {
-                self.gamma = Option::Some(g);
-                self
-            }
-
-            /// Sets the learning rate (default: gamma, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn eta(mut self, e: $ty) -> Self {
-                self.eta = Option::Some(e);
-                self
-            }
-
-            /// Sets the minimum samples before `is_primed()` returns true.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = Option::Some(n);
-                self
-            }
-
-            /// Builds the bandit.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let arms = self
-                    .arms
-                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
-                let gamma = self
-                    .gamma
-                    .ok_or(nexus_stats_core::ConfigError::Missing("gamma"))?;
-                if arms < 2 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
-                }
-                if gamma <= 0.0 as $ty || gamma > 1.0 as $ty || !gamma.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "gamma must be in (0, 1]",
-                    ));
-                }
-                let eta = self.eta.unwrap_or(gamma);
-                if eta <= 0.0 as $ty || !eta.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "eta must be positive and finite",
-                    ));
-                }
-                let min_samples = self.min_samples.unwrap_or(arms as u64);
-                Ok($name {
-                    log_weights: vec![0.0 as $ty; arms].into_boxed_slice(),
-                    scratch: core::cell::UnsafeCell::new(
-                        vec![0.0 as $ty; arms].into_boxed_slice(),
-                    ),
-                    gamma,
-                    eta,
-                    total_pulls: 0,
-                    num_arms: arms,
-                    min_samples,
-                })
-            }
-        }
-    };
+/// EXP3 adversarial bandit.
+///
+/// Exponential-weight algorithm for Exploration and Exploitation.
+/// Unlike UCB1/Thompson which assume stochastic rewards, EXP3
+/// makes no assumptions about how rewards are generated — they
+/// can be adversarial.
+///
+/// Selection probability: `p_i = (1 - gamma) * w_i / sum(w) + gamma / K`
+///
+/// Weight update (log-space): `ln(w_i) += eta * reward / (K * p_i)`
+///
+/// Internally stores log-weights for numerical stability. No
+/// overflow possible regardless of learning rate or horizon.
+///
+/// Auer, Cesa-Bianchi, Freund, Schapire (2002).
+///
+/// # Parameters
+///
+/// - `arms` — number of arms K (>= 2)
+/// - `gamma` — exploration mixing rate, in (0, 1]. Higher = more uniform.
+/// - `eta` — learning rate (default: gamma)
+///
+/// # Reward range
+///
+/// Rewards must be in [0, 1]. Normalize before feeding.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::learning::Exp3F64;
+///
+/// let mut bandit = Exp3F64::builder()
+///     .arms(3)
+///     .gamma(0.1)
+///     .build()
+///     .unwrap();
+///
+/// let mut s: u64 = 42;
+/// let mut rng = || -> f64 {
+///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+///     (s >> 33) as f64 / (1u64 << 31) as f64
+/// };
+/// let (arm, prob) = bandit.select(&mut rng);
+/// bandit.update(arm, 0.8, prob).unwrap();
+/// ```
+#[derive(Debug)]
+pub struct Exp3F64 {
+    log_weights: Box<[f64]>,
+    scratch: core::cell::UnsafeCell<Box<[f64]>>,
+    gamma: f64,
+    eta: f64,
+    total_pulls: u64,
+    num_arms: usize,
+    min_samples: u64,
 }
 
-impl_exp3!(Exp3F64, Exp3F64Builder, f64);
-impl_exp3!(Exp3F32, Exp3F32Builder, f32);
+impl Clone for Exp3F64 {
+    fn clone(&self) -> Self {
+        Self {
+            log_weights: self.log_weights.clone(),
+            scratch: core::cell::UnsafeCell::new(vec![0.0; self.num_arms].into_boxed_slice()),
+            gamma: self.gamma,
+            eta: self.eta,
+            total_pulls: self.total_pulls,
+            num_arms: self.num_arms,
+            min_samples: self.min_samples,
+        }
+    }
+}
+
+/// Builder for [`Exp3F64`].
+#[derive(Debug, Clone)]
+pub struct Exp3F64Builder {
+    arms: Option<usize>,
+    gamma: Option<f64>,
+    eta: Option<f64>,
+    min_samples: Option<u64>,
+}
+
+impl Exp3F64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> Exp3F64Builder {
+        Exp3F64Builder {
+            arms: None,
+            gamma: None,
+            eta: None,
+            min_samples: None,
+        }
+    }
+
+    /// Samples an arm proportional to mixed weights.
+    ///
+    /// Returns `(arm_index, selection_probability)`. The caller
+    /// must pass the probability back to `update()`.
+    ///
+    /// Uses log-sum-exp with a cached scratch buffer to avoid
+    /// recomputing exp() values during CDF sampling.
+    #[must_use]
+    #[allow(clippy::suboptimal_flops)]
+    pub fn select(&self, rng: &mut impl FnMut() -> f64) -> (usize, f64) {
+        let k = self.num_arms as f64;
+        let gamma = self.gamma;
+
+        // SAFETY: scratch is a write-only cache derived from log_weights.
+        // No reference escapes this method and select() is not reentrant.
+        let scratch = unsafe { &mut *self.scratch.get() };
+
+        let max_lw = self
+            .log_weights
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, |a, b| if a > b { a } else { b });
+
+        // Compute exp values into scratch, accumulate sum (K exp calls)
+        let mut sum_exp = 0.0;
+        for (s, &lw) in scratch.iter_mut().zip(self.log_weights.iter()) {
+            *s = nexus_stats_core::math::exp(lw - max_lw);
+            sum_exp += *s;
+        }
+
+        let scale = (1.0 - gamma) / sum_exp;
+        let gamma_over_k = gamma / k;
+        let u = rng();
+        let mut cumulative = 0.0;
+
+        // CDF sampling from cached exp values — no exp() calls
+        for (i, &exp_w) in scratch.iter().enumerate() {
+            let p_i = exp_w * scale + gamma_over_k;
+            cumulative += p_i;
+            if u < cumulative {
+                return (i, p_i);
+            }
+        }
+
+        let last = self.num_arms - 1;
+        let p_last = scratch[last] * scale + gamma_over_k;
+        (last, p_last)
+    }
+
+    /// Records a reward for the selected arm.
+    ///
+    /// `prob` is the selection probability returned by `select()`.
+    /// Log-weight update: `ln(w_arm) += eta * reward / (K * prob)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1],
+    /// or if prob is NaN, infinite, or <= 0.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `arm >= num_arms`.
+    #[inline]
+    pub fn update(
+        &mut self,
+        arm: usize,
+        reward: f64,
+        prob: f64,
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(reward);
+        if reward < 0.0 || reward > 1.0 {
+            return Err(nexus_stats_core::DataError::Negative);
+        }
+        check_finite!(prob);
+        if prob <= 0.0 {
+            return Err(nexus_stats_core::DataError::Negative);
+        }
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+
+        let k = self.num_arms as f64;
+        self.log_weights[arm] += self.eta * reward / (k * prob);
+        self.total_pulls += 1;
+        Ok(())
+    }
+
+    /// Writes the current probability distribution into `out`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `out.len() != num_arms`.
+    #[allow(clippy::suboptimal_flops)]
+    pub fn probabilities(&self, out: &mut [f64]) {
+        assert_eq!(
+            out.len(),
+            self.num_arms,
+            "output length {} != num_arms {}",
+            out.len(),
+            self.num_arms,
+        );
+        let k = self.num_arms as f64;
+        let gamma = self.gamma;
+
+        // Log-sum-exp: use output buffer as scratch for exp values
+        let max_lw = self
+            .log_weights
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, |a, b| if a > b { a } else { b });
+        let mut sum_exp = 0.0;
+        for (o, &lw) in out.iter_mut().zip(self.log_weights.iter()) {
+            *o = nexus_stats_core::math::exp(lw - max_lw);
+            sum_exp += *o;
+        }
+        let scale = (1.0 - gamma) / sum_exp;
+        let gamma_over_k = gamma / k;
+        for o in out.iter_mut() {
+            *o = *o * scale + gamma_over_k;
+        }
+    }
+
+    /// Total pulls across all arms.
+    #[inline]
+    #[must_use]
+    pub fn total_pulls(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Number of arms.
+    #[inline]
+    #[must_use]
+    pub fn num_arms(&self) -> usize {
+        self.num_arms
+    }
+
+    /// Whether total pulls >= min_samples.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_pulls >= self.min_samples
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Resets log-weights to uniform (all zero = equal weight).
+    #[inline]
+    pub fn reset(&mut self) {
+        self.log_weights.fill(0.0);
+        self.total_pulls = 0;
+    }
+}
+
+impl Exp3F64Builder {
+    /// Sets the number of arms (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn arms(mut self, n: usize) -> Self {
+        self.arms = Some(n);
+        self
+    }
+
+    /// Sets the exploration mixing rate (required, in (0, 1]).
+    #[inline]
+    #[must_use]
+    pub fn gamma(mut self, g: f64) -> Self {
+        self.gamma = Some(g);
+        self
+    }
+
+    /// Sets the learning rate (default: gamma, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn eta(mut self, e: f64) -> Self {
+        self.eta = Some(e);
+        self
+    }
+
+    /// Sets the minimum samples before `is_primed()` returns true.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = Some(n);
+        self
+    }
+
+    /// Builds the bandit.
+    #[inline]
+    pub fn build(self) -> Result<Exp3F64, nexus_stats_core::ConfigError> {
+        let arms = self
+            .arms
+            .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+        let gamma = self
+            .gamma
+            .ok_or(nexus_stats_core::ConfigError::Missing("gamma"))?;
+        if arms < 2 {
+            return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+        }
+        if gamma <= 0.0 || gamma > 1.0 || !gamma.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "gamma must be in (0, 1]",
+            ));
+        }
+        let eta = self.eta.unwrap_or(gamma);
+        if eta <= 0.0 || !eta.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "eta must be positive and finite",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(arms as u64);
+        Ok(Exp3F64 {
+            log_weights: vec![0.0; arms].into_boxed_slice(),
+            scratch: core::cell::UnsafeCell::new(vec![0.0; arms].into_boxed_slice()),
+            gamma,
+            eta,
+            total_pulls: 0,
+            num_arms: arms,
+            min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-regression/src/learning/lms.rs
+++ b/nexus-stats-regression/src/learning/lms.rs
@@ -11,408 +11,391 @@ use alloc::boxed::Box;
 use alloc::vec;
 use nexus_stats_core::math::MulAdd;
 
-macro_rules! impl_lms_filter {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Least Mean Squares adaptive filter.
-        ///
-        /// Learns linear relationships between feature vectors and a scalar
-        /// target by gradient descent on the squared error. Convergence rate
-        /// depends on `learning_rate` and the eigenvalue spread of the input
-        /// correlation matrix.
-        ///
-        /// # Use Cases
-        /// - Online linear regression
-        /// - Noise cancellation
-        /// - System identification
-        ///
-        /// # Complexity
-        /// O(dims) per update, heap-allocated weight vector.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            weights: Box<[$ty]>,
-            learning_rate: $ty,
-            dims: usize,
-            count: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            dimensions: Option<usize>,
-            learning_rate: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    dimensions: Option::None,
-                    learning_rate: Option::None,
-                }
-            }
-
-            /// Computes the dot product w·x.
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            #[inline]
-            #[must_use]
-            pub fn predict(&self, features: &[$ty]) -> $ty {
-                assert_eq!(
-                    features.len(),
-                    self.dims,
-                    "feature length {} != dimensions {}",
-                    features.len(),
-                    self.dims,
-                );
-                let mut sum = 0.0 as $ty;
-                for i in 0..self.dims {
-                    sum = self.weights[i].fma(features[i], sum);
-                }
-                sum
-            }
-
-            /// Updates weights: w += lr * (target - predict(features)) * features.
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the target is NaN, or
-            /// `DataError::Infinite` if the target is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                features: &[$ty],
-                target: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(target);
-                debug_assert!(
-                    features.iter().all(|f| f.is_finite()),
-                    "features must be finite"
-                );
-                let prediction = self.predict(features);
-                let error = target - prediction;
-                let step = self.learning_rate * error;
-                for i in 0..self.dims {
-                    self.weights[i] = step.fma(features[i], self.weights[i]);
-                }
-                self.count += 1;
-                Ok(())
-            }
-
-            /// Returns the current weight vector.
-            #[inline]
-            #[must_use]
-            pub fn weights(&self) -> &[$ty] {
-                &self.weights
-            }
-
-            /// Returns the number of dimensions.
-            #[inline]
-            #[must_use]
-            pub fn dimensions(&self) -> usize {
-                self.dims
-            }
-
-            /// Returns the learning rate.
-            #[inline]
-            #[must_use]
-            pub fn learning_rate(&self) -> $ty {
-                self.learning_rate
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether any updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Zeros all weights, keeping configuration intact.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.weights.fill(0.0 as $ty);
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of input dimensions (required, >= 1).
-            #[inline]
-            #[must_use]
-            pub fn dimensions(mut self, dims: usize) -> Self {
-                self.dimensions = Option::Some(dims);
-                self
-            }
-
-            /// Sets the learning rate (required, > 0).
-            #[inline]
-            #[must_use]
-            pub fn learning_rate(mut self, lr: $ty) -> Self {
-                self.learning_rate = Option::Some(lr);
-                self
-            }
-
-            /// Builds the filter. Returns an error if parameters are missing or invalid.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let dims = self
-                    .dimensions
-                    .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
-                let lr = self
-                    .learning_rate
-                    .ok_or(nexus_stats_core::ConfigError::Missing("learning_rate"))?;
-                if dims < 1 {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "dimensions must be >= 1",
-                    ));
-                }
-                if lr <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "learning_rate must be positive",
-                    ));
-                }
-                Ok($name {
-                    weights: vec![0.0 as $ty; dims].into_boxed_slice(),
-                    learning_rate: lr,
-                    dims,
-                    count: 0,
-                })
-            }
-        }
-    };
+/// Least Mean Squares adaptive filter.
+///
+/// Learns linear relationships between feature vectors and a scalar
+/// target by gradient descent on the squared error. Convergence rate
+/// depends on `learning_rate` and the eigenvalue spread of the input
+/// correlation matrix.
+///
+/// # Use Cases
+/// - Online linear regression
+/// - Noise cancellation
+/// - System identification
+///
+/// # Complexity
+/// O(dims) per update, heap-allocated weight vector.
+#[derive(Debug, Clone)]
+pub struct LmsFilterF64 {
+    weights: Box<[f64]>,
+    learning_rate: f64,
+    dims: usize,
+    count: u64,
 }
 
-macro_rules! impl_nlms_filter {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Normalized Least Mean Squares adaptive filter.
-        ///
-        /// Like LMS but normalizes the step size by input power (x·x + epsilon),
-        /// making convergence robust to varying input scales. The epsilon term
-        /// prevents division by zero when the input is near-silent.
-        ///
-        /// # Use Cases
-        /// - Adaptive noise cancellation with varying input power
-        /// - Echo cancellation
-        /// - Channel equalization
-        ///
-        /// # Complexity
-        /// O(dims) per update, heap-allocated weight vector.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            weights: Box<[$ty]>,
-            learning_rate: $ty,
-            epsilon: $ty,
-            dims: usize,
-            count: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            dimensions: Option<usize>,
-            learning_rate: Option<$ty>,
-            epsilon: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    dimensions: Option::None,
-                    learning_rate: Option::None,
-                    epsilon: Option::None,
-                }
-            }
-
-            /// Computes the dot product w·x.
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            #[inline]
-            #[must_use]
-            pub fn predict(&self, features: &[$ty]) -> $ty {
-                assert_eq!(
-                    features.len(),
-                    self.dims,
-                    "feature length {} != dimensions {}",
-                    features.len(),
-                    self.dims,
-                );
-                let mut sum = 0.0 as $ty;
-                for i in 0..self.dims {
-                    sum = self.weights[i].fma(features[i], sum);
-                }
-                sum
-            }
-
-            /// Updates weights: w += (lr / (x·x + epsilon)) * (target - predict(features)) * features.
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the target is NaN, or
-            /// `DataError::Infinite` if the target is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                features: &[$ty],
-                target: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(target);
-                debug_assert!(
-                    features.iter().all(|f| f.is_finite()),
-                    "features must be finite"
-                );
-                let prediction = self.predict(features);
-                let error = target - prediction;
-                let mut norm_sq = 0.0 as $ty;
-                for i in 0..self.dims {
-                    norm_sq = features[i].fma(features[i], norm_sq);
-                }
-                let step = (self.learning_rate / (norm_sq + self.epsilon)) * error;
-                for i in 0..self.dims {
-                    self.weights[i] = step.fma(features[i], self.weights[i]);
-                }
-                self.count += 1;
-                Ok(())
-            }
-
-            /// Returns the current weight vector.
-            #[inline]
-            #[must_use]
-            pub fn weights(&self) -> &[$ty] {
-                &self.weights
-            }
-
-            /// Returns the number of dimensions.
-            #[inline]
-            #[must_use]
-            pub fn dimensions(&self) -> usize {
-                self.dims
-            }
-
-            /// Returns the learning rate.
-            #[inline]
-            #[must_use]
-            pub fn learning_rate(&self) -> $ty {
-                self.learning_rate
-            }
-
-            /// Returns the epsilon (regularization) parameter.
-            #[inline]
-            #[must_use]
-            pub fn epsilon(&self) -> $ty {
-                self.epsilon
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether any updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Zeros all weights, keeping configuration intact.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.weights.fill(0.0 as $ty);
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of input dimensions (required, >= 1).
-            #[inline]
-            #[must_use]
-            pub fn dimensions(mut self, dims: usize) -> Self {
-                self.dimensions = Option::Some(dims);
-                self
-            }
-
-            /// Sets the learning rate (required, > 0).
-            #[inline]
-            #[must_use]
-            pub fn learning_rate(mut self, lr: $ty) -> Self {
-                self.learning_rate = Option::Some(lr);
-                self
-            }
-
-            /// Sets the regularization term (default 1e-8, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn epsilon(mut self, eps: $ty) -> Self {
-                self.epsilon = Option::Some(eps);
-                self
-            }
-
-            /// Builds the filter. Returns an error if parameters are missing or invalid.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let dims = self
-                    .dimensions
-                    .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
-                let lr = self
-                    .learning_rate
-                    .ok_or(nexus_stats_core::ConfigError::Missing("learning_rate"))?;
-                let eps = self.epsilon.unwrap_or(1e-8 as $ty);
-                if dims < 1 {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "dimensions must be >= 1",
-                    ));
-                }
-                if lr <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "learning_rate must be positive",
-                    ));
-                }
-                if eps <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "epsilon must be positive",
-                    ));
-                }
-                Ok($name {
-                    weights: vec![0.0 as $ty; dims].into_boxed_slice(),
-                    learning_rate: lr,
-                    epsilon: eps,
-                    dims,
-                    count: 0,
-                })
-            }
-        }
-    };
+/// Builder for [`LmsFilterF64`].
+#[derive(Debug, Clone)]
+pub struct LmsFilterF64Builder {
+    dimensions: Option<usize>,
+    learning_rate: Option<f64>,
 }
 
-impl_lms_filter!(LmsFilterF64, LmsFilterF64Builder, f64);
-impl_lms_filter!(LmsFilterF32, LmsFilterF32Builder, f32);
-impl_nlms_filter!(NlmsFilterF64, NlmsFilterF64Builder, f64);
-impl_nlms_filter!(NlmsFilterF32, NlmsFilterF32Builder, f32);
+impl LmsFilterF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LmsFilterF64Builder {
+        LmsFilterF64Builder {
+            dimensions: None,
+            learning_rate: None,
+        }
+    }
+
+    /// Computes the dot product w·x.
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    #[inline]
+    #[must_use]
+    pub fn predict(&self, features: &[f64]) -> f64 {
+        assert_eq!(
+            features.len(),
+            self.dims,
+            "feature length {} != dimensions {}",
+            features.len(),
+            self.dims,
+        );
+        let mut sum = 0.0;
+        for i in 0..self.dims {
+            sum = self.weights[i].fma(features[i], sum);
+        }
+        sum
+    }
+
+    /// Updates weights: w += lr * (target - predict(features)) * features.
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the target is NaN, or
+    /// `DataError::Infinite` if the target is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        features: &[f64],
+        target: f64,
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(target);
+        debug_assert!(
+            features.iter().all(|f| f.is_finite()),
+            "features must be finite"
+        );
+        let prediction = self.predict(features);
+        let error = target - prediction;
+        let step = self.learning_rate * error;
+        for i in 0..self.dims {
+            self.weights[i] = step.fma(features[i], self.weights[i]);
+        }
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Returns the current weight vector.
+    #[inline]
+    #[must_use]
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+
+    /// Returns the number of dimensions.
+    #[inline]
+    #[must_use]
+    pub fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    /// Returns the learning rate.
+    #[inline]
+    #[must_use]
+    pub fn learning_rate(&self) -> f64 {
+        self.learning_rate
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether any updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Zeros all weights, keeping configuration intact.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.weights.fill(0.0);
+        self.count = 0;
+    }
+}
+
+impl LmsFilterF64Builder {
+    /// Sets the number of input dimensions (required, >= 1).
+    #[inline]
+    #[must_use]
+    pub fn dimensions(mut self, dims: usize) -> Self {
+        self.dimensions = Some(dims);
+        self
+    }
+
+    /// Sets the learning rate (required, > 0).
+    #[inline]
+    #[must_use]
+    pub fn learning_rate(mut self, lr: f64) -> Self {
+        self.learning_rate = Some(lr);
+        self
+    }
+
+    /// Builds the filter. Returns an error if parameters are missing or invalid.
+    #[inline]
+    pub fn build(self) -> Result<LmsFilterF64, nexus_stats_core::ConfigError> {
+        let dims = self
+            .dimensions
+            .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
+        let lr = self
+            .learning_rate
+            .ok_or(nexus_stats_core::ConfigError::Missing("learning_rate"))?;
+        if dims < 1 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "dimensions must be >= 1",
+            ));
+        }
+        if lr <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "learning_rate must be positive",
+            ));
+        }
+        Ok(LmsFilterF64 {
+            weights: vec![0.0; dims].into_boxed_slice(),
+            learning_rate: lr,
+            dims,
+            count: 0,
+        })
+    }
+}
+
+/// Normalized Least Mean Squares adaptive filter.
+///
+/// Like LMS but normalizes the step size by input power (x·x + epsilon),
+/// making convergence robust to varying input scales. The epsilon term
+/// prevents division by zero when the input is near-silent.
+///
+/// # Use Cases
+/// - Adaptive noise cancellation with varying input power
+/// - Echo cancellation
+/// - Channel equalization
+///
+/// # Complexity
+/// O(dims) per update, heap-allocated weight vector.
+#[derive(Debug, Clone)]
+pub struct NlmsFilterF64 {
+    weights: Box<[f64]>,
+    learning_rate: f64,
+    epsilon: f64,
+    dims: usize,
+    count: u64,
+}
+
+/// Builder for [`NlmsFilterF64`].
+#[derive(Debug, Clone)]
+pub struct NlmsFilterF64Builder {
+    dimensions: Option<usize>,
+    learning_rate: Option<f64>,
+    epsilon: Option<f64>,
+}
+
+impl NlmsFilterF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> NlmsFilterF64Builder {
+        NlmsFilterF64Builder {
+            dimensions: None,
+            learning_rate: None,
+            epsilon: None,
+        }
+    }
+
+    /// Computes the dot product w·x.
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    #[inline]
+    #[must_use]
+    pub fn predict(&self, features: &[f64]) -> f64 {
+        assert_eq!(
+            features.len(),
+            self.dims,
+            "feature length {} != dimensions {}",
+            features.len(),
+            self.dims,
+        );
+        let mut sum = 0.0;
+        for i in 0..self.dims {
+            sum = self.weights[i].fma(features[i], sum);
+        }
+        sum
+    }
+
+    /// Updates weights: w += (lr / (x·x + epsilon)) * (target - predict(features)) * features.
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the target is NaN, or
+    /// `DataError::Infinite` if the target is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        features: &[f64],
+        target: f64,
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(target);
+        debug_assert!(
+            features.iter().all(|f| f.is_finite()),
+            "features must be finite"
+        );
+        let prediction = self.predict(features);
+        let error = target - prediction;
+        let mut norm_sq = 0.0;
+        for i in 0..self.dims {
+            norm_sq = features[i].fma(features[i], norm_sq);
+        }
+        let step = (self.learning_rate / (norm_sq + self.epsilon)) * error;
+        for i in 0..self.dims {
+            self.weights[i] = step.fma(features[i], self.weights[i]);
+        }
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Returns the current weight vector.
+    #[inline]
+    #[must_use]
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+
+    /// Returns the number of dimensions.
+    #[inline]
+    #[must_use]
+    pub fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    /// Returns the learning rate.
+    #[inline]
+    #[must_use]
+    pub fn learning_rate(&self) -> f64 {
+        self.learning_rate
+    }
+
+    /// Returns the epsilon (regularization) parameter.
+    #[inline]
+    #[must_use]
+    pub fn epsilon(&self) -> f64 {
+        self.epsilon
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether any updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Zeros all weights, keeping configuration intact.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.weights.fill(0.0);
+        self.count = 0;
+    }
+}
+
+impl NlmsFilterF64Builder {
+    /// Sets the number of input dimensions (required, >= 1).
+    #[inline]
+    #[must_use]
+    pub fn dimensions(mut self, dims: usize) -> Self {
+        self.dimensions = Some(dims);
+        self
+    }
+
+    /// Sets the learning rate (required, > 0).
+    #[inline]
+    #[must_use]
+    pub fn learning_rate(mut self, lr: f64) -> Self {
+        self.learning_rate = Some(lr);
+        self
+    }
+
+    /// Sets the regularization term (default 1e-8, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn epsilon(mut self, eps: f64) -> Self {
+        self.epsilon = Some(eps);
+        self
+    }
+
+    /// Builds the filter. Returns an error if parameters are missing or invalid.
+    #[inline]
+    pub fn build(self) -> Result<NlmsFilterF64, nexus_stats_core::ConfigError> {
+        let dims = self
+            .dimensions
+            .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
+        let lr = self
+            .learning_rate
+            .ok_or(nexus_stats_core::ConfigError::Missing("learning_rate"))?;
+        let eps = self.epsilon.unwrap_or(1e-8);
+        if dims < 1 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "dimensions must be >= 1",
+            ));
+        }
+        if lr <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "learning_rate must be positive",
+            ));
+        }
+        if eps <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "epsilon must be positive",
+            ));
+        }
+        Ok(NlmsFilterF64 {
+            weights: vec![0.0; dims].into_boxed_slice(),
+            learning_rate: lr,
+            epsilon: eps,
+            dims,
+            count: 0,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -550,26 +533,6 @@ mod tests {
             .epsilon(-1.0)
             .build();
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut filter = LmsFilterF32::builder()
-            .dimensions(2)
-            .learning_rate(0.01)
-            .build()
-            .unwrap();
-
-        for i in 0..2000 {
-            let x1 = (i as f32 * 0.7).sin();
-            let x2 = (i as f32 * 1.3).cos();
-            let target = 2.0 * x1 + 3.0 * x2;
-            filter.update(&[x1, x2], target).unwrap();
-        }
-
-        let w = filter.weights();
-        assert!((w[0] - 2.0).abs() < 0.5, "w[0] = {}, expected ~2.0", w[0]);
-        assert!((w[1] - 3.0).abs() < 0.5, "w[1] = {}, expected ~3.0", w[1]);
     }
 
     #[test]

--- a/nexus-stats-regression/src/learning/rls.rs
+++ b/nexus-stats-regression/src/learning/rls.rs
@@ -3,339 +3,330 @@ use alloc::boxed::Box;
 use alloc::vec;
 use nexus_stats_core::math::MulAdd;
 
-macro_rules! impl_rls_filter {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Recursive Least Squares adaptive filter.
-        ///
-        /// Tracks linear relationships between feature vectors and a scalar
-        /// target using a recursive update of the covariance matrix. Converges
-        /// faster than LMS at the cost of O(d²) per update. The forgetting
-        /// factor controls how quickly old observations are downweighted.
-        ///
-        /// # Use Cases
-        /// - Online linear regression with fast convergence
-        /// - System identification with non-stationary parameters
-        /// - Adaptive noise cancellation
-        ///
-        /// # Complexity
-        /// O(d²) per update, heap-allocated weight vector and covariance matrix.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            weights: Box<[$ty]>,
-            p_matrix: Box<[$ty]>,
-            scratch_px: Box<[$ty]>,
-            scratch_k: Box<[$ty]>,
-            forgetting_factor: $ty,
-            initial_covariance: $ty,
-            max_covariance: Option<$ty>,
-            dims: usize,
-            count: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            dimensions: Option<usize>,
-            forgetting_factor: $ty,
-            initial_covariance: $ty,
-            max_covariance: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    dimensions: Option::None,
-                    forgetting_factor: 1.0 as $ty,
-                    initial_covariance: 1000.0 as $ty,
-                    max_covariance: Option::None,
-                }
-            }
-
-            /// Computes the dot product w·x (predicted output).
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            #[inline]
-            #[must_use]
-            pub fn predict(&self, features: &[$ty]) -> $ty {
-                assert_eq!(
-                    features.len(),
-                    self.dims,
-                    "feature length {} != dimensions {}",
-                    features.len(),
-                    self.dims,
-                );
-                let mut sum = 0.0 as $ty;
-                for i in 0..self.dims {
-                    sum = self.weights[i].fma(features[i], sum);
-                }
-                sum
-            }
-
-            /// Updates weights using the Sherman-Morrison rank-1 update.
-            ///
-            /// Computes the Kalman gain, updates weights by the prediction
-            /// error, and updates the inverse covariance matrix.
-            ///
-            /// # Panics
-            /// Panics if `features.len() != self.dimensions()`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the target is NaN, or
-            /// `DataError::Infinite` if the target is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                features: &[$ty],
-                target: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(target);
-                debug_assert!(
-                    features.iter().all(|f| f.is_finite()),
-                    "features must be finite"
-                );
-                assert_eq!(
-                    features.len(),
-                    self.dims,
-                    "feature length {} != dimensions {}",
-                    features.len(),
-                    self.dims,
-                );
-                let d = self.dims;
-                let lambda = self.forgetting_factor;
-
-                // px[i] = Σ_j P[i][j] * x[j]
-                for i in 0..d {
-                    let mut sum = 0.0 as $ty;
-                    for j in 0..d {
-                        sum = self.p_matrix[i * d + j].fma(features[j], sum);
-                    }
-                    self.scratch_px[i] = sum;
-                }
-
-                // xpx = Σ x[i] * px[i]
-                let mut xpx = 0.0 as $ty;
-                for i in 0..d {
-                    xpx = features[i].fma(self.scratch_px[i], xpx);
-                }
-
-                // k[i] = px[i] / (lambda + xpx)
-                // Epsilon floor prevents NaN if P degrades numerically.
-                // Reciprocal: one division outside the loop instead of d inside.
-                let inv_denom = 1.0 as $ty / (lambda + xpx).max(<$ty>::EPSILON);
-                for i in 0..d {
-                    self.scratch_k[i] = self.scratch_px[i] * inv_denom;
-                }
-
-                // error = target - w·x
-                let mut prediction = 0.0 as $ty;
-                for i in 0..d {
-                    prediction = self.weights[i].fma(features[i], prediction);
-                }
-                let error = target - prediction;
-
-                // w += k * error
-                for i in 0..d {
-                    self.weights[i] = self.scratch_k[i].fma(error, self.weights[i]);
-                }
-
-                // P[i][j] = (P[i][j] - k[i] * px[j]) / lambda
-                // Reciprocal: one division outside d² loop, multiply inside.
-                let inv_lambda = 1.0 as $ty / lambda;
-                for i in 0..d {
-                    for j in 0..d {
-                        self.p_matrix[i * d + j] = (-self.scratch_k[i])
-                            .fma(self.scratch_px[j], self.p_matrix[i * d + j])
-                            * inv_lambda;
-                    }
-                }
-
-                self.count += 1;
-
-                if let Option::Some(max) = self.max_covariance {
-                    let mut max_diag = 0.0 as $ty;
-                    for i in 0..d {
-                        let diag = self.p_matrix[i * d + i];
-                        if diag > max_diag {
-                            max_diag = diag;
-                        }
-                    }
-                    if max_diag > max {
-                        self.reset_covariance();
-                    }
-                }
-
-                Ok(())
-            }
-
-            #[cold]
-            fn reset_covariance(&mut self) {
-                let d = self.dims;
-                for p in self.p_matrix.iter_mut() {
-                    *p = 0.0 as $ty;
-                }
-                for i in 0..d {
-                    self.p_matrix[i * d + i] = self.initial_covariance;
-                }
-            }
-
-            /// Returns the current weight vector.
-            #[inline]
-            #[must_use]
-            pub fn weights(&self) -> &[$ty] {
-                &self.weights
-            }
-
-            /// Returns the number of dimensions.
-            #[inline]
-            #[must_use]
-            pub fn dimensions(&self) -> usize {
-                self.dims
-            }
-
-            /// Returns the forgetting factor.
-            #[inline]
-            #[must_use]
-            pub fn forgetting_factor(&self) -> $ty {
-                self.forgetting_factor
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Returns the P matrix diagonal (covariance estimates).
-            #[inline]
-            #[must_use]
-            pub fn covariance(&self) -> &[$ty] {
-                &self.p_matrix
-            }
-
-            /// Whether any updates have been performed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.count > 0
-            }
-
-            /// Zeros weights and resets covariance to initial state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.weights.fill(0.0 as $ty);
-                self.scratch_px.fill(0.0 as $ty);
-                self.scratch_k.fill(0.0 as $ty);
-                let d = self.dims;
-                let delta = self.initial_covariance;
-                for i in 0..d {
-                    for j in 0..d {
-                        self.p_matrix[i * d + j] = if i == j { delta } else { 0.0 as $ty };
-                    }
-                }
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of input dimensions (required, >= 1).
-            #[inline]
-            #[must_use]
-            pub fn dimensions(mut self, dims: usize) -> Self {
-                self.dimensions = Option::Some(dims);
-                self
-            }
-
-            /// Sets the forgetting factor (default 1.0, must be in (0, 1]).
-            ///
-            /// Values less than 1.0 downweight older observations exponentially.
-            /// A value of 1.0 gives equal weight to all observations (standard RLS).
-            #[inline]
-            #[must_use]
-            pub fn forgetting_factor(mut self, lambda: $ty) -> Self {
-                self.forgetting_factor = lambda;
-                self
-            }
-
-            /// Sets the initial covariance diagonal (default 1000.0, must be > 0).
-            ///
-            /// The initial covariance matrix P is set to `delta * I`.
-            /// Larger values mean less confidence in initial weights.
-            #[inline]
-            #[must_use]
-            pub fn initial_covariance(mut self, delta: $ty) -> Self {
-                self.initial_covariance = delta;
-                self
-            }
-
-            /// Maximum allowed diagonal covariance before auto-reset.
-            ///
-            /// When the largest P diagonal exceeds this threshold, P is reset
-            /// to `initial_covariance × I`. Prevents divergence in long-running
-            /// filters with forgetting factor < 1.0.
-            #[inline]
-            #[must_use]
-            pub fn max_covariance(mut self, threshold: $ty) -> Self {
-                self.max_covariance = Option::Some(threshold);
-                self
-            }
-
-            /// Builds the filter. Returns an error if parameters are missing or invalid.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let dims = self
-                    .dimensions
-                    .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
-                let lambda = self.forgetting_factor;
-                let delta = self.initial_covariance;
-
-                if dims < 1 {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "dimensions must be >= 1",
-                    ));
-                }
-                if lambda <= 0.0 as $ty || lambda > 1.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "forgetting_factor must be in (0, 1]",
-                    ));
-                }
-                if delta <= 0.0 as $ty {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "initial_covariance must be positive",
-                    ));
-                }
-
-                // Initialize P = delta * I
-                let mut p = vec![0.0 as $ty; dims * dims].into_boxed_slice();
-                for i in 0..dims {
-                    p[i * dims + i] = delta;
-                }
-
-                Ok($name {
-                    weights: vec![0.0 as $ty; dims].into_boxed_slice(),
-                    p_matrix: p,
-                    scratch_px: vec![0.0 as $ty; dims].into_boxed_slice(),
-                    scratch_k: vec![0.0 as $ty; dims].into_boxed_slice(),
-                    forgetting_factor: lambda,
-                    initial_covariance: delta,
-                    max_covariance: self.max_covariance,
-                    dims,
-                    count: 0,
-                })
-            }
-        }
-    };
+/// Recursive Least Squares adaptive filter.
+///
+/// Tracks linear relationships between feature vectors and a scalar
+/// target using a recursive update of the covariance matrix. Converges
+/// faster than LMS at the cost of O(d²) per update. The forgetting
+/// factor controls how quickly old observations are downweighted.
+///
+/// # Use Cases
+/// - Online linear regression with fast convergence
+/// - System identification with non-stationary parameters
+/// - Adaptive noise cancellation
+///
+/// # Complexity
+/// O(d²) per update, heap-allocated weight vector and covariance matrix.
+#[derive(Debug, Clone)]
+pub struct RlsFilterF64 {
+    weights: Box<[f64]>,
+    p_matrix: Box<[f64]>,
+    scratch_px: Box<[f64]>,
+    scratch_k: Box<[f64]>,
+    forgetting_factor: f64,
+    initial_covariance: f64,
+    max_covariance: Option<f64>,
+    dims: usize,
+    count: u64,
 }
 
-impl_rls_filter!(RlsFilterF64, RlsFilterF64Builder, f64);
-impl_rls_filter!(RlsFilterF32, RlsFilterF32Builder, f32);
+/// Builder for [`RlsFilterF64`].
+#[derive(Debug, Clone)]
+pub struct RlsFilterF64Builder {
+    dimensions: Option<usize>,
+    forgetting_factor: f64,
+    initial_covariance: f64,
+    max_covariance: Option<f64>,
+}
+
+impl RlsFilterF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> RlsFilterF64Builder {
+        RlsFilterF64Builder {
+            dimensions: None,
+            forgetting_factor: 1.0,
+            initial_covariance: 1000.0,
+            max_covariance: None,
+        }
+    }
+
+    /// Computes the dot product w·x (predicted output).
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    #[inline]
+    #[must_use]
+    pub fn predict(&self, features: &[f64]) -> f64 {
+        assert_eq!(
+            features.len(),
+            self.dims,
+            "feature length {} != dimensions {}",
+            features.len(),
+            self.dims,
+        );
+        let mut sum = 0.0;
+        for i in 0..self.dims {
+            sum = self.weights[i].fma(features[i], sum);
+        }
+        sum
+    }
+
+    /// Updates weights using the Sherman-Morrison rank-1 update.
+    ///
+    /// Computes the Kalman gain, updates weights by the prediction
+    /// error, and updates the inverse covariance matrix.
+    ///
+    /// # Panics
+    /// Panics if `features.len() != self.dimensions()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the target is NaN, or
+    /// `DataError::Infinite` if the target is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        features: &[f64],
+        target: f64,
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(target);
+        debug_assert!(
+            features.iter().all(|f| f.is_finite()),
+            "features must be finite"
+        );
+        assert_eq!(
+            features.len(),
+            self.dims,
+            "feature length {} != dimensions {}",
+            features.len(),
+            self.dims,
+        );
+        let d = self.dims;
+        let lambda = self.forgetting_factor;
+
+        // px[i] = Σ_j P[i][j] * x[j]
+        for i in 0..d {
+            let mut sum = 0.0;
+            for j in 0..d {
+                sum = self.p_matrix[i * d + j].fma(features[j], sum);
+            }
+            self.scratch_px[i] = sum;
+        }
+
+        // xpx = Σ x[i] * px[i]
+        let mut xpx = 0.0;
+        for i in 0..d {
+            xpx = features[i].fma(self.scratch_px[i], xpx);
+        }
+
+        // k[i] = px[i] / (lambda + xpx)
+        // Epsilon floor prevents NaN if P degrades numerically.
+        // Reciprocal: one division outside the loop instead of d inside.
+        let inv_denom = 1.0 / (lambda + xpx).max(f64::EPSILON);
+        for i in 0..d {
+            self.scratch_k[i] = self.scratch_px[i] * inv_denom;
+        }
+
+        // error = target - w·x
+        let mut prediction = 0.0;
+        for i in 0..d {
+            prediction = self.weights[i].fma(features[i], prediction);
+        }
+        let error = target - prediction;
+
+        // w += k * error
+        for i in 0..d {
+            self.weights[i] = self.scratch_k[i].fma(error, self.weights[i]);
+        }
+
+        // P[i][j] = (P[i][j] - k[i] * px[j]) / lambda
+        // Reciprocal: one division outside d² loop, multiply inside.
+        let inv_lambda = 1.0 / lambda;
+        for i in 0..d {
+            for j in 0..d {
+                self.p_matrix[i * d + j] = (-self.scratch_k[i])
+                    .fma(self.scratch_px[j], self.p_matrix[i * d + j])
+                    * inv_lambda;
+            }
+        }
+
+        self.count += 1;
+
+        if let Some(max) = self.max_covariance {
+            let mut max_diag = 0.0;
+            for i in 0..d {
+                let diag = self.p_matrix[i * d + i];
+                if diag > max_diag {
+                    max_diag = diag;
+                }
+            }
+            if max_diag > max {
+                self.reset_covariance();
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cold]
+    fn reset_covariance(&mut self) {
+        let d = self.dims;
+        for p in &mut *self.p_matrix {
+            *p = 0.0;
+        }
+        for i in 0..d {
+            self.p_matrix[i * d + i] = self.initial_covariance;
+        }
+    }
+
+    /// Returns the current weight vector.
+    #[inline]
+    #[must_use]
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+
+    /// Returns the number of dimensions.
+    #[inline]
+    #[must_use]
+    pub fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    /// Returns the forgetting factor.
+    #[inline]
+    #[must_use]
+    pub fn forgetting_factor(&self) -> f64 {
+        self.forgetting_factor
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Returns the P matrix diagonal (covariance estimates).
+    #[inline]
+    #[must_use]
+    pub fn covariance(&self) -> &[f64] {
+        &self.p_matrix
+    }
+
+    /// Whether any updates have been performed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count > 0
+    }
+
+    /// Zeros weights and resets covariance to initial state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.weights.fill(0.0);
+        self.scratch_px.fill(0.0);
+        self.scratch_k.fill(0.0);
+        let d = self.dims;
+        let delta = self.initial_covariance;
+        for i in 0..d {
+            for j in 0..d {
+                self.p_matrix[i * d + j] = if i == j { delta } else { 0.0 };
+            }
+        }
+        self.count = 0;
+    }
+}
+
+impl RlsFilterF64Builder {
+    /// Sets the number of input dimensions (required, >= 1).
+    #[inline]
+    #[must_use]
+    pub fn dimensions(mut self, dims: usize) -> Self {
+        self.dimensions = Some(dims);
+        self
+    }
+
+    /// Sets the forgetting factor (default 1.0, must be in (0, 1]).
+    ///
+    /// Values less than 1.0 downweight older observations exponentially.
+    /// A value of 1.0 gives equal weight to all observations (standard RLS).
+    #[inline]
+    #[must_use]
+    pub fn forgetting_factor(mut self, lambda: f64) -> Self {
+        self.forgetting_factor = lambda;
+        self
+    }
+
+    /// Sets the initial covariance diagonal (default 1000.0, must be > 0).
+    ///
+    /// The initial covariance matrix P is set to `delta * I`.
+    /// Larger values mean less confidence in initial weights.
+    #[inline]
+    #[must_use]
+    pub fn initial_covariance(mut self, delta: f64) -> Self {
+        self.initial_covariance = delta;
+        self
+    }
+
+    /// Maximum allowed diagonal covariance before auto-reset.
+    ///
+    /// When the largest P diagonal exceeds this threshold, P is reset
+    /// to `initial_covariance × I`. Prevents divergence in long-running
+    /// filters with forgetting factor < 1.0.
+    #[inline]
+    #[must_use]
+    pub fn max_covariance(mut self, threshold: f64) -> Self {
+        self.max_covariance = Some(threshold);
+        self
+    }
+
+    /// Builds the filter. Returns an error if parameters are missing or invalid.
+    #[inline]
+    pub fn build(self) -> Result<RlsFilterF64, nexus_stats_core::ConfigError> {
+        let dims = self
+            .dimensions
+            .ok_or(nexus_stats_core::ConfigError::Missing("dimensions"))?;
+        let lambda = self.forgetting_factor;
+        let delta = self.initial_covariance;
+
+        if dims < 1 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "dimensions must be >= 1",
+            ));
+        }
+        if lambda <= 0.0 || lambda > 1.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "forgetting_factor must be in (0, 1]",
+            ));
+        }
+        if delta <= 0.0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "initial_covariance must be positive",
+            ));
+        }
+
+        // Initialize P = delta * I
+        let mut p = vec![0.0; dims * dims].into_boxed_slice();
+        for i in 0..dims {
+            p[i * dims + i] = delta;
+        }
+
+        Ok(RlsFilterF64 {
+            weights: vec![0.0; dims].into_boxed_slice(),
+            p_matrix: p,
+            scratch_px: vec![0.0; dims].into_boxed_slice(),
+            scratch_k: vec![0.0; dims].into_boxed_slice(),
+            forgetting_factor: lambda,
+            initial_covariance: delta,
+            max_covariance: self.max_covariance,
+            dims,
+            count: 0,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -501,22 +492,6 @@ mod tests {
             .initial_covariance(-1.0)
             .build();
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut filter = RlsFilterF32::builder().dimensions(2).build().unwrap();
-
-        for i in 0..200 {
-            let x1 = (i as f32 * 0.7).sin();
-            let x2 = (i as f32 * 1.3).cos();
-            let target = 2.0 * x1 + 3.0 * x2;
-            filter.update(&[x1, x2], target).unwrap();
-        }
-
-        let w = filter.weights();
-        assert!((w[0] - 2.0).abs() < 0.1, "w[0] = {}, expected ~2.0", w[0]);
-        assert!((w[1] - 3.0).abs() < 0.1, "w[1] = {}, expected ~3.0", w[1]);
     }
 
     #[test]

--- a/nexus-stats-regression/src/learning/sampling.rs
+++ b/nexus-stats-regression/src/learning/sampling.rs
@@ -1,78 +1,68 @@
-macro_rules! impl_sampling {
-    ($mod_name:ident, $ty:ty) => {
-        pub(super) mod $mod_name {
-            /// Marsaglia polar method. Returns one standard normal sample.
-            /// Consumes at least two calls to `rng` per sample.
-            #[allow(clippy::cast_possible_truncation, clippy::suboptimal_flops)]
-            pub fn normal_sample(rng: &mut impl FnMut() -> $ty) -> $ty {
-                loop {
-                    let u = 2.0 as $ty * rng() - 1.0 as $ty;
-                    let v = 2.0 as $ty * rng() - 1.0 as $ty;
-                    let s = u * u + v * v;
-                    if s > 0.0 as $ty && s < 1.0 as $ty {
-                        let ln_s = nexus_stats_core::math::ln(s as f64) as $ty;
-                        let factor =
-                            nexus_stats_core::math::sqrt((-(2.0 as $ty) * ln_s / s) as f64) as $ty;
-                        return u * factor;
-                    }
-                }
-            }
-
-            /// Marsaglia-Tsang method for Gamma(shape, 1). Shape must be > 0.
-            /// For shape < 1: Gamma(shape) = Gamma(shape+1) * U^(1/shape).
-            #[allow(clippy::cast_possible_truncation, clippy::suboptimal_flops)]
-            pub fn gamma_sample(shape: $ty, rng: &mut impl FnMut() -> $ty) -> $ty {
-                if shape < 1.0 as $ty {
-                    let g = gamma_sample(shape + 1.0 as $ty, rng);
-                    let u = rng();
-                    let pow = nexus_stats_core::math::exp(
-                        nexus_stats_core::math::ln(u as f64) / shape as f64,
-                    ) as $ty;
-                    return g * pow;
-                }
-
-                let d = shape - 1.0 as $ty / 3.0 as $ty;
-                let c = (1.0 / nexus_stats_core::math::sqrt((9.0 as $ty * d) as f64)) as $ty;
-
-                loop {
-                    let x = normal_sample(rng);
-                    let v_base = 1.0 as $ty + c * x;
-                    if v_base <= 0.0 as $ty {
-                        continue;
-                    }
-                    let v = v_base * v_base * v_base;
-                    let u = rng();
-                    let x2 = x * x;
-
-                    if u < 1.0 as $ty - 0.0331 as $ty * x2 * x2 {
-                        return d * v;
-                    }
-
-                    let ln_u = nexus_stats_core::math::ln(u as f64) as $ty;
-                    let ln_v = nexus_stats_core::math::ln(v as f64) as $ty;
-                    if ln_u < 0.5 as $ty * x2 + d * (1.0 as $ty - v + ln_v) {
-                        return d * v;
-                    }
-                }
-            }
-
-            /// Beta(alpha, beta) via ratio of two Gamma samples.
-            #[allow(clippy::float_cmp)]
-            pub fn beta_sample(alpha: $ty, beta: $ty, rng: &mut impl FnMut() -> $ty) -> $ty {
-                let x = gamma_sample(alpha, rng);
-                let y = gamma_sample(beta, rng);
-                let sum = x + y;
-                if sum == 0.0 as $ty {
-                    return 0.5 as $ty;
-                }
-                x / sum
+pub(super) mod f64_impl {
+    /// Marsaglia polar method. Returns one standard normal sample.
+    /// Consumes at least two calls to `rng` per sample.
+    #[allow(clippy::suboptimal_flops)]
+    pub fn normal_sample(rng: &mut impl FnMut() -> f64) -> f64 {
+        loop {
+            let u = 2.0 * rng() - 1.0;
+            let v = 2.0 * rng() - 1.0;
+            let s = u * u + v * v;
+            if s > 0.0 && s < 1.0 {
+                let ln_s = nexus_stats_core::math::ln(s);
+                let factor = nexus_stats_core::math::sqrt(-2.0 * ln_s / s);
+                return u * factor;
             }
         }
-    };
-}
+    }
 
-impl_sampling!(f64_impl, f64);
-impl_sampling!(f32_impl, f32);
+    /// Marsaglia-Tsang method for Gamma(shape, 1). Shape must be > 0.
+    /// For shape < 1: Gamma(shape) = Gamma(shape+1) * U^(1/shape).
+    #[allow(clippy::many_single_char_names, clippy::suboptimal_flops)]
+    pub fn gamma_sample(shape: f64, rng: &mut impl FnMut() -> f64) -> f64 {
+        if shape < 1.0 {
+            let g = gamma_sample(shape + 1.0, rng);
+            let u = rng();
+            let pow = nexus_stats_core::math::exp(nexus_stats_core::math::ln(u) / shape);
+            return g * pow;
+        }
+
+        let d = shape - 1.0 / 3.0;
+        let c = 1.0 / nexus_stats_core::math::sqrt(9.0 * d);
+
+        loop {
+            let x = normal_sample(rng);
+            let v_base = 1.0 + c * x;
+            if v_base <= 0.0 {
+                continue;
+            }
+            let v = v_base * v_base * v_base;
+            let u = rng();
+            let x2 = x * x;
+
+            if u < 1.0 - 0.0331 * x2 * x2 {
+                return d * v;
+            }
+
+            let ln_u = nexus_stats_core::math::ln(u);
+            let ln_v = nexus_stats_core::math::ln(v);
+            if ln_u < 0.5 * x2 + d * (1.0 - v + ln_v) {
+                return d * v;
+            }
+        }
+    }
+
+    /// Beta(alpha, beta) via ratio of two Gamma samples.
+    #[allow(clippy::float_cmp)]
+    pub fn beta_sample(alpha: f64, beta: f64, rng: &mut impl FnMut() -> f64) -> f64 {
+        let x = gamma_sample(alpha, rng);
+        let y = gamma_sample(beta, rng);
+        let sum = x + y;
+        if sum == 0.0 {
+            return 0.5;
+        }
+        x / sum
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -160,24 +150,5 @@ mod tests {
             (mean - expected).abs() < 0.02,
             "mean={mean}, expected ~{expected}"
         );
-    }
-
-    #[test]
-    fn f32_normal_sample() {
-        let mut state: u64 = 42;
-        let mut rng = || -> f32 {
-            state = state
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (state >> 33) as f32 / (1u64 << 31) as f32
-        };
-        let mut sum = 0.0_f32;
-        for _ in 0..1_000 {
-            let x = f32_impl::normal_sample(&mut rng);
-            assert!(x.is_finite());
-            sum += x;
-        }
-        let mean = sum / 1000.0;
-        assert!(mean.abs() < 0.2, "f32 mean={mean}");
     }
 }

--- a/nexus-stats-regression/src/learning/thompson_beta.rs
+++ b/nexus-stats-regression/src/learning/thompson_beta.rs
@@ -2,274 +2,263 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
 
-macro_rules! impl_thompson_beta {
-    ($name:ident, $builder:ident, $ty:ty, $sampling:ident) => {
-        /// Thompson Sampling with Beta prior.
-        ///
-        /// Each arm maintains Beta(alpha, beta) parameters. Selection samples
-        /// from each arm's Beta posterior and picks the highest sample.
-        /// Arms with wider posteriors (more uncertain) are explored naturally.
-        ///
-        /// For binary rewards: alpha counts successes, beta counts failures.
-        /// For continuous [0, 1] rewards: alpha += reward, beta += (1 - reward).
-        ///
-        /// Thompson (1933), Agrawal & Goyal (2012).
-        ///
-        /// # Parameters
-        ///
-        /// - `arms` — number of arms (>= 2)
-        /// - `initial_alpha` — prior alpha for all arms (default: 1.0, uniform)
-        /// - `initial_beta` — prior beta for all arms (default: 1.0, uniform)
-        /// - `decay` — multiplicative discount on alpha, beta per update (default: 1.0)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_regression::learning::ThompsonBetaF64;
-        ///
-        /// let mut bandit = ThompsonBetaF64::builder()
-        ///     .arms(3)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// let mut s: u64 = 42;
-        /// let mut rng = || -> f64 {
-        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
-        ///     (s >> 33) as f64 / (1u64 << 31) as f64
-        /// };
-        /// let arm = bandit.select(&mut rng);
-        /// bandit.update(arm, 1.0).unwrap();
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            alphas: Box<[$ty]>,
-            betas: Box<[$ty]>,
-            initial_alpha: $ty,
-            initial_beta: $ty,
-            decay: $ty,
-            total_pulls: u64,
-            num_arms: usize,
-            min_samples: u64,
-        }
+use super::sampling::f64_impl;
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            arms: Option<usize>,
-            initial_alpha: $ty,
-            initial_beta: $ty,
-            decay: $ty,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    arms: Option::None,
-                    initial_alpha: 1.0 as $ty,
-                    initial_beta: 1.0 as $ty,
-                    decay: 1.0 as $ty,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Samples from each arm's Beta posterior, returns the arm
-            /// with the highest sample.
-            ///
-            /// `rng` must return independent uniform samples in [0, 1).
-            #[must_use]
-            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
-                let mut best_arm = 0;
-                let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
-                for (i, (&a, &b)) in self.alphas.iter().zip(self.betas.iter()).enumerate() {
-                    let sample = super::sampling::$sampling::beta_sample(a, b, rng);
-                    if sample > best_sample {
-                        best_sample = sample;
-                        best_arm = i;
-                    }
-                }
-                best_arm
-            }
-
-            /// Records a reward in [0, 1] for an arm.
-            ///
-            /// Updates: alpha += reward, beta += (1 - reward).
-            /// If `decay < 1.0`, all alpha/beta are discounted first.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1].
-            ///
-            /// # Panics
-            ///
-            /// Panics if `arm >= num_arms`.
-            #[inline]
-            pub fn update(
-                &mut self,
-                arm: usize,
-                reward: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(reward);
-                if reward < 0.0 as $ty || reward > 1.0 as $ty {
-                    return Err(nexus_stats_core::DataError::Negative);
-                }
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-
-                if self.decay < 1.0 as $ty {
-                    let decay = self.decay;
-                    for (a, b) in self.alphas.iter_mut().zip(self.betas.iter_mut()) {
-                        *a *= decay;
-                        *b *= decay;
-                    }
-                }
-
-                self.alphas[arm] += reward;
-                self.betas[arm] += 1.0 as $ty - reward;
-                self.total_pulls += 1;
-                Ok(())
-            }
-
-            /// Posterior mean for an arm: alpha / (alpha + beta).
-            #[inline]
-            #[must_use]
-            pub fn mean_reward(&self, arm: usize) -> $ty {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                self.alphas[arm] / (self.alphas[arm] + self.betas[arm])
-            }
-
-            /// Total pulls across all arms.
-            #[inline]
-            #[must_use]
-            pub fn total_pulls(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Number of arms.
-            #[inline]
-            #[must_use]
-            pub fn num_arms(&self) -> usize {
-                self.num_arms
-            }
-
-            /// Whether total pulls >= min_samples.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_pulls >= self.min_samples
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Resets alpha/beta to initial priors.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.alphas.fill(self.initial_alpha);
-                self.betas.fill(self.initial_beta);
-                self.total_pulls = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of arms (required, >= 2).
-            #[inline]
-            #[must_use]
-            pub fn arms(mut self, n: usize) -> Self {
-                self.arms = Option::Some(n);
-                self
-            }
-
-            /// Sets the initial alpha prior (default: 1.0, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn initial_alpha(mut self, a: $ty) -> Self {
-                self.initial_alpha = a;
-                self
-            }
-
-            /// Sets the initial beta prior (default: 1.0, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn initial_beta(mut self, b: $ty) -> Self {
-                self.initial_beta = b;
-                self
-            }
-
-            /// Sets the decay factor (default: 1.0, in (0, 1]).
-            #[inline]
-            #[must_use]
-            pub fn decay(mut self, d: $ty) -> Self {
-                self.decay = d;
-                self
-            }
-
-            /// Sets the minimum samples before `is_primed()` returns true.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = Option::Some(n);
-                self
-            }
-
-            /// Builds the bandit.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let arms = self
-                    .arms
-                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
-                if arms < 2 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
-                }
-                if self.initial_alpha <= 0.0 as $ty || !self.initial_alpha.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "initial_alpha must be positive and finite",
-                    ));
-                }
-                if self.initial_beta <= 0.0 as $ty || !self.initial_beta.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "initial_beta must be positive and finite",
-                    ));
-                }
-                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "decay must be in (0, 1]",
-                    ));
-                }
-                let min_samples = self.min_samples.unwrap_or(arms as u64);
-                Ok($name {
-                    alphas: vec![self.initial_alpha; arms].into_boxed_slice(),
-                    betas: vec![self.initial_beta; arms].into_boxed_slice(),
-                    initial_alpha: self.initial_alpha,
-                    initial_beta: self.initial_beta,
-                    decay: self.decay,
-                    total_pulls: 0,
-                    num_arms: arms,
-                    min_samples,
-                })
-            }
-        }
-    };
+/// Thompson Sampling with Beta prior.
+///
+/// Each arm maintains Beta(alpha, beta) parameters. Selection samples
+/// from each arm's Beta posterior and picks the highest sample.
+/// Arms with wider posteriors (more uncertain) are explored naturally.
+///
+/// For binary rewards: alpha counts successes, beta counts failures.
+/// For continuous [0, 1] rewards: alpha += reward, beta += (1 - reward).
+///
+/// Thompson (1933), Agrawal & Goyal (2012).
+///
+/// # Parameters
+///
+/// - `arms` — number of arms (>= 2)
+/// - `initial_alpha` — prior alpha for all arms (default: 1.0, uniform)
+/// - `initial_beta` — prior beta for all arms (default: 1.0, uniform)
+/// - `decay` — multiplicative discount on alpha, beta per update (default: 1.0)
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::learning::ThompsonBetaF64;
+///
+/// let mut bandit = ThompsonBetaF64::builder()
+///     .arms(3)
+///     .build()
+///     .unwrap();
+///
+/// let mut s: u64 = 42;
+/// let mut rng = || -> f64 {
+///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+///     (s >> 33) as f64 / (1u64 << 31) as f64
+/// };
+/// let arm = bandit.select(&mut rng);
+/// bandit.update(arm, 1.0).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct ThompsonBetaF64 {
+    alphas: Box<[f64]>,
+    betas: Box<[f64]>,
+    initial_alpha: f64,
+    initial_beta: f64,
+    decay: f64,
+    total_pulls: u64,
+    num_arms: usize,
+    min_samples: u64,
 }
 
-impl_thompson_beta!(ThompsonBetaF64, ThompsonBetaF64Builder, f64, f64_impl);
-impl_thompson_beta!(ThompsonBetaF32, ThompsonBetaF32Builder, f32, f32_impl);
+/// Builder for [`ThompsonBetaF64`].
+#[derive(Debug, Clone)]
+pub struct ThompsonBetaF64Builder {
+    arms: Option<usize>,
+    initial_alpha: f64,
+    initial_beta: f64,
+    decay: f64,
+    min_samples: Option<u64>,
+}
+
+impl ThompsonBetaF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> ThompsonBetaF64Builder {
+        ThompsonBetaF64Builder {
+            arms: None,
+            initial_alpha: 1.0,
+            initial_beta: 1.0,
+            decay: 1.0,
+            min_samples: None,
+        }
+    }
+
+    /// Samples from each arm's Beta posterior, returns the arm
+    /// with the highest sample.
+    ///
+    /// `rng` must return independent uniform samples in [0, 1).
+    #[must_use]
+    pub fn select(&self, rng: &mut impl FnMut() -> f64) -> usize {
+        let mut best_arm = 0;
+        let mut best_sample = f64::NEG_INFINITY;
+        for (i, (&a, &b)) in self.alphas.iter().zip(self.betas.iter()).enumerate() {
+            let sample = f64_impl::beta_sample(a, b, rng);
+            if sample > best_sample {
+                best_sample = sample;
+                best_arm = i;
+            }
+        }
+        best_arm
+    }
+
+    /// Records a reward in [0, 1] for an arm.
+    ///
+    /// Updates: alpha += reward, beta += (1 - reward).
+    /// If `decay < 1.0`, all alpha/beta are discounted first.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError` if reward is NaN, infinite, or outside [0, 1].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `arm >= num_arms`.
+    #[inline]
+    pub fn update(&mut self, arm: usize, reward: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(reward);
+        if reward < 0.0 || reward > 1.0 {
+            return Err(nexus_stats_core::DataError::Negative);
+        }
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+
+        if self.decay < 1.0 {
+            let decay = self.decay;
+            for (a, b) in self.alphas.iter_mut().zip(self.betas.iter_mut()) {
+                *a *= decay;
+                *b *= decay;
+            }
+        }
+
+        self.alphas[arm] += reward;
+        self.betas[arm] += 1.0 - reward;
+        self.total_pulls += 1;
+        Ok(())
+    }
+
+    /// Posterior mean for an arm: alpha / (alpha + beta).
+    #[inline]
+    #[must_use]
+    pub fn mean_reward(&self, arm: usize) -> f64 {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        self.alphas[arm] / (self.alphas[arm] + self.betas[arm])
+    }
+
+    /// Total pulls across all arms.
+    #[inline]
+    #[must_use]
+    pub fn total_pulls(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Number of arms.
+    #[inline]
+    #[must_use]
+    pub fn num_arms(&self) -> usize {
+        self.num_arms
+    }
+
+    /// Whether total pulls >= min_samples.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_pulls >= self.min_samples
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Resets alpha/beta to initial priors.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.alphas.fill(self.initial_alpha);
+        self.betas.fill(self.initial_beta);
+        self.total_pulls = 0;
+    }
+}
+
+impl ThompsonBetaF64Builder {
+    /// Sets the number of arms (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn arms(mut self, n: usize) -> Self {
+        self.arms = Some(n);
+        self
+    }
+
+    /// Sets the initial alpha prior (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn initial_alpha(mut self, a: f64) -> Self {
+        self.initial_alpha = a;
+        self
+    }
+
+    /// Sets the initial beta prior (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn initial_beta(mut self, b: f64) -> Self {
+        self.initial_beta = b;
+        self
+    }
+
+    /// Sets the decay factor (default: 1.0, in (0, 1]).
+    #[inline]
+    #[must_use]
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = d;
+        self
+    }
+
+    /// Sets the minimum samples before `is_primed()` returns true.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = Some(n);
+        self
+    }
+
+    /// Builds the bandit.
+    #[inline]
+    pub fn build(self) -> Result<ThompsonBetaF64, nexus_stats_core::ConfigError> {
+        let arms = self
+            .arms
+            .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+        if arms < 2 {
+            return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+        }
+        if self.initial_alpha <= 0.0 || !self.initial_alpha.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "initial_alpha must be positive and finite",
+            ));
+        }
+        if self.initial_beta <= 0.0 || !self.initial_beta.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "initial_beta must be positive and finite",
+            ));
+        }
+        if self.decay <= 0.0 || self.decay > 1.0 || !self.decay.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "decay must be in (0, 1]",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(arms as u64);
+        Ok(ThompsonBetaF64 {
+            alphas: vec![self.initial_alpha; arms].into_boxed_slice(),
+            betas: vec![self.initial_beta; arms].into_boxed_slice(),
+            initial_alpha: self.initial_alpha,
+            initial_beta: self.initial_beta,
+            decay: self.decay,
+            total_pulls: 0,
+            num_arms: arms,
+            min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-regression/src/learning/thompson_gamma.rs
+++ b/nexus-stats-regression/src/learning/thompson_gamma.rs
@@ -2,274 +2,263 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
 
-macro_rules! impl_thompson_gamma {
-    ($name:ident, $builder:ident, $ty:ty, $sampling:ident) => {
-        /// Thompson Sampling with Gamma prior.
-        ///
-        /// Each arm maintains Gamma(shape, rate) parameters. Selection
-        /// samples from each arm's Gamma posterior and picks the highest
-        /// sample. For positive continuous rewards where Beta (bounded
-        /// [0, 1]) is too restrictive.
-        ///
-        /// Conjugate update: shape += reward, rate += 1.
-        /// Posterior mean: shape / rate (approximates sample mean).
-        ///
-        /// # Parameters
-        ///
-        /// - `arms` — number of arms (>= 2)
-        /// - `initial_shape` — prior shape for all arms (default: 1.0)
-        /// - `initial_rate` — prior rate for all arms (default: 1.0)
-        /// - `decay` — multiplicative discount on shape, rate per update (default: 1.0)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_regression::learning::ThompsonGammaF64;
-        ///
-        /// let mut bandit = ThompsonGammaF64::builder()
-        ///     .arms(3)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// let mut s: u64 = 42;
-        /// let mut rng = || -> f64 {
-        ///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
-        ///     (s >> 33) as f64 / (1u64 << 31) as f64
-        /// };
-        /// let arm = bandit.select(&mut rng);
-        /// bandit.update(arm, 2.5).unwrap();
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            shapes: Box<[$ty]>,
-            rates: Box<[$ty]>,
-            initial_shape: $ty,
-            initial_rate: $ty,
-            decay: $ty,
-            total_pulls: u64,
-            num_arms: usize,
-            min_samples: u64,
-        }
+use super::sampling::f64_impl;
 
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            arms: Option<usize>,
-            initial_shape: $ty,
-            initial_rate: $ty,
-            decay: $ty,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    arms: Option::None,
-                    initial_shape: 1.0 as $ty,
-                    initial_rate: 1.0 as $ty,
-                    decay: 1.0 as $ty,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Samples from each arm's Gamma posterior, returns the arm
-            /// with the highest sample.
-            ///
-            /// `rng` must return independent uniform samples in [0, 1).
-            #[must_use]
-            pub fn select(&self, rng: &mut impl FnMut() -> $ty) -> usize {
-                let mut best_arm = 0;
-                let mut best_sample = -(1.0 as $ty / 0.0 as $ty);
-                for (i, (&shape, &rate)) in self.shapes.iter().zip(self.rates.iter()).enumerate() {
-                    let g = super::sampling::$sampling::gamma_sample(shape, rng);
-                    let sample = g / rate;
-                    if sample > best_sample {
-                        best_sample = sample;
-                        best_arm = i;
-                    }
-                }
-                best_arm
-            }
-
-            /// Records a positive reward for an arm.
-            ///
-            /// Updates: shape += reward, rate += 1.
-            /// If `decay < 1.0`, all shape/rate are discounted first.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError` if reward is NaN, infinite, or <= 0.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `arm >= num_arms`.
-            #[inline]
-            pub fn update(
-                &mut self,
-                arm: usize,
-                reward: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(reward);
-                if reward <= 0.0 as $ty {
-                    return Err(nexus_stats_core::DataError::Negative);
-                }
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-
-                if self.decay < 1.0 as $ty {
-                    let decay = self.decay;
-                    for (s, r) in self.shapes.iter_mut().zip(self.rates.iter_mut()) {
-                        *s *= decay;
-                        *r *= decay;
-                    }
-                }
-
-                self.shapes[arm] += reward;
-                self.rates[arm] += 1.0 as $ty;
-                self.total_pulls += 1;
-                Ok(())
-            }
-
-            /// Posterior mean for an arm: shape / rate.
-            #[inline]
-            #[must_use]
-            pub fn mean_reward(&self, arm: usize) -> $ty {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                self.shapes[arm] / self.rates[arm]
-            }
-
-            /// Total pulls across all arms.
-            #[inline]
-            #[must_use]
-            pub fn total_pulls(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Number of arms.
-            #[inline]
-            #[must_use]
-            pub fn num_arms(&self) -> usize {
-                self.num_arms
-            }
-
-            /// Whether total pulls >= min_samples.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_pulls >= self.min_samples
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Resets shape/rate to initial priors.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.shapes.fill(self.initial_shape);
-                self.rates.fill(self.initial_rate);
-                self.total_pulls = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of arms (required, >= 2).
-            #[inline]
-            #[must_use]
-            pub fn arms(mut self, n: usize) -> Self {
-                self.arms = Option::Some(n);
-                self
-            }
-
-            /// Sets the initial shape prior (default: 1.0, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn initial_shape(mut self, s: $ty) -> Self {
-                self.initial_shape = s;
-                self
-            }
-
-            /// Sets the initial rate prior (default: 1.0, must be > 0).
-            #[inline]
-            #[must_use]
-            pub fn initial_rate(mut self, r: $ty) -> Self {
-                self.initial_rate = r;
-                self
-            }
-
-            /// Sets the decay factor (default: 1.0, in (0, 1]).
-            #[inline]
-            #[must_use]
-            pub fn decay(mut self, d: $ty) -> Self {
-                self.decay = d;
-                self
-            }
-
-            /// Sets the minimum samples before `is_primed()` returns true.
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = Option::Some(n);
-                self
-            }
-
-            /// Builds the bandit.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let arms = self
-                    .arms
-                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
-                if arms < 2 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
-                }
-                if self.initial_shape <= 0.0 as $ty || !self.initial_shape.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "initial_shape must be positive and finite",
-                    ));
-                }
-                if self.initial_rate <= 0.0 as $ty || !self.initial_rate.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "initial_rate must be positive and finite",
-                    ));
-                }
-                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "decay must be in (0, 1]",
-                    ));
-                }
-                let min_samples = self.min_samples.unwrap_or(arms as u64);
-                Ok($name {
-                    shapes: vec![self.initial_shape; arms].into_boxed_slice(),
-                    rates: vec![self.initial_rate; arms].into_boxed_slice(),
-                    initial_shape: self.initial_shape,
-                    initial_rate: self.initial_rate,
-                    decay: self.decay,
-                    total_pulls: 0,
-                    num_arms: arms,
-                    min_samples,
-                })
-            }
-        }
-    };
+/// Thompson Sampling with Gamma prior.
+///
+/// Each arm maintains Gamma(shape, rate) parameters. Selection
+/// samples from each arm's Gamma posterior and picks the highest
+/// sample. For positive continuous rewards where Beta (bounded
+/// [0, 1]) is too restrictive.
+///
+/// Conjugate update: shape += reward, rate += 1.
+/// Posterior mean: shape / rate (approximates sample mean).
+///
+/// # Parameters
+///
+/// - `arms` — number of arms (>= 2)
+/// - `initial_shape` — prior shape for all arms (default: 1.0)
+/// - `initial_rate` — prior rate for all arms (default: 1.0)
+/// - `decay` — multiplicative discount on shape, rate per update (default: 1.0)
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::learning::ThompsonGammaF64;
+///
+/// let mut bandit = ThompsonGammaF64::builder()
+///     .arms(3)
+///     .build()
+///     .unwrap();
+///
+/// let mut s: u64 = 42;
+/// let mut rng = || -> f64 {
+///     s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+///     (s >> 33) as f64 / (1u64 << 31) as f64
+/// };
+/// let arm = bandit.select(&mut rng);
+/// bandit.update(arm, 2.5).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct ThompsonGammaF64 {
+    shapes: Box<[f64]>,
+    rates: Box<[f64]>,
+    initial_shape: f64,
+    initial_rate: f64,
+    decay: f64,
+    total_pulls: u64,
+    num_arms: usize,
+    min_samples: u64,
 }
 
-impl_thompson_gamma!(ThompsonGammaF64, ThompsonGammaF64Builder, f64, f64_impl);
-impl_thompson_gamma!(ThompsonGammaF32, ThompsonGammaF32Builder, f32, f32_impl);
+/// Builder for [`ThompsonGammaF64`].
+#[derive(Debug, Clone)]
+pub struct ThompsonGammaF64Builder {
+    arms: Option<usize>,
+    initial_shape: f64,
+    initial_rate: f64,
+    decay: f64,
+    min_samples: Option<u64>,
+}
+
+impl ThompsonGammaF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> ThompsonGammaF64Builder {
+        ThompsonGammaF64Builder {
+            arms: None,
+            initial_shape: 1.0,
+            initial_rate: 1.0,
+            decay: 1.0,
+            min_samples: None,
+        }
+    }
+
+    /// Samples from each arm's Gamma posterior, returns the arm
+    /// with the highest sample.
+    ///
+    /// `rng` must return independent uniform samples in [0, 1).
+    #[must_use]
+    pub fn select(&self, rng: &mut impl FnMut() -> f64) -> usize {
+        let mut best_arm = 0;
+        let mut best_sample = f64::NEG_INFINITY;
+        for (i, (&shape, &rate)) in self.shapes.iter().zip(self.rates.iter()).enumerate() {
+            let g = f64_impl::gamma_sample(shape, rng);
+            let sample = g / rate;
+            if sample > best_sample {
+                best_sample = sample;
+                best_arm = i;
+            }
+        }
+        best_arm
+    }
+
+    /// Records a positive reward for an arm.
+    ///
+    /// Updates: shape += reward, rate += 1.
+    /// If `decay < 1.0`, all shape/rate are discounted first.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError` if reward is NaN, infinite, or <= 0.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `arm >= num_arms`.
+    #[inline]
+    pub fn update(&mut self, arm: usize, reward: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(reward);
+        if reward <= 0.0 {
+            return Err(nexus_stats_core::DataError::Negative);
+        }
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+
+        if self.decay < 1.0 {
+            let decay = self.decay;
+            for (s, r) in self.shapes.iter_mut().zip(self.rates.iter_mut()) {
+                *s *= decay;
+                *r *= decay;
+            }
+        }
+
+        self.shapes[arm] += reward;
+        self.rates[arm] += 1.0;
+        self.total_pulls += 1;
+        Ok(())
+    }
+
+    /// Posterior mean for an arm: shape / rate.
+    #[inline]
+    #[must_use]
+    pub fn mean_reward(&self, arm: usize) -> f64 {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        self.shapes[arm] / self.rates[arm]
+    }
+
+    /// Total pulls across all arms.
+    #[inline]
+    #[must_use]
+    pub fn total_pulls(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Number of arms.
+    #[inline]
+    #[must_use]
+    pub fn num_arms(&self) -> usize {
+        self.num_arms
+    }
+
+    /// Whether total pulls >= min_samples.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_pulls >= self.min_samples
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Resets shape/rate to initial priors.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.shapes.fill(self.initial_shape);
+        self.rates.fill(self.initial_rate);
+        self.total_pulls = 0;
+    }
+}
+
+impl ThompsonGammaF64Builder {
+    /// Sets the number of arms (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn arms(mut self, n: usize) -> Self {
+        self.arms = Some(n);
+        self
+    }
+
+    /// Sets the initial shape prior (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn initial_shape(mut self, s: f64) -> Self {
+        self.initial_shape = s;
+        self
+    }
+
+    /// Sets the initial rate prior (default: 1.0, must be > 0).
+    #[inline]
+    #[must_use]
+    pub fn initial_rate(mut self, r: f64) -> Self {
+        self.initial_rate = r;
+        self
+    }
+
+    /// Sets the decay factor (default: 1.0, in (0, 1]).
+    #[inline]
+    #[must_use]
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = d;
+        self
+    }
+
+    /// Sets the minimum samples before `is_primed()` returns true.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = Some(n);
+        self
+    }
+
+    /// Builds the bandit.
+    #[inline]
+    pub fn build(self) -> Result<ThompsonGammaF64, nexus_stats_core::ConfigError> {
+        let arms = self
+            .arms
+            .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+        if arms < 2 {
+            return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+        }
+        if self.initial_shape <= 0.0 || !self.initial_shape.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "initial_shape must be positive and finite",
+            ));
+        }
+        if self.initial_rate <= 0.0 || !self.initial_rate.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "initial_rate must be positive and finite",
+            ));
+        }
+        if self.decay <= 0.0 || self.decay > 1.0 || !self.decay.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "decay must be in (0, 1]",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(arms as u64);
+        Ok(ThompsonGammaF64 {
+            shapes: vec![self.initial_shape; arms].into_boxed_slice(),
+            rates: vec![self.initial_rate; arms].into_boxed_slice(),
+            initial_shape: self.initial_shape,
+            initial_rate: self.initial_rate,
+            decay: self.decay,
+            total_pulls: 0,
+            num_arms: arms,
+            min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/nexus-stats-regression/src/learning/ucb1.rs
+++ b/nexus-stats-regression/src/learning/ucb1.rs
@@ -2,289 +2,273 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec;
 
-macro_rules! impl_ucb1 {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// UCB1 multi-armed bandit.
-        ///
-        /// Selects the arm maximizing `mean + c * sqrt(ln(N) / n_i)` where
-        /// `c` is the exploration constant, `N` is total effective pulls,
-        /// and `n_i` is the effective pull count for arm `i`. Arms with
-        /// zero pulls are selected first (lowest index priority).
-        ///
-        /// Deterministic — no RNG needed for selection.
-        ///
-        /// Auer, Cesa-Bianchi, Fischer (2002).
-        ///
-        /// # Parameters
-        ///
-        /// - `arms` — number of arms (>= 2)
-        /// - `exploration` — confidence scale `c` (default: sqrt(2) ≈ 1.414)
-        /// - `decay` — exponential discount on counts/rewards per update
-        ///   (default: 1.0 = stationary). Set < 1.0 for non-stationary rewards.
-        ///
-        /// # Reward scaling
-        ///
-        /// UCB1's regret bound assumes rewards in [0, 1]. The exploration
-        /// constant `c` should be scaled for other ranges.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use nexus_stats_regression::learning::Ucb1F64;
-        ///
-        /// let mut bandit = Ucb1F64::builder()
-        ///     .arms(3)
-        ///     .build()
-        ///     .unwrap();
-        ///
-        /// let arm = bandit.select();
-        /// bandit.update(arm, 1.0).unwrap();
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            counts: Box<[$ty]>,
-            rewards: Box<[$ty]>,
-            exploration: $ty,
-            decay: $ty,
-            total_pulls: u64,
-            num_arms: usize,
-            min_samples: u64,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            arms: Option<usize>,
-            exploration: $ty,
-            decay: $ty,
-            min_samples: Option<u64>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                #[allow(clippy::cast_possible_truncation)]
-                let sqrt2 = nexus_stats_core::math::sqrt(2.0) as $ty;
-                $builder {
-                    arms: Option::None,
-                    exploration: sqrt2,
-                    decay: 1.0 as $ty,
-                    min_samples: Option::None,
-                }
-            }
-
-            /// Selects the arm with the highest UCB score.
-            ///
-            /// Arms with zero pulls are returned first (lowest index).
-            /// Ties among pulled arms are broken by lowest index.
-            #[must_use]
-            #[allow(clippy::cast_possible_truncation, clippy::float_cmp)]
-            pub fn select(&self) -> usize {
-                for (i, &c) in self.counts.iter().enumerate() {
-                    if c == 0.0 as $ty {
-                        return i;
-                    }
-                }
-
-                let total_eff: $ty = self.counts.iter().copied().sum();
-                let ln_total = nexus_stats_core::math::ln(total_eff as f64) as $ty;
-                let scaled_exp = self.exploration
-                    * nexus_stats_core::math::sqrt(ln_total as f64) as $ty;
-
-                let mut best_arm = 0;
-                let mut best_score = -(1.0 as $ty / 0.0 as $ty); // -inf
-                for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
-                    let inv_c = 1.0 as $ty / c;
-                    let mean = r * inv_c;
-                    let bonus = scaled_exp
-                        * nexus_stats_core::math::sqrt(inv_c as f64) as $ty;
-                    let score = mean + bonus;
-                    if score > best_score {
-                        best_score = score;
-                        best_arm = i;
-                    }
-                }
-                best_arm
-            }
-
-            /// Records a reward for an arm.
-            ///
-            /// If `decay < 1.0`, all arm counts and rewards are multiplied
-            /// by `decay` before incorporating the new observation.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError` if reward is NaN or infinite.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `arm >= num_arms`.
-            #[inline]
-            pub fn update(
-                &mut self,
-                arm: usize,
-                reward: $ty,
-            ) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(reward);
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-
-                if self.decay < 1.0 as $ty {
-                    let decay = self.decay;
-                    for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
-                        *c *= decay;
-                        *r *= decay;
-                    }
-                }
-
-                self.counts[arm] += 1.0 as $ty;
-                self.rewards[arm] += reward;
-                self.total_pulls += 1;
-                Ok(())
-            }
-
-            /// Mean reward for an arm, or `None` if never pulled.
-            #[inline]
-            #[must_use]
-            #[allow(clippy::float_cmp)]
-            pub fn mean_reward(&self, arm: usize) -> Option<$ty> {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                if self.counts[arm] == 0.0 as $ty {
-                    return Option::None;
-                }
-                Option::Some(self.rewards[arm] / self.counts[arm])
-            }
-
-            /// Effective pull count for an arm (decayed).
-            #[inline]
-            #[must_use]
-            pub fn pulls(&self, arm: usize) -> $ty {
-                assert!(
-                    arm < self.num_arms,
-                    "arm {arm} >= num_arms {}",
-                    self.num_arms
-                );
-                self.counts[arm]
-            }
-
-            /// Total pulls across all arms (un-decayed counter).
-            #[inline]
-            #[must_use]
-            pub fn total_pulls(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Number of arms.
-            #[inline]
-            #[must_use]
-            pub fn num_arms(&self) -> usize {
-                self.num_arms
-            }
-
-            /// Whether all arms have been pulled at least once
-            /// and `total_pulls >= min_samples`.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0 as $ty)
-            }
-
-            /// Returns the number of updates performed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.total_pulls
-            }
-
-            /// Resets all state, keeping configuration.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.counts.fill(0.0 as $ty);
-                self.rewards.fill(0.0 as $ty);
-                self.total_pulls = 0;
-            }
-        }
-
-        impl $builder {
-            /// Sets the number of arms (required, >= 2).
-            #[inline]
-            #[must_use]
-            pub fn arms(mut self, n: usize) -> Self {
-                self.arms = Option::Some(n);
-                self
-            }
-
-            /// Sets the exploration constant `c` (default: sqrt(2)).
-            #[inline]
-            #[must_use]
-            pub fn exploration(mut self, c: $ty) -> Self {
-                self.exploration = c;
-                self
-            }
-
-            /// Sets the decay factor for non-stationary rewards (default: 1.0).
-            #[inline]
-            #[must_use]
-            pub fn decay(mut self, d: $ty) -> Self {
-                self.decay = d;
-                self
-            }
-
-            /// Sets the minimum samples before `is_primed()` returns true (default: arms).
-            #[inline]
-            #[must_use]
-            pub fn min_samples(mut self, n: u64) -> Self {
-                self.min_samples = Option::Some(n);
-                self
-            }
-
-            /// Builds the bandit.
-            #[inline]
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let arms = self
-                    .arms
-                    .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
-                if arms < 2 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
-                }
-                if self.exploration <= 0.0 as $ty || !self.exploration.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "exploration must be positive and finite",
-                    ));
-                }
-                if self.decay <= 0.0 as $ty || self.decay > 1.0 as $ty || !self.decay.is_finite() {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "decay must be in (0, 1]",
-                    ));
-                }
-                let min_samples = self.min_samples.unwrap_or(arms as u64);
-                Ok($name {
-                    counts: vec![0.0 as $ty; arms].into_boxed_slice(),
-                    rewards: vec![0.0 as $ty; arms].into_boxed_slice(),
-                    exploration: self.exploration,
-                    decay: self.decay,
-                    total_pulls: 0,
-                    num_arms: arms,
-                    min_samples,
-                })
-            }
-        }
-    };
+/// UCB1 multi-armed bandit.
+///
+/// Selects the arm maximizing `mean + c * sqrt(ln(N) / n_i)` where
+/// `c` is the exploration constant, `N` is total effective pulls,
+/// and `n_i` is the effective pull count for arm `i`. Arms with
+/// zero pulls are selected first (lowest index priority).
+///
+/// Deterministic — no RNG needed for selection.
+///
+/// Auer, Cesa-Bianchi, Fischer (2002).
+///
+/// # Parameters
+///
+/// - `arms` — number of arms (>= 2)
+/// - `exploration` — confidence scale `c` (default: sqrt(2) ≈ 1.414)
+/// - `decay` — exponential discount on counts/rewards per update
+///   (default: 1.0 = stationary). Set < 1.0 for non-stationary rewards.
+///
+/// # Reward scaling
+///
+/// UCB1's regret bound assumes rewards in [0, 1]. The exploration
+/// constant `c` should be scaled for other ranges.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::learning::Ucb1F64;
+///
+/// let mut bandit = Ucb1F64::builder()
+///     .arms(3)
+///     .build()
+///     .unwrap();
+///
+/// let arm = bandit.select();
+/// bandit.update(arm, 1.0).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct Ucb1F64 {
+    counts: Box<[f64]>,
+    rewards: Box<[f64]>,
+    exploration: f64,
+    decay: f64,
+    total_pulls: u64,
+    num_arms: usize,
+    min_samples: u64,
 }
 
-impl_ucb1!(Ucb1F64, Ucb1F64Builder, f64);
-impl_ucb1!(Ucb1F32, Ucb1F32Builder, f32);
+/// Builder for [`Ucb1F64`].
+#[derive(Debug, Clone)]
+pub struct Ucb1F64Builder {
+    arms: Option<usize>,
+    exploration: f64,
+    decay: f64,
+    min_samples: Option<u64>,
+}
+
+impl Ucb1F64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> Ucb1F64Builder {
+        let sqrt2 = nexus_stats_core::math::sqrt(2.0);
+        Ucb1F64Builder {
+            arms: None,
+            exploration: sqrt2,
+            decay: 1.0,
+            min_samples: None,
+        }
+    }
+
+    /// Selects the arm with the highest UCB score.
+    ///
+    /// Arms with zero pulls are returned first (lowest index).
+    /// Ties among pulled arms are broken by lowest index.
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn select(&self) -> usize {
+        for (i, &c) in self.counts.iter().enumerate() {
+            if c == 0.0 {
+                return i;
+            }
+        }
+
+        let total_eff: f64 = self.counts.iter().copied().sum();
+        let ln_total = nexus_stats_core::math::ln(total_eff);
+        let scaled_exp = self.exploration * nexus_stats_core::math::sqrt(ln_total);
+
+        let mut best_arm = 0;
+        let mut best_score = f64::NEG_INFINITY;
+        for (i, (&r, &c)) in self.rewards.iter().zip(self.counts.iter()).enumerate() {
+            let inv_c = 1.0 / c;
+            let mean = r * inv_c;
+            let bonus = scaled_exp * nexus_stats_core::math::sqrt(inv_c);
+            let score = mean + bonus;
+            if score > best_score {
+                best_score = score;
+                best_arm = i;
+            }
+        }
+        best_arm
+    }
+
+    /// Records a reward for an arm.
+    ///
+    /// If `decay < 1.0`, all arm counts and rewards are multiplied
+    /// by `decay` before incorporating the new observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError` if reward is NaN or infinite.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `arm >= num_arms`.
+    #[inline]
+    pub fn update(&mut self, arm: usize, reward: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(reward);
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+
+        if self.decay < 1.0 {
+            let decay = self.decay;
+            for (c, r) in self.counts.iter_mut().zip(self.rewards.iter_mut()) {
+                *c *= decay;
+                *r *= decay;
+            }
+        }
+
+        self.counts[arm] += 1.0;
+        self.rewards[arm] += reward;
+        self.total_pulls += 1;
+        Ok(())
+    }
+
+    /// Mean reward for an arm, or `None` if never pulled.
+    #[inline]
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn mean_reward(&self, arm: usize) -> Option<f64> {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        if self.counts[arm] == 0.0 {
+            return None;
+        }
+        Some(self.rewards[arm] / self.counts[arm])
+    }
+
+    /// Effective pull count for an arm (decayed).
+    #[inline]
+    #[must_use]
+    pub fn pulls(&self, arm: usize) -> f64 {
+        assert!(
+            arm < self.num_arms,
+            "arm {arm} >= num_arms {}",
+            self.num_arms
+        );
+        self.counts[arm]
+    }
+
+    /// Total pulls across all arms (un-decayed counter).
+    #[inline]
+    #[must_use]
+    pub fn total_pulls(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Number of arms.
+    #[inline]
+    #[must_use]
+    pub fn num_arms(&self) -> usize {
+        self.num_arms
+    }
+
+    /// Whether all arms have been pulled at least once
+    /// and `total_pulls >= min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.total_pulls >= self.min_samples && self.counts.iter().all(|&c| c > 0.0)
+    }
+
+    /// Returns the number of updates performed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.total_pulls
+    }
+
+    /// Resets all state, keeping configuration.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.counts.fill(0.0);
+        self.rewards.fill(0.0);
+        self.total_pulls = 0;
+    }
+}
+
+impl Ucb1F64Builder {
+    /// Sets the number of arms (required, >= 2).
+    #[inline]
+    #[must_use]
+    pub fn arms(mut self, n: usize) -> Self {
+        self.arms = Some(n);
+        self
+    }
+
+    /// Sets the exploration constant `c` (default: sqrt(2)).
+    #[inline]
+    #[must_use]
+    pub fn exploration(mut self, c: f64) -> Self {
+        self.exploration = c;
+        self
+    }
+
+    /// Sets the decay factor for non-stationary rewards (default: 1.0).
+    #[inline]
+    #[must_use]
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = d;
+        self
+    }
+
+    /// Sets the minimum samples before `is_primed()` returns true (default: arms).
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, n: u64) -> Self {
+        self.min_samples = Some(n);
+        self
+    }
+
+    /// Builds the bandit.
+    #[inline]
+    pub fn build(self) -> Result<Ucb1F64, nexus_stats_core::ConfigError> {
+        let arms = self
+            .arms
+            .ok_or(nexus_stats_core::ConfigError::Missing("arms"))?;
+        if arms < 2 {
+            return Err(nexus_stats_core::ConfigError::Invalid("arms must be >= 2"));
+        }
+        if self.exploration <= 0.0 || !self.exploration.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "exploration must be positive and finite",
+            ));
+        }
+        if self.decay <= 0.0 || self.decay > 1.0 || !self.decay.is_finite() {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "decay must be in (0, 1]",
+            ));
+        }
+        let min_samples = self.min_samples.unwrap_or(arms as u64);
+        Ok(Ucb1F64 {
+            counts: vec![0.0; arms].into_boxed_slice(),
+            rewards: vec![0.0; arms].into_boxed_slice(),
+            exploration: self.exploration,
+            decay: self.decay,
+            total_pulls: 0,
+            num_arms: arms,
+            min_samples,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -410,8 +394,8 @@ mod tests {
 
         bandit.reset();
         assert_eq!(bandit.total_pulls(), 0);
-        assert_eq!(bandit.mean_reward(0), Option::None);
-        assert_eq!(bandit.mean_reward(1), Option::None);
+        assert_eq!(bandit.mean_reward(0), None);
+        assert_eq!(bandit.mean_reward(1), None);
     }
 
     #[test]
@@ -447,14 +431,5 @@ mod tests {
         assert!(Ucb1F64::builder().arms(2).decay(0.0).build().is_err());
         assert!(Ucb1F64::builder().arms(2).decay(1.1).build().is_err());
         assert!(Ucb1F64::builder().build().is_err()); // missing arms
-    }
-
-    #[test]
-    fn f32_basic() {
-        let mut bandit = Ucb1F32::builder().arms(2).build().unwrap();
-        bandit.update(0, 1.0).unwrap();
-        bandit.update(1, 0.0).unwrap();
-        let arm = bandit.select();
-        assert_eq!(arm, 0);
     }
 }

--- a/nexus-stats-regression/src/regression/ew_polynomial_regression.rs
+++ b/nexus-stats-regression/src/regression/ew_polynomial_regression.rs
@@ -4,293 +4,274 @@
 // but with exponential decay on accumulators. Recent data dominates.
 // Degree and intercept are runtime-configured via builder.
 
-use super::polynomial_regression::{CoefficientsF32, CoefficientsF64};
+use super::polynomial_regression::CoefficientsF64;
 use nexus_stats_core::math::MulAdd;
 
-macro_rules! impl_ew_polynomial_regression {
-    ($name:ident, $builder:ident, $coeff:ident, $solve_fn:path, $ty:ty) => {
-        /// Exponentially-weighted online polynomial regression.
-        ///
-        /// Same accumulator structure as OLS polynomial regression but with
-        /// exponential decay. Recent observations are weighted more heavily,
-        /// making the fit adaptive to trend changes.
-        ///
-        /// `alpha` is the weight on the new observation (same convention as EMA).
-        ///
-        /// # Complexity
-        /// - O(degree) per update, O(degree³) per coefficient query.
-        /// - ~240 bytes state (f64), zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::builder().degree(2).alpha(0.05 as ", stringify!($ty), ").build().unwrap();")]
-        #[doc = concat!("for x in 0..200u64 { r.update(x as ", stringify!($ty), ", 2.0 as ", stringify!($ty), " * x as ", stringify!($ty), "); }")]
-        /// assert!(r.is_primed());
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_x: [$ty; 17],
-            sum_xy: [$ty; 9],
-            sum_y2: $ty,
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            effective_n: $ty,
-            count: u64,
-            degree: usize,
-            intercept: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            degree: Option<usize>,
-            intercept: bool,
-            alpha: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    degree: Option::None,
-                    intercept: true,
-                    alpha: Option::None,
-                }
-            }
-
-            fn dim(&self) -> usize {
-                self.degree + self.intercept as usize
-            }
-
-            /// Feeds an (x, y) observation.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if either value is NaN, or
-            /// `DataError::Infinite` if either value is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                self.count += 1;
-                self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0 as $ty);
-                self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
-
-                let mut x_pow = 1.0 as $ty;
-                let max_pow = 2 * self.degree;
-                for j in 0..=max_pow {
-                    self.sum_x[j] = self.one_minus_alpha.fma(self.sum_x[j], x_pow);
-                    if j <= self.degree {
-                        self.sum_xy[j] = self.one_minus_alpha.fma(self.sum_xy[j], x_pow * y);
-                    }
-                    x_pow *= x;
-                }
-                Ok(())
-            }
-
-            /// Solve for polynomial coefficients.
-            #[must_use]
-            pub fn coefficients(&self) -> Option<$coeff> {
-                let dim = self.dim();
-                if (self.effective_n as usize) < dim {
-                    return Option::None;
-                }
-
-                let mut a = [[0.0 as $ty; 9]; 9];
-                let mut b = [0.0 as $ty; 9];
-                let offset: usize = if self.intercept { 0 } else { 1 };
-
-                for i in 0..dim {
-                    for j in 0..dim {
-                        a[i][j] = self.sum_x[i + j + 2 * offset];
-                    }
-                    b[i] = self.sum_xy[i + offset];
-                }
-
-                if !$solve_fn(dim, &mut a, &mut b) {
-                    return Option::None;
-                }
-
-                let mut coeffs = $coeff {
-                    values: [0.0 as $ty; 9],
-                    len: dim,
-                };
-                for i in 0..dim {
-                    coeffs.values[i] = b[i];
-                }
-                Option::Some(coeffs)
-            }
-
-            /// R² goodness of fit.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                let coeffs = self.coefficients()?;
-                let dim = self.dim();
-                let offset: usize = if self.intercept { 0 } else { 1 };
-
-                let mut beta_dot_rhs = 0.0 as $ty;
-                for i in 0..dim {
-                    beta_dot_rhs += coeffs.values[i] * self.sum_xy[i + offset];
-                }
-                let ss_res = self.sum_y2 - beta_dot_rhs;
-
-                let ss_tot = if self.intercept {
-                    let sum_y = self.sum_xy[0];
-                    self.sum_y2 - sum_y * sum_y / self.effective_n
-                } else {
-                    self.sum_y2
-                };
-
-                if ss_tot <= 0.0 as $ty {
-                    return Option::None;
-                }
-
-                Option::Some(1.0 as $ty - ss_res / ss_tot)
-            }
-
-            /// Predict y for a given x.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                let coeffs = self.coefficients()?;
-                let dim = self.dim();
-
-                let mut y = 0.0 as $ty;
-                let mut x_pow = if self.intercept { 1.0 as $ty } else { x };
-                for i in 0..dim {
-                    y += coeffs.values[i] * x_pow;
-                    x_pow *= x;
-                }
-                Option::Some(y)
-            }
-
-            /// Number of observations processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Effective sample count (converges to 1/alpha as n → ∞).
-            #[inline]
-            #[must_use]
-            pub fn effective_count(&self) -> $ty {
-                self.effective_n
-            }
-
-            /// Alpha (weight on new observation).
-            #[inline]
-            #[must_use]
-            pub fn alpha(&self) -> $ty {
-                self.alpha
-            }
-
-            /// Configured polynomial degree.
-            #[inline]
-            #[must_use]
-            pub fn degree(&self) -> usize {
-                self.degree
-            }
-
-            /// Whether primed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                (self.effective_n as usize) >= self.dim()
-            }
-
-            /// Resets to empty state. Config unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_x = [0.0 as $ty; 17];
-                self.sum_xy = [0.0 as $ty; 9];
-                self.sum_y2 = 0.0 as $ty;
-                self.effective_n = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Polynomial degree (1..=8). Required.
-            #[inline]
-            #[must_use]
-            pub fn degree(mut self, degree: usize) -> Self {
-                self.degree = Option::Some(degree);
-                self
-            }
-
-            /// Whether to include the constant term. Default: `true`.
-            #[inline]
-            #[must_use]
-            pub fn intercept(mut self, intercept: bool) -> Self {
-                self.intercept = intercept;
-                self
-            }
-
-            /// Weight on new observation, in (0, 1). Required.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Builds the regression estimator.
-            ///
-            /// # Errors
-            ///
-            /// Returns errors if degree or alpha not set, or values out of range.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let degree = self.degree
-                    .ok_or(nexus_stats_core::ConfigError::Missing("degree"))?;
-                let alpha = self.alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-
-                if degree < 1 || degree > 8 {
-                    return Err(nexus_stats_core::ConfigError::Invalid("degree must be in 1..=8"));
-                }
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "alpha must be in (0, 1) exclusive",
-                    ));
-                }
-
-                Ok($name {
-                    sum_x: [0.0 as $ty; 17],
-                    sum_xy: [0.0 as $ty; 9],
-                    sum_y2: 0.0 as $ty,
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    effective_n: 0.0 as $ty,
-                    count: 0,
-                    degree,
-                    intercept: self.intercept,
-                })
-            }
-        }
-    };
+/// Exponentially-weighted online polynomial regression.
+///
+/// Same accumulator structure as OLS polynomial regression but with
+/// exponential decay. Recent observations are weighted more heavily,
+/// making the fit adaptive to trend changes.
+///
+/// `alpha` is the weight on the new observation (same convention as EMA).
+///
+/// # Complexity
+/// - O(degree) per update, O(degree³) per coefficient query.
+/// - ~240 bytes state, zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::EwPolynomialRegressionF64;
+///
+/// let mut r = EwPolynomialRegressionF64::builder().degree(2).alpha(0.05).build().unwrap();
+/// for x in 0..200u64 { r.update(x as f64, 2.0 * x as f64); }
+/// assert!(r.is_primed());
+/// ```
+#[derive(Debug, Clone)]
+pub struct EwPolynomialRegressionF64 {
+    sum_x: [f64; 17],
+    sum_xy: [f64; 9],
+    sum_y2: f64,
+    alpha: f64,
+    one_minus_alpha: f64,
+    effective_n: f64,
+    count: u64,
+    degree: usize,
+    intercept: bool,
 }
 
-impl_ew_polynomial_regression!(
-    EwPolynomialRegressionF64,
-    EwPolynomialRegressionF64Builder,
-    CoefficientsF64,
-    super::polynomial_regression::gauss_solve_f64,
-    f64
-);
-impl_ew_polynomial_regression!(
-    EwPolynomialRegressionF32,
-    EwPolynomialRegressionF32Builder,
-    CoefficientsF32,
-    super::polynomial_regression::gauss_solve_f32,
-    f32
-);
+/// Builder for [`EwPolynomialRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct EwPolynomialRegressionF64Builder {
+    degree: Option<usize>,
+    intercept: bool,
+    alpha: Option<f64>,
+}
+
+impl EwPolynomialRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EwPolynomialRegressionF64Builder {
+        EwPolynomialRegressionF64Builder {
+            degree: None,
+            intercept: true,
+            alpha: None,
+        }
+    }
+
+    fn dim(&self) -> usize {
+        self.degree + self.intercept as usize
+    }
+
+    /// Feeds an (x, y) observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either value is NaN, or
+    /// `DataError::Infinite` if either value is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        self.count += 1;
+        self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0);
+        self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
+
+        let mut x_pow = 1.0;
+        let max_pow = 2 * self.degree;
+        for j in 0..=max_pow {
+            self.sum_x[j] = self.one_minus_alpha.fma(self.sum_x[j], x_pow);
+            if j <= self.degree {
+                self.sum_xy[j] = self.one_minus_alpha.fma(self.sum_xy[j], x_pow * y);
+            }
+            x_pow *= x;
+        }
+        Ok(())
+    }
+
+    /// Solve for polynomial coefficients.
+    #[must_use]
+    pub fn coefficients(&self) -> Option<CoefficientsF64> {
+        let dim = self.dim();
+        if (self.effective_n as usize) < dim {
+            return None;
+        }
+
+        let mut a = [[0.0; 9]; 9];
+        let mut b = [0.0; 9];
+        let offset = usize::from(!self.intercept);
+
+        for i in 0..dim {
+            for j in 0..dim {
+                a[i][j] = self.sum_x[i + j + 2 * offset];
+            }
+            b[i] = self.sum_xy[i + offset];
+        }
+
+        if !super::polynomial_regression::gauss_solve_f64(dim, &mut a, &mut b) {
+            return None;
+        }
+
+        let mut coeffs = CoefficientsF64 {
+            values: [0.0; 9],
+            len: dim,
+        };
+        coeffs.values[..dim].copy_from_slice(&b[..dim]);
+        Some(coeffs)
+    }
+
+    /// R² goodness of fit.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        let coeffs = self.coefficients()?;
+        let dim = self.dim();
+        let offset = usize::from(!self.intercept);
+
+        let mut beta_dot_rhs = 0.0;
+        for i in 0..dim {
+            beta_dot_rhs += coeffs.values[i] * self.sum_xy[i + offset];
+        }
+        let ss_res = self.sum_y2 - beta_dot_rhs;
+
+        let ss_tot = if self.intercept {
+            let sum_y = self.sum_xy[0];
+            self.sum_y2 - sum_y * sum_y / self.effective_n
+        } else {
+            self.sum_y2
+        };
+
+        if ss_tot <= 0.0 {
+            return None;
+        }
+
+        Some(1.0 - ss_res / ss_tot)
+    }
+
+    /// Predict y for a given x.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        let coeffs = self.coefficients()?;
+        let dim = self.dim();
+
+        let mut y = 0.0;
+        let mut x_pow = if self.intercept { 1.0 } else { x };
+        for i in 0..dim {
+            y += coeffs.values[i] * x_pow;
+            x_pow *= x;
+        }
+        Some(y)
+    }
+
+    /// Number of observations processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Effective sample count (converges to 1/alpha as n -> inf).
+    #[inline]
+    #[must_use]
+    pub fn effective_count(&self) -> f64 {
+        self.effective_n
+    }
+
+    /// Alpha (weight on new observation).
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// Configured polynomial degree.
+    #[inline]
+    #[must_use]
+    pub fn degree(&self) -> usize {
+        self.degree
+    }
+
+    /// Whether primed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        (self.effective_n as usize) >= self.dim()
+    }
+
+    /// Resets to empty state. Config unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_x = [0.0; 17];
+        self.sum_xy = [0.0; 9];
+        self.sum_y2 = 0.0;
+        self.effective_n = 0.0;
+        self.count = 0;
+    }
+}
+
+impl EwPolynomialRegressionF64Builder {
+    /// Polynomial degree (1..=8). Required.
+    #[inline]
+    #[must_use]
+    pub fn degree(mut self, degree: usize) -> Self {
+        self.degree = Some(degree);
+        self
+    }
+
+    /// Whether to include the constant term. Default: `true`.
+    #[inline]
+    #[must_use]
+    pub fn intercept(mut self, intercept: bool) -> Self {
+        self.intercept = intercept;
+        self
+    }
+
+    /// Weight on new observation, in (0, 1). Required.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Builds the regression estimator.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if degree or alpha not set, or values out of range.
+    pub fn build(self) -> Result<EwPolynomialRegressionF64, nexus_stats_core::ConfigError> {
+        let degree = self
+            .degree
+            .ok_or(nexus_stats_core::ConfigError::Missing("degree"))?;
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+
+        if degree < 1 || degree > 8 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "degree must be in 1..=8",
+            ));
+        }
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "alpha must be in (0, 1) exclusive",
+            ));
+        }
+
+        Ok(EwPolynomialRegressionF64 {
+            sum_x: [0.0; 17],
+            sum_xy: [0.0; 9],
+            sum_y2: 0.0,
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            effective_n: 0.0,
+            count: 0,
+            degree,
+            intercept: self.intercept,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -396,19 +377,6 @@ mod tests {
         assert_eq!(r.count(), 0);
         assert!(r.coefficients().is_none());
         assert_eq!(r.degree(), 1);
-    }
-
-    #[test]
-    fn ew_f32_basic() {
-        let mut r = EwPolynomialRegressionF32::builder()
-            .degree(1)
-            .alpha(0.05)
-            .build()
-            .unwrap();
-        for x in 0..200u32 {
-            r.update(x as f32, 2.0 * x as f32 + 1.0).unwrap();
-        }
-        assert!(r.is_primed());
     }
 
     #[test]

--- a/nexus-stats-regression/src/regression/linear_regression.rs
+++ b/nexus-stats-regression/src/regression/linear_regression.rs
@@ -7,512 +7,487 @@
 
 use nexus_stats_core::math::MulAdd;
 
-macro_rules! impl_linear_regression {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Online linear regression with closed-form solve.
-        ///
-        /// Accumulates 5 sufficient statistics and solves directly —
-        /// no matrix operations, no loops. With intercept: `y = ax + b`.
-        /// Without intercept (through origin): `y = ax`.
-        ///
-        /// # Complexity
-        /// - O(1) per update (~6 adds, 2 muls), O(1) per query.
-        /// - 48 bytes state (f64), 28 bytes (f32). Zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::new();")]
-        #[doc = concat!("for x in 0..100u64 { r.update(x as ", stringify!($ty), ", 2.0 as ", stringify!($ty), " * x as ", stringify!($ty), " + 3.0 as ", stringify!($ty), "); }")]
-        /// let slope = r.slope().unwrap();
-        #[doc = concat!("assert!((slope - 2.0 as ", stringify!($ty), ").abs() < 0.001 as ", stringify!($ty), ");")]
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_x: $ty,
-            sum_x2: $ty,
-            sum_y: $ty,
-            sum_xy: $ty,
-            sum_y2: $ty,
-            count: u64,
-            intercept: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            intercept: bool,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder { intercept: true }
-            }
-
-            /// Linear regression with intercept: `y = ax + b`.
-            #[inline]
-            #[must_use]
-            pub fn new() -> Self {
-                Self {
-                    sum_x: 0.0 as $ty,
-                    sum_x2: 0.0 as $ty,
-                    sum_y: 0.0 as $ty,
-                    sum_xy: 0.0 as $ty,
-                    sum_y2: 0.0 as $ty,
-                    count: 0,
-                    intercept: true,
-                }
-            }
-
-            /// Linear regression through the origin: `y = ax`.
-            #[inline]
-            #[must_use]
-            pub fn through_origin() -> Self {
-                Self {
-                    sum_x: 0.0 as $ty,
-                    sum_x2: 0.0 as $ty,
-                    sum_y: 0.0 as $ty,
-                    sum_xy: 0.0 as $ty,
-                    sum_y2: 0.0 as $ty,
-                    count: 0,
-                    intercept: false,
-                }
-            }
-
-            /// System dimension: 2 with intercept, 1 without.
-            #[inline]
-            fn dim(&self) -> usize {
-                1 + self.intercept as usize
-            }
-
-            /// Feeds an (x, y) observation.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if either value is NaN, or
-            /// `DataError::Infinite` if either value is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                self.count += 1;
-                self.sum_x += x;
-                self.sum_x2 = x.fma(x, self.sum_x2);
-                self.sum_y += y;
-                self.sum_xy = x.fma(y, self.sum_xy);
-                self.sum_y2 = y.fma(y, self.sum_y2);
-                Ok(())
-            }
-
-            /// Slope of the fit, or `None` if not primed.
-            #[must_use]
-            pub fn slope(&self) -> Option<$ty> {
-                if (self.count as usize) < self.dim() {
-                    return Option::None;
-                }
-                if self.intercept {
-                    let n = self.count as $ty;
-                    let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
-                    if denom == 0.0 as $ty {
-                        return Option::None;
-                    }
-                    Option::Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
-                } else {
-                    if self.sum_x2 == 0.0 as $ty {
-                        return Option::None;
-                    }
-                    Option::Some(self.sum_xy / self.sum_x2)
-                }
-            }
-
-            /// Intercept value, or `None` if not primed or no intercept.
-            #[must_use]
-            pub fn intercept_value(&self) -> Option<$ty> {
-                if !self.intercept {
-                    return Option::None;
-                }
-                let slope = self.slope()?;
-                let n = self.count as $ty;
-                Option::Some(slope.fma(-self.sum_x, self.sum_y) / n)
-            }
-
-            /// R² goodness of fit, or `None` if not enough data.
-            ///
-            /// With intercept: centered R² = 1 - SS_res/SS_tot.
-            /// Without intercept: uncentered R² = 1 - SS_res/Σy².
-            #[must_use]
-            #[allow(clippy::suboptimal_flops)]
-            pub fn r_squared(&self) -> Option<$ty> {
-                let slope = self.slope()?;
-                let n = self.count as $ty;
-
-                // SS_res = Σy² - 2*slope*Σxy - 2*intercept*Σy + slope²*Σx² + 2*slope*intercept*Σx + n*intercept²
-                // Simplified via the closed-form:
-                let (ss_res, ss_tot) = if self.intercept {
-                    let intercept = (self.sum_y - slope * self.sum_x) / n;
-                    let ss_res = self.sum_y2
-                        - 2.0 as $ty * slope * self.sum_xy
-                        - 2.0 as $ty * intercept * self.sum_y
-                        + slope * slope * self.sum_x2
-                        + 2.0 as $ty * slope * intercept * self.sum_x
-                        + n * intercept * intercept;
-                    let ss_tot = self.sum_y2 - self.sum_y * self.sum_y / n;
-                    (ss_res, ss_tot)
-                } else {
-                    let ss_res = self.sum_y2
-                        - 2.0 as $ty * slope * self.sum_xy
-                        + slope * slope * self.sum_x2;
-                    (ss_res, self.sum_y2)
-                };
-
-                if ss_tot <= 0.0 as $ty {
-                    return Option::None;
-                }
-
-                Option::Some(1.0 as $ty - ss_res / ss_tot)
-            }
-
-            /// Predict y for a given x.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                let slope = self.slope()?;
-                if self.intercept {
-                    let intercept = self.intercept_value()?;
-                    Option::Some(slope.fma(x, intercept))
-                } else {
-                    Option::Some(slope * x)
-                }
-            }
-
-            /// Number of observations processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data to solve (>= 2 with intercept, >= 1 without).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                (self.count as usize) >= self.dim()
-            }
-
-            /// Whether the intercept is included.
-            #[inline]
-            #[must_use]
-            pub fn has_intercept(&self) -> bool {
-                self.intercept
-            }
-
-            /// Resets to empty state. Intercept setting unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_x = 0.0 as $ty;
-                self.sum_x2 = 0.0 as $ty;
-                self.sum_y = 0.0 as $ty;
-                self.sum_xy = 0.0 as $ty;
-                self.sum_y2 = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl $builder {
-            /// Whether to include the constant term. Default: `true`.
-            #[inline]
-            #[must_use]
-            pub fn intercept(mut self, intercept: bool) -> Self {
-                self.intercept = intercept;
-                self
-            }
-
-            /// Builds the regression.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                Ok($name {
-                    sum_x: 0.0 as $ty,
-                    sum_x2: 0.0 as $ty,
-                    sum_y: 0.0 as $ty,
-                    sum_xy: 0.0 as $ty,
-                    sum_y2: 0.0 as $ty,
-                    count: 0,
-                    intercept: self.intercept,
-                })
-            }
-        }
-    };
+/// Online linear regression with closed-form solve.
+///
+/// Accumulates 5 sufficient statistics and solves directly —
+/// no matrix operations, no loops. With intercept: `y = ax + b`.
+/// Without intercept (through origin): `y = ax`.
+///
+/// # Complexity
+/// - O(1) per update (~6 adds, 2 muls), O(1) per query.
+/// - 48 bytes state. Zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::LinearRegressionF64;
+///
+/// let mut r = LinearRegressionF64::new();
+/// for x in 0..100u64 { r.update(x as f64, 2.0 * x as f64 + 3.0); }
+/// let slope = r.slope().unwrap();
+/// assert!((slope - 2.0).abs() < 0.001);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinearRegressionF64 {
+    sum_x: f64,
+    sum_x2: f64,
+    sum_y: f64,
+    sum_xy: f64,
+    sum_y2: f64,
+    count: u64,
+    intercept: bool,
 }
 
-impl_linear_regression!(LinearRegressionF64, LinearRegressionF64Builder, f64);
-impl_linear_regression!(LinearRegressionF32, LinearRegressionF32Builder, f32);
+/// Builder for [`LinearRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct LinearRegressionF64Builder {
+    intercept: bool,
+}
+
+impl LinearRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LinearRegressionF64Builder {
+        LinearRegressionF64Builder { intercept: true }
+    }
+
+    /// Linear regression with intercept: `y = ax + b`.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            sum_x: 0.0,
+            sum_x2: 0.0,
+            sum_y: 0.0,
+            sum_xy: 0.0,
+            sum_y2: 0.0,
+            count: 0,
+            intercept: true,
+        }
+    }
+
+    /// Linear regression through the origin: `y = ax`.
+    #[inline]
+    #[must_use]
+    pub fn through_origin() -> Self {
+        Self {
+            sum_x: 0.0,
+            sum_x2: 0.0,
+            sum_y: 0.0,
+            sum_xy: 0.0,
+            sum_y2: 0.0,
+            count: 0,
+            intercept: false,
+        }
+    }
+
+    /// System dimension: 2 with intercept, 1 without.
+    #[inline]
+    fn dim(&self) -> usize {
+        1 + self.intercept as usize
+    }
+
+    /// Feeds an (x, y) observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either value is NaN, or
+    /// `DataError::Infinite` if either value is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        self.count += 1;
+        self.sum_x += x;
+        self.sum_x2 = x.fma(x, self.sum_x2);
+        self.sum_y += y;
+        self.sum_xy = x.fma(y, self.sum_xy);
+        self.sum_y2 = y.fma(y, self.sum_y2);
+        Ok(())
+    }
+
+    /// Slope of the fit, or `None` if not primed.
+    #[must_use]
+    pub fn slope(&self) -> Option<f64> {
+        if (self.count as usize) < self.dim() {
+            return None;
+        }
+        if self.intercept {
+            let n = self.count as f64;
+            let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
+            if denom == 0.0 {
+                return None;
+            }
+            Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
+        } else {
+            if self.sum_x2 == 0.0 {
+                return None;
+            }
+            Some(self.sum_xy / self.sum_x2)
+        }
+    }
+
+    /// Intercept value, or `None` if not primed or no intercept.
+    #[must_use]
+    pub fn intercept_value(&self) -> Option<f64> {
+        if !self.intercept {
+            return None;
+        }
+        let slope = self.slope()?;
+        let n = self.count as f64;
+        Some(slope.fma(-self.sum_x, self.sum_y) / n)
+    }
+
+    /// R² goodness of fit, or `None` if not enough data.
+    ///
+    /// With intercept: centered R² = 1 - SS_res/SS_tot.
+    /// Without intercept: uncentered R² = 1 - SS_res/Σy².
+    #[must_use]
+    #[allow(clippy::suboptimal_flops)]
+    pub fn r_squared(&self) -> Option<f64> {
+        let slope = self.slope()?;
+        let n = self.count as f64;
+
+        // SS_res = Σy² - 2*slope*Σxy - 2*intercept*Σy + slope²*Σx² + 2*slope*intercept*Σx + n*intercept²
+        // Simplified via the closed-form:
+        let (ss_res, ss_tot) = if self.intercept {
+            let intercept = (self.sum_y - slope * self.sum_x) / n;
+            let ss_res = self.sum_y2 - 2.0 * slope * self.sum_xy - 2.0 * intercept * self.sum_y
+                + slope * slope * self.sum_x2
+                + 2.0 * slope * intercept * self.sum_x
+                + n * intercept * intercept;
+            let ss_tot = self.sum_y2 - self.sum_y * self.sum_y / n;
+            (ss_res, ss_tot)
+        } else {
+            let ss_res = self.sum_y2 - 2.0 * slope * self.sum_xy + slope * slope * self.sum_x2;
+            (ss_res, self.sum_y2)
+        };
+
+        if ss_tot <= 0.0 {
+            return None;
+        }
+
+        Some(1.0 - ss_res / ss_tot)
+    }
+
+    /// Predict y for a given x.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        let slope = self.slope()?;
+        if self.intercept {
+            let intercept = self.intercept_value()?;
+            Some(slope.fma(x, intercept))
+        } else {
+            Some(slope * x)
+        }
+    }
+
+    /// Number of observations processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data to solve (>= 2 with intercept, >= 1 without).
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        (self.count as usize) >= self.dim()
+    }
+
+    /// Whether the intercept is included.
+    #[inline]
+    #[must_use]
+    pub fn has_intercept(&self) -> bool {
+        self.intercept
+    }
+
+    /// Resets to empty state. Intercept setting unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_x = 0.0;
+        self.sum_x2 = 0.0;
+        self.sum_y = 0.0;
+        self.sum_xy = 0.0;
+        self.sum_y2 = 0.0;
+        self.count = 0;
+    }
+}
+
+impl Default for LinearRegressionF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LinearRegressionF64Builder {
+    /// Whether to include the constant term. Default: `true`.
+    #[inline]
+    #[must_use]
+    pub fn intercept(mut self, intercept: bool) -> Self {
+        self.intercept = intercept;
+        self
+    }
+
+    /// Builds the regression.
+    pub fn build(self) -> Result<LinearRegressionF64, nexus_stats_core::ConfigError> {
+        Ok(LinearRegressionF64 {
+            sum_x: 0.0,
+            sum_x2: 0.0,
+            sum_y: 0.0,
+            sum_xy: 0.0,
+            sum_y2: 0.0,
+            count: 0,
+            intercept: self.intercept,
+        })
+    }
+}
 
 // ============================================================================
 // EW Linear Regression
 // ============================================================================
 
-macro_rules! impl_ew_linear_regression {
-    ($name:ident, $builder:ident, $ty:ty) => {
-        /// Exponentially-weighted online linear regression.
-        ///
-        /// Same closed-form solve as the non-EW linear regression types
-        /// but with exponential decay on accumulators. Recent data
-        /// dominates, making the fit adaptive to trend changes.
-        ///
-        /// # Complexity
-        /// - O(1) per update, O(1) per query.
-        /// - ~64 bytes state (f64). Zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::builder()")]
-        ///     .alpha(0.05)
-        ///     .build()
-        ///     .unwrap();
-        #[doc = concat!("for x in 0..200u64 { r.update(x as ", stringify!($ty), ", 2.0 as ", stringify!($ty), " * x as ", stringify!($ty), "); }")]
-        /// assert!(r.slope().is_some());
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_x: $ty,
-            sum_x2: $ty,
-            sum_y: $ty,
-            sum_xy: $ty,
-            sum_y2: $ty,
-            alpha: $ty,
-            one_minus_alpha: $ty,
-            effective_n: $ty,
-            count: u64,
-            intercept: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-            intercept: bool,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                    intercept: true,
-                }
-            }
-
-            fn dim(&self) -> usize {
-                1 + self.intercept as usize
-            }
-
-            /// Feeds an (x, y) observation.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if either value is NaN, or
-            /// `DataError::Infinite` if either value is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                self.count += 1;
-                self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0 as $ty);
-                self.sum_x = self.one_minus_alpha.fma(self.sum_x, x);
-                self.sum_x2 = self.one_minus_alpha.fma(self.sum_x2, x * x);
-                self.sum_y = self.one_minus_alpha.fma(self.sum_y, y);
-                self.sum_xy = self.one_minus_alpha.fma(self.sum_xy, x * y);
-                self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
-                Ok(())
-            }
-
-            /// Slope, or `None` if not primed.
-            #[must_use]
-            pub fn slope(&self) -> Option<$ty> {
-                if (self.effective_n as usize) < self.dim() {
-                    return Option::None;
-                }
-                if self.intercept {
-                    let n = self.effective_n;
-                    let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
-                    if denom == 0.0 as $ty {
-                        return Option::None;
-                    }
-                    Option::Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
-                } else {
-                    if self.sum_x2 == 0.0 as $ty {
-                        return Option::None;
-                    }
-                    Option::Some(self.sum_xy / self.sum_x2)
-                }
-            }
-
-            /// Intercept value, or `None` if not primed or no intercept.
-            #[must_use]
-            pub fn intercept_value(&self) -> Option<$ty> {
-                if !self.intercept {
-                    return Option::None;
-                }
-                let slope = self.slope()?;
-                Option::Some(slope.fma(-self.sum_x, self.sum_y) / self.effective_n)
-            }
-
-            /// R² goodness of fit.
-            #[must_use]
-            #[allow(clippy::suboptimal_flops)]
-            pub fn r_squared(&self) -> Option<$ty> {
-                let slope = self.slope()?;
-                let n = self.effective_n;
-
-                let (ss_res, ss_tot) = if self.intercept {
-                    let intercept = (self.sum_y - slope * self.sum_x) / n;
-                    let ss_res = self.sum_y2
-                        - 2.0 as $ty * slope * self.sum_xy
-                        - 2.0 as $ty * intercept * self.sum_y
-                        + slope * slope * self.sum_x2
-                        + 2.0 as $ty * slope * intercept * self.sum_x
-                        + n * intercept * intercept;
-                    let ss_tot = self.sum_y2 - self.sum_y * self.sum_y / n;
-                    (ss_res, ss_tot)
-                } else {
-                    let ss_res = self.sum_y2
-                        - 2.0 as $ty * slope * self.sum_xy
-                        + slope * slope * self.sum_x2;
-                    (ss_res, self.sum_y2)
-                };
-
-                if ss_tot <= 0.0 as $ty {
-                    return Option::None;
-                }
-
-                Option::Some(1.0 as $ty - ss_res / ss_tot)
-            }
-
-            /// Predict y.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                let slope = self.slope()?;
-                if self.intercept {
-                    let intercept = self.intercept_value()?;
-                    Option::Some(slope.fma(x, intercept))
-                } else {
-                    Option::Some(slope * x)
-                }
-            }
-
-            /// Number of observations.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Effective sample count.
-            #[inline]
-            #[must_use]
-            pub fn effective_count(&self) -> $ty {
-                self.effective_n
-            }
-
-            /// Alpha.
-            #[inline]
-            #[must_use]
-            pub fn alpha(&self) -> $ty {
-                self.alpha
-            }
-
-            /// Whether primed.
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                (self.effective_n as usize) >= self.dim()
-            }
-
-            /// Whether intercept is included.
-            #[inline]
-            #[must_use]
-            pub fn has_intercept(&self) -> bool {
-                self.intercept
-            }
-
-            /// Reset. Config unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_x = 0.0 as $ty;
-                self.sum_x2 = 0.0 as $ty;
-                self.sum_y = 0.0 as $ty;
-                self.sum_xy = 0.0 as $ty;
-                self.sum_y2 = 0.0 as $ty;
-                self.effective_n = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Weight on new observation, in (0, 1). Required.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Whether to include the constant term. Default: `true`.
-            #[inline]
-            #[must_use]
-            pub fn intercept(mut self, intercept: bool) -> Self {
-                self.intercept = intercept;
-                self
-            }
-
-            /// Builds the regression.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self.alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                if !(alpha > 0.0 as $ty && alpha < 1.0 as $ty) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "alpha must be in (0, 1) exclusive",
-                    ));
-                }
-
-                Ok($name {
-                    sum_x: 0.0 as $ty,
-                    sum_x2: 0.0 as $ty,
-                    sum_y: 0.0 as $ty,
-                    sum_xy: 0.0 as $ty,
-                    sum_y2: 0.0 as $ty,
-                    alpha,
-                    one_minus_alpha: 1.0 as $ty - alpha,
-                    effective_n: 0.0 as $ty,
-                    count: 0,
-                    intercept: self.intercept,
-                })
-            }
-        }
-    };
+/// Exponentially-weighted online linear regression.
+///
+/// Same closed-form solve as the non-EW linear regression types
+/// but with exponential decay on accumulators. Recent data
+/// dominates, making the fit adaptive to trend changes.
+///
+/// # Complexity
+/// - O(1) per update, O(1) per query.
+/// - ~64 bytes state. Zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::EwLinearRegressionF64;
+///
+/// let mut r = EwLinearRegressionF64::builder()
+///     .alpha(0.05)
+///     .build()
+///     .unwrap();
+/// for x in 0..200u64 { r.update(x as f64, 2.0 * x as f64); }
+/// assert!(r.slope().is_some());
+/// ```
+#[derive(Debug, Clone)]
+pub struct EwLinearRegressionF64 {
+    sum_x: f64,
+    sum_x2: f64,
+    sum_y: f64,
+    sum_xy: f64,
+    sum_y2: f64,
+    alpha: f64,
+    one_minus_alpha: f64,
+    effective_n: f64,
+    count: u64,
+    intercept: bool,
 }
 
-impl_ew_linear_regression!(EwLinearRegressionF64, EwLinearRegressionF64Builder, f64);
-impl_ew_linear_regression!(EwLinearRegressionF32, EwLinearRegressionF32Builder, f32);
+/// Builder for [`EwLinearRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct EwLinearRegressionF64Builder {
+    alpha: Option<f64>,
+    intercept: bool,
+}
+
+impl EwLinearRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EwLinearRegressionF64Builder {
+        EwLinearRegressionF64Builder {
+            alpha: None,
+            intercept: true,
+        }
+    }
+
+    fn dim(&self) -> usize {
+        1 + self.intercept as usize
+    }
+
+    /// Feeds an (x, y) observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either value is NaN, or
+    /// `DataError::Infinite` if either value is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        self.count += 1;
+        self.effective_n = self.one_minus_alpha.fma(self.effective_n, 1.0);
+        self.sum_x = self.one_minus_alpha.fma(self.sum_x, x);
+        self.sum_x2 = self.one_minus_alpha.fma(self.sum_x2, x * x);
+        self.sum_y = self.one_minus_alpha.fma(self.sum_y, y);
+        self.sum_xy = self.one_minus_alpha.fma(self.sum_xy, x * y);
+        self.sum_y2 = self.one_minus_alpha.fma(self.sum_y2, y * y);
+        Ok(())
+    }
+
+    /// Slope, or `None` if not primed.
+    #[must_use]
+    pub fn slope(&self) -> Option<f64> {
+        if (self.effective_n as usize) < self.dim() {
+            return None;
+        }
+        if self.intercept {
+            let n = self.effective_n;
+            let denom = n.fma(self.sum_x2, -(self.sum_x * self.sum_x));
+            if denom == 0.0 {
+                return None;
+            }
+            Some(n.fma(self.sum_xy, -(self.sum_x * self.sum_y)) / denom)
+        } else {
+            if self.sum_x2 == 0.0 {
+                return None;
+            }
+            Some(self.sum_xy / self.sum_x2)
+        }
+    }
+
+    /// Intercept value, or `None` if not primed or no intercept.
+    #[must_use]
+    pub fn intercept_value(&self) -> Option<f64> {
+        if !self.intercept {
+            return None;
+        }
+        let slope = self.slope()?;
+        Some(slope.fma(-self.sum_x, self.sum_y) / self.effective_n)
+    }
+
+    /// R² goodness of fit.
+    #[must_use]
+    #[allow(clippy::suboptimal_flops)]
+    pub fn r_squared(&self) -> Option<f64> {
+        let slope = self.slope()?;
+        let n = self.effective_n;
+
+        let (ss_res, ss_tot) = if self.intercept {
+            let intercept = (self.sum_y - slope * self.sum_x) / n;
+            let ss_res = self.sum_y2 - 2.0 * slope * self.sum_xy - 2.0 * intercept * self.sum_y
+                + slope * slope * self.sum_x2
+                + 2.0 * slope * intercept * self.sum_x
+                + n * intercept * intercept;
+            let ss_tot = self.sum_y2 - self.sum_y * self.sum_y / n;
+            (ss_res, ss_tot)
+        } else {
+            let ss_res = self.sum_y2 - 2.0 * slope * self.sum_xy + slope * slope * self.sum_x2;
+            (ss_res, self.sum_y2)
+        };
+
+        if ss_tot <= 0.0 {
+            return None;
+        }
+
+        Some(1.0 - ss_res / ss_tot)
+    }
+
+    /// Predict y.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        let slope = self.slope()?;
+        if self.intercept {
+            let intercept = self.intercept_value()?;
+            Some(slope.fma(x, intercept))
+        } else {
+            Some(slope * x)
+        }
+    }
+
+    /// Number of observations.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Effective sample count.
+    #[inline]
+    #[must_use]
+    pub fn effective_count(&self) -> f64 {
+        self.effective_n
+    }
+
+    /// Alpha.
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// Whether primed.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        (self.effective_n as usize) >= self.dim()
+    }
+
+    /// Whether intercept is included.
+    #[inline]
+    #[must_use]
+    pub fn has_intercept(&self) -> bool {
+        self.intercept
+    }
+
+    /// Reset. Config unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_x = 0.0;
+        self.sum_x2 = 0.0;
+        self.sum_y = 0.0;
+        self.sum_xy = 0.0;
+        self.sum_y2 = 0.0;
+        self.effective_n = 0.0;
+        self.count = 0;
+    }
+}
+
+impl EwLinearRegressionF64Builder {
+    /// Weight on new observation, in (0, 1). Required.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Whether to include the constant term. Default: `true`.
+    #[inline]
+    #[must_use]
+    pub fn intercept(mut self, intercept: bool) -> Self {
+        self.intercept = intercept;
+        self
+    }
+
+    /// Builds the regression.
+    pub fn build(self) -> Result<EwLinearRegressionF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        if !(alpha > 0.0 && alpha < 1.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "alpha must be in (0, 1) exclusive",
+            ));
+        }
+
+        Ok(EwLinearRegressionF64 {
+            sum_x: 0.0,
+            sum_x2: 0.0,
+            sum_y: 0.0,
+            sum_xy: 0.0,
+            sum_y2: 0.0,
+            alpha,
+            one_minus_alpha: 1.0 - alpha,
+            effective_n: 0.0,
+            count: 0,
+            intercept: self.intercept,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -628,15 +603,6 @@ mod tests {
     }
 
     #[test]
-    fn f32_basic() {
-        let mut r = LinearRegressionF32::new();
-        for x in 0..100u32 {
-            r.update(x as f32, 2.0 * x as f32 + 3.0).unwrap();
-        }
-        assert!((r.slope().unwrap() - 2.0).abs() < 0.01);
-    }
-
-    #[test]
     fn default_is_new() {
         let r = LinearRegressionF64::default();
         assert_eq!(r.count(), 0);
@@ -699,18 +665,6 @@ mod tests {
         r.reset();
         assert_eq!(r.count(), 0);
         assert!(r.slope().is_none());
-    }
-
-    #[test]
-    fn ew_f32() {
-        let mut r = EwLinearRegressionF32::builder()
-            .alpha(0.05)
-            .build()
-            .unwrap();
-        for x in 0..200u32 {
-            r.update(x as f32, x as f32).unwrap();
-        }
-        assert!(r.is_primed());
     }
 
     #[test]

--- a/nexus-stats-regression/src/regression/polynomial_regression.rs
+++ b/nexus-stats-regression/src/regression/polynomial_regression.rs
@@ -9,397 +9,361 @@
 // Normal equations with sums-of-powers can accumulate large values.
 #![allow(clippy::suboptimal_flops)]
 
-macro_rules! impl_coefficients {
-    ($name:ident, $ty:ty) => {
-        /// Polynomial coefficients returned by regression queries.
-        ///
-        /// With intercept: `values[0]` = constant (a₀), `values[1]` = x coefficient (a₁), etc.
-        /// Without intercept: `values[0]` = x¹ coefficient, `values[1]` = x² coefficient, etc.
-        #[derive(Debug, Clone, Copy)]
-        pub struct $name {
-            pub(crate) values: [$ty; 9],
-            pub(crate) len: usize,
-        }
-
-        impl $name {
-            /// Coefficients as a slice.
-            #[inline]
-            #[must_use]
-            pub fn as_slice(&self) -> &[$ty] {
-                &self.values[..self.len]
-            }
-
-            /// Number of coefficients.
-            #[inline]
-            #[must_use]
-            pub fn len(&self) -> usize {
-                self.len
-            }
-
-            /// Whether there are no coefficients (should never happen in practice).
-            #[inline]
-            #[must_use]
-            pub fn is_empty(&self) -> bool {
-                self.len == 0
-            }
-
-            /// Get the i-th coefficient, or `None` if out of range.
-            #[inline]
-            #[must_use]
-            pub fn get(&self, i: usize) -> Option<$ty> {
-                if i < self.len {
-                    Option::Some(self.values[i])
-                } else {
-                    Option::None
-                }
-            }
-        }
-
-        impl core::ops::Index<usize> for $name {
-            type Output = $ty;
-            #[inline]
-            fn index(&self, i: usize) -> &$ty {
-                assert!(
-                    i < self.len,
-                    "coefficient index {i} out of range (len={})",
-                    self.len
-                );
-                &self.values[i]
-            }
-        }
-    };
+/// Polynomial coefficients returned by regression queries.
+///
+/// With intercept: `values[0]` = constant (a₀), `values[1]` = x coefficient (a₁), etc.
+/// Without intercept: `values[0]` = x¹ coefficient, `values[1]` = x² coefficient, etc.
+#[derive(Debug, Clone, Copy)]
+pub struct CoefficientsF64 {
+    pub(crate) values: [f64; 9],
+    pub(crate) len: usize,
 }
 
-impl_coefficients!(CoefficientsF64, f64);
-impl_coefficients!(CoefficientsF32, f32);
+impl CoefficientsF64 {
+    /// Coefficients as a slice.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[f64] {
+        &self.values[..self.len]
+    }
+
+    /// Number of coefficients.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether there are no coefficients (should never happen in practice).
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Get the i-th coefficient, or `None` if out of range.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, i: usize) -> Option<f64> {
+        if i < self.len {
+            Some(self.values[i])
+        } else {
+            None
+        }
+    }
+}
+
+impl core::ops::Index<usize> for CoefficientsF64 {
+    type Output = f64;
+    #[inline]
+    fn index(&self, i: usize) -> &f64 {
+        assert!(
+            i < self.len,
+            "coefficient index {i} out of range (len={})",
+            self.len
+        );
+        &self.values[i]
+    }
+}
 
 /// Gaussian elimination with partial pivoting on a fixed-size system.
 /// Returns `true` if the solve succeeded (non-singular).
 /// On success, `rhs` contains the solution.
-macro_rules! impl_gauss_solve {
-    ($fn_name:ident, $ty:ty) => {
-        pub(crate) fn $fn_name(dim: usize, a: &mut [[$ty; 9]; 9], b: &mut [$ty; 9]) -> bool {
-            for col in 0..dim {
-                let mut max_row = col;
-                let mut max_val = if a[col][col] < 0.0 as $ty {
-                    -(a[col][col])
-                } else {
-                    a[col][col]
-                };
-                for row in (col + 1)..dim {
-                    let v = if a[row][col] < 0.0 as $ty {
-                        -(a[row][col])
-                    } else {
-                        a[row][col]
-                    };
-                    if v > max_val {
-                        max_val = v;
-                        max_row = row;
-                    }
-                }
-                if max_val < 1e-14 as $ty {
-                    return false;
-                }
-                if max_row != col {
-                    a.swap(col, max_row);
-                    b.swap(col, max_row);
-                }
-                for row in (col + 1)..dim {
-                    let factor = a[row][col] / a[col][col];
-                    for j in col..dim {
-                        a[row][j] -= factor * a[col][j];
-                    }
-                    b[row] -= factor * b[col];
-                }
+pub(crate) fn gauss_solve_f64(dim: usize, a: &mut [[f64; 9]; 9], b: &mut [f64; 9]) -> bool {
+    for col in 0..dim {
+        let mut max_row = col;
+        let mut max_val = if a[col][col] < 0.0 {
+            -(a[col][col])
+        } else {
+            a[col][col]
+        };
+        for row in (col + 1)..dim {
+            let v = if a[row][col] < 0.0 {
+                -(a[row][col])
+            } else {
+                a[row][col]
+            };
+            if v > max_val {
+                max_val = v;
+                max_row = row;
             }
-            for i in (0..dim).rev() {
-                for j in (i + 1)..dim {
-                    b[i] -= a[i][j] * b[j];
-                }
-                b[i] /= a[i][i];
-            }
-            true
         }
-    };
+        if max_val < 1e-14 {
+            return false;
+        }
+        if max_row != col {
+            a.swap(col, max_row);
+            b.swap(col, max_row);
+        }
+        for row in (col + 1)..dim {
+            let factor = a[row][col] / a[col][col];
+            for j in col..dim {
+                a[row][j] -= factor * a[col][j];
+            }
+            b[row] -= factor * b[col];
+        }
+    }
+    for i in (0..dim).rev() {
+        for j in (i + 1)..dim {
+            b[i] -= a[i][j] * b[j];
+        }
+        b[i] /= a[i][i];
+    }
+    true
 }
 
-impl_gauss_solve!(gauss_solve_f64, f64);
-impl_gauss_solve!(gauss_solve_f32, f32);
-
-macro_rules! impl_polynomial_regression {
-    ($name:ident, $builder:ident, $coeff:ident, $solve_fn:ident, $ty:ty) => {
-        /// Online polynomial regression via sufficient statistics.
-        ///
-        /// Accumulates sums of powers of x and cross-products with y.
-        /// Solves the normal equations at query time via Gaussian elimination
-        /// with partial pivoting.
-        ///
-        /// Degree and intercept are configured at construction via the builder.
-        /// Supports degree 1 (linear) through 8 (octic).
-        ///
-        /// For best numerical stability with high-degree fits or large x ranges,
-        /// center and scale your x values: `x_scaled = (x - x_mean) / x_std`.
-        ///
-        /// # Complexity
-        /// - O(degree) per update, O(degree³) per coefficient query.
-        /// - ~216 bytes state (f64), ~120 bytes (f32). Zero allocation.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        /// // Fit y = x² - 3x + 2 (quadratic)
-        #[doc = concat!("let mut r = ", stringify!($name), "::builder().degree(2).build().unwrap();")]
-        /// for x in -50..50i64 {
-        #[doc = concat!("    let xf = x as ", stringify!($ty), ";")]
-        #[doc = concat!("    r.update(xf, xf * xf - 3.0 as ", stringify!($ty), " * xf + 2.0 as ", stringify!($ty), ");")]
-        /// }
-        /// let c = r.coefficients().unwrap();
-        /// assert_eq!(c.len(), 3); // [constant, x, x²]
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            sum_x: [$ty; 17],
-            sum_xy: [$ty; 9],
-            sum_y2: $ty,
-            count: u64,
-            degree: usize,
-            intercept: bool,
-        }
-
-        /// Builder for [`
-        #[doc = stringify!($name)]
-        /// `].
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            degree: Option<usize>,
-            intercept: bool,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    degree: Option::None,
-                    intercept: true,
-                }
-            }
-
-            /// System dimension.
-            #[inline]
-            fn dim(&self) -> usize {
-                self.degree + self.intercept as usize
-            }
-
-            /// Configured polynomial degree.
-            #[inline]
-            #[must_use]
-            pub fn degree(&self) -> usize {
-                self.degree
-            }
-
-            /// Whether the intercept (constant term) is included.
-            #[inline]
-            #[must_use]
-            pub fn has_intercept(&self) -> bool {
-                self.intercept
-            }
-
-            /// Feeds an (x, y) observation.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if either value is NaN, or
-            /// `DataError::Infinite` if either value is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                self.count += 1;
-                self.sum_y2 += y * y;
-                let mut x_pow = 1.0 as $ty;
-                let max_pow = 2 * self.degree;
-                for j in 0..=max_pow {
-                    self.sum_x[j] += x_pow;
-                    if j <= self.degree {
-                        self.sum_xy[j] += x_pow * y;
-                    }
-                    x_pow *= x;
-                }
-                Ok(())
-            }
-
-            /// Solve for polynomial coefficients, or `None` if underdetermined.
-            ///
-            /// Returns coefficients indexed from constant term (a₀) to highest
-            /// power (aₖ). Without intercept, the first coefficient corresponds
-            /// to x¹.
-            #[must_use]
-            pub fn coefficients(&self) -> Option<$coeff> {
-                let dim = self.dim();
-                if (self.count as usize) < dim {
-                    return Option::None;
-                }
-
-                let mut a = [[0.0 as $ty; 9]; 9];
-                let mut b = [0.0 as $ty; 9];
-                let offset: usize = if self.intercept { 0 } else { 1 };
-
-                for i in 0..dim {
-                    for j in 0..dim {
-                        a[i][j] = self.sum_x[i + j + 2 * offset];
-                    }
-                    b[i] = self.sum_xy[i + offset];
-                }
-
-                if !$solve_fn(dim, &mut a, &mut b) {
-                    return Option::None;
-                }
-
-                let mut coeffs = $coeff {
-                    values: [0.0 as $ty; 9],
-                    len: dim,
-                };
-                for i in 0..dim {
-                    coeffs.values[i] = b[i];
-                }
-                Option::Some(coeffs)
-            }
-
-            /// R² goodness of fit, or `None` if not enough data.
-            ///
-            /// With intercept: centered R² = 1 - SS_res/SS_tot.
-            /// Without intercept: uncentered R² = 1 - SS_res/Σy².
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                let coeffs = self.coefficients()?;
-                let n = self.count as $ty;
-                let dim = self.dim();
-                let offset: usize = if self.intercept { 0 } else { 1 };
-
-                let mut beta_dot_rhs = 0.0 as $ty;
-                for i in 0..dim {
-                    beta_dot_rhs += coeffs.values[i] * self.sum_xy[i + offset];
-                }
-                let ss_res = self.sum_y2 - beta_dot_rhs;
-
-                let ss_tot = if self.intercept {
-                    let sum_y = self.sum_xy[0];
-                    self.sum_y2 - sum_y * sum_y / n
-                } else {
-                    self.sum_y2
-                };
-
-                if ss_tot <= 0.0 as $ty {
-                    return Option::None;
-                }
-
-                Option::Some(1.0 as $ty - ss_res / ss_tot)
-            }
-
-            /// Predict y for a given x using current coefficients.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                let coeffs = self.coefficients()?;
-                let dim = self.dim();
-
-                let mut y = 0.0 as $ty;
-                let mut x_pow = if self.intercept { 1.0 as $ty } else { x };
-                for i in 0..dim {
-                    y += coeffs.values[i] * x_pow;
-                    x_pow *= x;
-                }
-                Option::Some(y)
-            }
-
-            /// Number of observations processed.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.count
-            }
-
-            /// Whether enough data has been collected to solve (count >= dim).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                (self.count as usize) >= self.dim()
-            }
-
-            /// Resets to empty state. Degree and intercept unchanged.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.sum_x = [0.0 as $ty; 17];
-                self.sum_xy = [0.0 as $ty; 9];
-                self.sum_y2 = 0.0 as $ty;
-                self.count = 0;
-            }
-        }
-
-        impl $builder {
-            /// Polynomial degree (1..=8). Required.
-            #[inline]
-            #[must_use]
-            pub fn degree(mut self, degree: usize) -> Self {
-                self.degree = Option::Some(degree);
-                self
-            }
-
-            /// Whether to include the constant term. Default: `true`.
-            ///
-            /// `false` forces the fit through the origin.
-            #[inline]
-            #[must_use]
-            pub fn intercept(mut self, intercept: bool) -> Self {
-                self.intercept = intercept;
-                self
-            }
-
-            /// Builds the regression estimator.
-            ///
-            /// # Errors
-            ///
-            /// Returns `ConfigError::Missing` if degree not set.
-            /// Returns `ConfigError::Invalid` if degree not in 1..=8.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let degree = self.degree
-                    .ok_or(nexus_stats_core::ConfigError::Missing("degree"))?;
-                if degree < 1 || degree > 8 {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "degree must be in 1..=8",
-                    ));
-                }
-
-                Ok($name {
-                    sum_x: [0.0 as $ty; 17],
-                    sum_xy: [0.0 as $ty; 9],
-                    sum_y2: 0.0 as $ty,
-                    count: 0,
-                    degree,
-                    intercept: self.intercept,
-                })
-            }
-        }
-    };
+/// Online polynomial regression via sufficient statistics.
+///
+/// Accumulates sums of powers of x and cross-products with y.
+/// Solves the normal equations at query time via Gaussian elimination
+/// with partial pivoting.
+///
+/// Degree and intercept are configured at construction via the builder.
+/// Supports degree 1 (linear) through 8 (octic).
+///
+/// For best numerical stability with high-degree fits or large x ranges,
+/// center and scale your x values: `x_scaled = (x - x_mean) / x_std`.
+///
+/// # Complexity
+/// - O(degree) per update, O(degree³) per coefficient query.
+/// - ~216 bytes state. Zero allocation.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::PolynomialRegressionF64;
+///
+/// // Fit y = x² - 3x + 2 (quadratic)
+/// let mut r = PolynomialRegressionF64::builder().degree(2).build().unwrap();
+/// for x in -50..50i64 {
+///     let xf = x as f64;
+///     r.update(xf, xf * xf - 3.0 * xf + 2.0);
+/// }
+/// let c = r.coefficients().unwrap();
+/// assert_eq!(c.len(), 3); // [constant, x, x²]
+/// ```
+#[derive(Debug, Clone)]
+pub struct PolynomialRegressionF64 {
+    sum_x: [f64; 17],
+    sum_xy: [f64; 9],
+    sum_y2: f64,
+    count: u64,
+    degree: usize,
+    intercept: bool,
 }
 
-impl_polynomial_regression!(
-    PolynomialRegressionF64,
-    PolynomialRegressionF64Builder,
-    CoefficientsF64,
-    gauss_solve_f64,
-    f64
-);
-impl_polynomial_regression!(
-    PolynomialRegressionF32,
-    PolynomialRegressionF32Builder,
-    CoefficientsF32,
-    gauss_solve_f32,
-    f32
-);
+/// Builder for [`PolynomialRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct PolynomialRegressionF64Builder {
+    degree: Option<usize>,
+    intercept: bool,
+}
+
+impl PolynomialRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> PolynomialRegressionF64Builder {
+        PolynomialRegressionF64Builder {
+            degree: None,
+            intercept: true,
+        }
+    }
+
+    /// System dimension.
+    #[inline]
+    fn dim(&self) -> usize {
+        self.degree + self.intercept as usize
+    }
+
+    /// Configured polynomial degree.
+    #[inline]
+    #[must_use]
+    pub fn degree(&self) -> usize {
+        self.degree
+    }
+
+    /// Whether the intercept (constant term) is included.
+    #[inline]
+    #[must_use]
+    pub fn has_intercept(&self) -> bool {
+        self.intercept
+    }
+
+    /// Feeds an (x, y) observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either value is NaN, or
+    /// `DataError::Infinite` if either value is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        self.count += 1;
+        self.sum_y2 += y * y;
+        let mut x_pow = 1.0;
+        let max_pow = 2 * self.degree;
+        for j in 0..=max_pow {
+            self.sum_x[j] += x_pow;
+            if j <= self.degree {
+                self.sum_xy[j] += x_pow * y;
+            }
+            x_pow *= x;
+        }
+        Ok(())
+    }
+
+    /// Solve for polynomial coefficients, or `None` if underdetermined.
+    ///
+    /// Returns coefficients indexed from constant term (a₀) to highest
+    /// power (aₖ). Without intercept, the first coefficient corresponds
+    /// to x¹.
+    #[must_use]
+    pub fn coefficients(&self) -> Option<CoefficientsF64> {
+        let dim = self.dim();
+        if (self.count as usize) < dim {
+            return None;
+        }
+
+        let mut a = [[0.0; 9]; 9];
+        let mut b = [0.0; 9];
+        let offset = usize::from(!self.intercept);
+
+        for i in 0..dim {
+            for j in 0..dim {
+                a[i][j] = self.sum_x[i + j + 2 * offset];
+            }
+            b[i] = self.sum_xy[i + offset];
+        }
+
+        if !gauss_solve_f64(dim, &mut a, &mut b) {
+            return None;
+        }
+
+        let mut coeffs = CoefficientsF64 {
+            values: [0.0; 9],
+            len: dim,
+        };
+        coeffs.values[..dim].copy_from_slice(&b[..dim]);
+        Some(coeffs)
+    }
+
+    /// R² goodness of fit, or `None` if not enough data.
+    ///
+    /// With intercept: centered R² = 1 - SS_res/SS_tot.
+    /// Without intercept: uncentered R² = 1 - SS_res/Σy².
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        let coeffs = self.coefficients()?;
+        let n = self.count as f64;
+        let dim = self.dim();
+        let offset = usize::from(!self.intercept);
+
+        let mut beta_dot_rhs = 0.0;
+        for i in 0..dim {
+            beta_dot_rhs += coeffs.values[i] * self.sum_xy[i + offset];
+        }
+        let ss_res = self.sum_y2 - beta_dot_rhs;
+
+        let ss_tot = if self.intercept {
+            let sum_y = self.sum_xy[0];
+            self.sum_y2 - sum_y * sum_y / n
+        } else {
+            self.sum_y2
+        };
+
+        if ss_tot <= 0.0 {
+            return None;
+        }
+
+        Some(1.0 - ss_res / ss_tot)
+    }
+
+    /// Predict y for a given x using current coefficients.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        let coeffs = self.coefficients()?;
+        let dim = self.dim();
+
+        let mut y = 0.0;
+        let mut x_pow = if self.intercept { 1.0 } else { x };
+        for i in 0..dim {
+            y += coeffs.values[i] * x_pow;
+            x_pow *= x;
+        }
+        Some(y)
+    }
+
+    /// Number of observations processed.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether enough data has been collected to solve (count >= dim).
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        (self.count as usize) >= self.dim()
+    }
+
+    /// Resets to empty state. Degree and intercept unchanged.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.sum_x = [0.0; 17];
+        self.sum_xy = [0.0; 9];
+        self.sum_y2 = 0.0;
+        self.count = 0;
+    }
+}
+
+impl PolynomialRegressionF64Builder {
+    /// Polynomial degree (1..=8). Required.
+    #[inline]
+    #[must_use]
+    pub fn degree(mut self, degree: usize) -> Self {
+        self.degree = Some(degree);
+        self
+    }
+
+    /// Whether to include the constant term. Default: `true`.
+    ///
+    /// `false` forces the fit through the origin.
+    #[inline]
+    #[must_use]
+    pub fn intercept(mut self, intercept: bool) -> Self {
+        self.intercept = intercept;
+        self
+    }
+
+    /// Builds the regression estimator.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Missing` if degree not set.
+    /// Returns `ConfigError::Invalid` if degree not in 1..=8.
+    pub fn build(self) -> Result<PolynomialRegressionF64, nexus_stats_core::ConfigError> {
+        let degree = self
+            .degree
+            .ok_or(nexus_stats_core::ConfigError::Missing("degree"))?;
+        if degree < 1 || degree > 8 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "degree must be in 1..=8",
+            ));
+        }
+
+        Ok(PolynomialRegressionF64 {
+            sum_x: [0.0; 17],
+            sum_xy: [0.0; 9],
+            sum_y2: 0.0,
+            count: 0,
+            degree,
+            intercept: self.intercept,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -588,23 +552,6 @@ mod tests {
         assert_eq!(r.count(), 0);
         assert!(r.coefficients().is_none());
         assert_eq!(r.degree(), 2);
-    }
-
-    // =========================================================================
-    // f32 variant
-    // =========================================================================
-
-    #[test]
-    fn f32_quadratic() {
-        let mut r = PolynomialRegressionF32::builder()
-            .degree(2)
-            .build()
-            .unwrap();
-        for x in -20..20i32 {
-            let xf = x as f32;
-            r.update(xf, xf * xf).unwrap();
-        }
-        assert!(r.coefficients().is_some());
     }
 
     // =========================================================================

--- a/nexus-stats-regression/src/regression/signal_decay.rs
+++ b/nexus-stats-regression/src/regression/signal_decay.rs
@@ -89,10 +89,10 @@ impl SignalDecayCurve {
     #[must_use]
     pub fn useful_horizon(&self, threshold: f64) -> Option<usize> {
         for (i, p) in self.predictors.iter().enumerate() {
-            if let Some(r2) = p.r_squared() {
-                if r2 < threshold {
-                    return Some(self.lags[i]);
-                }
+            if let Some(r2) = p.r_squared()
+                && r2 < threshold
+            {
+                return Some(self.lags[i]);
             }
         }
         None

--- a/nexus-stats-regression/src/regression/transformed_regression.rs
+++ b/nexus-stats-regression/src/regression/transformed_regression.rs
@@ -1,756 +1,668 @@
 // Transformed Regression — Linearized Fits via ln
 //
 // Thin wrappers around linear regression that apply ln at the API boundary:
-// - Exponential: y = a * e^(bx)  →  ln(y) = ln(a) + bx
-// - Logarithmic: y = a * ln(x) + b  →  y = a * ln(x) + b  (already linear in ln(x))
-// - Power law: y = a * x^b  →  ln(y) = ln(a) + b * ln(x)
+// - Exponential: y = a * e^(bx)  ->  ln(y) = ln(a) + bx
+// - Logarithmic: y = a * ln(x) + b  ->  y = a * ln(x) + b  (already linear in ln(x))
+// - Power law: y = a * x^b  ->  ln(y) = ln(a) + b * ln(x)
 
-use super::linear_regression::{EwLinearRegressionF64, LinearRegressionF32, LinearRegressionF64};
+use super::linear_regression::{EwLinearRegressionF64, LinearRegressionF64};
 
 // ============================================================================
 // Exponential: y = a * e^(bx)
 // ============================================================================
 
-macro_rules! impl_exponential_regression {
-    ($name:ident, $inner:ident, $ty:ty) => {
-        /// Online exponential regression: `y = a · e^(bx)`.
-        ///
-        /// Linearized as `ln(y) = ln(a) + bx` and solved via linear regression.
-        /// Observations with `y <= 0` are silently skipped (ln undefined).
-        ///
-        /// R² is measured in log-space (goodness of fit of `ln(y)` vs `x`).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::new();")]
-        /// for x in 0..100 {
-        #[doc = concat!("    let y = 2.0 as ", stringify!($ty), " * (0.05 as ", stringify!($ty), " * x as ", stringify!($ty), ").exp();")]
-        ///     r.update(x as _, y);
-        /// }
-        /// let rate = r.growth_rate().unwrap();
-        /// assert!((rate - 0.05).abs() < 0.01);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
-        }
-
-        impl $name {
-            /// Creates a new empty exponential regression.
-            #[inline]
-            #[must_use]
-            pub fn new() -> Self {
-                Self { inner: $inner::new() }
-            }
-
-            /// Feeds (x, y). Silently skips if `y <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if y > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_y = nexus_stats_core::math::ln(y as f64) as $ty;
-                    self.inner.update(x, ln_y)?;
-                }
-                Ok(())
-            }
-
-            /// Growth/decay rate (the exponent b), or `None` if not primed.
-            #[must_use]
-            pub fn growth_rate(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
-
-            /// Scale factor `a = e^(intercept)`, or `None` if not primed.
-            #[must_use]
-            pub fn scale(&self) -> Option<$ty> {
-                self.inner.intercept_value().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    { nexus_stats_core::math::exp(v as f64) as $ty }
-                })
-            }
-
-            /// R² in log-space.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
-
-            /// Predict `y = a · e^(bx)`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                self.inner.predict(x).map(|ln_y| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    { nexus_stats_core::math::exp(ln_y as f64) as $ty }
-                })
-            }
-
-            /// Number of accepted observations (y > 0).
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-
-            /// Whether enough data for a fit (>= 2 observations with y > 0).
-            #[inline]
-            #[must_use]
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online exponential regression: `y = a * e^(bx)`.
+///
+/// Linearized as `ln(y) = ln(a) + bx` and solved via linear regression.
+/// Observations with `y <= 0` are silently skipped (ln undefined).
+///
+/// R² is measured in log-space (goodness of fit of `ln(y)` vs `x`).
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::ExponentialRegressionF64;
+///
+/// let mut r = ExponentialRegressionF64::new();
+/// for x in 0..100 {
+///     let y = 2.0_f64 * (0.05_f64 * x as f64).exp();
+///     r.update(x as _, y);
+/// }
+/// let rate = r.growth_rate().unwrap();
+/// assert!((rate - 0.05).abs() < 0.01);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ExponentialRegressionF64 {
+    inner: LinearRegressionF64,
 }
 
-impl_exponential_regression!(ExponentialRegressionF64, LinearRegressionF64, f64);
-impl_exponential_regression!(ExponentialRegressionF32, LinearRegressionF32, f32);
+impl ExponentialRegressionF64 {
+    /// Creates a new empty exponential regression.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: LinearRegressionF64::new(),
+        }
+    }
+
+    /// Feeds (x, y). Silently skips if `y <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if y > 0.0 {
+            let ln_y = nexus_stats_core::math::ln(y);
+            self.inner.update(x, ln_y)?;
+        }
+        Ok(())
+    }
+
+    /// Growth/decay rate (the exponent b), or `None` if not primed.
+    #[must_use]
+    pub fn growth_rate(&self) -> Option<f64> {
+        self.inner.slope()
+    }
+
+    /// Scale factor `a = e^(intercept)`, or `None` if not primed.
+    #[must_use]
+    pub fn scale(&self) -> Option<f64> {
+        self.inner
+            .intercept_value()
+            .map(nexus_stats_core::math::exp)
+    }
+
+    /// R² in log-space.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
+
+    /// Predict `y = a * e^(bx)`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        self.inner.predict(x).map(nexus_stats_core::math::exp)
+    }
+
+    /// Number of accepted observations (y > 0).
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
+
+    /// Whether enough data for a fit (>= 2 observations with y > 0).
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
+
+impl Default for ExponentialRegressionF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ============================================================================
 // Logarithmic: y = a * ln(x) + b
 // ============================================================================
 
-macro_rules! impl_logarithmic_regression {
-    ($name:ident, $inner:ident, $ty:ty) => {
-        /// Online logarithmic regression: `y = a · ln(x) + b`.
-        ///
-        /// Linearized by substituting `u = ln(x)`, solving `y = a·u + b`.
-        /// Observations with `x <= 0` are silently skipped (ln undefined).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::new();")]
-        /// for x in 1..200 {
-        #[doc = concat!("    let y = 3.0 as ", stringify!($ty), " * (x as ", stringify!($ty), ").ln() + 1.0 as ", stringify!($ty), ";")]
-        ///     r.update(x as _, y);
-        /// }
-        /// let slope = r.slope().unwrap();
-        /// assert!((slope - 3.0).abs() < 0.01);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
-        }
-
-        impl $name {
-            /// Creates a new empty logarithmic regression.
-            #[inline]
-            #[must_use]
-            pub fn new() -> Self {
-                Self { inner: $inner::new() }
-            }
-
-            /// Feeds (x, y). Silently skips if `x <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if x > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                    self.inner.update(ln_x, y)?;
-                }
-                Ok(())
-            }
-
-            /// Slope (coefficient of ln(x)), or `None` if not primed.
-            #[must_use]
-            pub fn slope(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
-
-            /// Intercept (constant term b), or `None` if not primed.
-            #[must_use]
-            pub fn intercept_value(&self) -> Option<$ty> {
-                self.inner.intercept_value()
-            }
-
-            /// R² goodness of fit.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
-
-            /// Predict `y = a · ln(x) + b`. Returns `None` if not primed or `x <= 0`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                if x <= 0.0 as $ty {
-                    return Option::None;
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                self.inner.predict(ln_x)
-            }
-
-            /// Number of accepted observations (x > 0).
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-
-            #[inline]
-            #[must_use]
-            /// Whether enough data for a fit.
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online logarithmic regression: `y = a * ln(x) + b`.
+///
+/// Linearized by substituting `u = ln(x)`, solving `y = a*u + b`.
+/// Observations with `x <= 0` are silently skipped (ln undefined).
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::LogarithmicRegressionF64;
+///
+/// let mut r = LogarithmicRegressionF64::new();
+/// for x in 1..200 {
+///     let y = 3.0_f64 * (x as f64).ln() + 1.0_f64;
+///     r.update(x as _, y);
+/// }
+/// let slope = r.slope().unwrap();
+/// assert!((slope - 3.0).abs() < 0.01);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LogarithmicRegressionF64 {
+    inner: LinearRegressionF64,
 }
 
-impl_logarithmic_regression!(LogarithmicRegressionF64, LinearRegressionF64, f64);
-impl_logarithmic_regression!(LogarithmicRegressionF32, LinearRegressionF32, f32);
+impl LogarithmicRegressionF64 {
+    /// Creates a new empty logarithmic regression.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: LinearRegressionF64::new(),
+        }
+    }
+
+    /// Feeds (x, y). Silently skips if `x <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if x > 0.0 {
+            let ln_x = nexus_stats_core::math::ln(x);
+            self.inner.update(ln_x, y)?;
+        }
+        Ok(())
+    }
+
+    /// Slope (coefficient of ln(x)), or `None` if not primed.
+    #[must_use]
+    pub fn slope(&self) -> Option<f64> {
+        self.inner.slope()
+    }
+
+    /// Intercept (constant term b), or `None` if not primed.
+    #[must_use]
+    pub fn intercept_value(&self) -> Option<f64> {
+        self.inner.intercept_value()
+    }
+
+    /// R² goodness of fit.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
+
+    /// Predict `y = a * ln(x) + b`. Returns `None` if not primed or `x <= 0`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        if x <= 0.0 {
+            return None;
+        }
+        let ln_x = nexus_stats_core::math::ln(x);
+        self.inner.predict(ln_x)
+    }
+
+    /// Number of accepted observations (x > 0).
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Whether enough data for a fit.
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
+
+impl Default for LogarithmicRegressionF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ============================================================================
 // Power Law: y = a * x^b
 // ============================================================================
 
-macro_rules! impl_power_regression {
-    ($name:ident, $inner:ident, $ty:ty) => {
-        /// Online power law regression: `y = a · x^b`.
-        ///
-        /// Linearized as `ln(y) = ln(a) + b · ln(x)`. Observations with
-        /// `x <= 0` or `y <= 0` are silently skipped.
-        ///
-        /// R² is measured in log-log space.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        #[doc = concat!("use nexus_stats_regression::regression::", stringify!($name), ";")]
-        ///
-        #[doc = concat!("let mut r = ", stringify!($name), "::new();")]
-        /// for x in 1..200 {
-        #[doc = concat!("    let y = 4.0 as ", stringify!($ty), " * (x as ", stringify!($ty), ").powf(2.5);")]
-        ///     r.update(x as _, y);
-        /// }
-        /// let exp = r.exponent().unwrap();
-        /// assert!((exp - 2.5).abs() < 0.01);
-        /// ```
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
-        }
-
-        impl $name {
-            /// Creates a new empty power law regression.
-            #[inline]
-            #[must_use]
-            pub fn new() -> Self {
-                Self { inner: $inner::new() }
-            }
-
-            /// Feeds (x, y). Silently skips if `x <= 0` or `y <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if x > 0.0 as $ty && y > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_y = nexus_stats_core::math::ln(y as f64) as $ty;
-                    self.inner.update(ln_x, ln_y)?;
-                }
-                Ok(())
-            }
-
-            /// Exponent (the power b), or `None` if not primed.
-            #[must_use]
-            pub fn exponent(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
-
-            /// Scale factor `a = e^(intercept)`, or `None` if not primed.
-            #[must_use]
-            pub fn scale(&self) -> Option<$ty> {
-                self.inner.intercept_value().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    { nexus_stats_core::math::exp(v as f64) as $ty }
-                })
-            }
-
-            /// R² in log-log space.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
-
-            /// Predict `y = a · x^b`. Returns `None` if not primed or `x <= 0`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                if x <= 0.0 as $ty {
-                    return Option::None;
-                }
-                let intercept = self.inner.intercept_value()?;
-                let slope = self.inner.slope()?;
-                #[allow(clippy::cast_possible_truncation)]
-                {
-                    let a = nexus_stats_core::math::exp(intercept as f64);
-                    let b = slope as f64;
-                    let result = a * (x as f64).powf(b);
-                    Option::Some(result as $ty)
-                }
-            }
-
-            /// Number of accepted observations.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-
-            #[inline]
-            #[must_use]
-            /// Whether enough data for a fit.
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-
-            /// Resets to empty state.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl Default for $name {
-            #[inline]
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-    };
+/// Online power law regression: `y = a * x^b`.
+///
+/// Linearized as `ln(y) = ln(a) + b * ln(x)`. Observations with
+/// `x <= 0` or `y <= 0` are silently skipped.
+///
+/// R² is measured in log-log space.
+///
+/// # Examples
+///
+/// ```
+/// use nexus_stats_regression::regression::PowerRegressionF64;
+///
+/// let mut r = PowerRegressionF64::new();
+/// for x in 1..200 {
+///     let y = 4.0_f64 * (x as f64).powf(2.5);
+///     r.update(x as _, y);
+/// }
+/// let exp = r.exponent().unwrap();
+/// assert!((exp - 2.5).abs() < 0.01);
+/// ```
+#[derive(Debug, Clone)]
+pub struct PowerRegressionF64 {
+    inner: LinearRegressionF64,
 }
 
-impl_power_regression!(PowerRegressionF64, LinearRegressionF64, f64);
-impl_power_regression!(PowerRegressionF32, LinearRegressionF32, f32);
+impl PowerRegressionF64 {
+    /// Creates a new empty power law regression.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: LinearRegressionF64::new(),
+        }
+    }
+
+    /// Feeds (x, y). Silently skips if `x <= 0` or `y <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if x > 0.0 && y > 0.0 {
+            let ln_x = nexus_stats_core::math::ln(x);
+            let ln_y = nexus_stats_core::math::ln(y);
+            self.inner.update(ln_x, ln_y)?;
+        }
+        Ok(())
+    }
+
+    /// Exponent (the power b), or `None` if not primed.
+    #[must_use]
+    pub fn exponent(&self) -> Option<f64> {
+        self.inner.slope()
+    }
+
+    /// Scale factor `a = e^(intercept)`, or `None` if not primed.
+    #[must_use]
+    pub fn scale(&self) -> Option<f64> {
+        self.inner
+            .intercept_value()
+            .map(nexus_stats_core::math::exp)
+    }
+
+    /// R² in log-log space.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
+
+    /// Predict `y = a * x^b`. Returns `None` if not primed or `x <= 0`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        if x <= 0.0 {
+            return None;
+        }
+        let intercept = self.inner.intercept_value()?;
+        let slope = self.inner.slope()?;
+        let a = nexus_stats_core::math::exp(intercept);
+        let result = a * x.powf(slope);
+        Some(result)
+    }
+
+    /// Number of accepted observations.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Whether enough data for a fit.
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
+
+    /// Resets to empty state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
+
+impl Default for PowerRegressionF64 {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ============================================================================
 // EW Transformed Variants
 // ============================================================================
 
-macro_rules! impl_ew_exponential_regression {
-    ($name:ident, $builder:ident, $inner:ident, $ty:ty) => {
-        /// Exponentially-weighted exponential regression: `y = a · e^(bx)`.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
-        }
-
-        #[doc = concat!("Builder for [`", stringify!($name), "`].")]
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                }
-            }
-
-            /// Feeds (x, y). Silently skips if `y <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if y > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_y = nexus_stats_core::math::ln(y as f64) as $ty;
-                    self.inner.update(x, ln_y)?;
-                }
-                Ok(())
-            }
-
-            /// Growth/decay rate.
-            #[must_use]
-            pub fn growth_rate(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
-
-            /// Scale factor `a = e^(intercept)`.
-            #[must_use]
-            pub fn scale(&self) -> Option<$ty> {
-                self.inner.intercept_value().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        nexus_stats_core::math::exp(v as f64) as $ty
-                    }
-                })
-            }
-
-            /// R² in log-space.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
-
-            /// Predict `y = a · e^(bx)`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                self.inner.predict(x).map(|ln_y| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        nexus_stats_core::math::exp(ln_y as f64) as $ty
-                    }
-                })
-            }
-
-            /// Number of accepted observations.
-            #[inline]
-            #[must_use]
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-
-            #[inline]
-            #[must_use]
-            /// Whether primed.
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-
-            /// Reset.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl $builder {
-            /// Weight on new observation, in (0, 1).
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Builds the estimator.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                let inner = $inner::builder().alpha(alpha).build()?;
-                Ok($name { inner })
-            }
-        }
-    };
+/// Exponentially-weighted exponential regression: `y = a * e^(bx)`.
+#[derive(Debug, Clone)]
+pub struct EwExponentialRegressionF64 {
+    inner: EwLinearRegressionF64,
 }
 
-impl_ew_exponential_regression!(
-    EwExponentialRegressionF64,
-    EwExponentialRegressionF64Builder,
-    EwLinearRegressionF64,
-    f64
-);
-
-macro_rules! impl_ew_logarithmic_regression {
-    ($name:ident, $builder:ident, $inner:ident, $ty:ty) => {
-        /// Exponentially-weighted logarithmic regression: `y = a · ln(x) + b`.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
-        }
-
-        #[doc = concat!("Builder for [`", stringify!($name), "`].")]
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-        }
-
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                }
-            }
-
-            /// Feeds (x, y). Silently skips if `x <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if x > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                    self.inner.update(ln_x, y)?;
-                }
-                Ok(())
-            }
-
-            /// Slope (coefficient of ln(x)).
-            #[must_use]
-            pub fn slope(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
-
-            /// Intercept.
-            #[must_use]
-            pub fn intercept_value(&self) -> Option<$ty> {
-                self.inner.intercept_value()
-            }
-
-            /// R².
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
-
-            /// Predict `y = a · ln(x) + b`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                if x <= 0.0 as $ty {
-                    return Option::None;
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                self.inner.predict(ln_x)
-            }
-
-            #[inline]
-            #[must_use]
-            /// Count.
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-            #[inline]
-            #[must_use]
-            /// Primed.
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-            /// Reset.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl $builder {
-            /// Alpha.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Build.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                let inner = $inner::builder().alpha(alpha).build()?;
-                Ok($name { inner })
-            }
-        }
-    };
+/// Builder for [`EwExponentialRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct EwExponentialRegressionF64Builder {
+    alpha: Option<f64>,
 }
 
-impl_ew_logarithmic_regression!(
-    EwLogarithmicRegressionF64,
-    EwLogarithmicRegressionF64Builder,
-    EwLinearRegressionF64,
-    f64
-);
+impl EwExponentialRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EwExponentialRegressionF64Builder {
+        EwExponentialRegressionF64Builder { alpha: None }
+    }
 
-macro_rules! impl_ew_power_regression {
-    ($name:ident, $builder:ident, $inner:ident, $ty:ty) => {
-        /// Exponentially-weighted power law regression: `y = a · x^b`.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            inner: $inner,
+    /// Feeds (x, y). Silently skips if `y <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if y > 0.0 {
+            let ln_y = nexus_stats_core::math::ln(y);
+            self.inner.update(x, ln_y)?;
         }
+        Ok(())
+    }
 
-        #[doc = concat!("Builder for [`", stringify!($name), "`].")]
-        #[derive(Debug, Clone)]
-        pub struct $builder {
-            alpha: Option<$ty>,
-        }
+    /// Growth/decay rate.
+    #[must_use]
+    pub fn growth_rate(&self) -> Option<f64> {
+        self.inner.slope()
+    }
 
-        impl $name {
-            /// Creates a builder.
-            #[inline]
-            #[must_use]
-            pub fn builder() -> $builder {
-                $builder {
-                    alpha: Option::None,
-                }
-            }
+    /// Scale factor `a = e^(intercept)`.
+    #[must_use]
+    pub fn scale(&self) -> Option<f64> {
+        self.inner
+            .intercept_value()
+            .map(nexus_stats_core::math::exp)
+    }
 
-            /// Feeds (x, y). Silently skips if `x <= 0` or `y <= 0`.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if x or y is NaN, or
-            /// `DataError::Infinite` if x or y is infinite.
-            #[inline]
-            pub fn update(&mut self, x: $ty, y: $ty) -> Result<(), nexus_stats_core::DataError> {
-                check_finite!(x);
-                check_finite!(y);
-                if x > 0.0 as $ty && y > 0.0 as $ty {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_x = nexus_stats_core::math::ln(x as f64) as $ty;
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ln_y = nexus_stats_core::math::ln(y as f64) as $ty;
-                    self.inner.update(ln_x, ln_y)?;
-                }
-                Ok(())
-            }
+    /// R² in log-space.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
 
-            /// Exponent b.
-            #[must_use]
-            pub fn exponent(&self) -> Option<$ty> {
-                self.inner.slope()
-            }
+    /// Predict `y = a * e^(bx)`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        self.inner.predict(x).map(nexus_stats_core::math::exp)
+    }
 
-            /// Scale `a = e^(intercept)`.
-            #[must_use]
-            pub fn scale(&self) -> Option<$ty> {
-                self.inner.intercept_value().map(|v| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    {
-                        nexus_stats_core::math::exp(v as f64) as $ty
-                    }
-                })
-            }
+    /// Number of accepted observations.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
 
-            /// R² in log-log space.
-            #[must_use]
-            pub fn r_squared(&self) -> Option<$ty> {
-                self.inner.r_squared()
-            }
+    #[inline]
+    #[must_use]
+    /// Whether primed.
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
 
-            /// Predict `y = a · x^b`.
-            #[must_use]
-            pub fn predict(&self, x: $ty) -> Option<$ty> {
-                if x <= 0.0 as $ty {
-                    return Option::None;
-                }
-                let intercept = self.inner.intercept_value()?;
-                let slope = self.inner.slope()?;
-                #[allow(clippy::cast_possible_truncation)]
-                {
-                    let a = nexus_stats_core::math::exp(intercept as f64);
-                    let b = slope as f64;
-                    let result = a * (x as f64).powf(b);
-                    Option::Some(result as $ty)
-                }
-            }
-
-            #[inline]
-            #[must_use]
-            /// Count.
-            pub fn count(&self) -> u64 {
-                self.inner.count()
-            }
-            #[inline]
-            #[must_use]
-            /// Primed.
-            pub fn is_primed(&self) -> bool {
-                self.inner.is_primed()
-            }
-            /// Reset.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.inner.reset();
-            }
-        }
-
-        impl $builder {
-            /// Alpha.
-            #[inline]
-            #[must_use]
-            pub fn alpha(mut self, alpha: $ty) -> Self {
-                self.alpha = Option::Some(alpha);
-                self
-            }
-
-            /// Build.
-            pub fn build(self) -> Result<$name, nexus_stats_core::ConfigError> {
-                let alpha = self
-                    .alpha
-                    .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
-                let inner = $inner::builder().alpha(alpha).build()?;
-                Ok($name { inner })
-            }
-        }
-    };
+    /// Reset.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
 }
 
-impl_ew_power_regression!(
-    EwPowerRegressionF64,
-    EwPowerRegressionF64Builder,
-    EwLinearRegressionF64,
-    f64
-);
+impl EwExponentialRegressionF64Builder {
+    /// Weight on new observation, in (0, 1).
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Builds the estimator.
+    pub fn build(self) -> Result<EwExponentialRegressionF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        let inner = EwLinearRegressionF64::builder().alpha(alpha).build()?;
+        Ok(EwExponentialRegressionF64 { inner })
+    }
+}
+
+/// Exponentially-weighted logarithmic regression: `y = a * ln(x) + b`.
+#[derive(Debug, Clone)]
+pub struct EwLogarithmicRegressionF64 {
+    inner: EwLinearRegressionF64,
+}
+
+/// Builder for [`EwLogarithmicRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct EwLogarithmicRegressionF64Builder {
+    alpha: Option<f64>,
+}
+
+impl EwLogarithmicRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EwLogarithmicRegressionF64Builder {
+        EwLogarithmicRegressionF64Builder { alpha: None }
+    }
+
+    /// Feeds (x, y). Silently skips if `x <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if x > 0.0 {
+            let ln_x = nexus_stats_core::math::ln(x);
+            self.inner.update(ln_x, y)?;
+        }
+        Ok(())
+    }
+
+    /// Slope (coefficient of ln(x)).
+    #[must_use]
+    pub fn slope(&self) -> Option<f64> {
+        self.inner.slope()
+    }
+
+    /// Intercept.
+    #[must_use]
+    pub fn intercept_value(&self) -> Option<f64> {
+        self.inner.intercept_value()
+    }
+
+    /// R².
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
+
+    /// Predict `y = a * ln(x) + b`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        if x <= 0.0 {
+            return None;
+        }
+        let ln_x = nexus_stats_core::math::ln(x);
+        self.inner.predict(ln_x)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Count.
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
+    #[inline]
+    #[must_use]
+    /// Primed.
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
+    /// Reset.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
+
+impl EwLogarithmicRegressionF64Builder {
+    /// Alpha.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Build.
+    pub fn build(self) -> Result<EwLogarithmicRegressionF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        let inner = EwLinearRegressionF64::builder().alpha(alpha).build()?;
+        Ok(EwLogarithmicRegressionF64 { inner })
+    }
+}
+
+/// Exponentially-weighted power law regression: `y = a * x^b`.
+#[derive(Debug, Clone)]
+pub struct EwPowerRegressionF64 {
+    inner: EwLinearRegressionF64,
+}
+
+/// Builder for [`EwPowerRegressionF64`].
+#[derive(Debug, Clone)]
+pub struct EwPowerRegressionF64Builder {
+    alpha: Option<f64>,
+}
+
+impl EwPowerRegressionF64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EwPowerRegressionF64Builder {
+        EwPowerRegressionF64Builder { alpha: None }
+    }
+
+    /// Feeds (x, y). Silently skips if `x <= 0` or `y <= 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if x or y is NaN, or
+    /// `DataError::Infinite` if x or y is infinite.
+    #[inline]
+    pub fn update(&mut self, x: f64, y: f64) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(x);
+        check_finite!(y);
+        if x > 0.0 && y > 0.0 {
+            let ln_x = nexus_stats_core::math::ln(x);
+            let ln_y = nexus_stats_core::math::ln(y);
+            self.inner.update(ln_x, ln_y)?;
+        }
+        Ok(())
+    }
+
+    /// Exponent b.
+    #[must_use]
+    pub fn exponent(&self) -> Option<f64> {
+        self.inner.slope()
+    }
+
+    /// Scale `a = e^(intercept)`.
+    #[must_use]
+    pub fn scale(&self) -> Option<f64> {
+        self.inner
+            .intercept_value()
+            .map(nexus_stats_core::math::exp)
+    }
+
+    /// R² in log-log space.
+    #[must_use]
+    pub fn r_squared(&self) -> Option<f64> {
+        self.inner.r_squared()
+    }
+
+    /// Predict `y = a * x^b`.
+    #[must_use]
+    pub fn predict(&self, x: f64) -> Option<f64> {
+        if x <= 0.0 {
+            return None;
+        }
+        let intercept = self.inner.intercept_value()?;
+        let slope = self.inner.slope()?;
+        let a = nexus_stats_core::math::exp(intercept);
+        let result = a * x.powf(slope);
+        Some(result)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Count.
+    pub fn count(&self) -> u64 {
+        self.inner.count()
+    }
+    #[inline]
+    #[must_use]
+    /// Primed.
+    pub fn is_primed(&self) -> bool {
+        self.inner.is_primed()
+    }
+    /// Reset.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
+
+impl EwPowerRegressionF64Builder {
+    /// Alpha.
+    #[inline]
+    #[must_use]
+    pub fn alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha);
+        self
+    }
+
+    /// Build.
+    pub fn build(self) -> Result<EwPowerRegressionF64, nexus_stats_core::ConfigError> {
+        let alpha = self
+            .alpha
+            .ok_or(nexus_stats_core::ConfigError::Missing("alpha"))?;
+        let inner = EwLinearRegressionF64::builder().alpha(alpha).build()?;
+        Ok(EwPowerRegressionF64 { inner })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -892,38 +804,6 @@ mod tests {
             r.update(x as f64, 3.0 * (x as f64).powf(1.5)).unwrap();
         }
         assert!(r.is_primed());
-    }
-
-    // =========================================================================
-    // f32 variants
-    // =========================================================================
-
-    #[test]
-    fn f32_exponential() {
-        let mut r = ExponentialRegressionF32::new();
-        for x in 0..100u32 {
-            let xf = x as f32;
-            r.update(xf, 2.0 * (0.05 * xf).exp()).unwrap();
-        }
-        assert!(r.growth_rate().is_some());
-    }
-
-    #[test]
-    fn f32_logarithmic() {
-        let mut r = LogarithmicRegressionF32::new();
-        for x in 1..100u32 {
-            r.update(x as f32, 3.0 * (x as f32).ln() + 1.0).unwrap();
-        }
-        assert!(r.slope().is_some());
-    }
-
-    #[test]
-    fn f32_power() {
-        let mut r = PowerRegressionF32::new();
-        for x in 1..100u32 {
-            r.update(x as f32, 4.0 * (x as f32).powf(2.0)).unwrap();
-        }
-        assert!(r.exponent().is_some());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Closes #380. Part of umbrella #366.

Removes all F32 type variants from `nexus-stats-regression`. All 20 cut types are
Category A (f64 only) — accumulating, transcendental, or conditioning-sensitive
algorithms where f32 precision is a footgun with no concrete callers.

**No deprecation phase** — straight removal, consistent with #382 (core), #383
(smoothing), and #384 (detection).

## Types removed (20)

### regression/ (8 types + builders)

- `LinearRegressionF32` / `LinearRegressionF32Builder`
- `EwLinearRegressionF32` / `EwLinearRegressionF32Builder`
- `CoefficientsF32`
- `PolynomialRegressionF32` / `PolynomialRegressionF32Builder`
- `EwPolynomialRegressionF32` / `EwPolynomialRegressionF32Builder`
- `ExponentialRegressionF32`
- `LogarithmicRegressionF32`
- `PowerRegressionF32`

### estimation/ (4 types + builders)

- `BetaBinomialF32` / `BetaBinomialF32Builder`
- `GammaPoissonF32` / `GammaPoissonF32Builder`
- `Kalman2dF32` / `Kalman2dF32Builder`
- `Kalman3dF32` / `Kalman3dF32Builder`

### learning/ (8 types + builders)

- `Ucb1F32` / `Ucb1F32Builder`
- `ThompsonBetaF32` / `ThompsonBetaF32Builder`
- `ThompsonGammaF32` / `ThompsonGammaF32Builder`
- `EpsilonGreedyF32` / `EpsilonGreedyF32Builder`
- `Exp3F32` / `Exp3F32Builder`
- `RlsFilterF32` / `RlsFilterF32Builder`
- `LmsFilterF32` / `LmsFilterF32Builder`
- `NlmsFilterF32` / `NlmsFilterF32Builder`

## Macro inlining (25 macros)

Every macro in this crate had exactly two invocations (F64 + F32). After F32
removal, each had one invocation — all 25 were inlined per the "if we don't need
a macro, we should forgo the macro" policy.

Includes 3 macros in `transformed_regression.rs` that were already f64-only
(`impl_ew_exponential_regression!`, `impl_ew_logarithmic_regression!`,
`impl_ew_power_regression!`) — inlined for consistency.

`sampling.rs`: `f32_impl` module removed, `f64_impl` module kept (referenced by
`thompson_beta` and `thompson_gamma`).

### Inlining cleanup applied

- `$ty` → `f64`, removed `as $ty` / `as f64` casts on literals
- `stringify!($Name)` / `concat!()` → plain string literals in doc examples
- Removed `#[allow(clippy::cast_possible_truncation)]` (no f64→f32 casts)
- Simplified math calls: `nexus_stats_core::math::ln(x as f64) as $ty` → `nexus_stats_core::math::ln(x)`
- `Option::None` → `None`, `Option::Some` → `Some`
- Redundant closures from cast removal: `.map(|v| exp(v))` → `.map(exp)`

## Additional fixes

- `signal_decay.rs`: fixed pre-existing collapsible `if` clippy lint (unrelated to audit)
- `polynomial_regression.rs`: clippy `bool_to_int_with_if` and `manual_memcpy` fixes exposed by inlining

## Files changed

18 files, net −506 lines.

| Module | Files |
|--------|-------|
| regression/ | `linear_regression.rs`, `polynomial_regression.rs`, `ew_polynomial_regression.rs`, `transformed_regression.rs`, `signal_decay.rs` |
| estimation/ | `beta_binomial.rs`, `gamma_poisson.rs`, `kalman2d.rs`, `kalman3d.rs` |
| learning/ | `ucb1.rs`, `thompson_beta.rs`, `thompson_gamma.rs`, `epsilon_greedy.rs`, `exp3.rs`, `rls.rs`, `lms.rs`, `sampling.rs` |
| root | `CHANGELOG.md` |

## Verification

- 255 unit tests + 20 doc-tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Downstream `nexus-stats` builds and tests pass (glob re-exports, no changes needed)
- Zero `macro_rules!` definitions remain (except crate-level `check_finite!`)
- Zero `F32` / `f32` references remain in source

## Test plan

- [x] `cargo test -p nexus-stats-regression --all-features`
- [x] `cargo clippy -p nexus-stats-regression --all-features -- -D warnings`
- [x] `cargo fmt -p nexus-stats-regression -- --check`
- [x] `cargo test -p nexus-stats --all-features` (downstream)
- [x] Grep for residual F32/f32 references
- [x] Grep for residual `macro_rules!` (only `check_finite!` remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)