### PR TITLE
type-variant audit: nexus-stats-control (#381)

### DIFF
--- a/nexus-stats-control/CHANGELOG.md
+++ b/nexus-stats-control/CHANGELOG.md
@@ -10,6 +10,12 @@ contained.
 
 ## [Unreleased]
 
+### Removed
+
+- `PeakDetectorF32` — use `PeakDetectorF64`
+- `PeakDetectorI32` — use `PeakDetectorI64`
+- `PeakDetectorI128` — use `PeakDetectorI64`
+
 ## [1.0.3] — 2026-05-26
 
 ## [1.0.2] and earlier

--- a/nexus-stats-control/docs/INDEX.md
+++ b/nexus-stats-control/docs/INDEX.md
@@ -22,7 +22,7 @@ The base control primitives (`DeadBand`, `Hysteresis`, `Debounce`, `LevelCrossin
 
 | Type | Module | Feature | Detects / Tracks |
 |------|--------|---------|-------------------|
-| `PeakDetectorF64` / `F32` | `control` | — | Local maxima above a prominence threshold |
+| `PeakDetectorF64` / `I64` | `control` | — | Local maxima above a prominence threshold |
 | `BoolWindow` | `control` | `alloc` | Rolling pass/fail fraction |
 | `TopK<K>` | `frequency` | `alloc` | Top-K frequent items (Space-Saving) |
 | `FlexProportion` / `FlexProportionAtomic` | `frequency` | — | Per-entity share of a streaming count |

--- a/nexus-stats-control/docs/peak-detector.md
+++ b/nexus-stats-control/docs/peak-detector.md
@@ -1,6 +1,6 @@
 # PeakDetector
 
-**Types:** `PeakDetectorF64`, `PeakDetectorF32`
+**Types:** `PeakDetectorF64`, `PeakDetectorI64`
 **Import:** `use nexus_stats_control::control::PeakDetectorF64;`
 **Feature flags:** None required.
 

--- a/nexus-stats-control/src/frequency/flex_proportion.rs
+++ b/nexus-stats-control/src/frequency/flex_proportion.rs
@@ -67,7 +67,7 @@ impl FlexProportionGlobal {
     #[inline]
     pub fn update(&mut self) {
         self.total += 1;
-        if self.total % self.half_life == 0 {
+        if self.total.is_multiple_of(self.half_life) {
             self.period += 1;
         }
     }

--- a/nexus-stats-control/src/frequency/topk.rs
+++ b/nexus-stats-control/src/frequency/topk.rs
@@ -71,11 +71,11 @@ impl<K: Eq + Clone, const CAP: usize> TopK<K, CAP> {
         let mut min_idx = 0;
         let mut min_count = u64::MAX;
         for (i, entry) in self.entries.iter().enumerate() {
-            if let Some(e) = entry {
-                if e.count < min_count {
-                    min_count = e.count;
-                    min_idx = i;
-                }
+            if let Some(e) = entry
+                && e.count < min_count
+            {
+                min_count = e.count;
+                min_idx = i;
             }
         }
 

--- a/nexus-stats-control/src/peak_detector.rs
+++ b/nexus-stats-control/src/peak_detector.rs
@@ -7,192 +7,178 @@ pub struct Peak<T> {
     pub is_maximum: bool,
 }
 
-macro_rules! impl_peak_detector_float {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Peak detector — identifies local maxima and minima with prominence filtering.
-        ///
-        /// A peak is reported when the signal reverses direction by more than
-        /// the prominence threshold. This filters out small oscillations.
-        ///
-        /// # Use Cases
-        /// - Finding local highs/lows in price data
-        /// - Cycle detection in oscillating signals
-        /// - Inflection point identification
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prominence: $ty,
-            extreme: $ty,
-            rising: bool,
-            count: u64,
-        }
-
-        impl $name {
-            /// Creates a new peak detector with the given prominence threshold.
-            ///
-            /// A reversal must exceed `prominence` to qualify as a peak.
-            #[inline]
-            pub fn new(prominence: $ty) -> Result<Self, nexus_stats_core::ConfigError> {
-                #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                if !(prominence >= $zero) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "prominence must be non-negative",
-                    ));
-                }
-                Ok(Self {
-                    prominence,
-                    extreme: $zero,
-                    rising: true,
-                    count: 0,
-                })
-            }
-
-            /// Feeds a sample. Returns `Ok(Some(Peak))` when a peak is detected.
-            ///
-            /// # Errors
-            ///
-            /// Returns `DataError::NotANumber` if the sample is NaN, or
-            /// `DataError::Infinite` if the sample is infinite.
-            #[inline]
-            pub fn update(
-                &mut self,
-                sample: $ty,
-            ) -> Result<Option<Peak<$ty>>, nexus_stats_core::DataError> {
-                check_finite!(sample);
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.extreme = sample;
-                    return Ok(Option::None);
-                }
-
-                if self.rising {
-                    if sample > self.extreme {
-                        self.extreme = sample;
-                        Ok(Option::None)
-                    } else if self.extreme - sample >= self.prominence {
-                        let peak = Peak {
-                            value: self.extreme,
-                            is_maximum: true,
-                        };
-                        self.extreme = sample;
-                        self.rising = false;
-                        Ok(Option::Some(peak))
-                    } else {
-                        Ok(Option::None)
-                    }
-                } else if sample < self.extreme {
-                    self.extreme = sample;
-                    Ok(Option::None)
-                } else if sample - self.extreme >= self.prominence {
-                    let peak = Peak {
-                        value: self.extreme,
-                        is_maximum: false,
-                    };
-                    self.extreme = sample;
-                    self.rising = true;
-                    Ok(Option::Some(peak))
-                } else {
-                    Ok(Option::None)
-                }
-            }
-
-            /// Resets the detector.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.extreme = $zero;
-                self.rising = true;
-                self.count = 0;
-            }
-        }
-    };
+/// Peak detector — identifies local maxima and minima with prominence filtering.
+///
+/// A peak is reported when the signal reverses direction by more than
+/// the prominence threshold. This filters out small oscillations.
+///
+/// # Use Cases
+/// - Finding local highs/lows in price data
+/// - Cycle detection in oscillating signals
+/// - Inflection point identification
+#[derive(Debug, Clone)]
+pub struct PeakDetectorF64 {
+    prominence: f64,
+    extreme: f64,
+    rising: bool,
+    count: u64,
 }
 
-macro_rules! impl_peak_detector_int {
-    ($name:ident, $ty:ty, $zero:expr) => {
-        /// Peak detector — identifies local maxima and minima with prominence filtering.
-        #[derive(Debug, Clone)]
-        pub struct $name {
-            prominence: $ty,
-            extreme: $ty,
-            rising: bool,
-            count: u64,
+impl PeakDetectorF64 {
+    /// Creates a new peak detector with the given prominence threshold.
+    ///
+    /// A reversal must exceed `prominence` to qualify as a peak.
+    #[inline]
+    pub fn new(prominence: f64) -> Result<Self, nexus_stats_core::ConfigError> {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(prominence >= 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "prominence must be non-negative",
+            ));
+        }
+        Ok(Self {
+            prominence,
+            extreme: 0.0,
+            rising: true,
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample. Returns `Ok(Some(Peak))` when a peak is detected.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if the sample is NaN, or
+    /// `DataError::Infinite` if the sample is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        sample: f64,
+    ) -> Result<Option<Peak<f64>>, nexus_stats_core::DataError> {
+        check_finite!(sample);
+        self.count += 1;
+
+        if self.count == 1 {
+            self.extreme = sample;
+            return Ok(None);
         }
 
-        impl $name {
-            /// Creates a new peak detector with the given prominence threshold.
-            #[inline]
-            pub fn new(prominence: $ty) -> Result<Self, nexus_stats_core::ConfigError> {
-                if !(prominence >= $zero) {
-                    return Err(nexus_stats_core::ConfigError::Invalid(
-                        "prominence must be non-negative",
-                    ));
-                }
-                Ok(Self {
-                    prominence,
-                    extreme: $zero,
-                    rising: true,
-                    count: 0,
-                })
+        if self.rising {
+            if sample > self.extreme {
+                self.extreme = sample;
+                Ok(None)
+            } else if self.extreme - sample >= self.prominence {
+                let peak = Peak {
+                    value: self.extreme,
+                    is_maximum: true,
+                };
+                self.extreme = sample;
+                self.rising = false;
+                Ok(Some(peak))
+            } else {
+                Ok(None)
             }
-
-            /// Feeds a sample. Returns `Some(Peak)` when a peak is detected.
-            #[inline]
-            #[must_use]
-            pub fn update(&mut self, sample: $ty) -> Option<Peak<$ty>> {
-                self.count += 1;
-
-                if self.count == 1 {
-                    self.extreme = sample;
-                    return Option::None;
-                }
-
-                if self.rising {
-                    if sample > self.extreme {
-                        self.extreme = sample;
-                        Option::None
-                    } else if self.extreme - sample >= self.prominence {
-                        let peak = Peak {
-                            value: self.extreme,
-                            is_maximum: true,
-                        };
-                        self.extreme = sample;
-                        self.rising = false;
-                        Option::Some(peak)
-                    } else {
-                        Option::None
-                    }
-                } else if sample < self.extreme {
-                    self.extreme = sample;
-                    Option::None
-                } else if sample - self.extreme >= self.prominence {
-                    let peak = Peak {
-                        value: self.extreme,
-                        is_maximum: false,
-                    };
-                    self.extreme = sample;
-                    self.rising = true;
-                    Option::Some(peak)
-                } else {
-                    Option::None
-                }
-            }
-
-            /// Resets the detector.
-            #[inline]
-            pub fn reset(&mut self) {
-                self.extreme = $zero;
-                self.rising = true;
-                self.count = 0;
-            }
+        } else if sample < self.extreme {
+            self.extreme = sample;
+            Ok(None)
+        } else if sample - self.extreme >= self.prominence {
+            let peak = Peak {
+                value: self.extreme,
+                is_maximum: false,
+            };
+            self.extreme = sample;
+            self.rising = true;
+            Ok(Some(peak))
+        } else {
+            Ok(None)
         }
-    };
+    }
+
+    /// Resets the detector.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.extreme = 0.0;
+        self.rising = true;
+        self.count = 0;
+    }
 }
 
-impl_peak_detector_float!(PeakDetectorF64, f64, 0.0);
-impl_peak_detector_float!(PeakDetectorF32, f32, 0.0);
-impl_peak_detector_int!(PeakDetectorI64, i64, 0);
-impl_peak_detector_int!(PeakDetectorI32, i32, 0);
-impl_peak_detector_int!(PeakDetectorI128, i128, 0);
+/// Peak detector — identifies local maxima and minima with prominence filtering.
+#[derive(Debug, Clone)]
+pub struct PeakDetectorI64 {
+    prominence: i64,
+    extreme: i64,
+    rising: bool,
+    count: u64,
+}
+
+impl PeakDetectorI64 {
+    /// Creates a new peak detector with the given prominence threshold.
+    #[inline]
+    pub fn new(prominence: i64) -> Result<Self, nexus_stats_core::ConfigError> {
+        if prominence < 0 {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "prominence must be non-negative",
+            ));
+        }
+        Ok(Self {
+            prominence,
+            extreme: 0,
+            rising: true,
+            count: 0,
+        })
+    }
+
+    /// Feeds a sample. Returns `Some(Peak)` when a peak is detected.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, sample: i64) -> Option<Peak<i64>> {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.extreme = sample;
+            return None;
+        }
+
+        if self.rising {
+            if sample > self.extreme {
+                self.extreme = sample;
+                None
+            } else if self.extreme - sample >= self.prominence {
+                let peak = Peak {
+                    value: self.extreme,
+                    is_maximum: true,
+                };
+                self.extreme = sample;
+                self.rising = false;
+                Some(peak)
+            } else {
+                None
+            }
+        } else if sample < self.extreme {
+            self.extreme = sample;
+            None
+        } else if sample - self.extreme >= self.prominence {
+            let peak = Peak {
+                value: self.extreme,
+                is_maximum: false,
+            };
+            self.extreme = sample;
+            self.rising = true;
+            Some(peak)
+        } else {
+            None
+        }
+    }
+
+    /// Resets the detector.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.extreme = 0;
+        self.rising = true;
+        self.count = 0;
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -275,21 +261,6 @@ mod tests {
             PeakDetectorF64::new(-1.0),
             Err(nexus_stats_core::ConfigError::Invalid(_))
         ));
-    }
-
-    #[test]
-    fn i128_basic() {
-        let mut pd = PeakDetectorI128::new(10).unwrap();
-        let _ = pd.update(0);
-        let _ = pd.update(50);
-        let peak = pd.update(30); // dropped 20 > 10
-        assert_eq!(
-            peak,
-            Some(Peak {
-                value: 50,
-                is_maximum: true
-            })
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #381. Part of umbrella #366.

Removes F32, I32, and I128 type variants from `nexus-stats-control`. Only
`PeakDetector` had variants to trim — the rest of the crate (`BoolWindow`,
`TopK`, `FlexProportion`, `DecayAccum`) are already type-specific.

`PeakDetector` is Category B (comparison/extremum, no accumulation) — keeps
F64 + I64.

**No deprecation phase** — straight removal, consistent with #382 (core), #383
(smoothing), #384 (detection), and #385 (regression).

## Types removed (3)

- `PeakDetectorF32` — use `PeakDetectorF64`
- `PeakDetectorI32` — use `PeakDetectorI64`
- `PeakDetectorI128` — use `PeakDetectorI64`

## Macro inlining (2 macros)

Both macros (`impl_peak_detector_float!`, `impl_peak_detector_int!`) had their
cut variants removed, leaving one invocation each. Both inlined.

### Inlining cleanup applied

- `$name` / `$ty` / `$zero` → concrete types and literals
- `Option::None` → `None`, `Option::Some` → `Some`
- `!(prominence >= 0)` → `prominence < 0` (clippy `boolean_expression` simplification)

## Additional fixes

- `flex_proportion.rs`: `total % half_life == 0` → `.is_multiple_of()` (pre-existing clippy lint)
- `topk.rs`: collapsible `if` (pre-existing clippy lint)
- `docs/INDEX.md`: updated type listing from `F64 / F32` to `F64 / I64`
- `docs/peak-detector.md`: updated type listing to `PeakDetectorF64`, `PeakDetectorI64`

## Files changed

6 files, net −23 lines.

| Path | Change |
|------|--------|
| `src/peak_detector.rs` | Removed 3 types, inlined 2 macros |
| `src/frequency/flex_proportion.rs` | Pre-existing clippy fix |
| `src/frequency/topk.rs` | Pre-existing clippy fix |
| `docs/INDEX.md` | Updated type listing |
| `docs/peak-detector.md` | Updated type listing |
| `CHANGELOG.md` | 3 removed type entries |

## Verification

- 38 unit tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Downstream `nexus-stats` builds and tests pass
- Zero `macro_rules!` definitions remain (except crate-level `check_finite!`)
- Zero F32/I32/I128 type references remain

## Test plan

- [x] `cargo test -p nexus-stats-control --all-features`
- [x] `cargo clippy -p nexus-stats-control --all-features -- -D warnings`
- [x] `cargo fmt -p nexus-stats-control -- --check`
- [x] `cargo test -p nexus-stats --all-features` (downstream)
- [x] Grep for residual F32/I32/I128 references

🤖 Generated with [Claude Code](https://claude.com/claude-code)