### PR TITLE
add loom tests for nexus-slot seqlock + README benchmark links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Each crate is small, focused, and honest about its constraints. No kitchen sinks
 
 | Crate | Description |
 |-------|-------------|
-| [**nexus-slab**](./nexus-slab) | Manual memory management with SLUB-style slab allocation. `bounded::Slab` (fixed capacity) and `unbounded::Slab` (growable via chunks). `rc` feature adds `RcSlot` with borrow guards for shared ownership. 1 cycle alloc, sub-cycle free. |
+| [**nexus-slab**](./nexus-slab) | Manual memory management with SLUB-style slab allocation. `bounded::Slab` (fixed capacity) and `unbounded::Slab` (growable via chunks). `rc` feature adds `RcSlot` with borrow guards for shared ownership. 1 cycle alloc, sub-cycle free ([benchmarks](./nexus-slab/BENCHMARKS.md)). |
 | [**nexus-pool**](./nexus-pool) | Object pools with RAII guards. Single-threaded `BoundedPool` and thread-safe `sync::Pool` (one acquirer, any returner). |
 | [**nexus-smartptr**](./nexus-smartptr) | Inline and flexible smart pointers for type-erased storage. `FlatBox` (fixed inline), `FlexBox` (inline or heap). Avoids boxing for small handler types. |
 
@@ -75,13 +75,13 @@ Each crate is small, focused, and honest about its constraints. No kitchen sinks
 
 | Crate | Description |
 |-------|-------------|
-| [**nexus-collections**](./nexus-collections) | Slab-backed intrusive collections. O(1) linked lists, O(log n) heaps, red-black trees, B-trees. External allocation via `nexus-slab` — user owns the slab, collection wires pointers. 2-3 cycle list operations, 15 cycle tree lookups. |
+| [**nexus-collections**](./nexus-collections) | Slab-backed intrusive collections. O(1) linked lists, O(log n) heaps, red-black trees, B-trees. External allocation via `nexus-slab` — user owns the slab, collection wires pointers. 2-3 cycle list operations, 15 cycle tree lookups ([benchmarks](./nexus-collections/BENCHMARKS.md)). |
 
 ### Flow Control
 
 | Crate | Description |
 |-------|-------------|
-| [**nexus-rate**](./nexus-rate) | Rate limiting. GCRA, token bucket, sliding window counter. Single-threaded and thread-safe variants. Weighted requests. ~2-4 cycle hot path. |
+| [**nexus-rate**](./nexus-rate) | Rate limiting. GCRA, token bucket, sliding window counter. Single-threaded and thread-safe variants. Weighted requests. ~2-4 cycle hot path ([benchmarks](./nexus-rate/BENCHMARKS.md)). |
 
 ### Concurrency & Communication
 
@@ -90,15 +90,15 @@ Each crate is small, focused, and honest about its constraints. No kitchen sinks
 | [**nexus-queue**](./nexus-queue) | Lock-free SPSC, MPSC, and SPMC ring buffers with per-slot lap counters. Index-based (NUMA-friendly) and slot-based (shared-L3 friendly) implementations. |
 | [**nexus-channel**](./nexus-channel) | Blocking SPSC channel built on nexus-queue. Three-phase backoff (spin → yield → park) minimizes syscalls under load. |
 | [**nexus-slot**](./nexus-slot) | Single-value conflation slot. Writer always overwrites, reader gets latest value exactly once. For "latest wins" patterns like market data snapshots. |
-| [**nexus-notify**](./nexus-notify) | Cross-thread event queue with conflation and FIFO delivery. Non-blocking `event_queue` and blocking `event_channel`. Dedup flags + MPSC ring buffer — O(limit) poll, ~5 cycles/token. |
+| [**nexus-notify**](./nexus-notify) | Cross-thread event queue with conflation and FIFO delivery. Non-blocking `event_queue` and blocking `event_channel`. Dedup flags + MPSC ring buffer — O(limit) poll, ~5 cycles/token ([benchmarks](./nexus-notify/BENCHMARKS.md)). |
 | [**nexus-logbuf**](./nexus-logbuf) | Bounded SPSC and MPSC byte ring buffers. Claim-based API for variable-length messages. The hot-path primitive for getting data off the event loop without syscalls. |
 
 ### Networking
 
 | Crate | Description |
 |-------|-------------|
