### PR TITLE
release: nexus-async-net 0.9.0

### DIFF
--- a/nexus-async-net/CHANGELOG.md
+++ b/nexus-async-net/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-30
+
 ### Changed
 
 - **Breaking**: `WsStreamBuilder::connect()`, `connect_with()`, and

--- a/nexus-async-net/Cargo.toml
+++ b/nexus-async-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-async-net"
-version = "0.8.0"
+version = "0.9.0"
 description = "Async WebSocket adapter for nexus-net. Tokio-compatible, zero-copy, SIMD-accelerated."
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG for nexus-async-net 0.9.0.

Includes the breaking API changes from #401:
- `WsStreamBuilder::connect()` / `connect_with()` / `accept()` return `(WsReader, WsWriter, S)` tuples
- Blanket `pub use nexus_net` replaced with targeted re-exports
- `WsStream` demoted to Stream/Sink adapter (tokio only)

## Release checklist

- [x] Cargo.toml version: 0.9.0
- [x] CHANGELOG `[Unreleased]` → `[0.9.0] — 2026-05-30`
- [x] After merge: `tools/release.sh nexus-async-net minor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)