### PR TITLE
refactor(async-net): sans-IO decomposed WS API + targeted re-exports

### DIFF
--- a/nexus-async-net/CHANGELOG.md
+++ b/nexus-async-net/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: `WsStreamBuilder::connect()`, `connect_with()`, and
+  `accept()` now return `(WsReader, WsWriter, S)` tuples instead of
+  `WsStream`. The decomposed sans-IO API is the primary interface —
+  reader and writer are independent borrows, enabling zero-copy recv
+  while sending concurrently.
+- **Breaking**: Removed blanket `pub use nexus_net` re-export. Downstream
+  code that used `nexus_async_net::nexus_net::…` paths must import from
+  `nexus_net` directly or use the new targeted re-exports
+  (`CloseCode`, `FrameReader`, `FrameWriter`, `Message`, `Role`,
+  `WireStream`, `WriteBuf`, etc.).
+- `WsStream` (tokio only) demoted to Stream/Sink ecosystem adapter.
+  Construct via `WsStream::from_parts(reader, writer, conn)`. Uses
+  `OwnedMessage` (allocating) — prefer `WsReader`/`WsWriter` for
+  performance-sensitive paths.
+
+### Added
+
+- `WsReader` / `WsWriter` as the primary decomposed WebSocket API,
+  shared across tokio and nexus backends.
+- `WsReader::from_raw_parts()` and `WsWriter::from_raw_parts()` for
+  custom handshakes, testing, and benchmarks.
+
 ## [0.8.0] — 2026-05-11
 
 ### Changed

--- a/nexus-async-net/benches/perf_async_ws.rs
+++ b/nexus-async-net/benches/perf_async_ws.rs
@@ -125,20 +125,23 @@ impl AsyncWrite for MockAsyncReader<'_> {
 // =============================================================================
 
 async fn bench_inmemory_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
-    use nexus_async_net::ws::WsStream;
+    use nexus_async_net::ws::{WsReader, WsWriter};
+    use nexus_net::buf::WriteBuf;
     use nexus_net::ws::{FrameReader, FrameWriter, Message, Role};
 