-| [**nexus-net**](./nexus-net) | Sans-IO WebSocket (RFC 6455) and HTTP/1.1 REST primitives. Zero-copy, SIMD-accelerated. 3x faster than tungstenite, 3x faster than reqwest. Typestate request builder, chunked transfer encoding, connection poisoning. 517/517 Autobahn + 16/16 httpbin conformance. |
-| [**nexus-async-net**](./nexus-async-net) | Async adapters for nexus-net. Tokio-compatible. WebSocket `WsStream<S>`, HTTP `AsyncHttpConnection<S>`, and `ClientPool`/`AtomicClientPool` with self-healing reconnect. `try_acquire` (fast path) and `acquire` (patient path with backoff). 3.5x faster than tokio-tungstenite. |
+| [**nexus-net**](./nexus-net) | Sans-IO WebSocket (RFC 6455) and HTTP/1.1 REST primitives. Zero-copy, SIMD-accelerated. 3x faster than tungstenite, 3x faster than reqwest ([benchmarks](./nexus-net/BENCHMARKS.md)). Typestate request builder, chunked transfer encoding, connection poisoning. 517/517 Autobahn + 16/16 httpbin conformance. |
+| [**nexus-async-net**](./nexus-async-net) | Async adapters for nexus-net. Tokio-compatible. WebSocket `WsStream<S>`, HTTP `AsyncHttpConnection<S>`, and `ClientPool`/`AtomicClientPool` with self-healing reconnect. `try_acquire` (fast path) and `acquire` (patient path with backoff). 3.5x faster than tokio-tungstenite ([benchmarks](./nexus-async-net/BENCHMARKS.md)). |
 
 ### Runtime
 
@@ -155,6 +155,15 @@ individual crate `BENCHMARKS.md` files for methodology and results.
 ### Minimal dependencies
 
 These are foundational crates. Dependency trees are kept small and intentional.
+
+## Benchmark Conditions
+
+Performance numbers are measured on an Intel Core Ultra 7 165U (12C/14T,
+12MB L3) running Arch Linux with `rustc 1.94.0`. Comparative numbers
+(speedup ratios) are measured with turbo boost disabled and cores pinned
+via `taskset`; finalized cycle counts are with turbo boost enabled. Results
+vary by hardware — each crate's `BENCHMARKS.md` records the specific
+machine, toolchain, comparison-crate versions, and reproduction steps.
 
 ## Platform Support
 

--- a/nexus-slot/Cargo.toml
+++ b/nexus-slot/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 crossbeam-queue = "0.3"

--- a/nexus-slot/src/lib.rs
+++ b/nexus-slot/src/lib.rs
@@ -57,8 +57,11 @@
 
 pub mod spmc;
 pub mod spsc;
+pub(crate) mod loom_impl;
 
+#[cfg(not(loom))]
 use std::mem::{MaybeUninit, align_of, size_of};
+#[cfg(not(loom))]
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 /// Marker trait for types safe to use in a conflated slot.
@@ -107,6 +110,7 @@ pub unsafe trait Pod: Sized {
 // This is the canonical set of Pod guarantees.
 unsafe impl<T: Copy> Pod for T {}
 
+#[cfg(not(loom))]
 /// Atomically stores `size_of::<T>()` bytes into shared memory.
 ///
 /// Word-at-a-time `AtomicUsize` stores when alignment permits,
@@ -151,6 +155,7 @@ pub(crate) unsafe fn atomic_store<T: Pod>(dst: *mut T, src: &T) {
     }
 }
 
+#[cfg(not(loom))]
 /// Atomically loads `size_of::<T>()` bytes from shared memory.
 ///
 /// Word-at-a-time `AtomicUsize` loads when alignment permits,

