### PR TITLE
Design notes: shm foundation

### DIFF
--- a/docs/design/nexus-shm.md
+++ b/docs/design/nexus-shm.md
@@ -74,6 +74,18 @@ Regardless of crate structure, the foundation layer handles:
 - **Crash/stale peer detection:** Heartbeat or epoch mechanism to
   distinguish dead peers from slow ones. This is the core invariant
   the upper layers depend on.
+
+> **[altug]** I'd steer the foundation away from timing as the source of truth for liveness. A heartbeat threshold can't actually separate a dead peer from a busy one. Too tight and a peer mid-burst looks dead, too loose and you carry stale state for seconds.
+>
+> The robust answer is to ask the kernel instead of inferring from a clock. Two options that give crash detection for free:
+>
+> - A robust futex on the control word (FUTEX_OWNER_DIED, PTHREAD_MUTEX_ROBUST). The kernel flags it when the owning process dies, the next attacher gets EOWNERDEAD and runs recovery. Canonical Linux answer to "shm lock owner died".
+> - An flock or OFD lock per process. The kernel releases it on death, so a peer can test it to know definitively whether the other side is alive.
+>
+> Pair either one with a generation counter in the control block so restarts and PID reuse stay unambiguous. A restarted peer bumps the generation, and stale state from the dead instance is detectable structurally, not by timing.
+>
+> Heartbeat is still useful as a soft "making progress" hint for the slow-but-alive case. It just shouldn't be the thing that declares a peer dead. That call should come from the OS.
+
 - **Recovery routine:** Given a mapping that may contain half-written
   data from a crashed writer, restore to a consistent state.
 
@@ -123,6 +135,11 @@ recovery. Primary caller: FIX message journaling.
   thread, no extra copies
 - Crash recovery: scan last segment on startup, find the last
   committed record, discard partial writes
+
+> **[altug]** Worth making the commit-ordering invariant explicit, since the whole recovery story rests on it. Write body first, publish the length or a commit marker last behind a release fence. Recovery scans forward while records carry a valid committed marker and stops at the first partial one. That ordering is the real correctness property, and it's exactly the kind of thing a later refactor can silently reorder and break.
+>
+> One open call: a SIGKILL can land mid-memcpy on the payload, so a length-last marker alone won't catch a torn body. A per-record checksum catches it but costs you on the hot path. Might be worth a config flag. Checksums on for the journal where durability matters, off for callers fine with discarding the last partial record on a length mismatch.
+
 - Cross-process read: other processes mmap segments read-only
 
 **Design question: sequence awareness**
@@ -213,6 +230,10 @@ Lock-free readers, no torn reads.
 (version left odd)? Options: timeout-based staleness detection, or
 epoch/heartbeat in a separate field so readers know the writer is
 alive.
+
+> **[altug]** I'd reuse the foundation liveness primitive here rather than add a separate timeout. Reader logic: if the version is odd, check writer liveness with the same robust-futex or lock signal from the foundation. If the writer is alive, retry, it's genuinely mid-write. If it's dead, fall back to the last good value and surface a staleness flag instead of spinning forever or risking a torn read.
+>
+> That means the reader keeps a shadow of the last even-version snapshot it read. Cheap for Pod types, and it gives a clean degraded mode: last-good plus "writer gone" rather than a hang.
 
 ### 4. ShmMap — Shared memory map (Chronicle-Map style)
 

--- a/docs/design/nexus-shm.md
+++ b/docs/design/nexus-shm.md
@@ -86,6 +86,47 @@ Regardless of crate structure, the foundation layer handles:
 >
 > Heartbeat is still useful as a soft "making progress" hint for the slow-but-alive case. It just shouldn't be the thing that declares a peer dead. That call should come from the OS.
 
