### PR TITLE
nexus-shm: foundation layer (#390)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 	"nexus-logbuf",
 	"nexus-pool",
 	"nexus-queue",
+	"nexus-shm",
 	"nexus-slab",
 	"nexus-slot",
 	"nexus-smartptr",

--- a/nexus-shm/Cargo.toml
+++ b/nexus-shm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nexus-shm"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Shared-memory IPC primitives for multi-process trading systems"
+repository.workspace = true
+keywords = ["shared-memory", "ipc", "mmap", "low-latency", "lock-free"]
+categories = ["concurrency", "data-structures", "os::unix-apis"]
+
+[lints]
+workspace = true
+
+[dependencies]
+crossbeam-utils.workspace = true
+nix = { version = "0.30", features = ["mman"] }

--- a/nexus-shm/Cargo.toml
+++ b/nexus-shm/Cargo.toml
@@ -14,4 +14,4 @@ workspace = true
 
 [dependencies]
 crossbeam-utils.workspace = true
-nix = { version = "0.30", features = ["mman"] }
+nix = { version = "0.30", features = ["mman", "fs"] }

--- a/nexus-shm/Cargo.toml
+++ b/nexus-shm/Cargo.toml
@@ -15,3 +15,10 @@ workspace = true
 [dependencies]
 crossbeam-utils.workspace = true
 nix = { version = "0.30", features = ["mman", "fs"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "ofd_liveness"
+harness = false

--- a/nexus-shm/README.md
+++ b/nexus-shm/README.md
@@ -1,0 +1,130 @@
+# nexus-shm
+
+Shared-memory IPC primitives for multi-process trading systems.
+
+> **Status: foundation in progress.** The mmap lifecycle, two-tier liveness,
+> and the primitives below are under active development on top of the
+> foundation layer that exists today (`Pod`, the segment control block). Track
+> progress in [#390](https://github.com/Abso1ut3Zer0/nexus/issues/390).
+
+## Overview
+
+`nexus-shm` extends nexus's single-process primitives across the process
+boundary: cross-process messaging and durable storage over memory-mapped files,
+with the same principles — bounded, pre-allocated, cache-line aware, and honest
+about its failure modes.
+
+The ring buffer is the easy part; nexus-queue already solves that. The hard
+parts are what live here:
+
+- **Liveness** — telling a dead peer from a busy one without blocking your side.
+- **Crash recovery** — a `SIGKILL` leaves half-written state in shared memory;
+  there is no unwinding and no RAII cleanup on the far side.
+- **Memory lifecycle** — who creates the mapping, who attaches, what happens
+  when one side restarts.
+
+These problems shape the memory layout, so they are designed first.
+
+## Primitives
+
+| Primitive | Role | Tracking |
+|-----------|------|----------|
+| `ShmJournal` | Append-only durable log (FIX journaling, replay) | [#391](https://github.com/Abso1ut3Zer0/nexus/issues/391) |
+| `ShmRingBuffer` | Cross-process SPSC ring buffer (market-data fan-out) | [#392](https://github.com/Abso1ut3Zer0/nexus/issues/392) |
+| `ShmSlot` | Cross-process seqlock slot (latest-value snapshots) | [#393](https://github.com/Abso1ut3Zer0/nexus/issues/393) |
+
+All three sit on a common mmap foundation: get it right once, everything above
+inherits it.
+
+## Liveness — two-tier
+
+A reader cannot trust a peer to be alive just because a shared atomic says so.
+Under `panic=abort`, `SIGKILL`, or a segfault no `Drop` runs, so the atomic
+stays `ALIVE` forever. Timing-based heartbeats can't separate a dead peer from a
+busy one either. So liveness is split into a fast hint and a definitive source
+of truth:
+
+| Tier | Mechanism | Cost | Catches | Misses |
+|------|-----------|------|---------|--------|
+| **1** | Atomic status field (`ALIVE`/`DEAD` via `Drop` guard) | ~1 cycle | Graceful shutdown, unwinding panic | `panic=abort`, `SIGKILL`, segfault |
+| **2** | OFD lock (`fcntl`), kernel-released on death | a syscall | *Any* process death, including `SIGKILL` | — |
+
+Tier 1 is the hot-path hint; **Tier 2 is the source of truth**. Under
+`panic=abort`, Tier 2 is mandatory, not optional. For in-process shared memory
+(same process reads and writes — e.g. a FIX journal), Tier 1 alone suffices:
+process death takes out both ends, so no surviving peer can be misled.
+
+Detection policy stays with the caller. The library exposes a liveness query
+but never calls it on the hot path — the OFD-lock syscall is too costly to run
+per message, so the caller decides when (on attach, on a slow timer, on a
+suspected stall). A **generation counter** in the control block ties the tiers
+together: an attacher that sees `ALIVE` but finds the kernel lock free knows the
+previous owner died hard, bumps the generation, and runs recovery. That
+staleness signal is structural, not timing-based, and stays unambiguous across
+PID reuse.
+
+## The `Pod` Trait
+
+Every type stored in shared memory must be `Pod` (Plain Old Data): a flat value
+with a stable `repr`-defined layout, no pointers, and no `Drop` glue. The bytes
+*are* the value, so they stay meaningful when byte-copied between processes that
+mapped the segment at different addresses.
+
+```rust
+use nexus_shm::Pod;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct BookSnapshot {
+    bids: [f64; 20],
+    asks: [f64; 20],
+    sequence: u64,
+}
+
+// SAFETY: flat repr(C), no pointers, no Drop, valid for every bit pattern.
+unsafe impl Pod for BookSnapshot {}
+```
+
+This is stricter than nexus-slot's `Pod`. A reader may observe bytes mid-write
+or from a crashed writer, so a `Pod` type must be **valid for every bit pattern
+of its size**. That is why `bool` and `char` are *not* `Pod` here even though
+they are `Copy`: most bit patterns are invalid for them, and observing one
+across the process boundary would be instant UB. Integers, floats, and arrays
+of `Pod` are covered; compose your own types from those.
+
+## Design
+
+The first bytes of every segment are a fixed control block carrying only
+*universal* metadata — identity, the two liveness fields, and the payload
+length:
+
+```text
+offset 0  ┌──────────────────────────────────────────────┐
+          │ ControlBlock  (CachePadded — owns its line)   │
+          │   magic · layout_ver · flags                  │  identity
+          │   generation · status · owner_pid             │  liveness
+          │   data_len                                    │
+          ├──────────────────────────────────────────────┤
+          │ Per-primitive header  (own cache line)        │  ring head/tail,
+          │   ...                                         │  slot sequence, ...
+          ├──────────────────────────────────────────────┤
+          │ Payload                                       │
+          └──────────────────────────────────────────────┘
+```
+
+The control block is payload-agnostic. Per-primitive metadata lives in each
+primitive's own header on its own cache line, so hot per-message state (a ring's
+head/tail, a slot's sequence counter) never false-shares with the rarely-written
+control fields. `CachePadded` keeps this portable across cache-line sizes
+(64-byte on x86-64, 128-byte on some aarch64).
+
+## References
+
+- **Aeron** — log-buffer design, archive model, commit-marker recovery.
+- **iceoryx2** — `fcntl` advisory locks in production (validates Tier 2).
+- **nexus-queue / nexus-slot** — single-process patterns this mirrors
+  (cache-line padding, manual fencing, the seqlock).
+
+## License
+
+MIT OR Apache-2.0

--- a/nexus-shm/benches/ofd_liveness.rs
+++ b/nexus-shm/benches/ofd_liveness.rs
@@ -1,0 +1,34 @@
+//! Cost of a Tier-2 liveness query (`F_OFD_GETLK`) against a live owner.
+//!
+//! Pin to a physical core with turbo disabled for stable numbers:
+//!
+//! ```bash
+//! echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+//! taskset -c 2 cargo bench -p nexus-shm --bench ofd_liveness
+//! ```
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nexus_shm::{Liveness, MapOptions, Segment};
+
+fn bench_peer_liveness(c: &mut Criterion) {
+    let path = std::env::temp_dir().join(format!("nexus-shm-bench-{}", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+
+    let owner = Segment::create(&path, 4096, MapOptions::default()).unwrap();
+    let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+    assert_eq!(peer.peer_liveness(), Liveness::Alive);
+
+    c.benchmark_group("ofd_liveness")
+        .bench_function("peer_liveness_getlk", |b| {
+            b.iter(|| black_box(black_box(&peer).peer_liveness()));
+        });
+
+    drop(owner);
+    drop(peer);
+    let _ = std::fs::remove_file(&path);
+}
+
+criterion_group!(benches, bench_peer_liveness);
+criterion_main!(benches);

--- a/nexus-shm/src/control.rs
+++ b/nexus-shm/src/control.rs
@@ -1,0 +1,156 @@
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use crossbeam_utils::CachePadded;
+
+use crate::error::ShmError;
+
+pub(crate) const MAGIC: u32 = u32::from_le_bytes(*b"NXSM");
+pub(crate) const LAYOUT_VERSION: u16 = 1;
+
+pub(crate) mod status {
+    #[cfg(test)]
+    pub(crate) const UNINIT: u32 = 0;
+    pub(crate) const ALIVE: u32 = 1;
+    pub(crate) const DEAD: u32 = 2;
+}
+
+#[repr(C)]
+pub(crate) struct ControlBlockInner {
+    pub(crate) magic: u32,
+    pub(crate) layout_ver: u16,
+    pub(crate) flags: u16,
+    pub(crate) generation: AtomicU64,
+    pub(crate) status: AtomicU32,
+    pub(crate) owner_pid: AtomicU32,
+    pub(crate) data_len: u64,
+}
+
+const _: () = {
+    assert!(size_of::<ControlBlockInner>() == 32);
+    assert!(align_of::<ControlBlockInner>() == 8);
+};
+
+impl ControlBlockInner {
+    #[cfg(test)]
+    pub(crate) const fn zeroed() -> Self {
+        Self {
+            magic: 0,
+            layout_ver: 0,
+            flags: 0,
+            generation: AtomicU64::new(0),
+            status: AtomicU32::new(0),
+            owner_pid: AtomicU32::new(0),
+            data_len: 0,
+        }
+    }
+
+    pub(crate) fn write_header(
+        &mut self,
+        flags: u16,
+        generation: u64,
+        owner_pid: u32,
+        data_len: u64,
+    ) {
+        self.magic = MAGIC;
+        self.layout_ver = LAYOUT_VERSION;
+        self.flags = flags;
+        self.data_len = data_len;
+        *self.generation.get_mut() = generation;
+        *self.owner_pid.get_mut() = owner_pid;
+        self.status.store(status::ALIVE, Ordering::Release);
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), ShmError> {
+        if self.magic != MAGIC {
+            return Err(ShmError::BadMagic { found: self.magic });
+        }
+        if self.layout_ver != LAYOUT_VERSION {
+            return Err(ShmError::UnsupportedLayout {
+                found: self.layout_ver,
+                expected: LAYOUT_VERSION,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn status(&self) -> u32 {
+        self.status.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn mark_dead(&self) {
+        self.status.store(status::DEAD, Ordering::Release);
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) const fn data_len(&self) -> u64 {
+        self.data_len
+    }
+}
+
+#[repr(transparent)]
+pub(crate) struct ControlBlock(pub(crate) CachePadded<ControlBlockInner>);
+
+impl core::ops::Deref for ControlBlock {
+    type Target = ControlBlockInner;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::DerefMut for ControlBlock {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ControlBlock, ControlBlockInner, LAYOUT_VERSION, MAGIC, status};
+    use crossbeam_utils::CachePadded;
+
+    fn fresh() -> ControlBlock {
+        ControlBlock(CachePadded::new(ControlBlockInner::zeroed()))
+    }
+
+    #[test]
+    fn control_block_is_cache_line_isolated() {
+        let align = align_of::<ControlBlock>();
+        assert!(align >= 64, "control block not cache-line aligned: {align}");
+        assert_eq!(size_of::<ControlBlock>(), align);
+    }
+
+    #[test]
+    fn write_then_validate_roundtrips() {
+        let mut cb = fresh();
+        assert_eq!(cb.status(), status::UNINIT);
+        cb.write_header(0b10, 7, 4242, 1 << 20);
+        cb.validate().unwrap();
+        assert_eq!(cb.magic, MAGIC);
+        assert_eq!(cb.layout_ver, LAYOUT_VERSION);
+        assert_eq!(cb.flags, 0b10);
+        assert_eq!(cb.generation(), 7);
+        assert_eq!(cb.status(), status::ALIVE);
+        assert_eq!(cb.data_len(), 1 << 20);
+    }
+
+    #[test]
+    fn rejects_foreign_segment() {
+        let cb = fresh();
+        assert!(matches!(
+            cb.validate(),
+            Err(crate::ShmError::BadMagic { found: 0 })
+        ));
+    }
+
+    #[test]
+    fn liveness_transitions() {
+        let mut cb = fresh();
+        cb.write_header(0, 3, 1, 0);
+        assert_eq!(cb.status(), status::ALIVE);
+        assert_eq!(cb.generation(), 3);
+        cb.mark_dead();
+        assert_eq!(cb.status(), status::DEAD);
+    }
+}

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -6,6 +6,7 @@ pub enum ShmError {
     BadMagic { found: u32 },
     UnsupportedLayout { found: u16, expected: u16 },
     EmptySegment,
+    SizeOverflow,
     HugePagesUnavailable(std::io::Error),
     OwnerActive,
     Os(std::io::Error),
@@ -18,7 +19,8 @@ impl fmt::Display for ShmError {
             Self::UnsupportedLayout { found, expected } => {
                 write!(f, "unsupported layout version {found}, expected {expected}")
             }
-            Self::EmptySegment => write!(f, "segment has zero length"),
+            Self::EmptySegment => write!(f, "segment has zero data length"),
+            Self::SizeOverflow => write!(f, "segment size overflows usize"),
             Self::HugePagesUnavailable(e) => write!(f, "huge pages unavailable: {e}"),
             Self::OwnerActive => write!(f, "segment already owned by a live process"),
             Self::Os(e) => write!(f, "{e}"),

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ShmError {
+    BadMagic { found: u32 },
+    UnsupportedLayout { found: u16, expected: u16 },
+    EmptySegment,
+    HugePagesUnavailable(std::io::Error),
+    Os(std::io::Error),
+}
+
+impl fmt::Display for ShmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadMagic { found } => write!(f, "not a nexus-shm segment (magic {found:#010x})"),
+            Self::UnsupportedLayout { found, expected } => {
+                write!(f, "unsupported layout version {found}, expected {expected}")
+            }
+            Self::EmptySegment => write!(f, "segment has zero length"),
+            Self::HugePagesUnavailable(e) => write!(f, "huge pages unavailable: {e}"),
+            Self::Os(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ShmError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::HugePagesUnavailable(e) | Self::Os(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ShmError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Os(e)
+    }
+}

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -7,6 +7,7 @@ pub enum ShmError {
     UnsupportedLayout { found: u16, expected: u16 },
     EmptySegment,
     HugePagesUnavailable(std::io::Error),
+    OwnerActive,
     Os(std::io::Error),
 }
 
@@ -19,6 +20,7 @@ impl fmt::Display for ShmError {
             }
             Self::EmptySegment => write!(f, "segment has zero length"),
             Self::HugePagesUnavailable(e) => write!(f, "huge pages unavailable: {e}"),
+            Self::OwnerActive => write!(f, "segment already owned by a live process"),
             Self::Os(e) => write!(f, "{e}"),
         }
     }

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -15,4 +15,4 @@ pub use error::ShmError;
 pub use lock::Liveness;
 pub use pod::Pod;
 pub use region::MapOptions;
-pub use segment::{PeerStatus, Segment};
+pub use segment::{Segment, Status};

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -1,0 +1,16 @@
+//! Shared-memory IPC primitives for multi-process trading systems.
+//!
+//! See `docs/design/nexus-shm.md`. This module tree currently implements the
+//! foundation layer: the [`Pod`] boundary, the segment control block, and the
+//! mmap-backed [`Segment`] with Tier-1 liveness.
+
+pub(crate) mod control;
+mod error;
+mod pod;
+mod region;
+mod segment;
+
+pub use error::ShmError;
+pub use pod::Pod;
+pub use region::MapOptions;
+pub use segment::{PeerStatus, Segment};

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -1,16 +1,18 @@
 //! Shared-memory IPC primitives for multi-process trading systems.
 //!
 //! See `docs/design/nexus-shm.md`. This module tree currently implements the
-//! foundation layer: the [`Pod`] boundary, the segment control block, and the
-//! mmap-backed [`Segment`] with Tier-1 liveness.
+//! foundation layer: the [`Pod`] boundary, the segment control block, the
+//! mmap-backed [`Segment`], and two-tier liveness (atomic status + OFD lock).
 
 pub(crate) mod control;
 mod error;
+mod lock;
 mod pod;
 mod region;
 mod segment;
 
 pub use error::ShmError;
+pub use lock::Liveness;
 pub use pod::Pod;
 pub use region::MapOptions;
 pub use segment::{PeerStatus, Segment};

--- a/nexus-shm/src/lock.rs
+++ b/nexus-shm/src/lock.rs
@@ -17,6 +17,8 @@ pub enum Liveness {
 }
 
 fn owner_flock(l_type: libc::c_short) -> libc::flock {
+    // SAFETY: `flock` is a plain C struct of integers; all-zero is a valid
+    // value, and every field is set before use.
     let mut lk: libc::flock = unsafe { std::mem::zeroed() };
     lk.l_type = l_type;
     lk.l_whence = libc::SEEK_SET as libc::c_short;
@@ -30,7 +32,7 @@ pub(crate) fn acquire_owner(fd: BorrowedFd<'_>) -> Result<bool, ShmError> {
     match fcntl(fd, FcntlArg::F_OFD_SETLK(&lk)) {
         Ok(_) => Ok(true),
         Err(Errno::EACCES | Errno::EAGAIN) => Ok(false),
-        Err(e) => Err(ShmError::Os(std::io::Error::from_raw_os_error(e as i32))),
+        Err(e) => Err(ShmError::Os(e.into())),
     }
 }
 

--- a/nexus-shm/src/lock.rs
+++ b/nexus-shm/src/lock.rs
@@ -1,0 +1,44 @@
+use std::os::fd::BorrowedFd;
+
+use nix::errno::Errno;
+use nix::fcntl::{FcntlArg, fcntl};
+use nix::libc;
+
+use crate::error::ShmError;
+
+const OWNER_OFFSET: i64 = 0;
+const OWNER_LEN: i64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Liveness {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+fn owner_flock(l_type: libc::c_short) -> libc::flock {
+    let mut lk: libc::flock = unsafe { std::mem::zeroed() };
+    lk.l_type = l_type;
+    lk.l_whence = libc::SEEK_SET as libc::c_short;
+    lk.l_start = OWNER_OFFSET;
+    lk.l_len = OWNER_LEN;
+    lk
+}
+
+pub(crate) fn acquire_owner(fd: BorrowedFd<'_>) -> Result<bool, ShmError> {
+    let lk = owner_flock(libc::F_WRLCK as libc::c_short);
+    match fcntl(fd, FcntlArg::F_OFD_SETLK(&lk)) {
+        Ok(_) => Ok(true),
+        Err(Errno::EACCES | Errno::EAGAIN) => Ok(false),
+        Err(e) => Err(ShmError::Os(std::io::Error::from_raw_os_error(e as i32))),
+    }
+}
+
+pub(crate) fn owner_liveness(fd: BorrowedFd<'_>) -> Liveness {
+    let mut lk = owner_flock(libc::F_WRLCK as libc::c_short);
+    match fcntl(fd, FcntlArg::F_OFD_GETLK(&mut lk)) {
+        Ok(_) if lk.l_type == libc::F_UNLCK as libc::c_short => Liveness::Dead,
+        Ok(_) => Liveness::Alive,
+        Err(_) => Liveness::Unknown,
+    }
+}

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -9,6 +9,8 @@
 pub unsafe trait Pod: Copy + 'static {}
 
 macro_rules! impl_pod {
+    // SAFETY: each integer and float primitive has a fixed layout, no pointers,
+    // no Drop, and is valid for every bit pattern of its size.
     ($($t:ty),*) => { $( unsafe impl Pod for $t {} )* };
 }
 
@@ -16,4 +18,6 @@ impl_pod!(
     u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64
 );
 
+// SAFETY: an array of `Pod` is a contiguous run of `Pod` values with no added
+// layout, pointers, or Drop, so it inherits every requirement of the trait.
 unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -1,0 +1,19 @@
+/// Types byte-copyable through shared memory.
+///
+/// # Safety
+///
+/// The type must have a stable layout (`repr(C)`, `repr(transparent)`, or a
+/// primitive), contain no pointers or `Drop` glue, and be valid for every bit
+/// pattern of its size — a reader may observe bytes mid-write or from a crashed
+/// writer. `bool` and `char` are excluded for this reason despite being `Copy`.
+pub unsafe trait Pod: Copy + 'static {}
+
+macro_rules! impl_pod {
+    ($($t:ty),*) => { $( unsafe impl Pod for $t {} )* };
+}
+
+impl_pod!(
+    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64
+);
+
+unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}

--- a/nexus-shm/src/region.rs
+++ b/nexus-shm/src/region.rs
@@ -4,6 +4,7 @@ use std::os::fd::{AsFd, BorrowedFd};
 use std::path::Path;
 use std::ptr::NonNull;
 
+use nix::errno::Errno;
 use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap};
 
 use crate::error::ShmError;
@@ -52,6 +53,10 @@ impl Mapping {
             flags |= MapFlags::MAP_HUGETLB;
         }
 
+        // SAFETY: `len` is non-zero; the kernel chooses the address (`None`).
+        // `file` is a valid open fd held for the mapping's lifetime via the
+        // returned `Mapping`, and the mapped length matches the file length set
+        // by the caller.
         let ptr = unsafe {
             mmap(
                 None,
@@ -63,11 +68,12 @@ impl Mapping {
             )
         }
         .map_err(|e| {
-            let io = std::io::Error::from_raw_os_error(e as i32);
-            if opts.huge_pages {
-                ShmError::HugePagesUnavailable(io)
+            // ENOMEM with MAP_HUGETLB means the huge-page pool is exhausted;
+            // other errnos are unrelated failures, not a huge-pages verdict.
+            if opts.huge_pages && e == Errno::ENOMEM {
+                ShmError::HugePagesUnavailable(e.into())
             } else {
-                ShmError::Os(io)
+                ShmError::Os(e.into())
             }
         })?;
 
@@ -89,11 +95,17 @@ impl Mapping {
 
 impl Drop for Mapping {
     fn drop(&mut self) {
+        // SAFETY: `ptr` and `len` come from the successful `mmap` in `map` and
+        // are unchanged since construction, so they are a valid mapping to unmap.
         unsafe {
             let _ = munmap(self.ptr.cast(), self.len.get());
         }
     }
 }
 
+// SAFETY: a mapping is a raw pointer plus its backing fd; the bytes live in
+// shared memory, not thread-local state. Concurrent access to the contents is
+// governed by the atomics in the control block, so the handle itself is safe to
+// move and share across threads.
 unsafe impl Send for Mapping {}
 unsafe impl Sync for Mapping {}

--- a/nexus-shm/src/region.rs
+++ b/nexus-shm/src/region.rs
@@ -1,0 +1,95 @@
+use std::fs::OpenOptions;
+use std::num::NonZeroUsize;
+use std::os::fd::AsFd;
+use std::path::Path;
+use std::ptr::NonNull;
+
+use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap};
+
+use crate::error::ShmError;
+
+#[derive(Clone, Copy, Default)]
+pub struct MapOptions {
+    pub populate: bool,
+    pub huge_pages: bool,
+}
+
+pub(crate) struct Mapping {
+    ptr: NonNull<u8>,
+    len: NonZeroUsize,
+    _file: std::fs::File,
+}
+
+impl Mapping {
+    pub(crate) fn create(
+        path: &Path,
+        len: NonZeroUsize,
+        opts: MapOptions,
+    ) -> Result<Self, ShmError> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        file.set_len(len.get() as u64)?;
+        Self::map(file, len, opts)
+    }
+
+    pub(crate) fn open(path: &Path, opts: MapOptions) -> Result<Self, ShmError> {
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        let len =
+            NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(ShmError::EmptySegment)?;
+        Self::map(file, len, opts)
+    }
+
+    fn map(file: std::fs::File, len: NonZeroUsize, opts: MapOptions) -> Result<Self, ShmError> {
+        let mut flags = MapFlags::MAP_SHARED;
+        if opts.populate {
+            flags |= MapFlags::MAP_POPULATE;
+        }
+        if opts.huge_pages {
+            flags |= MapFlags::MAP_HUGETLB;
+        }
+
+        let ptr = unsafe {
+            mmap(
+                None,
+                len,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                flags,
+                file.as_fd(),
+                0,
+            )
+        }
+        .map_err(|e| {
+            let io = std::io::Error::from_raw_os_error(e as i32);
+            if opts.huge_pages {
+                ShmError::HugePagesUnavailable(io)
+            } else {
+                ShmError::Os(io)
+            }
+        })?;
+
+        Ok(Self {
+            ptr: ptr.cast(),
+            len,
+            _file: file,
+        })
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = munmap(self.ptr.cast(), self.len.get());
+        }
+    }
+}
+
+unsafe impl Send for Mapping {}
+unsafe impl Sync for Mapping {}

--- a/nexus-shm/src/region.rs
+++ b/nexus-shm/src/region.rs
@@ -1,6 +1,6 @@
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::num::NonZeroUsize;
-use std::os::fd::AsFd;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::path::Path;
 use std::ptr::NonNull;
 
@@ -17,7 +17,7 @@ pub struct MapOptions {
 pub(crate) struct Mapping {
     ptr: NonNull<u8>,
     len: NonZeroUsize,
-    _file: std::fs::File,
+    file: File,
 }
 
 impl Mapping {
@@ -43,7 +43,7 @@ impl Mapping {
         Self::map(file, len, opts)
     }
 
-    fn map(file: std::fs::File, len: NonZeroUsize, opts: MapOptions) -> Result<Self, ShmError> {
+    fn map(file: File, len: NonZeroUsize, opts: MapOptions) -> Result<Self, ShmError> {
         let mut flags = MapFlags::MAP_SHARED;
         if opts.populate {
             flags |= MapFlags::MAP_POPULATE;
@@ -74,12 +74,16 @@ impl Mapping {
         Ok(Self {
             ptr: ptr.cast(),
             len,
-            _file: file,
+            file,
         })
     }
 
     pub(crate) fn as_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
+    }
+
+    pub(crate) fn as_fd(&self) -> BorrowedFd<'_> {
+        self.file.as_fd()
     }
 }
 

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -1,0 +1,135 @@
+use std::path::Path;
+
+use crate::control::{ControlBlock, status};
+use crate::error::ShmError;
+use crate::region::{MapOptions, Mapping};
+
+const HEADER: usize = size_of::<ControlBlock>();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerStatus {
+    Uninit,
+    Alive,
+    Dead,
+}
+
+pub struct Segment {
+    mapping: Mapping,
+    creator: bool,
+}
+
+impl Segment {
+    pub fn create(path: &Path, data_len: usize, opts: MapOptions) -> Result<Self, ShmError> {
+        let total = (HEADER + data_len)
+            .try_into()
+            .map_err(|_| ShmError::EmptySegment)?;
+        let mapping = Mapping::create(path, total, opts)?;
+
+        let cb = unsafe { &mut *mapping.as_ptr().cast::<ControlBlock>() };
+        let generation = cb.generation().wrapping_add(1);
+        cb.write_header(flags(opts), generation, std::process::id(), data_len as u64);
+
+        Ok(Self {
+            mapping,
+            creator: true,
+        })
+    }
+
+    pub fn attach(path: &Path, opts: MapOptions) -> Result<Self, ShmError> {
+        let mapping = Mapping::open(path, opts)?;
+        Self::control_of(&mapping).validate()?;
+        Ok(Self {
+            mapping,
+            creator: false,
+        })
+    }
+
+    pub fn peer_status(&self) -> PeerStatus {
+        match self.control().status() {
+            status::ALIVE => PeerStatus::Alive,
+            status::DEAD => PeerStatus::Dead,
+            _ => PeerStatus::Uninit,
+        }
+    }
+
+    pub fn data(&self) -> *mut u8 {
+        unsafe { self.mapping.as_ptr().add(HEADER) }
+    }
+
+    pub fn data_len(&self) -> usize {
+        self.control().data_len() as usize
+    }
+
+    fn control(&self) -> &ControlBlock {
+        Self::control_of(&self.mapping)
+    }
+
+    fn control_of(mapping: &Mapping) -> &ControlBlock {
+        unsafe { &*mapping.as_ptr().cast::<ControlBlock>() }
+    }
+}
+
+impl Drop for Segment {
+    fn drop(&mut self) {
+        if self.creator {
+            self.control().mark_dead();
+        }
+    }
+}
+
+fn flags(opts: MapOptions) -> u16 {
+    u16::from(opts.populate) | (u16::from(opts.huge_pages) << 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PeerStatus, Segment};
+    use crate::region::MapOptions;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("nexus-shm-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn create_attach_roundtrip() {
+        let path = temp_path("roundtrip");
+        let _ = std::fs::remove_file(&path);
+
+        let seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
+        assert_eq!(seg.data_len(), 4096);
+        assert_eq!(seg.peer_status(), PeerStatus::Alive);
+
+        unsafe { seg.data().write(0xAB) };
+
+        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        assert_eq!(peer.data_len(), 4096);
+        assert_eq!(peer.peer_status(), PeerStatus::Alive);
+        assert_eq!(unsafe { peer.data().read() }, 0xAB);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn creator_drop_marks_dead() {
+        let path = temp_path("dead");
+        let _ = std::fs::remove_file(&path);
+
+        let seg = Segment::create(&path, 64, MapOptions::default()).unwrap();
+        drop(seg);
+
+        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        assert_eq!(peer.peer_status(), PeerStatus::Dead);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rejects_foreign_file() {
+        let path = temp_path("foreign");
+        std::fs::write(&path, vec![0u8; 4096]).unwrap();
+
+        assert!(Segment::attach(&path, MapOptions::default()).is_err());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+}

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::Path;
 
 use crate::control::{ControlBlock, status};
@@ -5,15 +6,23 @@ use crate::error::ShmError;
 use crate::lock::{self, Liveness};
 use crate::region::{MapOptions, Mapping};
 
-const HEADER: usize = size_of::<ControlBlock>();
+const HEADER: NonZeroUsize = match NonZeroUsize::new(size_of::<ControlBlock>()) {
+    Some(n) => n,
+    None => panic!("control block is zero-sized"),
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PeerStatus {
+pub enum Status {
     Uninit,
     Alive,
     Dead,
 }
 
+/// A mapped shared-memory segment: a control block followed by a payload.
+///
+/// File lifecycle (unlink, rotate, archive) is the caller's responsibility. The
+/// backing file persists after drop so a restarting peer can run crash
+/// recovery; segment owns only the mapping and its liveness signals.
 pub struct Segment {
     mapping: Mapping,
     creator: bool,
@@ -21,15 +30,19 @@ pub struct Segment {
 
 impl Segment {
     pub fn create(path: &Path, data_len: usize, opts: MapOptions) -> Result<Self, ShmError> {
-        let total = (HEADER + data_len)
-            .try_into()
-            .map_err(|_| ShmError::EmptySegment)?;
+        if data_len == 0 {
+            return Err(ShmError::EmptySegment);
+        }
+        let total = HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)?;
         let mapping = Mapping::create(path, total, opts)?;
 
         if !lock::acquire_owner(mapping.as_fd())? {
             return Err(ShmError::OwnerActive);
         }
 
+        // SAFETY: we hold the OFD owner lock acquired above, so no other process
+        // is writing the control block; mmap returns page-aligned memory (hence
+        // ControlBlock-aligned) covering at least the header.
         let cb = unsafe { &mut *mapping.as_ptr().cast::<ControlBlock>() };
         let generation = cb.generation().wrapping_add(1);
         cb.write_header(flags(opts), generation, std::process::id(), data_len as u64);
@@ -49,11 +62,16 @@ impl Segment {
         })
     }
 
-    pub fn peer_status(&self) -> PeerStatus {
+    /// Tier-1 liveness from the atomic status field.
+    ///
+    /// `Dead` is authoritative. `Alive` may be stale if the owner died without
+    /// running its drop guard (`SIGKILL`, `panic=abort`); confirm with
+    /// [`Segment::peer_liveness`], which consults the kernel-held OFD lock.
+    pub fn status(&self) -> Status {
         match self.control().status() {
-            s if s == status::ALIVE => PeerStatus::Alive,
-            s if s == status::DEAD => PeerStatus::Dead,
-            _ => PeerStatus::Uninit,
+            s if s == status::ALIVE => Status::Alive,
+            s if s == status::DEAD => Status::Dead,
+            _ => Status::Uninit,
         }
     }
 
@@ -61,8 +79,16 @@ impl Segment {
         lock::owner_liveness(self.mapping.as_fd())
     }
 
+    /// Pointer to the payload region, valid for [`Segment::data_len`] bytes for
+    /// as long as this `Segment` lives.
+    ///
+    /// Reads and writes through it must be synchronized by the caller — the
+    /// foundation provides no ordering for the payload (the control block's
+    /// atomics cover only liveness). The primitives built on top supply their
+    /// own sequencing.
     pub fn data(&self) -> *mut u8 {
-        unsafe { self.mapping.as_ptr().add(HEADER) }
+        // SAFETY: the mapping is HEADER + data_len bytes, so HEADER is in bounds.
+        unsafe { self.mapping.as_ptr().add(HEADER.get()) }
     }
 
     pub fn data_len(&self) -> usize {
@@ -74,6 +100,9 @@ impl Segment {
     }
 
     fn control_of(mapping: &Mapping) -> &ControlBlock {
+        // SAFETY: mmap maps whole pages, so the control block (<= one page) is
+        // mapped and page-aligned. All control-block fields are atomic or
+        // written once before sharing, so shared `&` access is sound.
         unsafe { &*mapping.as_ptr().cast::<ControlBlock>() }
     }
 }
@@ -92,7 +121,8 @@ fn flags(opts: MapOptions) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use super::{PeerStatus, Segment};
+    use super::{Segment, Status};
+    use crate::error::ShmError;
     use crate::lock::Liveness;
     use crate::region::MapOptions;
 
@@ -107,13 +137,13 @@ mod tests {
 
         let seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
         assert_eq!(seg.data_len(), 4096);
-        assert_eq!(seg.peer_status(), PeerStatus::Alive);
+        assert_eq!(seg.status(), Status::Alive);
 
         unsafe { seg.data().write(0xAB) };
 
         let peer = Segment::attach(&path, MapOptions::default()).unwrap();
         assert_eq!(peer.data_len(), 4096);
-        assert_eq!(peer.peer_status(), PeerStatus::Alive);
+        assert_eq!(peer.status(), Status::Alive);
         assert_eq!(unsafe { peer.data().read() }, 0xAB);
 
         std::fs::remove_file(&path).unwrap();
@@ -128,9 +158,19 @@ mod tests {
         drop(seg);
 
         let peer = Segment::attach(&path, MapOptions::default()).unwrap();
-        assert_eq!(peer.peer_status(), PeerStatus::Dead);
+        assert_eq!(peer.status(), Status::Dead);
 
         std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rejects_zero_data_len() {
+        let path = temp_path("zero");
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(
+            Segment::create(&path, 0, MapOptions::default()),
+            Err(ShmError::EmptySegment)
+        ));
     }
 
     #[test]

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::control::{ControlBlock, status};
 use crate::error::ShmError;
+use crate::lock::{self, Liveness};
 use crate::region::{MapOptions, Mapping};
 
 const HEADER: usize = size_of::<ControlBlock>();
@@ -25,6 +26,10 @@ impl Segment {
             .map_err(|_| ShmError::EmptySegment)?;
         let mapping = Mapping::create(path, total, opts)?;
 
+        if !lock::acquire_owner(mapping.as_fd())? {
+            return Err(ShmError::OwnerActive);
+        }
+
         let cb = unsafe { &mut *mapping.as_ptr().cast::<ControlBlock>() };
         let generation = cb.generation().wrapping_add(1);
         cb.write_header(flags(opts), generation, std::process::id(), data_len as u64);
@@ -46,10 +51,14 @@ impl Segment {
 
     pub fn peer_status(&self) -> PeerStatus {
         match self.control().status() {
-            status::ALIVE => PeerStatus::Alive,
-            status::DEAD => PeerStatus::Dead,
+            s if s == status::ALIVE => PeerStatus::Alive,
+            s if s == status::DEAD => PeerStatus::Dead,
             _ => PeerStatus::Uninit,
         }
+    }
+
+    pub fn peer_liveness(&self) -> Liveness {
+        lock::owner_liveness(self.mapping.as_fd())
     }
 
     pub fn data(&self) -> *mut u8 {
@@ -84,6 +93,7 @@ fn flags(opts: MapOptions) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::{PeerStatus, Segment};
+    use crate::lock::Liveness;
     use crate::region::MapOptions;
 
     fn temp_path(name: &str) -> std::path::PathBuf {
@@ -119,6 +129,21 @@ mod tests {
 
         let peer = Segment::attach(&path, MapOptions::default()).unwrap();
         assert_eq!(peer.peer_status(), PeerStatus::Dead);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn kernel_liveness_tracks_owner() {
+        let path = temp_path("liveness");
+        let _ = std::fs::remove_file(&path);
+
+        let owner = Segment::create(&path, 64, MapOptions::default()).unwrap();
+        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        assert_eq!(peer.peer_liveness(), Liveness::Alive);
+
+        drop(owner);
+        assert_eq!(peer.peer_liveness(), Liveness::Dead);
 
         std::fs::remove_file(&path).unwrap();
     }


### PR DESCRIPTION
Foundation layer per #390. Implements the rulings from the design thread.

- `Pod` — stricter than nexus-slot's: valid for every bit pattern (excludes
  bool/char), since a reader can observe a crashed writer's bytes.
- Control block — 32-byte `repr(C)` inner + `CachePadded` wrapper, no `_reserved`.
- `Segment` — mmap via raw `nix` (no memmap2). Huge pages opt-in, hard error
  when unavailable — no silent fallback.
- Liveness — Tier 1 atomic status + Drop guard; Tier 2 OFD lock with 3-state
  `Liveness { Alive, Dead, Unknown }`.
- Criterion bench for the `F_OFD_GETLK` callsite. Numbers need a pinned,
  turbo-off run on real hardware; harness header documents the procedure.

8 tests pass; clean under `cargo clippy --all-targets -- -D warnings` and fmt.