--- a/nexus-slot/src/loom_impl.rs
+++ b/nexus-slot/src/loom_impl.rs
@@ -1,0 +1,59 @@
+#[cfg(loom)]
+pub(crate) use loom::sync::Arc;
+#[cfg(not(loom))]
+pub(crate) use std::sync::Arc;
+
+#[cfg(loom)]
+pub(crate) use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+#[cfg(not(loom))]
+pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+
+#[cfg(loom)]
+#[inline(always)]
+pub(crate) fn spin_yield() {
+    loom::thread::yield_now();
+}
+
+#[cfg(not(loom))]
+#[inline(always)]
+pub(crate) fn spin_yield() {
+    core::hint::spin_loop();
+}
+
+// Under loom, the seqlock's word-at-a-time Relaxed stores/loads are modeled
+// as a single Relaxed AtomicUsize operation. Word-at-a-time correctness is
+// separately verified by miri; loom tests the fence/sequence protocol.
+
+#[cfg(loom)]
+pub(crate) fn loom_store<T>(data: &AtomicUsize, value: &T) {
+    const { assert!(std::mem::size_of::<T>() <= std::mem::size_of::<usize>()) };
+    let mut bits = 0usize;
+    // SAFETY: T fits in usize (const-asserted). We copy T's bytes into a
+    // zero-initialized usize. Remaining bytes stay zero.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            (value as *const T).cast::<u8>(),
+            std::ptr::addr_of_mut!(bits).cast::<u8>(),
+            std::mem::size_of::<T>(),
+        );
+    }
+    data.store(bits, Ordering::Relaxed);
+}
+
+#[cfg(loom)]
+pub(crate) fn loom_load<T>(data: &AtomicUsize) -> T {
+    const { assert!(std::mem::size_of::<T>() <= std::mem::size_of::<usize>()) };
+    let bits = data.load(Ordering::Relaxed);
+    // SAFETY: T fits in usize (const-asserted). We copy the relevant bytes
+    // from the loaded usize into a zeroed T-sized buffer. All bytes of T
+    // are written before assume_init.
+    unsafe {
+        let mut value = std::mem::MaybeUninit::<T>::zeroed();
+        std::ptr::copy_nonoverlapping(
+            std::ptr::addr_of!(bits).cast::<u8>(),
+            value.as_mut_ptr().cast::<u8>(),
+            std::mem::size_of::<T>(),
+        );
+        value.assume_init()
+    }
+}

--- a/nexus-slot/src/spmc.rs
+++ b/nexus-slot/src/spmc.rs
@@ -25,13 +25,18 @@
 //! assert!(reader2.read().is_none());
 //! ```
 
+#[cfg(not(loom))]
 use std::cell::UnsafeCell;
 use std::fmt;
+#[cfg(not(loom))]
 use std::mem::MaybeUninit;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
+#[cfg(loom)]
+use std::marker::PhantomData;
 
-use crate::{Pod, atomic_load, atomic_store};
+use crate::Pod;
+#[cfg(not(loom))]
+use crate::{atomic_load, atomic_store};
+use crate::loom_impl::{Arc, AtomicBool, AtomicUsize, Ordering, fence};
 
 /// Shared state between writer and readers.
 #[repr(C)]
@@ -40,7 +45,12 @@ struct Inner<T> {
     seq: AtomicUsize,
     /// Set to `false` when the writer is dropped.
     writer_alive: AtomicBool,
+    #[cfg(not(loom))]
     data: UnsafeCell<MaybeUninit<T>>,
+    #[cfg(loom)]
+    data: AtomicUsize,
+    #[cfg(loom)]
+    _marker: PhantomData<T>,
 }
 
 // SAFETY: Inner is shared via Arc between one Writer and multiple SharedReaders.