-    let mock = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
-    let reader = FrameReader::builder()
-        .role(Role::Client)
-        .buffer_capacity(64 * 1024)
-        .build();
-    let mut ws = WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client));
+    let mut conn = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
+    let mut reader = WsReader::from_raw_parts(
+        FrameReader::builder()
+            .role(Role::Client)
+            .buffer_capacity(64 * 1024)
+            .build(),
+        usize::MAX,
+    );
 
     let start = Instant::now();
     let mut received = 0u64;
     while received < msg_count {
-        match ws.recv().await.unwrap() {
+        match reader.recv(&mut conn).await.unwrap() {
             Some(Message::Binary(d)) => {
                 black_box(&d);
                 received += 1;
@@ -270,20 +273,22 @@ async fn bench_json_nexus<T: for<'de> Deserialize<'de>>(
     wire: &[u8],
     msg_count: u64,
 ) -> (Duration, u64) {
-    use nexus_net::ws::{FrameReader, FrameWriter, Message, Role};
+    use nexus_async_net::ws::WsReader;
+    use nexus_net::ws::{FrameReader, Message, Role};
 
-    let mock = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
-    let reader = FrameReader::builder()
-        .role(Role::Client)
-        .buffer_capacity(64 * 1024)
-        .build();
-    let mut ws =
-        nexus_async_net::ws::WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client));
+    let mut conn = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
+    let mut reader = WsReader::from_raw_parts(
+        FrameReader::builder()
+            .role(Role::Client)
+            .buffer_capacity(64 * 1024)
+            .build(),
+        usize::MAX,
+    );
 
     let start = Instant::now();
     let mut received = 0u64;
     while received < msg_count {
-        match ws.recv().await.unwrap() {
+        match reader.recv(&mut conn).await.unwrap() {
             Some(Message::Text(s)) => {
                 let val: T = sonic_rs::from_str(s).unwrap();
                 black_box(&val);
@@ -344,15 +349,21 @@ fn bench_deser_only<T: for<'de> Deserialize<'de>>(json: &str, msg_count: u64) ->
 
 async fn bench_stream_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
     use futures_util::StreamExt;
+    use nexus_async_net::ws::{WsReader, WsStream, WsWriter};
+    use nexus_net::buf::WriteBuf;
     use nexus_net::ws::{FrameReader, FrameWriter, Role};
 
-    let mock = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
-    let reader = FrameReader::builder()
-        .role(Role::Client)
-        .buffer_capacity(64 * 1024)
-        .build();
-    let mut ws =
-        nexus_async_net::ws::WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client));
+    let conn = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
+    let reader = WsReader::from_raw_parts(
+        FrameReader::builder()
+            .role(Role::Client)
+            .buffer_capacity(64 * 1024)
+            .build(),
+        usize::MAX,
+    );
+    let writer =
+        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14));
+    let mut ws = WsStream::from_parts(reader, writer, conn);
 
     let start = Instant::now();
     let mut received = 0u64;
@@ -373,7 +384,7 @@ async fn bench_stream_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
 // =============================================================================
 
 async fn bench_loopback_nexus(port: u16, wire: Vec<u8>, msg_count: u64) -> (Duration, u64) {
-    use nexus_async_net::ws::WsStream;
+    use nexus_async_net::ws::WsStreamBuilder;
     use nexus_net::ws::Message;
 
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
@@ -383,9 +394,7 @@ async fn bench_loopback_nexus(port: u16, wire: Vec<u8>, msg_count: u64) -> (Dura
     let server = tokio::spawn(async move {
         let (tcp, _) = listener.accept().await.unwrap();
         tcp.set_nodelay(true).unwrap();
-        // Accept WS handshake using tungstenite (server side)
         let mut ws = tokio_tungstenite::accept_async(tcp).await.unwrap();
-        // Get raw stream, blast frames
         let raw = ws.get_mut();
         tokio::io::AsyncWriteExt::write_all(raw, &wire)
             .await
@@ -400,17 +409,18 @@ async fn bench_loopback_nexus(port: u16, wire: Vec<u8>, msg_count: u64) -> (Dura
         .await
         .unwrap();
     tcp.set_nodelay(true).unwrap();
-    let mut ws = WsStream::connect_with(
-        AsyncReadAdapter::new(tcp),
-        &format!("ws://127.0.0.1:{port}/"),
-    )
-    .await
-    .unwrap();
+    let (mut reader, _writer, mut conn) = WsStreamBuilder::new()
+        .connect_with(
+            AsyncReadAdapter::new(tcp),
+            &format!("ws://127.0.0.1:{port}/"),
+        )
+        .await
+        .unwrap();
 
     let start = Instant::now();
     let mut received = 0u64;
     while received < msg_count {
-        match ws.recv().await.unwrap() {
+        match reader.recv(&mut conn).await.unwrap() {
             Some(Message::Binary(d)) => {
                 black_box(&d);
                 received += 1;
@@ -812,7 +822,7 @@ async fn tls_accept_and_blast(
 }
 
 async fn bench_tls_loopback_nexus(port: u16, wire: Vec<u8>, msg_count: u64) -> (Duration, u64) {
-    use nexus_async_net::ws::WsStream;
+    use nexus_async_net::ws::WsStreamBuilder;
     use nexus_net::ws::Message;
 
     let addr = format!("127.0.0.1:{port}");
@@ -832,14 +842,15 @@ async fn bench_tls_loopback_nexus(port: u16, wire: Vec<u8>, msg_count: u64) -> (
         .to_owned();
     let tls_stream = connector.connect(server_name, tcp).await.unwrap();
 
-    let mut ws = WsStream::connect_with(AsyncReadAdapter::new(tls_stream), "ws://localhost/")
+    let (mut reader, _writer, mut conn) = WsStreamBuilder::new()
+        .connect_with(AsyncReadAdapter::new(tls_stream), "ws://localhost/")
         .await
         .unwrap();
 
     let start = Instant::now();
     let mut received = 0u64;
     while received < msg_count {
-        match ws.recv().await.unwrap() {
+        match reader.recv(&mut conn).await.unwrap() {
             Some(Message::Binary(d)) => {
                 black_box(&d);
                 received += 1;

--- a/nexus-async-net/benches/perf_async_ws.rs
+++ b/nexus-async-net/benches/perf_async_ws.rs
@@ -125,9 +125,8 @@ impl AsyncWrite for MockAsyncReader<'_> {
 // =============================================================================
 
 async fn bench_inmemory_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
-    use nexus_async_net::ws::{WsReader, WsWriter};
-    use nexus_net::buf::WriteBuf;
-    use nexus_net::ws::{FrameReader, FrameWriter, Message, Role};
+    use nexus_async_net::ws::WsReader;
+    use nexus_net::ws::{FrameReader, Message, Role};
 
     let mut conn = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
     let mut reader = WsReader::from_raw_parts(

--- a/nexus-async-net/benches/perf_async_ws_nexus.rs
+++ b/nexus-async-net/benches/perf_async_ws_nexus.rs
@@ -138,21 +138,23 @@ fn block_on<F: std::future::Future>(f: F) -> F::Output {
 // =============================================================================
 
 fn bench_inmemory(wire: &[u8], msg_count: u64) -> (Duration, u64) {
-    use nexus_async_net::ws::WsStream;
-    use nexus_net::ws::{FrameReader, FrameWriter, Message, Role};
+    use nexus_async_net::ws::WsReader;
+    use nexus_net::ws::{FrameReader, Message, Role};
 
-    let mock = NexusAsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
-    let reader = FrameReader::builder()
-        .role(Role::Client)
-        .buffer_capacity(64 * 1024)
-        .build();
-    let mut ws = WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client));
+    let mut conn = NexusAsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
+    let mut reader = WsReader::from_raw_parts(
+        FrameReader::builder()
+            .role(Role::Client)
+            .buffer_capacity(64 * 1024)
+            .build(),
+        usize::MAX,
+    );
 
     let start = Instant::now();
     let mut received = 0u64;
     block_on(async {
         while received < msg_count {
-            match ws.recv().await.unwrap() {
+            match reader.recv(&mut conn).await.unwrap() {
                 Some(Message::Binary(d)) => {
                     black_box(&d);
                     received += 1;

--- a/nexus-async-net/benches/perf_ws_cycles_nexus.rs
+++ b/nexus-async-net/benches/perf_ws_cycles_nexus.rs
@@ -14,8 +14,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use nexus_async_net::NexusAsyncReadAdapter;
-use nexus_async_net::ws::WsStream;
+use nexus_async_net::ws::{WsReader, WsWriter};
 use nexus_async_rt::{AsyncRead, AsyncWrite};
+use nexus_net::buf::WriteBuf;
 use nexus_net::ws::{FrameReader, FrameWriter, Role};
 
 // =============================================================================
@@ -195,13 +196,20 @@ fn wire_bytes(payload_size: usize, count: usize) -> usize {
     frame_len * count
 }
 
-fn make_ws(wire: &[u8], total_bytes: usize) -> WsStream<NexusAsyncReadAdapter<MockStream<'_>>> {
+fn make_parts(
+    wire: &[u8],
+    total_bytes: usize,
+) -> (WsReader, WsWriter, NexusAsyncReadAdapter<MockStream<'_>>) {
     let mock = NexusAsyncReadAdapter::new(MockStream::new(wire, total_bytes));
     let reader = FrameReader::builder()
         .role(Role::Client)
         .buffer_capacity(256 * 1024)
         .build();
-    WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client))
+    (
+        WsReader::from_raw_parts(reader, usize::MAX),
+        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14)),
+        mock,
+    )
 }
 
 // =============================================================================
@@ -222,13 +230,13 @@ fn bench_recv_per_msg(label: &str, payload_size: usize) {
     let total = WARMUP + SAMPLES;
     let wire = build_wire_chunk(payload_size);
     let total_bytes = wire_bytes(payload_size, total);
-    let mut ws = make_ws(&wire, total_bytes);
+    let (mut reader, _writer, mut conn) = make_parts(&wire, total_bytes);
     let mut samples = Vec::with_capacity(SAMPLES);
 
     for i in 0..total {
         let start = rdtsc_start();
         block_on(async {
-            let msg = ws.recv().await.unwrap();
+            let msg = reader.recv(&mut conn).await.unwrap();
             black_box(&msg);
         });
         let end = rdtsc_end();
@@ -245,14 +253,14 @@ fn bench_recv_batched(label: &str, payload_size: usize) {
     let total_msgs = total_batches * BATCH as usize;
     let wire = build_wire_chunk(payload_size);
     let total_bytes = wire_bytes(payload_size, total_msgs);
-    let mut ws = make_ws(&wire, total_bytes);
+    let (mut reader, _writer, mut conn) = make_parts(&wire, total_bytes);
     let mut samples = Vec::with_capacity(BATCH_SAMPLES);
 
     for i in 0..total_batches {
         let start = rdtsc_start();
         block_on(async {
             for _ in 0..BATCH {
-                let msg = ws.recv().await.unwrap();
+                let msg = reader.recv(&mut conn).await.unwrap();
                 black_box(&msg);
             }
         });
@@ -272,13 +280,13 @@ fn bench_recv_batched(label: &str, payload_size: usize) {
 fn bench_send_per_msg(label: &str, payload_size: usize) {
     let text = "x".repeat(payload_size);
     let wire = build_wire_chunk(payload_size);
-    let mut ws = make_ws(&wire, 0);
+    let (_reader, mut writer, mut conn) = make_parts(&wire, 0);
     let mut samples = Vec::with_capacity(SAMPLES);
     let total = WARMUP + SAMPLES;
 
     for i in 0..total {
         let start = rdtsc_start();
-        block_on(ws.send_text(&text)).unwrap();
+        block_on(writer.send_text(&mut conn, &text)).unwrap();
         let end = rdtsc_end();
         if i >= WARMUP {
             samples.push(end - start);
@@ -291,7 +299,7 @@ fn bench_send_per_msg(label: &str, payload_size: usize) {
 fn bench_send_batched(label: &str, payload_size: usize) {
     let text = "x".repeat(payload_size);
     let wire = build_wire_chunk(payload_size);
-    let mut ws = make_ws(&wire, 0);
+    let (_reader, mut writer, mut conn) = make_parts(&wire, 0);
     let mut samples = Vec::with_capacity(BATCH_SAMPLES);
     let total_batches = BATCH_WARMUP + BATCH_SAMPLES;
 
@@ -299,7 +307,7 @@ fn bench_send_batched(label: &str, payload_size: usize) {
         let start = rdtsc_start();
         block_on(async {
             for _ in 0..BATCH {
-                ws.send_text(&text).await.unwrap();
+                writer.send_text(&mut conn, &text).await.unwrap();
             }
         });
         let end = rdtsc_end();

--- a/nexus-async-net/benches/perf_ws_cycles_tokio.rs
+++ b/nexus-async-net/benches/perf_ws_cycles_tokio.rs
@@ -13,7 +13,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use nexus_async_net::AsyncReadAdapter;
-use nexus_async_net::ws::WsStream;
+use nexus_async_net::ws::{WsReader, WsWriter};
+use nexus_net::buf::WriteBuf;
 use nexus_net::ws::{FrameReader, FrameWriter, Role};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -194,13 +195,20 @@ fn wire_bytes(payload_size: usize, count: usize) -> usize {
     frame_len * count
 }
 
-fn make_ws(wire: &[u8], total_bytes: usize) -> WsStream<AsyncReadAdapter<MockStream<'_>>> {
+fn make_parts(
+    wire: &[u8],
+    total_bytes: usize,
+) -> (WsReader, WsWriter, AsyncReadAdapter<MockStream<'_>>) {
     let mock = AsyncReadAdapter::new(MockStream::new(wire, total_bytes));
     let reader = FrameReader::builder()
         .role(Role::Client)
         .buffer_capacity(256 * 1024)
         .build();
-    WsStream::from_parts(mock, reader, FrameWriter::new(Role::Client))
+    (
+        WsReader::from_raw_parts(reader, usize::MAX),
+        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14)),
+        mock,
+    )
 }
 
 // =============================================================================
@@ -221,13 +229,13 @@ fn bench_recv_per_msg(label: &str, payload_size: usize) {
     let total = WARMUP + SAMPLES;
     let wire = build_wire_chunk(payload_size);
     let total_bytes = wire_bytes(payload_size, total);
-    let mut ws = make_ws(&wire, total_bytes);
+    let (mut reader, _writer, mut conn) = make_parts(&wire, total_bytes);
     let mut samples = Vec::with_capacity(SAMPLES);
 
     for i in 0..total {
         let start = rdtsc_start();
         block_on(async {
-            let msg = ws.recv().await.unwrap();
+            let msg = reader.recv(&mut conn).await.unwrap();
             black_box(&msg);
         });
         let end = rdtsc_end();
@@ -244,14 +252,14 @@ fn bench_recv_batched(label: &str, payload_size: usize) {
     let total_msgs = total_batches * BATCH as usize;
     let wire = build_wire_chunk(payload_size);
     let total_bytes = wire_bytes(payload_size, total_msgs);
-    let mut ws = make_ws(&wire, total_bytes);
+    let (mut reader, _writer, mut conn) = make_parts(&wire, total_bytes);
     let mut samples = Vec::with_capacity(BATCH_SAMPLES);
 
     for i in 0..total_batches {
         let start = rdtsc_start();
         block_on(async {
             for _ in 0..BATCH {
-                let msg = ws.recv().await.unwrap();
+                let msg = reader.recv(&mut conn).await.unwrap();
                 black_box(&msg);
             }
         });
@@ -271,13 +279,13 @@ fn bench_recv_batched(label: &str, payload_size: usize) {
 fn bench_send_per_msg(label: &str, payload_size: usize) {
     let text = "x".repeat(payload_size);
     let wire = build_wire_chunk(payload_size);
-    let mut ws = make_ws(&wire, 0);
+    let (_reader, mut writer, mut conn) = make_parts(&wire, 0);
     let mut samples = Vec::with_capacity(SAMPLES);
     let total = WARMUP + SAMPLES;
 
     for i in 0..total {
         let start = rdtsc_start();
-        block_on(ws.send_text(&text)).unwrap();
+        block_on(writer.send_text(&mut conn, &text)).unwrap();
         let end = rdtsc_end();
         if i >= WARMUP {
             samples.push(end - start);
@@ -290,7 +298,7 @@ fn bench_send_per_msg(label: &str, payload_size: usize) {
 fn bench_send_batched(label: &str, payload_size: usize) {
     let text = "x".repeat(payload_size);
     let wire = build_wire_chunk(payload_size);
-    let mut ws = make_ws(&wire, 0);
+    let (_reader, mut writer, mut conn) = make_parts(&wire, 0);
     let mut samples = Vec::with_capacity(BATCH_SAMPLES);
     let total_batches = BATCH_WARMUP + BATCH_SAMPLES;
 
@@ -298,7 +306,7 @@ fn bench_send_batched(label: &str, payload_size: usize) {
         let start = rdtsc_start();
         block_on(async {
             for _ in 0..BATCH {
-                ws.send_text(&text).await.unwrap();
+                writer.send_text(&mut conn, &text).await.unwrap();
             }
         });
         let end = rdtsc_end();

--- a/nexus-async-net/src/lib.rs
+++ b/nexus-async-net/src/lib.rs
@@ -56,5 +56,19 @@ pub use wire::AsyncReadAdapter;
 #[cfg(feature = "nexus")]
 pub use wire::NexusAsyncReadAdapter;
 
-// Re-export nexus-net types for convenience
-pub use nexus_net;
+// Re-export nexus-net types that appear in our public API.
+// Users who need deeper access can depend on nexus-net directly.
+pub use nexus_net::ws::{
+    CloseCode, CloseFrame, Error as WsError, FrameReader, FrameReaderBuilder, FrameWriter,
+    HandshakeError, Message, OwnedCloseFrame, OwnedMessage, Role,
+};
+pub use nexus_net::{WireStream, buf::WriteBuf};
+
+/// REST types used in [`rest::HttpConnection`] and [`rest::ClientSlot`].
+pub mod rest_types {
+    pub use nexus_net::http::ResponseReader;
+    pub use nexus_net::rest::{Request, RequestWriter, RestError, RestResponse};
+}
+
+#[cfg(feature = "tls")]
+pub use nexus_net::tls::{TlsConfig, TlsError};

--- a/nexus-async-net/src/lib.rs
+++ b/nexus-async-net/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # Custom transports
 //!
-//! `WsStream<S>` / `HttpConnection<S>` consume a
+//! `WsReader`/`WsWriter` and `HttpConnection<S>` accept any
 //! [`WireStream`](nexus_net::WireStream) — the canonical `MaybeTls`
 //! transport implements it directly. To plug a custom
 //! `AsyncRead+AsyncWrite` transport into the same API, wrap it at
@@ -31,7 +31,7 @@
 //!
 //! ```ignore
 //! let tcp = tokio::net::TcpStream::connect(addr).await?;
-//! let ws = WsStreamBuilder::new()
+//! let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
 //!     .connect_with(AsyncReadAdapter::new(tcp), url)
 //!     .await?;
 //! ```

--- a/nexus-async-net/src/rest/nexus/connection.rs
+++ b/nexus-async-net/src/rest/nexus/connection.rs
@@ -366,12 +366,11 @@ impl<S: WireStream + Unpin> HttpConnection<S> {
     #[cold]
     #[allow(clippy::unused_self)]
     fn diagnose_error(&self, err: RestError) -> RestError {
-        if let RestError::Io(ref io_err) = err {
-            if io_err.kind() == io::ErrorKind::TimedOut
-                || io_err.kind() == io::ErrorKind::WouldBlock
-            {
-                return RestError::ConnectionStale;
-            }
+        if let RestError::Io(ref io_err) = err
+            && (io_err.kind() == io::ErrorKind::TimedOut
+                || io_err.kind() == io::ErrorKind::WouldBlock)
+        {
+            return RestError::ConnectionStale;
         }
         err
     }

--- a/nexus-async-net/src/ws/mod.rs
+++ b/nexus-async-net/src/ws/mod.rs
@@ -1,17 +1,42 @@
 //! Async WebSocket — adapts nexus-net for async runtimes.
 //!
-//! Both the `tokio-rt` and `nexus` backends expose `WsStream` and
-//! `WsStreamBuilder` with the same `recv()`/`send_*()` API.
+//! The primary API is [`WsReader`] and [`WsWriter`] — sans-IO types
+//! that own the frame parser and encoder independently. The transport
+//! connection (`conn`) is passed to each call, enabling zero-copy
+//! messages and independent read/write borrows.
 //!
-//! The tokio backend additionally implements `futures_core::Stream` and
-//! `futures_sink::Sink` for ecosystem compatibility. The nexus backend
-//! omits these intentionally — direct `recv()`/`send_*()` methods are
-//! preferred for latency-sensitive single-threaded code.
+//! ```ignore
+//! let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+//!     .connect("ws://localhost:8080/ws")
+//!     .await?;
+//!
+//! while let Some(msg) = reader.recv(&mut conn).await? {
+//!     match msg {
+//!         Message::Ping(data) => writer.send_pong(&mut conn, data).await?,
+//!         Message::Text(text) => {
+//!             let response = process(text);
+//!             writer.send_text(&mut conn, &response).await?;
+//!         }
+//!         _ => {}
+//!     }
+//! }
+//! ```
+//!
+//! The tokio backend also provides [`WsStream`] — a bundled adapter
+//! that implements `futures_core::Stream` and `futures_sink::Sink` for
+//! ecosystem compatibility. This uses `OwnedMessage` (allocates per
+//! message) and cannot overlap read/write borrows. Use it when you
+//! need `StreamExt`/`SinkExt` combinators; use `WsReader`/`WsWriter`
+//! for performance-sensitive code.
+
+mod parts;
 
 #[cfg(feature = "nexus")]
 mod nexus;
 #[cfg(feature = "tokio-rt")]
 mod tokio;
+
+pub use parts::{WsReader, WsWriter};
 
 #[cfg(feature = "nexus")]
 pub use self::nexus::*;

--- a/nexus-async-net/src/ws/nexus/mod.rs
+++ b/nexus-async-net/src/ws/nexus/mod.rs
@@ -1,4 +1,4 @@
-//! Async WebSocket — nexus-async-rt adapter for nexus-net.
+//! Async WebSocket — nexus-async-rt backend.
 //!
 //! Same FrameReader, same zero-copy Message, same performance.
 //! The only difference is `.await` on socket I/O.
@@ -6,4 +6,4 @@
 mod stream;
 
 pub use crate::maybe_tls::MaybeTls;
-pub use stream::{WsStream, WsStreamBuilder};
+pub use stream::WsStreamBuilder;

--- a/nexus-async-net/src/ws/nexus/mod.rs
+++ b/nexus-async-net/src/ws/nexus/mod.rs
@@ -1,7 +1,8 @@
 //! Async WebSocket — nexus-async-rt backend.
 //!
-//! Same FrameReader, same zero-copy Message, same performance.
-//! The only difference is `.await` on socket I/O.
+//! Provides [`WsStreamBuilder`] for connection setup. The primary API
+//! types ([`WsReader`](super::WsReader) / [`WsWriter`](super::WsWriter))
+//! are re-exported from the parent `ws` module.
 
 mod stream;
 

--- a/nexus-async-net/src/ws/nexus/stream.rs
+++ b/nexus-async-net/src/ws/nexus/stream.rs
@@ -1,415 +1,227 @@
-//! Async WebSocket stream — nexus-async-rt backend.
+//! Async WebSocket — nexus-async-rt backend.
+//!
+//! Builder + handshake logic. `WsReader`/`WsWriter` (the primary API)
+//! live in the shared `ws::parts` module.
 
 use std::io;
 use std::net::ToSocketAddrs;
-use std::pin::Pin;
 
 use nexus_async_rt::TcpStream;
+use nexus_net::WireStream;
 use nexus_net::buf::WriteBuf;
 use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_net::ws::{
-    CloseCode, Error as WsError, FrameReader, FrameReaderBuilder, FrameWriter, HandshakeError,
-    Message, Role, parse_ws_url,
+    Error as WsError, FrameReader, FrameReaderBuilder, FrameWriter, HandshakeError, Role,
+    parse_ws_url,
 };
-use nexus_net::{ParserSink, WireStream};
 
 use crate::maybe_tls::MaybeTls;
+use crate::ws::parts::{WsReader, WsWriter, fill_async, write_all_async};
 
 // =============================================================================
-// Async I/O helpers (poll_fn wrappers over WireStream)
+// Handshake — standalone async functions
 // =============================================================================
 
-/// Drive a single `poll_fill_into` call on the stream.
-async fn fill_async<W: WireStream + Unpin, P: ParserSink>(
-    s: &mut W,
-    sink: &mut P,
-    max: usize,
-) -> io::Result<usize> {
-    std::future::poll_fn(|cx| Pin::new(&mut *s).poll_fill_into(cx, sink, max)).await
-}
-
-async fn write_all_async<W: WireStream + Unpin>(s: &mut W, mut buf: &[u8]) -> io::Result<()> {
-    while !buf.is_empty() {
-        let n = std::future::poll_fn(|cx| Pin::new(&mut *s).poll_write(cx, buf)).await?;
-        if n == 0 {
-            return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
-        }
-        buf = &buf[n..];
-    }
-    Ok(())
-}
-
-// =============================================================================
-// WsStream
-// =============================================================================
-
-/// Async WebSocket stream (nexus-async-rt backend).
-///
-/// Wraps nexus-net's synchronous FrameReader/FrameWriter with async I/O.
-/// Same zero-copy parsing, same Message type — just `.await` on socket ops.
-///
-/// # Usage
-///
-/// ```ignore
-/// use nexus_async_net::ws::WsStreamBuilder;
-/// use nexus_net::tls::TlsConfig;
-///
-/// // Plain WebSocket
-/// let mut ws = WsStreamBuilder::new().connect("ws://localhost:8080/ws").await?;
-///
-/// // TLS WebSocket
-/// let tls = TlsConfig::new()?;
-/// let mut ws = WsStreamBuilder::new().tls(&tls).connect("wss://exchange.com/ws").await?;
-///
-/// ws.send_text("Hello!").await?;
-/// while let Some(msg) = ws.recv().await? {
-///     // msg is nexus_net::ws::Message<'_>
-/// }
-/// ```
-pub struct WsStream<S> {
-    stream: S,
-    reader: FrameReader,
-    writer: FrameWriter,
-    write_buf: WriteBuf,
+async fn connect_handshake<S: WireStream + Unpin>(
+    mut stream: S,
+    url: &str,
+    reader_builder: FrameReaderBuilder,
+    write_cap: usize,
     max_read_size: usize,
-}
+) -> Result<(WsReader, WsWriter, S), WsError> {
+    let parsed = parse_ws_url(url)?;
+    let host_header = parsed.host_header();
 
-// -- Generic impl for any WireStream-bearing transport ----------------------
+    let key = nexus_net::ws::handshake::generate_key();
+    let key_str =
+        std::str::from_utf8(&key).expect("base64-encoded key is always valid ASCII/UTF-8");
 
-impl<S: WireStream + Unpin> WsStream<S> {
-    /// Connect with a pre-connected async stream.
-    pub async fn connect_with(stream: S, url: &str) -> Result<Self, WsError> {
-        WsStreamBuilder::new().connect_with(stream, url).await
-    }
+    let headers: [(&str, &str); 5] = [
+        ("Host", &host_header),
+        ("Upgrade", "websocket"),
+        ("Connection", "Upgrade"),
+        ("Sec-WebSocket-Key", key_str),
+        ("Sec-WebSocket-Version", "13"),
+    ];
+    let req_size = nexus_net::http::request_size("GET", parsed.path, &headers);
+    let mut req_buf = vec![0u8; req_size];
+    let n = nexus_net::http::write_request("GET", parsed.path, &headers, &mut req_buf)
+        .map_err(|_| HandshakeError::MalformedHttp)?;
 
-    /// Accept an incoming WebSocket connection (server-side).
-    ///
-    /// Reads the client's HTTP upgrade request, validates it,
-    /// sends back 101 Switching Protocols, and returns a server-role
-    /// WsStream ready for recv/send.
-    pub async fn accept(stream: S) -> Result<Self, WsError> {
-        WsStreamBuilder::new().accept(stream).await
-    }
+    write_all_async(&mut stream, &req_buf[..n]).await?;
 
-    /// Create from pre-existing parts. For testing or custom handshakes.
-    ///
-    /// `max_read_size` defaults to unlimited. Call [`set_max_read_size`](Self::set_max_read_size)
-    /// after construction to cap per-recv read size for better tail latency.
-    pub fn from_parts(stream: S, reader: FrameReader, writer: FrameWriter) -> Self {
-        Self {
-            stream,
-            reader,
-            writer,
-            write_buf: WriteBuf::new(65_536, 14),
-            max_read_size: usize::MAX,
+    let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
+    loop {
+        if resp_reader.spare().is_empty() {
+            return Err(HandshakeError::MalformedHttp.into());
         }
-    }
-
-    /// Receive the next message.
-    pub async fn recv(&mut self) -> Result<Option<Message<'_>>, WsError> {
-        loop {
-            if self.reader.poll()? {
-                return Ok(self.reader.next()?);
-            }
-
-            if self.reader.should_compact() {
-                self.reader.compact();
-            }
-            if self.reader.spare().is_empty() {
-                self.reader.compact();
-                if self.reader.spare().is_empty() {
-                    return Ok(None); // buffer genuinely full
+        let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
+        if n == 0 {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        match resp_reader.next() {
+            Ok(Some(resp)) => {
+                if resp.status != 101 {
+                    return Err(HandshakeError::UnexpectedStatus(resp.status).into());
                 }
-            }
+                let upgrade = resp
+                    .header("Upgrade")
+                    .ok_or(HandshakeError::MissingUpgrade)?;
+                if !upgrade.eq_ignore_ascii_case("websocket") {
+                    return Err(HandshakeError::MissingUpgrade.into());
+                }
+                let conn = resp
+                    .header("Connection")
+                    .ok_or(HandshakeError::MissingConnection)?;
+                if !conn
+                    .as_bytes()
+                    .windows(7)
+                    .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
+                {
+                    return Err(HandshakeError::MissingConnection.into());
+                }
+                let accept = resp
+                    .header("Sec-WebSocket-Accept")
+                    .ok_or(HandshakeError::InvalidAcceptKey)?;
+                if !nexus_net::ws::handshake::validate_accept(key_str, accept) {
+                    return Err(HandshakeError::InvalidAcceptKey.into());
+                }
 
-            // poll_fill_into delivers bytes directly into reader.spare()
-            // and commits via reader.filled(n) — zero-copy on adapters
-            // that support it (nexus-async-rt TLS).
-            let n = fill_async(&mut self.stream, &mut self.reader, self.max_read_size).await?;
-            if n == 0 {
-                return Ok(None); // EOF
-            }
-        }
-    }
+                let mut reader = reader_builder.role(Role::Client).build();
+                let remainder = resp_reader.remainder();
+                if !remainder.is_empty() {
+                    reader
+                        .read(remainder)
+                        .map_err(|_| HandshakeError::MalformedHttp)?;
+                }
 
-    /// Send a text message.
-    pub async fn send_text(&mut self, text: &str) -> Result<(), WsError> {
-        self.writer
-            .encode_text_into(text.as_bytes(), &mut self.write_buf);
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a binary message.
-    pub async fn send_binary(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer.encode_binary_into(data, &mut self.write_buf);
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a ping.
-    pub async fn send_ping(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer
-            .encode_ping_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a pong.
-    pub async fn send_pong(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer
-            .encode_pong_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Initiate close handshake.
-    pub async fn close(&mut self, code: CloseCode, reason: &str) -> Result<(), WsError> {
-        if code == CloseCode::NoStatus {
-            let mut dst = [0u8; 14];
-            let n = self.writer.encode_empty_close(&mut dst);
-            write_all_async(&mut self.stream, &dst[..n]).await?;
-        } else {
-            self.writer
-                .encode_close_into(code.as_u16(), reason.as_bytes(), &mut self.write_buf)
-                .map_err(WsError::Encode)?;
-            write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        }
-        Ok(())
-    }
-
-    /// Access the underlying stream.
-    pub fn stream(&self) -> &S {
-        &self.stream
-    }
-
-    /// Mutable access to the underlying stream.
-    pub fn stream_mut(&mut self) -> &mut S {
-        &mut self.stream
-    }
-
-    /// Access the FrameReader.
-    pub fn reader(&self) -> &FrameReader {
-        &self.reader
-    }
-
-    /// Access the FrameWriter.
-    pub fn frame_writer(&self) -> &FrameWriter {
-        &self.writer
-    }
-
-    /// Override max bytes read per recv call.
-    pub fn set_max_read_size(&mut self, n: usize) {
-        self.max_read_size = n.max(1);
-    }
-
-    // =========================================================================
-    // Internal — async handshake (client connect)
-    // =========================================================================
-
-    async fn connect_impl(
-        mut stream: S,
-        url: &str,
-        reader_builder: FrameReaderBuilder,
-        write_cap: usize,
-        max_read_size: usize,
-    ) -> Result<Self, WsError> {
-        let parsed = parse_ws_url(url)?;
-        let host_header = parsed.host_header();
-
-        let key = nexus_net::ws::handshake::generate_key();
-        let key_str =
-            std::str::from_utf8(&key).expect("base64-encoded key is always valid ASCII/UTF-8");
-
-        let headers: [(&str, &str); 5] = [
-            ("Host", &host_header),
-            ("Upgrade", "websocket"),
-            ("Connection", "Upgrade"),
-            ("Sec-WebSocket-Key", key_str),
-            ("Sec-WebSocket-Version", "13"),
-        ];
-        let req_size = nexus_net::http::request_size("GET", parsed.path, &headers);
-        let mut req_buf = vec![0u8; req_size];
-        let n = nexus_net::http::write_request("GET", parsed.path, &headers, &mut req_buf)
-            .map_err(|_| HandshakeError::MalformedHttp)?;
-
-        write_all_async(&mut stream, &req_buf[..n]).await?;
-
-        // Feed bytes directly into resp_reader's spare region via
-        // WireStream — one fewer copy than reading into a tmp slice
-        // and pushing through resp_reader.read().
-        let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
-        loop {
-            // Pre-check the WireStream::poll_fill_into precondition
-            // (sink.spare() non-empty). If full without a parsed
-            // response, the head exceeds capacity — treat as malformed.
-            if resp_reader.spare().is_empty() {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
-            if n == 0 {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            match resp_reader.next() {
-                Ok(Some(resp)) => {
-                    if resp.status != 101 {
-                        return Err(HandshakeError::UnexpectedStatus(resp.status).into());
-                    }
-                    let upgrade = resp
-                        .header("Upgrade")
-                        .ok_or(HandshakeError::MissingUpgrade)?;
-                    if !upgrade.eq_ignore_ascii_case("websocket") {
-                        return Err(HandshakeError::MissingUpgrade.into());
-                    }
-                    let conn = resp
-                        .header("Connection")
-                        .ok_or(HandshakeError::MissingConnection)?;
-                    if !conn
-                        .as_bytes()
-                        .windows(7)
-                        .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
-                    {
-                        return Err(HandshakeError::MissingConnection.into());
-                    }
-                    let accept = resp
-                        .header("Sec-WebSocket-Accept")
-                        .ok_or(HandshakeError::InvalidAcceptKey)?;
-                    if !nexus_net::ws::handshake::validate_accept(key_str, accept) {
-                        return Err(HandshakeError::InvalidAcceptKey.into());
-                    }
-
-                    let mut reader = reader_builder.role(Role::Client).build();
-                    let remainder = resp_reader.remainder();
-                    if !remainder.is_empty() {
-                        reader
-                            .read(remainder)
-                            .map_err(|_| HandshakeError::MalformedHttp)?;
-                    }
-
-                    return Ok(Self {
-                        stream,
+                return Ok((
+                    WsReader {
                         reader,
+                        max_read_size,
+                    },
+                    WsWriter {
                         writer: FrameWriter::new(Role::Client),
                         write_buf: WriteBuf::new(write_cap, 14),
-                        max_read_size,
-                    });
-                }
-                Ok(None) => {} // need more bytes
-                Err(_) => return Err(HandshakeError::MalformedHttp.into()),
+                    },
+                    stream,
+                ));
             }
+            Ok(None) => {}
+            Err(_) => return Err(HandshakeError::MalformedHttp.into()),
+        }
+    }
+}
+
+async fn accept_handshake<S: WireStream + Unpin>(
+    mut stream: S,
+    reader_builder: FrameReaderBuilder,
+    write_cap: usize,
+    max_read_size: usize,
+) -> Result<(WsReader, WsWriter, S), WsError> {
+    let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
+
+    let ws_key;
+    loop {
+        if req_reader.spare().is_empty() {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
+        if n == 0 {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        match req_reader.next() {
+            Ok(Some(req)) => {
+                if req.method != "GET" {
+                    return Err(HandshakeError::MalformedHttp.into());
+                }
+                let upgrade = req
+                    .header("Upgrade")
+                    .ok_or(HandshakeError::MissingUpgrade)?;
+                if !upgrade.eq_ignore_ascii_case("websocket") {
+                    return Err(HandshakeError::MissingUpgrade.into());
+                }
+                let conn = req
+                    .header("Connection")
+                    .ok_or(HandshakeError::MissingConnection)?;
+                if !conn
+                    .as_bytes()
+                    .windows(7)
+                    .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
+                {
+                    return Err(HandshakeError::MissingConnection.into());
+                }
+                let version = req
+                    .header("Sec-WebSocket-Version")
+                    .ok_or(HandshakeError::UnsupportedVersion)?;
+                if version != "13" {
+                    return Err(HandshakeError::UnsupportedVersion.into());
+                }
+                let key = req
+                    .header("Sec-WebSocket-Key")
+                    .ok_or(HandshakeError::MissingKey)?;
+                ws_key = key.to_owned();
+                break;
+            }
+            Ok(None) => {}
+            Err(_) => return Err(HandshakeError::MalformedHttp.into()),
         }
     }
 
-    // =========================================================================
-    // Internal — async accept (server-side)
-    // =========================================================================
+    let accept = nexus_net::ws::handshake::compute_accept_key(&ws_key);
+    let accept_str = std::str::from_utf8(&accept).expect("base64 output is valid ASCII");
 
-    async fn accept_impl(
-        mut stream: S,
-        reader_builder: FrameReaderBuilder,
-        write_cap: usize,
-        max_read_size: usize,
-    ) -> Result<Self, WsError> {
-        let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
+    let resp_headers = [
+        ("Upgrade", "websocket"),
+        ("Connection", "Upgrade"),
+        ("Sec-WebSocket-Accept", accept_str),
+    ];
+    let resp_size = nexus_net::http::response_size("Switching Protocols", &resp_headers);
+    let mut resp_buf = vec![0u8; resp_size];
+    let n =
+        nexus_net::http::write_response(101, "Switching Protocols", &resp_headers, &mut resp_buf)
+            .map_err(|_| HandshakeError::MalformedHttp)?;
+    write_all_async(&mut stream, &resp_buf[..n]).await?;
 
-        let ws_key;
-        loop {
-            // Pre-check the WireStream::poll_fill_into precondition
-            // (sink.spare() non-empty). If full without a parsed
-            // request, the head exceeds capacity — treat as malformed.
-            if req_reader.spare().is_empty() {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            // Direct-feed via WireStream — bytes land in
-            // req_reader.spare() without a tmp slice intermediate.
-            let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
-            if n == 0 {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            match req_reader.next() {
-                Ok(Some(req)) => {
-                    if req.method != "GET" {
-                        return Err(HandshakeError::MalformedHttp.into());
-                    }
-                    let upgrade = req
-                        .header("Upgrade")
-                        .ok_or(HandshakeError::MissingUpgrade)?;
-                    if !upgrade.eq_ignore_ascii_case("websocket") {
-                        return Err(HandshakeError::MissingUpgrade.into());
-                    }
-                    let conn = req
-                        .header("Connection")
-                        .ok_or(HandshakeError::MissingConnection)?;
-                    if !conn
-                        .as_bytes()
-                        .windows(7)
-                        .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
-                    {
-                        return Err(HandshakeError::MissingConnection.into());
-                    }
-                    let version = req
-                        .header("Sec-WebSocket-Version")
-                        .ok_or(HandshakeError::UnsupportedVersion)?;
-                    if version != "13" {
-                        return Err(HandshakeError::UnsupportedVersion.into());
-                    }
-                    let key = req
-                        .header("Sec-WebSocket-Key")
-                        .ok_or(HandshakeError::MissingKey)?;
-                    ws_key = key.to_owned();
-                    break;
-                }
-                Ok(None) => {}
-                Err(_) => return Err(HandshakeError::MalformedHttp.into()),
-            }
-        }
+    let mut reader = reader_builder.role(Role::Server).build();
+    let remainder = req_reader.remainder();
+    if !remainder.is_empty() {
+        reader
+            .read(remainder)
+            .map_err(|_| HandshakeError::MalformedHttp)?;
+    }
 
-        let accept = nexus_net::ws::handshake::compute_accept_key(&ws_key);
-        let accept_str = std::str::from_utf8(&accept).expect("base64 output is valid ASCII");
-
-        let resp_headers = [
-            ("Upgrade", "websocket"),
-            ("Connection", "Upgrade"),
-            ("Sec-WebSocket-Accept", accept_str),
-        ];
-        let resp_size = nexus_net::http::response_size("Switching Protocols", &resp_headers);
-        let mut resp_buf = vec![0u8; resp_size];
-        let n = nexus_net::http::write_response(
-            101,
-            "Switching Protocols",
-            &resp_headers,
-            &mut resp_buf,
-        )
-        .map_err(|_| HandshakeError::MalformedHttp)?;
-        write_all_async(&mut stream, &resp_buf[..n]).await?;
-
-        let mut reader = reader_builder.role(Role::Server).build();
-        let remainder = req_reader.remainder();
-        if !remainder.is_empty() {
-            reader
-                .read(remainder)
-                .map_err(|_| HandshakeError::MalformedHttp)?;
-        }
-
-        Ok(Self {
-            stream,
+    Ok((
+        WsReader {
             reader,
+            max_read_size,
+        },
+        WsWriter {
             writer: FrameWriter::new(Role::Server),
             write_buf: WriteBuf::new(write_cap, 14),
-            max_read_size,
-        })
-    }
+        },
+        stream,
+    ))
 }
 
 // =============================================================================
 // Builder
 // =============================================================================
 
-/// Builder for [`WsStream`].
+/// Builder for WebSocket connections (nexus-async-rt backend).
+///
+/// Returns `(WsReader, WsWriter, S)` — the decomposed sans-IO types.
+///
+/// # Example
+///
+/// ```ignore
+/// let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+///     .disable_nagle()
+///     .connect("ws://localhost:8080/ws")
+///     .await?;
+/// ```
 pub struct WsStreamBuilder {
     reader_builder: FrameReaderBuilder,
     write_buf_capacity: usize,
@@ -455,7 +267,6 @@ impl WsStreamBuilder {
         }
     }
 
-    /// Resolve max_read_size: user override clamped to buffer, or default 1/8 of buffer.
     fn resolved_max_read_size(&self) -> usize {
         self.max_read_size.map_or_else(
             || (self.buffer_capacity / 8).max(1),
@@ -586,7 +397,7 @@ impl WsStreamBuilder {
     /// DNS resolution uses blocking `ToSocketAddrs` (cold path).
     /// TCP connect uses `nexus_async_rt::TcpStream::connect` (mio, non-blocking).
     #[allow(clippy::future_not_send)]
-    pub async fn connect(self, url: &str) -> Result<WsStream<MaybeTls>, WsError> {
+    pub async fn connect(self, url: &str) -> Result<(WsReader, WsWriter, MaybeTls), WsError> {
         let parsed = parse_ws_url(url)?;
         let addr_str = format!("{}:{}", parsed.host, parsed.port);
         let addr = addr_str
@@ -605,7 +416,7 @@ impl WsStreamBuilder {
             Ok::<TcpStream, WsError>(tcp)
         };
 
-        #[allow(unused_mut)] // mut needed when tls feature is enabled
+        #[allow(unused_mut)]
         let mut tcp = match self.connect_timeout {
             Some(dur) => nexus_async_rt::timeout(dur, connect_fn)
                 .await
@@ -643,7 +454,7 @@ impl WsStreamBuilder {
         };
 
         let max_read_size = self.resolved_max_read_size();
-        WsStream::connect_impl(
+        connect_handshake(
             stream,
             url,
             self.reader_builder,
@@ -658,9 +469,9 @@ impl WsStreamBuilder {
         self,
         stream: S,
         url: &str,
-    ) -> Result<WsStream<S>, WsError> {
+    ) -> Result<(WsReader, WsWriter, S), WsError> {
         let max_read_size = self.resolved_max_read_size();
-        WsStream::connect_impl(
+        connect_handshake(
             stream,
             url,
             self.reader_builder,
@@ -671,9 +482,12 @@ impl WsStreamBuilder {
     }
 
     /// Accept an incoming WebSocket connection (server-side).
-    pub async fn accept<S: WireStream + Unpin>(self, stream: S) -> Result<WsStream<S>, WsError> {
+    pub async fn accept<S: WireStream + Unpin>(
+        self,
+        stream: S,
+    ) -> Result<(WsReader, WsWriter, S), WsError> {
         let max_read_size = self.resolved_max_read_size();
-        WsStream::accept_impl(
+        accept_handshake(
             stream,
             self.reader_builder,
             self.write_buf_capacity,
@@ -716,14 +530,14 @@ impl Default for WsStreamBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NexusAsyncReadAdapter;
+    use nexus_net::ws::{CloseCode, Message};
     use std::io::Cursor;
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
-    use crate::NexusAsyncReadAdapter;
     use nexus_async_rt::{AsyncRead, AsyncWrite};
 
-    /// Mock async stream backed by a byte buffer.
     struct MockStream {
         read: Cursor<Vec<u8>>,
         written: Vec<u8>,
@@ -766,7 +580,6 @@ mod tests {
         }
     }
 
-    /// Minimal single-poll executor for futures that resolve immediately.
     fn block_on<F: std::future::Future>(f: F) -> F::Output {
         use std::task::{RawWaker, RawWakerVTable, Waker};
 
@@ -808,19 +621,29 @@ mod tests {
         frame
     }
 
-    fn ws_from_bytes(data: Vec<u8>) -> WsStream<NexusAsyncReadAdapter<MockStream>> {
+    fn parts_from_bytes(data: Vec<u8>) -> (WsReader, WsWriter, NexusAsyncReadAdapter<MockStream>) {
         let mock = NexusAsyncReadAdapter::new(MockStream::from_bytes(data));
         let reader = FrameReader::builder().role(Role::Client).build();
         let writer = FrameWriter::new(Role::Client);
-        WsStream::from_parts(mock, reader, writer)
+        (
+            WsReader {
+                reader,
+                max_read_size: usize::MAX,
+            },
+            WsWriter {
+                writer,
+                write_buf: WriteBuf::new(65_536, 14),
+            },
+            mock,
+        )
     }
 
     #[test]
     fn recv_text() {
         let frame = make_frame(true, 0x1, b"Hello");
-        let mut ws = ws_from_bytes(frame);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "Hello"),
                 other => panic!("expected Text, got {other:?}"),
             }
@@ -830,9 +653,9 @@ mod tests {
     #[test]
     fn recv_binary() {
         let frame = make_frame(true, 0x2, &[0x42; 100]);
-        let mut ws = ws_from_bytes(frame);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Binary(b) => assert_eq!(b.len(), 100),
                 other => panic!("expected Binary, got {other:?}"),
             }
@@ -842,9 +665,9 @@ mod tests {
     #[test]
     fn recv_ping() {
         let frame = make_frame(true, 0x9, b"ping");
-        let mut ws = ws_from_bytes(frame);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Ping(p) => assert_eq!(p, b"ping"),
                 other => panic!("expected Ping, got {other:?}"),
             }
@@ -855,9 +678,9 @@ mod tests {
     fn recv_fragmented_text() {
         let mut data = make_frame(false, 0x1, b"Hel");
         data.extend_from_slice(&make_frame(true, 0x0, b"lo"));
-        let mut ws = ws_from_bytes(data);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "Hello"),
                 other => panic!("expected Text, got {other:?}"),
             }
@@ -869,15 +692,13 @@ mod tests {
         let mut data = make_frame(false, 0x1, b"Hel");
         data.extend_from_slice(&make_frame(true, 0x9, b"ping"));
         data.extend_from_slice(&make_frame(true, 0x0, b"lo"));
-        let mut ws = ws_from_bytes(data);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
         block_on(async {
-            // Ping first
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Ping(p) => assert_eq!(p, b"ping"),
                 other => panic!("expected Ping, got {other:?}"),
             }
-            // Then assembled text
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "Hello"),
                 other => panic!("expected Text, got {other:?}"),
             }
@@ -890,9 +711,9 @@ mod tests {
         payload.extend_from_slice(&1000u16.to_be_bytes());
         payload.extend_from_slice(b"bye");
         let frame = make_frame(true, 0x8, &payload);
-        let mut ws = ws_from_bytes(frame);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Close(cf) => {
                     assert_eq!(cf.code, CloseCode::Normal);
                     assert_eq!(cf.reason, "bye");
@@ -904,9 +725,9 @@ mod tests {
 
     #[test]
     fn eof_returns_none() {
-        let mut ws = ws_from_bytes(Vec::new());
+        let (mut reader, _writer, mut conn) = parts_from_bytes(Vec::new());
         block_on(async {
-            assert!(ws.recv().await.unwrap().is_none());
+            assert!(reader.recv(&mut conn).await.unwrap().is_none());
         });
     }
 
@@ -915,18 +736,18 @@ mod tests {
         let mut data = make_frame(true, 0x1, b"first");
         data.extend_from_slice(&make_frame(true, 0x1, b"second"));
         data.extend_from_slice(&make_frame(true, 0x1, b"third"));
-        let mut ws = ws_from_bytes(data);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
 
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "first"),
                 other => panic!("expected first, got {other:?}"),
             }
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "second"),
                 other => panic!("expected second, got {other:?}"),
             }
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "third"),
                 other => panic!("expected third, got {other:?}"),
             }
@@ -935,40 +756,60 @@ mod tests {
 
     #[test]
     fn send_text_writes_frame() {
-        let mut ws = ws_from_bytes(Vec::new());
+        let (_, mut writer, mut conn) = parts_from_bytes(Vec::new());
         block_on(async {
-            ws.send_text("hello").await.unwrap();
+            writer.send_text(&mut conn, "hello").await.unwrap();
         });
-        // Verify bytes were written to the mock (peek through the adapter).
-        assert!(!ws.stream.get_ref().written.is_empty());
+        assert!(!conn.get_ref().written.is_empty());
     }
 
     #[test]
     fn send_binary_writes_frame() {
-        let mut ws = ws_from_bytes(Vec::new());
+        let (_, mut writer, mut conn) = parts_from_bytes(Vec::new());
         block_on(async {
-            ws.send_binary(&[1, 2, 3]).await.unwrap();
+            writer.send_binary(&mut conn, &[1, 2, 3]).await.unwrap();
         });
-        assert!(!ws.stream.get_ref().written.is_empty());
+        assert!(!conn.get_ref().written.is_empty());
     }
 
     #[test]
-    fn from_parts_construction() {
-        let mock =
-            NexusAsyncReadAdapter::new(MockStream::from_bytes(make_frame(true, 0x1, b"test")));
-        let reader = FrameReader::builder().role(Role::Client).build();
-        let writer = FrameWriter::new(Role::Client);
-        let mut ws = WsStream::from_parts(mock, reader, writer);
+    fn ping_echo_split_borrow() {
+        let mut data = make_frame(true, 0x9, b"ping-data");
+        data.extend_from_slice(&make_frame(true, 0x1, b"hello"));
+        let (mut reader, mut writer, mut conn) = parts_from_bytes(data);
 
         block_on(async {
-            match ws.recv().await.unwrap().unwrap() {
-                Message::Text(s) => assert_eq!(s, "test"),
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
+                Message::Ping(payload) => {
+                    writer.send_pong(&mut conn, payload).await.unwrap();
+                }
+                other => panic!("expected Ping, got {other:?}"),
+            }
+
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
+                Message::Text(s) => assert_eq!(s, "hello"),
                 other => panic!("expected Text, got {other:?}"),
             }
         });
     }
 
-    /// A mock stream that fails all writes with BrokenPipe.
+    #[test]
+    fn text_response_while_holding_message() {
+        let data = make_frame(true, 0x1, b"request");
+        let (mut reader, mut writer, mut conn) = parts_from_bytes(data);
+
+        block_on(async {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
+                Message::Text(req) => {
+                    assert_eq!(req, "request");
+                    let response = format!("echo: {req}");
+                    writer.send_text(&mut conn, &response).await.unwrap();
+                }
+                other => panic!("expected Text, got {other:?}"),
+            }
+        });
+    }
+
     struct BrokenWriteStream(Cursor<Vec<u8>>);
 
     impl AsyncRead for BrokenWriteStream {
@@ -1004,15 +845,17 @@ mod tests {
     #[test]
     fn send_on_broken_stream_returns_error() {
         let mock = NexusAsyncReadAdapter::new(BrokenWriteStream(Cursor::new(Vec::new())));
-        let reader = FrameReader::builder().role(Role::Client).build();
-        let writer = FrameWriter::new(Role::Client);
-        let mut ws = WsStream::from_parts(mock, reader, writer);
+        let mut writer = WsWriter {
+            writer: FrameWriter::new(Role::Client),
+            write_buf: WriteBuf::new(65_536, 14),
+        };
+        let mut conn = mock;
 
         block_on(async {
-            let result = ws.send_text("hello").await;
+            let result = writer.send_text(&mut conn, "hello").await;
             assert!(result.is_err(), "send on broken stream should return error");
 
-            let result = ws.send_binary(&[1, 2, 3]).await;
+            let result = writer.send_binary(&mut conn, &[1, 2, 3]).await;
             assert!(result.is_err(), "subsequent send should also fail");
         });
     }

--- a/nexus-async-net/src/ws/parts.rs
+++ b/nexus-async-net/src/ws/parts.rs
@@ -1,0 +1,226 @@
+//! Sans-IO WebSocket reader/writer — shared by all async backends.
+//!
+//! `WsReader` and `WsWriter` are thin async wrappers around nexus-net's
+//! `FrameReader` and `FrameWriter`. They are runtime-agnostic — any
+//! `S: WireStream + Unpin` transport works.
+
+use std::io;
+use std::pin::Pin;
+
+use nexus_net::buf::WriteBuf;
+use nexus_net::ws::{CloseCode, Error as WsError, FrameReader, FrameWriter, Message};
+use nexus_net::{ParserSink, WireStream};
+
+// =============================================================================
+// Async I/O helpers (poll_fn wrappers over WireStream)
+// =============================================================================
+
+pub(crate) async fn fill_async<W: WireStream + Unpin, P: ParserSink>(
+    s: &mut W,
+    sink: &mut P,
+    max: usize,
+) -> io::Result<usize> {
+    std::future::poll_fn(|cx| Pin::new(&mut *s).poll_fill_into(cx, sink, max)).await
+}
+
+pub(crate) async fn write_all_async<W: WireStream + Unpin>(
+    s: &mut W,
+    mut buf: &[u8],
+) -> io::Result<()> {
+    while !buf.is_empty() {
+        let n = std::future::poll_fn(|cx| Pin::new(&mut *s).poll_write(cx, buf)).await?;
+        if n == 0 {
+            return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
+        }
+        buf = &buf[n..];
+    }
+    Ok(())
+}
+
+// =============================================================================
+// WsReader / WsWriter — decomposed sans-IO halves
+// =============================================================================
+
+/// Read half of a WebSocket connection.
+///
+/// Owns the [`FrameReader`] and parse state. Messages returned by
+/// [`recv`](Self::recv) borrow from this reader's internal buffer,
+/// independently of any [`WsWriter`] or transport state.
+///
+/// # Example
+///
+/// ```ignore
+/// let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+///     .connect("ws://localhost:8080/ws")
+///     .await?;
+///
+/// while let Some(msg) = reader.recv(&mut conn).await? {
+///     match msg {
+///         Message::Ping(data) => writer.send_pong(&mut conn, data).await?,
+///         Message::Text(text) => {
+///             // text borrows from reader — writer and conn are independent
+///             let response = process(text);
+///             writer.send_text(&mut conn, &response).await?;
+///         }
+///         _ => {}
+///     }
+/// }
+/// ```
+pub struct WsReader {
+    pub(crate) reader: FrameReader,
+    pub(crate) max_read_size: usize,
+}
+
+impl WsReader {
+    /// Construct from raw nexus-net types.
+    ///
+    /// For custom handshakes or testing. Prefer using
+    /// [`WsStreamBuilder`](super::WsStreamBuilder) for normal connections.
+    pub fn from_raw_parts(reader: FrameReader, max_read_size: usize) -> Self {
+        Self {
+            reader,
+            max_read_size: max_read_size.max(1),
+        }
+    }
+
+    /// Receive the next message, using `conn` for transport I/O.
+    ///
+    /// The returned [`Message`] borrows from this reader's internal
+    /// buffer. Because the reader and writer are independent types,
+    /// you can hold the message while sending a response through a
+    /// [`WsWriter`].
+    pub async fn recv<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+    ) -> Result<Option<Message<'_>>, WsError> {
+        loop {
+            if self.reader.poll()? {
+                return Ok(self.reader.next()?);
+            }
+
+            if self.reader.should_compact() {
+                self.reader.compact();
+            }
+            if self.reader.spare().is_empty() {
+                self.reader.compact();
+                if self.reader.spare().is_empty() {
+                    return Ok(None);
+                }
+            }
+
+            let n = fill_async(conn, &mut self.reader, self.max_read_size).await?;
+            if n == 0 {
+                return Ok(None);
+            }
+        }
+    }
+
+    /// Access the underlying [`FrameReader`].
+    pub fn frame_reader(&self) -> &FrameReader {
+        &self.reader
+    }
+
+    /// Mutable access to the underlying [`FrameReader`].
+    pub fn frame_reader_mut(&mut self) -> &mut FrameReader {
+        &mut self.reader
+    }
+
+    /// Override max bytes read per recv call.
+    pub fn set_max_read_size(&mut self, n: usize) {
+        self.max_read_size = n.max(1);
+    }
+}
+
+/// Write half of a WebSocket connection.
+///
+/// Owns the [`FrameWriter`] and [`WriteBuf`]. Encodes outgoing
+/// frames and flushes them through a transport connection passed
+/// to each send method.
+pub struct WsWriter {
+    pub(crate) writer: FrameWriter,
+    pub(crate) write_buf: WriteBuf,
+}
+
+impl WsWriter {
+    /// Construct from raw nexus-net types.
+    ///
+    /// For custom handshakes or testing. Prefer using
+    /// [`WsStreamBuilder`](super::WsStreamBuilder) for normal connections.
+    pub fn from_raw_parts(writer: FrameWriter, write_buf: WriteBuf) -> Self {
+        Self { writer, write_buf }
+    }
+
+    /// Send a text message.
+    pub async fn send_text<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+        text: &str,
+    ) -> Result<(), WsError> {
+        self.writer
+            .encode_text_into(text.as_bytes(), &mut self.write_buf);
+        write_all_async(conn, self.write_buf.data()).await?;
+        Ok(())
+    }
+
+    /// Send a binary message.
+    pub async fn send_binary<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+        data: &[u8],
+    ) -> Result<(), WsError> {
+        self.writer.encode_binary_into(data, &mut self.write_buf);
+        write_all_async(conn, self.write_buf.data()).await?;
+        Ok(())
+    }
+
+    /// Send a ping.
+    pub async fn send_ping<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+        data: &[u8],
+    ) -> Result<(), WsError> {
+        self.writer
+            .encode_ping_into(data, &mut self.write_buf)
+            .map_err(WsError::Encode)?;
+        write_all_async(conn, self.write_buf.data()).await?;
+        Ok(())
+    }
+
+    /// Send a pong.
+    pub async fn send_pong<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+        data: &[u8],
+    ) -> Result<(), WsError> {
+        self.writer
+            .encode_pong_into(data, &mut self.write_buf)
+            .map_err(WsError::Encode)?;
+        write_all_async(conn, self.write_buf.data()).await?;
+        Ok(())
+    }
+
+    /// Initiate close handshake.
+    pub async fn close<S: WireStream + Unpin>(
+        &mut self,
+        conn: &mut S,
+        code: CloseCode,
+        reason: &str,
+    ) -> Result<(), WsError> {
+        if code == CloseCode::NoStatus {
+            let mut dst = [0u8; 14];
+            let n = self.writer.encode_empty_close(&mut dst);
+            write_all_async(conn, &dst[..n]).await?;
+        } else {
+            self.writer
+                .encode_close_into(code.as_u16(), reason.as_bytes(), &mut self.write_buf)
+                .map_err(WsError::Encode)?;
+            write_all_async(conn, self.write_buf.data()).await?;
+        }
+        Ok(())
+    }
+
+    /// Access the underlying [`FrameWriter`].
+    pub fn frame_writer(&self) -> &FrameWriter {
+        &self.writer
+    }
+}

--- a/nexus-async-net/src/ws/tokio/mod.rs
+++ b/nexus-async-net/src/ws/tokio/mod.rs
@@ -1,7 +1,9 @@
-//! Async WebSocket — tokio adapter for nexus-net.
+//! Async WebSocket — tokio backend.
 //!
-//! Same FrameReader, same zero-copy Message, same performance.
-//! The only difference is `.await` on socket I/O.
+//! Provides [`WsStreamBuilder`] for connection setup and [`WsStream`]
+//! for `Stream`/`Sink` ecosystem compatibility. The primary API types
+//! ([`WsReader`](super::WsReader) / [`WsWriter`](super::WsWriter))
+//! are re-exported from the parent `ws` module.
 
 mod stream;
 

--- a/nexus-async-net/src/ws/tokio/stream.rs
+++ b/nexus-async-net/src/ws/tokio/stream.rs
@@ -1,70 +1,231 @@
-//! Async WebSocket stream — thin wrapper over nexus-net primitives.
+//! Async WebSocket — tokio backend.
+//!
+//! Builder + handshake logic. `WsReader`/`WsWriter` (the primary API)
+//! live in the shared `ws::parts` module.
 
-use std::io;
 use std::pin::Pin;
 
+use nexus_net::WireStream;
 use nexus_net::buf::WriteBuf;
 use nexus_net::http::HTTP_HANDSHAKE_BUFFER;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_net::ws::{
     CloseCode, Error as WsError, FrameReader, FrameReaderBuilder, FrameWriter, HandshakeError,
-    Message, Role, parse_ws_url,
+    Role, parse_ws_url,
 };
-use nexus_net::{ParserSink, WireStream};
 use tokio::net::TcpStream;
 
 use crate::maybe_tls::MaybeTls;
+use crate::ws::parts::{WsReader, WsWriter, fill_async, write_all_async};
 
 // =============================================================================
-// Async I/O helpers (poll_fn wrappers over WireStream)
+// Handshake — standalone async functions
 // =============================================================================
 
-async fn fill_async<W: WireStream + Unpin, P: ParserSink>(
-    s: &mut W,
-    sink: &mut P,
-    max: usize,
-) -> io::Result<usize> {
-    std::future::poll_fn(|cx| Pin::new(&mut *s).poll_fill_into(cx, sink, max)).await
-}
+async fn connect_handshake<S: WireStream + Unpin>(
+    mut stream: S,
+    url: &str,
+    reader_builder: FrameReaderBuilder,
+    write_cap: usize,
+    max_read_size: usize,
+) -> Result<(WsReader, WsWriter, S), WsError> {
+    let parsed = parse_ws_url(url)?;
+    let host_header = parsed.host_header();
 
-async fn write_all_async<W: WireStream + Unpin>(s: &mut W, mut buf: &[u8]) -> io::Result<()> {
-    while !buf.is_empty() {
-        let n = std::future::poll_fn(|cx| Pin::new(&mut *s).poll_write(cx, buf)).await?;
-        if n == 0 {
-            return Err(io::Error::new(io::ErrorKind::WriteZero, "write returned 0"));
+    let key = nexus_net::ws::handshake::generate_key();
+    let key_str =
+        std::str::from_utf8(&key).expect("base64-encoded key is always valid ASCII/UTF-8");
+
+    let headers: [(&str, &str); 5] = [
+        ("Host", &host_header),
+        ("Upgrade", "websocket"),
+        ("Connection", "Upgrade"),
+        ("Sec-WebSocket-Key", key_str),
+        ("Sec-WebSocket-Version", "13"),
+    ];
+    let req_size = nexus_net::http::request_size("GET", parsed.path, &headers);
+    let mut req_buf = vec![0u8; req_size];
+    let n = nexus_net::http::write_request("GET", parsed.path, &headers, &mut req_buf)
+        .map_err(|_| HandshakeError::MalformedHttp)?;
+
+    write_all_async(&mut stream, &req_buf[..n]).await?;
+
+    let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
+    loop {
+        if resp_reader.spare().is_empty() {
+            return Err(HandshakeError::MalformedHttp.into());
         }
-        buf = &buf[n..];
+        let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
+        if n == 0 {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        match resp_reader.next() {
+            Ok(Some(resp)) => {
+                if resp.status != 101 {
+                    return Err(HandshakeError::UnexpectedStatus(resp.status).into());
+                }
+                let upgrade = resp
+                    .header("Upgrade")
+                    .ok_or(HandshakeError::MissingUpgrade)?;
+                if !upgrade.eq_ignore_ascii_case("websocket") {
+                    return Err(HandshakeError::MissingUpgrade.into());
+                }
+                let conn = resp
+                    .header("Connection")
+                    .ok_or(HandshakeError::MissingConnection)?;
+                if !conn
+                    .as_bytes()
+                    .windows(7)
+                    .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
+                {
+                    return Err(HandshakeError::MissingConnection.into());
+                }
+                let accept = resp
+                    .header("Sec-WebSocket-Accept")
+                    .ok_or(HandshakeError::InvalidAcceptKey)?;
+                if !nexus_net::ws::handshake::validate_accept(key_str, accept) {
+                    return Err(HandshakeError::InvalidAcceptKey.into());
+                }
+
+                let mut reader = reader_builder.role(Role::Client).build();
+                let remainder = resp_reader.remainder();
+                if !remainder.is_empty() {
+                    reader
+                        .read(remainder)
+                        .map_err(|_| HandshakeError::MalformedHttp)?;
+                }
+
+                return Ok((
+                    WsReader {
+                        reader,
+                        max_read_size,
+                    },
+                    WsWriter {
+                        writer: FrameWriter::new(Role::Client),
+                        write_buf: WriteBuf::new(write_cap, 14),
+                    },
+                    stream,
+                ));
+            }
+            Ok(None) => {}
+            Err(_) => return Err(HandshakeError::MalformedHttp.into()),
+        }
     }
-    Ok(())
+}
+
+async fn accept_handshake<S: WireStream + Unpin>(
+    mut stream: S,
+    reader_builder: FrameReaderBuilder,
+    write_cap: usize,
+    max_read_size: usize,
+) -> Result<(WsReader, WsWriter, S), WsError> {
+    let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
+
+    let ws_key;
+    loop {
+        if req_reader.spare().is_empty() {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
+        if n == 0 {
+            return Err(HandshakeError::MalformedHttp.into());
+        }
+        match req_reader.next() {
+            Ok(Some(req)) => {
+                if req.method != "GET" {
+                    return Err(HandshakeError::MalformedHttp.into());
+                }
+                let upgrade = req
+                    .header("Upgrade")
+                    .ok_or(HandshakeError::MissingUpgrade)?;
+                if !upgrade.eq_ignore_ascii_case("websocket") {
+                    return Err(HandshakeError::MissingUpgrade.into());
+                }
+                let conn = req
+                    .header("Connection")
+                    .ok_or(HandshakeError::MissingConnection)?;
+                if !conn
+                    .as_bytes()
+                    .windows(7)
+                    .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
+                {
+                    return Err(HandshakeError::MissingConnection.into());
+                }
+                let version = req
+                    .header("Sec-WebSocket-Version")
+                    .ok_or(HandshakeError::UnsupportedVersion)?;
+                if version != "13" {
+                    return Err(HandshakeError::UnsupportedVersion.into());
+                }
+                let key = req
+                    .header("Sec-WebSocket-Key")
+                    .ok_or(HandshakeError::MissingKey)?;
+                ws_key = key.to_owned();
+                break;
+            }
+            Ok(None) => {}
+            Err(_) => return Err(HandshakeError::MalformedHttp.into()),
+        }
+    }
+
+    let accept = nexus_net::ws::handshake::compute_accept_key(&ws_key);
+    let accept_str = std::str::from_utf8(&accept).expect("base64 output is valid ASCII");
+
+    let resp_headers = [
+        ("Upgrade", "websocket"),
+        ("Connection", "Upgrade"),
+        ("Sec-WebSocket-Accept", accept_str),
+    ];
+    let resp_size = nexus_net::http::response_size("Switching Protocols", &resp_headers);
+    let mut resp_buf = vec![0u8; resp_size];
+    let n =
+        nexus_net::http::write_response(101, "Switching Protocols", &resp_headers, &mut resp_buf)
+            .map_err(|_| HandshakeError::MalformedHttp)?;
+    write_all_async(&mut stream, &resp_buf[..n]).await?;
+
+    let mut reader = reader_builder.role(Role::Server).build();
+    let remainder = req_reader.remainder();
+    if !remainder.is_empty() {
+        reader
+            .read(remainder)
+            .map_err(|_| HandshakeError::MalformedHttp)?;
+    }
+
+    Ok((
+        WsReader {
+            reader,
+            max_read_size,
+        },
+        WsWriter {
+            writer: FrameWriter::new(Role::Server),
+            write_buf: WriteBuf::new(write_cap, 14),
+        },
+        stream,
+    ))
 }
 
 // =============================================================================
-// WsStream
+// WsStream — Stream/Sink ecosystem adapter
 // =============================================================================
 
-/// Async WebSocket stream.
+/// Bundled WebSocket stream for `Stream`/`Sink` ecosystem compatibility.
 ///
-/// Wraps nexus-net's synchronous FrameReader/FrameWriter with async I/O.
-/// Same zero-copy parsing, same Message type — just `.await` on socket ops.
+/// This type exists solely to implement `futures_core::Stream` and
+/// `futures_sink::Sink<OwnedMessage>`. It uses owned messages
+/// (allocates per message) and cannot overlap read/write borrows.
 ///
-/// # Usage
+/// For performance-sensitive code, use [`WsReader`] and [`WsWriter`]
+/// directly — they provide zero-copy messages and independent borrows.
+///
+/// # Construction
 ///
 /// ```ignore
-/// use nexus_async_net::ws::WsStreamBuilder;
-/// use nexus_net::tls::TlsConfig;
-///
-/// // Plain WebSocket
-/// let mut ws = WsStreamBuilder::new().connect("ws://localhost:8080/ws").await?;
-///
-/// // TLS WebSocket
-/// let tls = TlsConfig::new()?;
-/// let mut ws = WsStreamBuilder::new().tls(&tls).connect("wss://exchange.com/ws").await?;
-///
-/// ws.send_text("Hello!").await?;
-/// while let Some(msg) = ws.recv().await? {
-///     // msg is nexus_net::ws::Message<'_>
-/// }
+/// // Connect, then bundle for Stream/Sink usage
+/// let (reader, writer, conn) = WsStreamBuilder::new()
+///     .connect("ws://localhost:8080/ws")
+///     .await?;
+/// let ws = WsStream::from_parts(reader, writer, conn);
 /// ```
 pub struct WsStream<S> {
     stream: S,
@@ -74,28 +235,40 @@ pub struct WsStream<S> {
     max_read_size: usize,
 }
 
-// -- Generic impl for any WireStream-bearing transport ----------------------
-
-impl<S: WireStream + Unpin> WsStream<S> {
-    /// Connect with a pre-connected async stream.
-    pub async fn connect_with(stream: S, url: &str) -> Result<Self, WsError> {
-        WsStreamBuilder::new().connect_with(stream, url).await
+impl<S> WsStream<S> {
+    /// Construct from decomposed parts.
+    ///
+    /// Inverse of [`into_parts`](Self::into_parts).
+    pub fn from_parts(reader: WsReader, writer: WsWriter, stream: S) -> Self {
+        Self {
+            stream,
+            max_read_size: reader.max_read_size,
+            reader: reader.reader,
+            writer: writer.writer,
+            write_buf: writer.write_buf,
+        }
     }
 
-    /// Accept an incoming WebSocket connection (server-side).
-    ///
-    /// Reads the client's HTTP upgrade request, validates it,
-    /// sends back 101 Switching Protocols, and returns a server-role
-    /// WsStream ready for recv/send.
-    pub async fn accept(stream: S) -> Result<Self, WsError> {
-        WsStreamBuilder::new().accept(stream).await
+    /// Decompose into reader, writer, and transport stream.
+    pub fn into_parts(self) -> (WsReader, WsWriter, S) {
+        (
+            WsReader {
+                reader: self.reader,
+                max_read_size: self.max_read_size,
+            },
+            WsWriter {
+                writer: self.writer,
+                write_buf: self.write_buf,
+            },
+            self.stream,
+        )
     }
 
-    /// Create from pre-existing parts. For testing or custom handshakes.
+    /// Low-level construction from raw nexus-net types.
     ///
-    /// `max_read_size` defaults to unlimited. Call [`set_max_read_size`](Self::set_max_read_size)
-    /// after construction to cap per-recv read size for better tail latency.
-    pub fn from_parts(stream: S, reader: FrameReader, writer: FrameWriter) -> Self {
+    /// For testing or custom handshakes. Prefer [`from_parts`](Self::from_parts)
+    /// with builder-produced components.
+    pub fn from_raw_parts(stream: S, reader: FrameReader, writer: FrameWriter) -> Self {
         Self {
             stream,
             reader,
@@ -104,303 +277,24 @@ impl<S: WireStream + Unpin> WsStream<S> {
             max_read_size: usize::MAX,
         }
     }
-
-    /// Receive the next message.
-    pub async fn recv(&mut self) -> Result<Option<Message<'_>>, WsError> {
-        loop {
-            if self.reader.poll()? {
-                return Ok(self.reader.next()?);
-            }
-
-            if self.reader.should_compact() {
-                self.reader.compact();
-            }
-            if self.reader.spare().is_empty() {
-                self.reader.compact();
-                if self.reader.spare().is_empty() {
-                    return Ok(None); // buffer genuinely full
-                }
-            }
-
-            // poll_fill_into delivers bytes directly into reader.spare().
-            let n = fill_async(&mut self.stream, &mut self.reader, self.max_read_size).await?;
-            if n == 0 {
-                return Ok(None); // EOF
-            }
-        }
-    }
-
-    /// Send a text message.
-    pub async fn send_text(&mut self, text: &str) -> Result<(), WsError> {
-        self.writer
-            .encode_text_into(text.as_bytes(), &mut self.write_buf);
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a binary message.
-    pub async fn send_binary(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer.encode_binary_into(data, &mut self.write_buf);
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a ping.
-    pub async fn send_ping(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer
-            .encode_ping_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Send a pong.
-    pub async fn send_pong(&mut self, data: &[u8]) -> Result<(), WsError> {
-        self.writer
-            .encode_pong_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        Ok(())
-    }
-
-    /// Initiate close handshake.
-    pub async fn close(&mut self, code: CloseCode, reason: &str) -> Result<(), WsError> {
-        if code == CloseCode::NoStatus {
-            let mut dst = [0u8; 14];
-            let n = self.writer.encode_empty_close(&mut dst);
-            write_all_async(&mut self.stream, &dst[..n]).await?;
-        } else {
-            self.writer
-                .encode_close_into(code.as_u16(), reason.as_bytes(), &mut self.write_buf)
-                .map_err(WsError::Encode)?;
-            write_all_async(&mut self.stream, self.write_buf.data()).await?;
-        }
-        Ok(())
-    }
-
-    /// Access the underlying stream.
-    pub fn stream(&self) -> &S {
-        &self.stream
-    }
-
-    /// Mutable access to the underlying stream.
-    pub fn stream_mut(&mut self) -> &mut S {
-        &mut self.stream
-    }
-
-    /// Access the FrameReader.
-    pub fn reader(&self) -> &FrameReader {
-        &self.reader
-    }
-
-    /// Access the FrameWriter.
-    pub fn frame_writer(&self) -> &FrameWriter {
-        &self.writer
-    }
-
-    /// Override max bytes read per recv call.
-    pub fn set_max_read_size(&mut self, n: usize) {
-        self.max_read_size = n.max(1);
-    }
-
-    // =========================================================================
-    // Internal — async handshake
-    // =========================================================================
-
-    async fn connect_impl(
-        mut stream: S,
-        url: &str,
-        reader_builder: FrameReaderBuilder,
-        write_cap: usize,
-        max_read_size: usize,
-    ) -> Result<Self, WsError> {
-        let parsed = parse_ws_url(url)?;
-        let host_header = parsed.host_header();
-
-        let key = nexus_net::ws::handshake::generate_key();
-        let key_str =
-            std::str::from_utf8(&key).expect("base64-encoded key is always valid ASCII/UTF-8");
-
-        let headers: [(&str, &str); 5] = [
-            ("Host", &host_header),
-            ("Upgrade", "websocket"),
-            ("Connection", "Upgrade"),
-            ("Sec-WebSocket-Key", key_str),
-            ("Sec-WebSocket-Version", "13"),
-        ];
-        let req_size = nexus_net::http::request_size("GET", parsed.path, &headers);
-        let mut req_buf = vec![0u8; req_size];
-        let n = nexus_net::http::write_request("GET", parsed.path, &headers, &mut req_buf)
-            .map_err(|_| HandshakeError::MalformedHttp)?;
-
-        write_all_async(&mut stream, &req_buf[..n]).await?;
-
-        let mut resp_reader = nexus_net::http::ResponseReader::new(HTTP_HANDSHAKE_BUFFER);
-        loop {
-            // Pre-check the WireStream::poll_fill_into precondition
-            // (sink.spare() non-empty). If full without a parsed
-            // response, the head exceeds capacity — treat as malformed.
-            if resp_reader.spare().is_empty() {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            let n = fill_async(&mut stream, &mut resp_reader, HTTP_HANDSHAKE_BUFFER).await?;
-            if n == 0 {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            match resp_reader.next() {
-                Ok(Some(resp)) => {
-                    if resp.status != 101 {
-                        return Err(HandshakeError::UnexpectedStatus(resp.status).into());
-                    }
-                    let upgrade = resp
-                        .header("Upgrade")
-                        .ok_or(HandshakeError::MissingUpgrade)?;
-                    if !upgrade.eq_ignore_ascii_case("websocket") {
-                        return Err(HandshakeError::MissingUpgrade.into());
-                    }
-                    let conn = resp
-                        .header("Connection")
-                        .ok_or(HandshakeError::MissingConnection)?;
-                    if !conn
-                        .as_bytes()
-                        .windows(7)
-                        .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
-                    {
-                        return Err(HandshakeError::MissingConnection.into());
-                    }
-                    let accept = resp
-                        .header("Sec-WebSocket-Accept")
-                        .ok_or(HandshakeError::InvalidAcceptKey)?;
-                    if !nexus_net::ws::handshake::validate_accept(key_str, accept) {
-                        return Err(HandshakeError::InvalidAcceptKey.into());
-                    }
-
-                    let mut reader = reader_builder.role(Role::Client).build();
-                    let remainder = resp_reader.remainder();
-                    if !remainder.is_empty() {
-                        reader
-                            .read(remainder)
-                            .map_err(|_| HandshakeError::MalformedHttp)?;
-                    }
-
-                    return Ok(Self {
-                        stream,
-                        reader,
-                        writer: FrameWriter::new(Role::Client),
-                        write_buf: WriteBuf::new(write_cap, 14),
-                        max_read_size,
-                    });
-                }
-                Ok(None) => {} // need more bytes
-                Err(_) => return Err(HandshakeError::MalformedHttp.into()),
-            }
-        }
-    }
-
-    // =========================================================================
-    // Internal — async accept (server-side)
-    // =========================================================================
-
-    async fn accept_impl(
-        mut stream: S,
-        reader_builder: FrameReaderBuilder,
-        write_cap: usize,
-        max_read_size: usize,
-    ) -> Result<Self, WsError> {
-        let mut req_reader = nexus_net::http::RequestReader::new(HTTP_HANDSHAKE_BUFFER);
-
-        let ws_key;
-        loop {
-            // Pre-check the WireStream::poll_fill_into precondition
-            // (sink.spare() non-empty). If full without a parsed
-            // request, the head exceeds capacity — treat as malformed.
-            if req_reader.spare().is_empty() {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            let n = fill_async(&mut stream, &mut req_reader, HTTP_HANDSHAKE_BUFFER).await?;
-            if n == 0 {
-                return Err(HandshakeError::MalformedHttp.into());
-            }
-            match req_reader.next() {
-                Ok(Some(req)) => {
-                    if req.method != "GET" {
-                        return Err(HandshakeError::MalformedHttp.into());
-                    }
-                    let upgrade = req
-                        .header("Upgrade")
-                        .ok_or(HandshakeError::MissingUpgrade)?;
-                    if !upgrade.eq_ignore_ascii_case("websocket") {
-                        return Err(HandshakeError::MissingUpgrade.into());
-                    }
-                    let conn = req
-                        .header("Connection")
-                        .ok_or(HandshakeError::MissingConnection)?;
-                    if !conn
-                        .as_bytes()
-                        .windows(7)
-                        .any(|w| w.eq_ignore_ascii_case(b"upgrade"))
-                    {
-                        return Err(HandshakeError::MissingConnection.into());
-                    }
-                    let version = req
-                        .header("Sec-WebSocket-Version")
-                        .ok_or(HandshakeError::UnsupportedVersion)?;
-                    if version != "13" {
-                        return Err(HandshakeError::UnsupportedVersion.into());
-                    }
-                    let key = req
-                        .header("Sec-WebSocket-Key")
-                        .ok_or(HandshakeError::MissingKey)?;
-                    ws_key = key.to_owned();
-                    break;
-                }
-                Ok(None) => {}
-                Err(_) => return Err(HandshakeError::MalformedHttp.into()),
-            }
-        }
-
-        let accept = nexus_net::ws::handshake::compute_accept_key(&ws_key);
-        let accept_str = std::str::from_utf8(&accept).expect("base64 output is valid ASCII");
-
-        let resp_headers = [
-            ("Upgrade", "websocket"),
-            ("Connection", "Upgrade"),
-            ("Sec-WebSocket-Accept", accept_str),
-        ];
-        let resp_size = nexus_net::http::response_size("Switching Protocols", &resp_headers);
-        let mut resp_buf = vec![0u8; resp_size];
-        let n = nexus_net::http::write_response(
-            101,
-            "Switching Protocols",
-            &resp_headers,
-            &mut resp_buf,
-        )
-        .map_err(|_| HandshakeError::MalformedHttp)?;
-        write_all_async(&mut stream, &resp_buf[..n]).await?;
-
-        let mut reader = reader_builder.role(Role::Server).build();
-        let remainder = req_reader.remainder();
-        if !remainder.is_empty() {
-            reader
-                .read(remainder)
-                .map_err(|_| HandshakeError::MalformedHttp)?;
-        }
-
-        Ok(Self {
-            stream,
-            reader,
-            writer: FrameWriter::new(Role::Server),
-            write_buf: WriteBuf::new(write_cap, 14),
-            max_read_size,
-        })
-    }
 }
 
 // =============================================================================
 // Builder
 // =============================================================================
 
-/// Builder for [`WsStream`].
+/// Builder for WebSocket connections.
+///
+/// Returns `(WsReader, WsWriter, S)` — the decomposed sans-IO types.
+///
+/// # Example
+///
+/// ```ignore
+/// let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+///     .disable_nagle()
+///     .connect("ws://localhost:8080/ws")
+///     .await?;
+/// ```
 pub struct WsStreamBuilder {
     reader_builder: FrameReaderBuilder,
     write_buf_capacity: usize,
@@ -442,7 +336,6 @@ impl WsStreamBuilder {
         }
     }
 
-    /// Resolve max_read_size: user override clamped to buffer, or default 1/8 of buffer.
     fn resolved_max_read_size(&self) -> usize {
         self.max_read_size.map_or_else(
             || (self.buffer_capacity / 8).max(1),
@@ -466,9 +359,10 @@ impl WsStreamBuilder {
     ///
     /// Default: 1/8 of buffer capacity. Clamped to `[1, buffer_capacity]`.
     ///
-    /// **Note:** This only affects `recv()`. The `Stream` implementation
-    /// uses the full spare slice for compatibility with `StreamExt` combinators.
-    /// For latency-sensitive code, use `recv()` directly.
+    /// **Note:** This only affects `WsReader::recv()`. The `Stream`
+    /// implementation on [`WsStream`] uses the full spare slice for
+    /// compatibility with `StreamExt` combinators. For latency-sensitive
+    /// code, use `WsReader::recv()` directly.
     #[must_use]
     pub fn max_read_size(mut self, n: usize) -> Self {
         self.max_read_size = Some(n);
@@ -480,8 +374,8 @@ impl WsStreamBuilder {
     /// See [`FrameReaderBuilder::compact_at`](nexus_net::ws::FrameReaderBuilder::compact_at)
     /// for details. Default: 0.5.
     ///
-    /// **Note:** This only affects `recv()`. The `Stream` implementation
-    /// does not use proactive compaction.
+    /// **Note:** This only affects `WsReader::recv()`. The `Stream`
+    /// implementation does not use proactive compaction.
     #[must_use]
     pub fn compact_at(mut self, fraction: f64) -> Self {
         self.reader_builder = self.reader_builder.compact_at(fraction);
@@ -559,7 +453,7 @@ impl WsStreamBuilder {
     }
 
     /// Connect to a WebSocket server. Creates TCP socket, handles TLS.
-    pub async fn connect(self, url: &str) -> Result<WsStream<MaybeTls>, WsError> {
+    pub async fn connect(self, url: &str) -> Result<(WsReader, WsWriter, MaybeTls), WsError> {
         let parsed = parse_ws_url(url)?;
         let addr = format!("{}:{}", parsed.host, parsed.port);
 
@@ -612,7 +506,7 @@ impl WsStreamBuilder {
         };
 
         let max_read_size = self.resolved_max_read_size();
-        WsStream::connect_impl(
+        connect_handshake(
             stream,
             url,
             self.reader_builder,
@@ -627,9 +521,9 @@ impl WsStreamBuilder {
         self,
         stream: S,
         url: &str,
-    ) -> Result<WsStream<S>, WsError> {
+    ) -> Result<(WsReader, WsWriter, S), WsError> {
         let max_read_size = self.resolved_max_read_size();
-        WsStream::connect_impl(
+        connect_handshake(
             stream,
             url,
             self.reader_builder,
@@ -640,9 +534,12 @@ impl WsStreamBuilder {
     }
 
     /// Accept an incoming WebSocket connection (server-side).
-    pub async fn accept<S: WireStream + Unpin>(self, stream: S) -> Result<WsStream<S>, WsError> {
+    pub async fn accept<S: WireStream + Unpin>(
+        self,
+        stream: S,
+    ) -> Result<(WsReader, WsWriter, S), WsError> {
         let max_read_size = self.resolved_max_read_size();
-        WsStream::accept_impl(
+        accept_handshake(
             stream,
             self.reader_builder,
             self.write_buf_capacity,
@@ -677,7 +574,7 @@ impl Default for WsStreamBuilder {
 }
 
 // =============================================================================
-// Stream + Sink (ergonomic path — allocates per message)
+// Stream + Sink (ecosystem compat — allocates per message)
 // =============================================================================
 
 use std::task::{Context, Poll};
@@ -692,8 +589,6 @@ impl<S: WireStream + Unpin> Stream for WsStream<S> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        // Same recv loop structure as recv() — including should_compact
-        // and max_read_size — so Stream users get identical tail latency.
         loop {
             match this.reader.poll() {
                 Ok(true) => {
@@ -703,7 +598,7 @@ impl<S: WireStream + Unpin> Stream for WsStream<S> {
                         Err(e) => Poll::Ready(Some(Err(e.into()))),
                     };
                 }
-                Ok(false) => {} // need more bytes
+                Ok(false) => {}
                 Err(e) => return Poll::Ready(Some(Err(e.into()))),
             }
 
@@ -713,8 +608,6 @@ impl<S: WireStream + Unpin> Stream for WsStream<S> {
             if this.reader.spare().is_empty() {
                 this.reader.compact();
                 if this.reader.spare().is_empty() {
-                    // Buffer full is not EOF — return an error so Stream
-                    // consumers don't silently stop receiving.
                     return Poll::Ready(Some(Err(std::io::Error::other(
                         "websocket read buffer full",
                     )
@@ -727,8 +620,8 @@ impl<S: WireStream + Unpin> Stream for WsStream<S> {
                 &mut this.reader,
                 this.max_read_size,
             ) {
-                Poll::Ready(Ok(0)) => return Poll::Ready(None), // EOF
-                Poll::Ready(Ok(_)) => {}                        // loop back to try parsing
+                Poll::Ready(Ok(0)) => return Poll::Ready(None),
+                Poll::Ready(Ok(_)) => {}
                 Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e.into()))),
                 Poll::Pending => return Poll::Pending,
             }
@@ -785,7 +678,6 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
-        // Write all buffered data, handling partial writes
         while !this.write_buf.is_empty() {
             let data = this.write_buf.data();
             match Pin::new(&mut this.stream).poll_write(cx, data) {
@@ -802,14 +694,12 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
                 Poll::Pending => return Poll::Pending,
             }
         }
-        // All data written — flush the underlying stream
         Pin::new(&mut this.stream)
             .poll_flush(cx)
             .map_err(WsError::Io)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Flush pending data first, then shutdown
         match <Self as Sink<OwnedMessage>>::poll_flush(self.as_mut(), cx) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
@@ -822,16 +712,20 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
     }
 }
 
+// =============================================================================
+// Tests
+// =============================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::AsyncReadAdapter;
+    use nexus_net::ws::Message;
     use std::io::Cursor;
     use std::pin::Pin;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-    /// Mock async stream backed by a byte buffer.
     struct MockStream(Cursor<Vec<u8>>);
 
     impl AsyncRead for MockStream {
@@ -879,18 +773,21 @@ mod tests {
         frame
     }
 
-    fn ws_from_bytes(data: Vec<u8>) -> WsStream<AsyncReadAdapter<MockStream>> {
+    fn parts_from_bytes(data: Vec<u8>) -> (WsReader, WsWriter, AsyncReadAdapter<MockStream>) {
         let mock = AsyncReadAdapter::new(MockStream(Cursor::new(data)));
         let reader = FrameReader::builder().role(Role::Client).build();
         let writer = FrameWriter::new(Role::Client);
-        WsStream::from_parts(mock, reader, writer)
+        let ws = WsStream::from_raw_parts(mock, reader, writer);
+        ws.into_parts()
     }
+
+    // -- Primary API tests (WsReader / WsWriter) -----------------------------
 
     #[tokio::test]
     async fn recv_text() {
         let frame = make_frame(true, 0x1, b"Hello");
-        let mut ws = ws_from_bytes(frame);
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "Hello"),
             other => panic!("expected Text, got {other:?}"),
         }
@@ -899,8 +796,8 @@ mod tests {
     #[tokio::test]
     async fn recv_binary() {
         let frame = make_frame(true, 0x2, &[0x42; 100]);
-        let mut ws = ws_from_bytes(frame);
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Binary(b) => assert_eq!(b.len(), 100),
             other => panic!("expected Binary, got {other:?}"),
         }
@@ -909,8 +806,8 @@ mod tests {
     #[tokio::test]
     async fn recv_ping() {
         let frame = make_frame(true, 0x9, b"ping");
-        let mut ws = ws_from_bytes(frame);
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Ping(p) => assert_eq!(p, b"ping"),
             other => panic!("expected Ping, got {other:?}"),
         }
@@ -920,8 +817,8 @@ mod tests {
     async fn recv_fragmented_text() {
         let mut data = make_frame(false, 0x1, b"Hel");
         data.extend_from_slice(&make_frame(true, 0x0, b"lo"));
-        let mut ws = ws_from_bytes(data);
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "Hello"),
             other => panic!("expected Text, got {other:?}"),
         }
@@ -932,14 +829,12 @@ mod tests {
         let mut data = make_frame(false, 0x1, b"Hel");
         data.extend_from_slice(&make_frame(true, 0x9, b"ping"));
         data.extend_from_slice(&make_frame(true, 0x0, b"lo"));
-        let mut ws = ws_from_bytes(data);
-        // Ping first
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Ping(p) => assert_eq!(p, b"ping"),
             other => panic!("expected Ping, got {other:?}"),
         }
-        // Then assembled text
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "Hello"),
             other => panic!("expected Text, got {other:?}"),
         }
@@ -951,8 +846,8 @@ mod tests {
         payload.extend_from_slice(&1000u16.to_be_bytes());
         payload.extend_from_slice(b"bye");
         let frame = make_frame(true, 0x8, &payload);
-        let mut ws = ws_from_bytes(frame);
-        match ws.recv().await.unwrap().unwrap() {
+        let (mut reader, _writer, mut conn) = parts_from_bytes(frame);
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Close(cf) => {
                 assert_eq!(cf.code, CloseCode::Normal);
                 assert_eq!(cf.reason, "bye");
@@ -963,8 +858,8 @@ mod tests {
 
     #[tokio::test]
     async fn eof_returns_none() {
-        let mut ws = ws_from_bytes(Vec::new());
-        assert!(ws.recv().await.unwrap().is_none());
+        let (mut reader, _writer, mut conn) = parts_from_bytes(Vec::new());
+        assert!(reader.recv(&mut conn).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -972,25 +867,57 @@ mod tests {
         let mut data = make_frame(true, 0x1, b"first");
         data.extend_from_slice(&make_frame(true, 0x1, b"second"));
         data.extend_from_slice(&make_frame(true, 0x1, b"third"));
-        let mut ws = ws_from_bytes(data);
+        let (mut reader, _writer, mut conn) = parts_from_bytes(data);
 
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "first"),
             other => panic!("expected first, got {other:?}"),
         }
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "second"),
             other => panic!("expected second, got {other:?}"),
         }
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "third"),
             other => panic!("expected third, got {other:?}"),
         }
     }
 
-    // =====================================================================
-    // Stream trait tests
-    // =====================================================================
+    #[tokio::test]
+    async fn ping_echo_split_borrow() {
+        let mut data = make_frame(true, 0x9, b"ping-data");
+        data.extend_from_slice(&make_frame(true, 0x1, b"hello"));
+        let (mut reader, mut writer, mut conn) = parts_from_bytes(data);
+
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
+            Message::Ping(payload) => {
+                writer.send_pong(&mut conn, payload).await.unwrap();
+            }
+            other => panic!("expected Ping, got {other:?}"),
+        }
+
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
+            Message::Text(s) => assert_eq!(s, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn text_response_while_holding_message() {
+        let data = make_frame(true, 0x1, b"request");
+        let (mut reader, mut writer, mut conn) = parts_from_bytes(data);
+
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
+            Message::Text(req) => {
+                assert_eq!(req, "request");
+                let response = format!("echo: {req}");
+                writer.send_text(&mut conn, &response).await.unwrap();
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    // -- Stream/Sink tests (WsStream) ----------------------------------------
 
     #[tokio::test]
     async fn stream_yields_owned_messages() {
@@ -998,10 +925,10 @@ mod tests {
 
         let mut data = make_frame(true, 0x1, b"hello");
         data.extend_from_slice(&make_frame(true, 0x2, &[0x42]));
-        let ws = ws_from_bytes(data);
+        let (reader, writer, conn) = parts_from_bytes(data);
+        let ws = WsStream::from_parts(reader, writer, conn);
         let mut ws = pin!(ws);
 
-        // Poll via Stream trait
         let poll_result = futures_core::Stream::poll_next(ws.as_mut(), &mut noop_cx());
         match poll_result {
             Poll::Ready(Some(Ok(OwnedMessage::Text(s)))) => assert_eq!(s, "hello"),
@@ -1013,10 +940,9 @@ mod tests {
             other => panic!("expected Binary, got {other:?}"),
         }
         let poll_result = futures_core::Stream::poll_next(ws.as_mut(), &mut noop_cx());
-        assert!(matches!(poll_result, Poll::Ready(None))); // EOF
+        assert!(matches!(poll_result, Poll::Ready(None)));
     }
 
-    /// Create a no-op waker context for synchronous poll testing.
     fn noop_cx() -> Context<'static> {
         use std::task::{RawWaker, RawWakerVTable, Waker};
         const VTABLE: RawWakerVTable =
@@ -1025,7 +951,6 @@ mod tests {
         // that never dereference the data pointer, so the null data pointer is sound.
         // The vtable is 'static (const) and correctly returns a valid RawWaker on clone.
         let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
-        // Leak the waker to get 'static — fine for tests
         let waker = Box::leak(Box::new(waker));
         Context::from_waker(waker)
     }
@@ -1037,31 +962,35 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        // Server: accept WS upgrade
         let server = tokio::spawn(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut ws = WsStream::accept(AsyncReadAdapter::new(tcp)).await.unwrap();
-            // Server receives a text message
-            match ws.recv().await.unwrap().unwrap() {
+            let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+                .accept(AsyncReadAdapter::new(tcp))
+                .await
+                .unwrap();
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "hello from client"),
                 other => panic!("expected Text, got {other:?}"),
             }
-            // Server sends a response
-            ws.send_text("hello from server").await.unwrap();
+            writer
+                .send_text(&mut conn, "hello from server")
+                .await
+                .unwrap();
         });
 
-        // Client: connect via raw TCP + manual handshake
         let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", addr.port());
-        let mut ws = WsStream::connect_with(AsyncReadAdapter::new(tcp), &url)
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+            .connect_with(AsyncReadAdapter::new(tcp), &url)
             .await
             .unwrap();
 
-        // Client sends
-        ws.send_text("hello from client").await.unwrap();
+        writer
+            .send_text(&mut conn, "hello from client")
+            .await
+            .unwrap();
 
-        // Client receives
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "hello from server"),
             other => panic!("expected Text, got {other:?}"),
         }
@@ -1069,7 +998,6 @@ mod tests {
         server.await.unwrap();
     }
 
-    /// A mock stream that fails all writes with BrokenPipe.
     struct BrokenWriteStream(Cursor<Vec<u8>>);
 
     impl AsyncRead for BrokenWriteStream {
@@ -1108,13 +1036,26 @@ mod tests {
         let mock = AsyncReadAdapter::new(BrokenWriteStream(Cursor::new(Vec::new())));
         let reader = FrameReader::builder().role(Role::Client).build();
         let writer = FrameWriter::new(Role::Client);
-        let mut ws = WsStream::from_parts(mock, reader, writer);
+        let (_, mut ws_writer, mut conn) =
+            WsStream::from_raw_parts(mock, reader, writer).into_parts();
 
-        let result = ws.send_text("hello").await;
+        let result = ws_writer.send_text(&mut conn, "hello").await;
         assert!(result.is_err(), "send on broken stream should return error");
 
-        // Second send should also fail.
-        let result = ws.send_binary(&[1, 2, 3]).await;
+        let result = ws_writer.send_binary(&mut conn, &[1, 2, 3]).await;
         assert!(result.is_err(), "subsequent send should also fail");
+    }
+
+    #[tokio::test]
+    async fn from_parts_roundtrip() {
+        let data = make_frame(true, 0x1, b"test");
+        let (reader, writer, conn) = parts_from_bytes(data);
+        let ws = WsStream::from_parts(reader, writer, conn);
+        let (mut reader, _writer, mut conn) = ws.into_parts();
+
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
+            Message::Text(s) => assert_eq!(s, "test"),
+            other => panic!("expected Text, got {other:?}"),
+        }
     }
 }

--- a/nexus-async-net/tests/maybe_tls_nexus_backpressure.rs
+++ b/nexus-async-net/tests/maybe_tls_nexus_backpressure.rs
@@ -165,9 +165,8 @@ fn maybe_tls_handles_oversize_app_data_burst() {
             .build()
             .expect("client tls config");
 
-        let mut ws = WsStreamBuilder::new()
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
             .tls(&tls_config)
-            // Frame reader buffer must hold the whole 256 KiB message.
             .buffer_capacity(2 * PAYLOAD_LEN)
             .max_frame_size(PAYLOAD_LEN as u64 + 1024)
             .max_message_size(PAYLOAD_LEN + 1024)
@@ -176,8 +175,8 @@ fn maybe_tls_handles_oversize_app_data_burst() {
             .await
             .expect("client wss connect");
 
-        let msg = ws
-            .recv()
+        let msg = reader
+            .recv(&mut conn)
             .await
             .expect("client recv")
             .expect("server closed early");
@@ -189,7 +188,8 @@ fn maybe_tls_handles_oversize_app_data_burst() {
             other => panic!("expected Binary, got {other:?}"),
         }
 
-        ws.close(CloseCode::Normal, "done")
+        writer
+            .close(&mut conn, CloseCode::Normal, "done")
             .await
             .expect("client close");
     });
@@ -218,7 +218,7 @@ fn maybe_tls_handles_large_write_via_chunking() {
 
         // write_buffer_capacity must hold one whole frame; 256 KiB
         // payload + WS header.
-        let mut ws = WsStreamBuilder::new()
+        let (mut _reader, mut writer, mut conn) = WsStreamBuilder::new()
             .tls(&tls_config)
             .write_buffer_capacity(PAYLOAD_LEN + 1024)
             .connect_timeout(Duration::from_secs(15))
@@ -227,9 +227,13 @@ fn maybe_tls_handles_large_write_via_chunking() {
             .expect("client wss connect");
 
         let payload = vec![b'z'; PAYLOAD_LEN];
-        ws.send_binary(&payload).await.expect("client send big");
+        writer
+            .send_binary(&mut conn, &payload)
+            .await
+            .expect("client send big");
 
-        ws.close(CloseCode::Normal, "done")
+        writer
+            .close(&mut conn, CloseCode::Normal, "done")
             .await
             .expect("client close");
     });
@@ -267,7 +271,7 @@ fn maybe_tls_oversize_write_with_tiny_pending_write() {
         let capacities = nexus_net::tls::TlsBufferCapacities::builder()
             .pending_write(8 * 1024)
             .build();
-        let mut ws = WsStreamBuilder::new()
+        let (mut _reader, mut writer, mut conn) = WsStreamBuilder::new()
             .tls(&tls_config)
             .write_buffer_capacity(payload_len + 1024)
             .tls_buffer_capacities(capacities)
@@ -277,9 +281,13 @@ fn maybe_tls_oversize_write_with_tiny_pending_write() {
             .expect("client wss connect");
 
         let payload = vec![b'y'; payload_len];
-        ws.send_binary(&payload).await.expect("client send");
+        writer
+            .send_binary(&mut conn, &payload)
+            .await
+            .expect("client send");
 
-        ws.close(CloseCode::Normal, "done")
+        writer
+            .close(&mut conn, CloseCode::Normal, "done")
             .await
             .expect("client close");
     });

--- a/nexus-async-net/tests/ws_nexus_integration.rs
+++ b/nexus-async-net/tests/ws_nexus_integration.rs
@@ -8,7 +8,7 @@
 #![cfg(feature = "nexus")]
 
 use nexus_async_net::NexusAsyncReadAdapter;
-use nexus_async_net::ws::{WsStream, WsStreamBuilder};
+use nexus_async_net::ws::WsStreamBuilder;
 use nexus_async_rt::{Runtime, TcpListener, TcpStream, spawn_boxed};
 use nexus_net::ws::{CloseCode, Message};
 use nexus_rt::WorldBuilder;
@@ -30,30 +30,35 @@ fn text_echo_loopback() {
         let mut listener = TcpListener::bind(addr).unwrap();
         let local_addr = listener.local_addr().unwrap();
 
-        // Server
         let server = spawn_boxed(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut ws = WsStream::accept(NexusAsyncReadAdapter::new(tcp))
+            let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+                .accept(NexusAsyncReadAdapter::new(tcp))
                 .await
                 .unwrap();
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Text(s) => assert_eq!(s, "hello from client"),
                 other => panic!("server expected Text, got {other:?}"),
             }
-            ws.send_text("hello from server").await.unwrap();
+            writer
+                .send_text(&mut conn, "hello from server")
+                .await
+                .unwrap();
         });
 
-        // Client
         let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
-        let mut ws = WsStreamBuilder::new()
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
             .await
             .unwrap();
 
-        ws.send_text("hello from client").await.unwrap();
+        writer
+            .send_text(&mut conn, "hello from client")
+            .await
+            .unwrap();
 
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Text(s) => assert_eq!(s, "hello from server"),
             other => panic!("client expected Text, got {other:?}"),
         }
@@ -79,29 +84,30 @@ fn binary_roundtrip_loopback() {
 
         let server = spawn_boxed(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut ws = WsStream::accept(NexusAsyncReadAdapter::new(tcp))
+            let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+                .accept(NexusAsyncReadAdapter::new(tcp))
                 .await
                 .unwrap();
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Binary(b) => {
                     assert_eq!(b.len(), 256);
                     assert_eq!(b[0], 0xAB);
                 }
                 other => panic!("server expected Binary, got {other:?}"),
             }
-            ws.send_binary(&[0xCD; 128]).await.unwrap();
+            writer.send_binary(&mut conn, &[0xCD; 128]).await.unwrap();
         });
 
         let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
-        let mut ws = WsStreamBuilder::new()
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
             .await
             .unwrap();
 
-        ws.send_binary(&[0xAB; 256]).await.unwrap();
+        writer.send_binary(&mut conn, &[0xAB; 256]).await.unwrap();
 
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Binary(b) => {
                 assert_eq!(b.len(), 128);
                 assert_eq!(b[0], 0xCD);
@@ -130,31 +136,30 @@ fn ping_pong_loopback() {
 
         let server = spawn_boxed(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut ws = WsStream::accept(NexusAsyncReadAdapter::new(tcp))
+            let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
+                .accept(NexusAsyncReadAdapter::new(tcp))
                 .await
                 .unwrap();
-            // Receive ping
-            let ping_data = match ws.recv().await.unwrap().unwrap() {
+            let ping_data = match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Ping(p) => {
                     assert_eq!(p, b"heartbeat");
                     p.to_vec()
                 }
                 other => panic!("server expected Ping, got {other:?}"),
             };
-            // Reply with pong
-            ws.send_pong(&ping_data).await.unwrap();
+            writer.send_pong(&mut conn, &ping_data).await.unwrap();
         });
 
         let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
-        let mut ws = WsStreamBuilder::new()
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
             .await
             .unwrap();
 
-        ws.send_ping(b"heartbeat").await.unwrap();
+        writer.send_ping(&mut conn, b"heartbeat").await.unwrap();
 
-        match ws.recv().await.unwrap().unwrap() {
+        match reader.recv(&mut conn).await.unwrap().unwrap() {
             Message::Pong(p) => assert_eq!(p, b"heartbeat"),
             other => panic!("client expected Pong, got {other:?}"),
         }
@@ -180,10 +185,11 @@ fn close_handshake_loopback() {
 
         let server = spawn_boxed(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut ws = WsStream::accept(NexusAsyncReadAdapter::new(tcp))
+            let (mut reader, _writer, mut conn) = WsStreamBuilder::new()
+                .accept(NexusAsyncReadAdapter::new(tcp))
                 .await
                 .unwrap();
-            match ws.recv().await.unwrap().unwrap() {
+            match reader.recv(&mut conn).await.unwrap().unwrap() {
                 Message::Close(cf) => {
                     assert_eq!(cf.code, CloseCode::Normal);
                     assert_eq!(cf.reason, "done");
@@ -194,12 +200,15 @@ fn close_handshake_loopback() {
 
         let tcp = TcpStream::connect(local_addr).unwrap();
         let url = format!("ws://127.0.0.1:{}/ws", local_addr.port());
-        let mut ws = WsStreamBuilder::new()
+        let (_reader, mut writer, mut conn) = WsStreamBuilder::new()
             .connect_with(NexusAsyncReadAdapter::new(tcp), &url)
             .await
             .unwrap();
 
-        ws.close(CloseCode::Normal, "done").await.unwrap();
+        writer
+            .close(&mut conn, CloseCode::Normal, "done")
+            .await
+            .unwrap();
 
         server.await;
     });

--- a/nexus-async-net/tests/ws_nexus_tls_loopback.rs
+++ b/nexus-async-net/tests/ws_nexus_tls_loopback.rs
@@ -171,7 +171,7 @@ fn nexus_async_wss_echo_with_oversize_handshake_burst() {
         // async TLS handshake which calls `read_and_process_tls` on
         // each ciphertext chunk read from the async socket — the bug
         // surface for #200.
-        let mut ws = WsStreamBuilder::new()
+        let (mut reader, mut writer, mut conn) = WsStreamBuilder::new()
             .tls(&tls_config)
             .connect_timeout(Duration::from_secs(15))
             .connect(&format!("wss://127.0.0.1:{port}/"))
@@ -180,9 +180,12 @@ fn nexus_async_wss_echo_with_oversize_handshake_burst() {
 
         // Text echo round-trip.
         let probe = "hello-from-#200-async-regression-test";
-        ws.send_text(probe).await.expect("client send");
-        match ws
-            .recv()
+        writer
+            .send_text(&mut conn, probe)
+            .await
+            .expect("client send");
+        match reader
+            .recv(&mut conn)
             .await
             .expect("client recv")
             .expect("server closed early")
@@ -193,9 +196,12 @@ fn nexus_async_wss_echo_with_oversize_handshake_burst() {
 
         // Larger payload to keep the data path honest.
         let big = "x".repeat(8192);
-        ws.send_text(&big).await.expect("client send big");
-        match ws
-            .recv()
+        writer
+            .send_text(&mut conn, &big)
+            .await
+            .expect("client send big");
+        match reader
+            .recv(&mut conn)
             .await
             .expect("client recv big")
             .expect("server closed early")
@@ -204,7 +210,8 @@ fn nexus_async_wss_echo_with_oversize_handshake_burst() {
             other => panic!("expected Text, got {other:?}"),
         }
 
-        ws.close(CloseCode::Normal, "done")
+        writer
+            .close(&mut conn, CloseCode::Normal, "done")
             .await
             .expect("client close");
     });


### PR DESCRIPTION
## Summary

- **Decomposed WebSocket API (#400)**: `WsReader`/`WsWriter` are now the primary interface. Builders return `(WsReader, WsWriter, S)` tuples instead of a bundled `WsStream`. Reader and writer are independent borrows — zero-copy `Message<'_>` from recv can be held while sending through the writer. `WsStream` is demoted to a Stream/Sink ecosystem adapter (tokio backend only).
- **Targeted re-exports (#399)**: Replace blanket `pub use nexus_net` with explicit re-exports (`CloseCode`, `FrameReader`, `Message`, `Role`, `WireStream`, `WriteBuf`, etc.). Downstream crates see exactly what nexus-async-net intends to expose.
- Pre-existing clippy `collapsible_if` fix in `rest/nexus/connection.rs`.

## Motivation

The bundled `WsStream` struct created a split-borrow conflict: `recv()` returns `Message<'_>` borrowing from the reader, blocking any `send_*(&mut self)` call until the message is dropped. The decomposed API eliminates this — reader, writer, and connection are independent types with independent borrows. This is the sans-IO pattern used in HFT systems and matches how nexus-net already separates `FrameReader`/`FrameWriter`.

## Test plan

- [x] Tokio backend: 46 unit tests pass
- [x] Nexus backend: 28 unit + 4 integration + 3 TLS backpressure + 1 TLS loopback + 1 handshake = 37 tests pass
- [x] All 4 benchmark files compile and use decomposed API
- [x] `cargo clippy -- -D warnings` clean (tokio, nexus, +tls combinations)
- [x] `cargo fmt --check` clean

Closes #399, closes #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)