+> **[mike]** Agree — timing is not a source of truth for death. Resolved
+> as a two-tier model:
+>
+> **Tier 1 — Atomic status field** in the shared memory header. `ALIVE`
+> on attach, `DEAD` in a Drop guard. Covers graceful shutdown and
+> unwinding panic. ~1 cycle. Always present, zero cost. For in-process
+> shm (e.g., FIX journal where the same process reads and writes), this
+> alone is sufficient — SIGKILL takes out the whole app, no surviving
+> peer needs to detect it.
+>
+> **Tier 2 — OFD lock via fcntl** (`nix` crate). Acquired on attach,
+> kernel releases on process death including SIGKILL. Library exposes
+> `peer_alive_kernel()` but never calls it automatically. User decides
+> when and where (monitoring thread, health check, periodic sweep).
+> Only relevant for cross-process communication.
+>
+> **`panic=abort` caveat:** Tier 1's Drop guard only fires on graceful
+> shutdown and unwinding panic. Under `panic=abort`, Drop never runs —
+> the atomic stays `ALIVE`. Same for SIGKILL and segfault. A
+> `panic=abort` build needs Tier 2 as mandatory, not optional.
+>
+> Benchmarked `F_OFD_GETLK`: ~330 cycles p50 (~95ns), ~500 cycles p999.
+> Max hit ~87µs from system noise (TLB shootdowns, SMI, scheduler
+> preemption). Needs further benchmarking under realistic workloads —
+> a syscall on the event loop is a potential latency killer under load.
+> This is why detection policy stays with the user so they can isolate
+> the syscall to a non-critical thread.
+>
+> Going with OFD locks over robust futex — fcntl via `nix` is a clean
+> typed API, and iceoryx2 validates this approach in production. Robust
+> futex adds mutex semantics we don't need (we're not locking, just
+> detecting).
+>
+> Generation counter — agreed. In control block for PID reuse safety.
+>
+> Resolved as one crate (`nexus-shm`) with mmap foundation as an
+> internal module. No separate `nexus-memmap`. Extract later if a
+> caller materializes.
+>
+> Tracked in #390.
+
 - **Recovery routine:** Given a mapping that may contain half-written
   data from a crashed writer, restore to a consistent state.
 
@@ -139,6 +180,23 @@ recovery. Primary caller: FIX message journaling.
 > **[altug]** Worth making the commit-ordering invariant explicit, since the whole recovery story rests on it. Write body first, publish the length or a commit marker last behind a release fence. Recovery scans forward while records carry a valid committed marker and stops at the first partial one. That ordering is the real correctness property, and it's exactly the kind of thing a later refactor can silently reorder and break.
 >
 > One open call: a SIGKILL can land mid-memcpy on the payload, so a length-last marker alone won't catch a torn body. A per-record checksum catches it but costs you on the hot path. Might be worth a config flag. Checksums on for the journal where durability matters, off for callers fine with discarding the last partial record on a length mismatch.
+
+> **[mike]** Agree — the commit ordering is the correctness property and
+> must be documented as such. Following Aeron's model: write body →
+> release fence → publish commit marker. Recovery scans forward, stops
+> at first uncommitted record. Aeron uses negative frame length as a
+> sentinel (claimed, not committed) and recovery writes a PAD frame
+> over uncommitted claims. Artio is built on top of this for production
+> FIX, so the pattern is proven.
+>
+> On checksums: the sentinel-based commit marker covers the crash case
+> fully. The marker is a single aligned store written after the body,
+> so recovery never sees a committed-but-torn record. Checksums earn
+> their place against a different failure domain — storage corruption
+> on the durable file (torn page writeback, bit rot). Opt-in config
+> flag for the file-backed journal, off by default.
+>
+> Tracked in #391.
 
 - Cross-process read: other processes mmap segments read-only
 
@@ -234,6 +292,30 @@ alive.
 > **[altug]** I'd reuse the foundation liveness primitive here rather than add a separate timeout. Reader logic: if the version is odd, check writer liveness with the same robust-futex or lock signal from the foundation. If the writer is alive, retry, it's genuinely mid-write. If it's dead, fall back to the last good value and surface a staleness flag instead of spinning forever or risking a torn read.
 >
 > That means the reader keeps a shadow of the last even-version snapshot it read. Cheap for Pod types, and it gives a clean degraded mode: last-good plus "writer gone" rather than a hang.
+
+> **[mike]** Agree — reuse foundation liveness, no separate mechanism.
+> Reader logic:
+>
+> 1. Version even → read value, verify version unchanged after read
+> 2. Version odd (mid-write) → check atomic status (~1 cycle)
+> 3. Atomic says ALIVE → retry, writer is genuinely mid-write
+> 4. Atomic says DEAD → shadow copy + staleness flag
+> 5. User wants SIGKILL coverage → call `peer_alive_kernel()` (opt-in)
+>
+> Shadow = last successfully read even-version value. Explicit memcpy
+> by the reader.
+>
+> Important distinction: Pod is not Copy. A 4KB book snapshot is Pod
+> (flat repr, no heap pointers, safe for shm) but should not have
+> implicit Copy semantics. The shadow is an explicit memcpy, not a
+> Copy trait bound.
+>
+> Retry cost note: seqlock retry copies the whole struct per attempt,
+> so retry cost scales with size. Fine for low-write-rate config and
+> book snapshots. Worth documenting if a slot is ever both large and
+> hot.
+>
+> Tracked in #393.
 
 ### 4. ShmMap — Shared memory map (Chronicle-Map style)
 


### PR DESCRIPTION
Adds three inline reviewer notes to docs/design/nexus-shm.md covering foundation liveness, journal crash recovery, and the slot dead-writer case. The throughline: prefer kernel-backed liveness (robust futex / OFD locks) over timing-based heartbeats, and reuse that one primitive across the journal and slot designs.