@@ -102,7 +112,12 @@ pub fn shared_slot<T: Pod>() -> (Writer<T>, SharedReader<T>) {
     let inner = Arc::new(Inner {
         seq: AtomicUsize::new(2),
         writer_alive: AtomicBool::new(true),
+        #[cfg(not(loom))]
         data: UnsafeCell::new(MaybeUninit::uninit()),
+        #[cfg(loom)]
+        data: AtomicUsize::new(0),
+        #[cfg(loom)]
+        _marker: PhantomData,
     });
 
     (
@@ -132,7 +147,13 @@ impl<T: Pod> Writer<T> {
 
         // SAFETY: Same as spsc::Writer::write — sole writer, data accessed
         // through word-at-a-time atomics, no references created.
-        unsafe { atomic_store(inner.data.get().cast::<T>(), &value) };
+        #[cfg(not(loom))]
+        // SAFETY: sole writer, data from UnsafeCell, word-at-a-time atomics.
+        unsafe {
+            atomic_store(inner.data.get().cast::<T>(), &value);
+        }
+        #[cfg(loom)]
+        crate::loom_impl::loom_store(&inner.data, &value);
 
         fence(Ordering::Release);
         self.local_seq = seq.wrapping_add(2);
@@ -183,14 +204,17 @@ impl<T: Pod> SharedReader<T> {
 
             // Write in progress
             if seq1 & 1 != 0 {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
                 continue;
             }
 
             fence(Ordering::Acquire);
 
             // SAFETY: Same as spsc::Reader::read.
+            #[cfg(not(loom))]
             let value = unsafe { atomic_load(inner.data.get().cast::<T>()) };
+            #[cfg(loom)]
+            let value = crate::loom_impl::loom_load::<T>(&inner.data);
 
             fence(Ordering::Acquire);
             let seq2 = inner.seq.load(Ordering::Relaxed);
@@ -221,14 +245,17 @@ impl<T: Pod> SharedReader<T> {
             }
 
             if seq1 & 1 != 0 {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
                 continue;
             }
 
             fence(Ordering::Acquire);
 
             // SAFETY: Same as spsc::Reader::read_versioned.
+            #[cfg(not(loom))]
             let value = unsafe { atomic_load(inner.data.get().cast::<T>()) };
+            #[cfg(loom)]
+            let value = crate::loom_impl::loom_load::<T>(&inner.data);
 
             fence(Ordering::Acquire);
             let seq2 = inner.seq.load(Ordering::Relaxed);
@@ -274,7 +301,7 @@ impl<T: Pod> fmt::Debug for SharedReader<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod tests {
     use super::*;
 

--- a/nexus-slot/src/spsc.rs
+++ b/nexus-slot/src/spsc.rs
@@ -20,20 +20,30 @@
 //! assert!(reader.read().is_none()); // consumed
 //! ```
 
+#[cfg(not(loom))]
 use std::cell::UnsafeCell;
 use std::fmt;
+#[cfg(not(loom))]
 use std::mem::MaybeUninit;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering, fence};
+#[cfg(loom)]
+use std::marker::PhantomData;
 
-use crate::{Pod, atomic_load, atomic_store};
+use crate::Pod;
+#[cfg(not(loom))]
+use crate::{atomic_load, atomic_store};
+use crate::loom_impl::{Arc, AtomicUsize, Ordering, fence};
 
 /// Shared state between writer and reader.
 #[repr(C)]
 struct Inner<T> {
     /// Sequence number. Odd = write in progress, even = stable, 0 = never written.
     seq: AtomicUsize,
+    #[cfg(not(loom))]
     data: UnsafeCell<MaybeUninit<T>>,
+    #[cfg(loom)]
+    data: AtomicUsize,
+    #[cfg(loom)]
+    _marker: PhantomData<T>,
 }
 
 // SAFETY: Inner is shared via Arc between exactly one Writer and one Reader,
@@ -82,7 +92,12 @@ pub fn slot<T: Pod>() -> (Writer<T>, Reader<T>) {
     // "write complete" and odd for "write in progress": 2→3→4→5→...
     let inner = Arc::new(Inner {
         seq: AtomicUsize::new(2),
+        #[cfg(not(loom))]
         data: UnsafeCell::new(MaybeUninit::uninit()),
+        #[cfg(loom)]
+        data: AtomicUsize::new(0),
+        #[cfg(loom)]
+        _marker: PhantomData,
     });
 
     (
@@ -115,7 +130,13 @@ impl<T: Pod> Writer<T> {
         // sequence will spin. The data pointer is from UnsafeCell — no
         // references are created to the shared data, only raw pointer access
         // through word-at-a-time atomics.
-        unsafe { atomic_store(inner.data.get().cast::<T>(), &value) };
+        #[cfg(not(loom))]
+        // SAFETY: sole writer, data from UnsafeCell, word-at-a-time atomics.
+        unsafe {
+            atomic_store(inner.data.get().cast::<T>(), &value);
+        }
+        #[cfg(loom)]
+        crate::loom_impl::loom_store(&inner.data, &value);
 
         fence(Ordering::Release);
         self.local_seq = seq.wrapping_add(2);
@@ -162,7 +183,7 @@ impl<T: Pod> Reader<T> {
 
             // Write in progress
             if seq1 & 1 != 0 {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
                 continue;
             }
 
@@ -172,7 +193,10 @@ impl<T: Pod> Reader<T> {
             // The Acquire fence synchronizes with the writer's Release fence.
             // If a concurrent write occurs, we detect it via seq2 != seq1.
             // No references are created — raw pointer access through atomics.
+            #[cfg(not(loom))]
             let value = unsafe { atomic_load(inner.data.get().cast::<T>()) };
+            #[cfg(loom)]
+            let value = crate::loom_impl::loom_load::<T>(&inner.data);
 
             fence(Ordering::Acquire);
             let seq2 = inner.seq.load(Ordering::Relaxed);
@@ -220,14 +244,17 @@ impl<T: Pod> Reader<T> {
             }
 
             if seq1 & 1 != 0 {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
                 continue;
             }
 
             fence(Ordering::Acquire);
 
             // SAFETY: same as read() — seq1 is even and non-zero.
+            #[cfg(not(loom))]
             let value = unsafe { atomic_load(inner.data.get().cast::<T>()) };
+            #[cfg(loom)]
+            let value = crate::loom_impl::loom_load::<T>(&inner.data);
 
             fence(Ordering::Acquire);
             let seq2 = inner.seq.load(Ordering::Relaxed);
@@ -266,7 +293,7 @@ impl<T: Pod> fmt::Debug for Reader<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod tests {
     use super::*;
 
@@ -389,7 +416,7 @@ mod tests {
 
         let handle = thread::spawn(move || {
             while reader.read().is_none() {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
             }
         });
 
@@ -531,7 +558,7 @@ mod tests {
         let handle = thread::spawn(move || {
             for i in 0..10_000u64 {
                 while r1.read().is_none() {
-                    core::hint::spin_loop();
+                    crate::loom_impl::spin_yield();
                 }
                 w2.write(i);
             }
@@ -540,7 +567,7 @@ mod tests {
         for i in 0..10_000u64 {
             w1.write(i);
             while r2.read().is_none() {
-                core::hint::spin_loop();
+                crate::loom_impl::spin_yield();
             }
         }
 

--- a/nexus-slot/tests/loom_spmc.rs
+++ b/nexus-slot/tests/loom_spmc.rs
@@ -1,0 +1,105 @@
+#![cfg(loom)]
+
+use loom::thread;
+use nexus_slot::spmc;
+
+#[test]
+fn write_then_read() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spmc::shared_slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        w.join().unwrap();
+        assert_eq!(reader.read(), Some(42));
+    });
+}
+
+#[test]
+fn no_torn_reads() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spmc::shared_slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        loop {
+            if let Some(v) = reader.read() {
+                assert_eq!(v, 42);
+                break;
+            }
+            if reader.is_disconnected() {
+                if let Some(v) = reader.read() {
+                    assert_eq!(v, 42);
+                }
+                break;
+            }
+            thread::yield_now();
+        }
+
+        w.join().unwrap();
+    });
+}
+
+#[test]
+fn writer_disconnect_ordering() {
+    // Writer's Drop stores writer_alive=false with Release.
+    // Reader's is_disconnected loads with Acquire.
+    // If the reader sees disconnected, the writer's final write must be visible.
+    loom::model(|| {
+        let (mut writer, mut reader) = spmc::shared_slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        loop {
+            if reader.is_disconnected() {
+                if reader.has_update() {
+                    let v = reader.read().unwrap();
+                    assert_eq!(v, 42);
+                }
+                break;
+            }
+            if let Some(v) = reader.read() {
+                assert_eq!(v, 42);
+            }
+            thread::yield_now();
+        }
+
+        w.join().unwrap();
+    });
+}
+
+#[test]
+fn disconnect_all_readers() {
+    loom::model(|| {
+        let (writer, reader1) = spmc::shared_slot::<usize>();
+        let reader2 = reader1.clone();
+
+        assert!(!writer.is_disconnected());
+        drop(reader1);
+        assert!(!writer.is_disconnected());
+        drop(reader2);
+        assert!(writer.is_disconnected());
+    });
+}
+
+#[test]
+fn cloned_reader_disconnect() {
+    loom::model(|| {
+        let (writer, reader) = spmc::shared_slot::<usize>();
+        let reader2 = reader.clone();
+
+        assert!(!reader.is_disconnected());
+        assert!(!reader2.is_disconnected());
+
+        drop(writer);
+
+        assert!(reader.is_disconnected());
+        assert!(reader2.is_disconnected());
+    });
+}

--- a/nexus-slot/tests/loom_spmc.rs
+++ b/nexus-slot/tests/loom_spmc.rs
@@ -56,19 +56,24 @@ fn writer_disconnect_ordering() {
             writer.write(42);
         });
 
+        let mut seen = false;
         loop {
             if reader.is_disconnected() {
                 if reader.has_update() {
                     let v = reader.read().unwrap();
                     assert_eq!(v, 42);
+                    seen = true;
                 }
                 break;
             }
             if let Some(v) = reader.read() {
                 assert_eq!(v, 42);
+                seen = true;
             }
             thread::yield_now();
         }
+
+        assert!(seen, "writer wrote but reader never observed the value");
 
         w.join().unwrap();
     });

--- a/nexus-slot/tests/loom_spsc.rs
+++ b/nexus-slot/tests/loom_spsc.rs
@@ -1,0 +1,131 @@
+#![cfg(loom)]
+
+use loom::thread;
+use nexus_slot::spsc;
+
+#[test]
+fn write_then_read() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spsc::slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        w.join().unwrap();
+        assert_eq!(reader.read(), Some(42));
+        assert!(reader.read().is_none());
+    });
+}
+
+#[test]
+fn no_torn_reads() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spsc::slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        loop {
+            if let Some(v) = reader.read() {
+                assert_eq!(v, 42);
+                break;
+            }
+            if reader.is_disconnected() {
+                if let Some(v) = reader.read() {
+                    assert_eq!(v, 42);
+                }
+                break;
+            }
+            thread::yield_now();
+        }
+
+        w.join().unwrap();
+    });
+}
+
+#[test]
+fn two_writes_no_torn_reads() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spsc::slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(0xAAAA);
+            writer.write(0xBBBB);
+        });
+
+        loop {
+            if let Some(v) = reader.read() {
+                assert!(v == 0xAAAA || v == 0xBBBB, "torn read: {v:#x}");
+            }
+            if reader.is_disconnected() && !reader.has_update() {
+                break;
+            }
+            thread::yield_now();
+        }
+
+        w.join().unwrap();
+    });
+}
+
+#[test]
+fn conflation() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spsc::slot::<usize>();
+
+        writer.write(1);
+        writer.write(2);
+        writer.write(3);
+
+        assert_eq!(reader.read(), Some(3));
+        assert!(reader.read().is_none());
+    });
+}
+
+#[test]
+fn disconnect_writer() {
+    loom::model(|| {
+        let (writer, reader) = spsc::slot::<usize>();
+        assert!(!reader.is_disconnected());
+        drop(writer);
+        assert!(reader.is_disconnected());
+    });
+}
+
+#[test]
+fn disconnect_reader() {
+    loom::model(|| {
+        let (writer, reader) = spsc::slot::<usize>();
+        assert!(!writer.is_disconnected());
+        drop(reader);
+        assert!(writer.is_disconnected());
+    });
+}
+
+#[test]
+fn read_versioned_consistent() {
+    loom::model(|| {
+        let (mut writer, mut reader) = spsc::slot::<usize>();
+
+        let w = thread::spawn(move || {
+            writer.write(42);
+        });
+
+        loop {
+            if let Some((v, _ver)) = reader.read_versioned() {
+                assert_eq!(v, 42);
+                break;
+            }
+            if reader.is_disconnected() {
+                if let Some((v, _ver)) = reader.read_versioned() {
+                    assert_eq!(v, 42);
+                }
+                break;
+            }
+            thread::yield_now();
+        }
+
+        w.join().unwrap();
+    });
+}


### PR DESCRIPTION
## Summary

- Add exhaustive loom model checking for nexus-slot SPSC and SPMC seqlocks (12 tests)
- Verify fence correctness, torn read prevention, and disconnect ordering across all interleavings
- Add benchmark links and measurement methodology to workspace README

Closes #394, closes #396.

### Loom model

Seqlocks have benign data races (reader speculatively reads during writer's copy, validates via sequence check). Loom's `UnsafeCell` false-positives on these concurrent accesses, so under `cfg(loom)` we model data as `AtomicUsize` with `Relaxed` ordering — faithfully representing the real word-at-a-time Relaxed stores. Word-at-a-time correctness is separately verified by miri.

Key changes:
- `loom_impl.rs` — cfg-switched atomics, `spin_yield()` (loom's scheduler needs `yield_now`, not `spin_loop`), `loom_store`/`loom_load` for T↔usize conversion
- SPSC/SPMC structs cfg'd between `UnsafeCell<MaybeUninit<T>>` (real) and `AtomicUsize` (loom)
- Existing unit tests gated `#[cfg(all(test, not(loom)))]` since test types exceed usize

### README

- Added `([benchmarks](./crate/BENCHMARKS.md))` links to 6 crate performance claims
- Added "Benchmark Conditions" section documenting hardware, toolchain, and methodology (turbo boost off for comparisons, on for finalized numbers)

## Test plan

- [x] All 12 loom tests pass (`RUSTFLAGS="--cfg loom" cargo test -p nexus-slot --test loom_spsc --test loom_spmc`)
- [x] All 32 existing unit tests pass (`cargo test -p nexus-slot`)
- [x] `cargo clippy -p nexus-slot -- -D warnings` clean
- [x] README benchmark links resolve to correct files


🤖 Generated with [Claude Code](https://claude.com/claude-code)