### PR TITLE
feat(shm): ShmJournal append-only durable log (#391)

### DIFF
--- a/nexus-shm/Cargo.toml
+++ b/nexus-shm/Cargo.toml
@@ -23,3 +23,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "ofd_liveness"
 harness = false
+
+[[bench]]
+name = "journal"
+harness = false

--- a/nexus-shm/benches/journal.rs
+++ b/nexus-shm/benches/journal.rs
@@ -77,7 +77,7 @@ fn bench_read(c: &mut Criterion) {
         b.iter_batched(
             || Journal::<FixHeader>::open(&base, cfg(1 << 20)).unwrap(),
             |(w, mut r)| {
-                while let Some(rec) = r.next_record() {
+                while let Some(rec) = r.next_record().unwrap() {
                     black_box(rec.payload());
                 }
                 drop((w, r));

--- a/nexus-shm/benches/journal.rs
+++ b/nexus-shm/benches/journal.rs
@@ -1,0 +1,81 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use nexus_shm::{FixHeader, Journal, JournalConfig, MapOptions};
+
+fn cfg(segment_size: usize) -> JournalConfig {
+    JournalConfig {
+        segment_size,
+        map: MapOptions::default(),
+    }
+}
+
+fn cleanup(base: &std::path::Path) {
+    for i in 0..64u64 {
+        let mut p = base.as_os_str().to_owned();
+        p.push(format!(".{i}"));
+        let _ = std::fs::remove_file(std::path::PathBuf::from(p));
+    }
+}
+
+fn bench_write(c: &mut Criterion) {
+    let base = std::env::temp_dir().join(format!("nexus-journal-bench-w-{}", std::process::id()));
+    cleanup(&base);
+
+    let (mut w, _r) = Journal::<FixHeader>::open(&base, cfg(1 << 31)).unwrap();
+    let payload = [0u8; 32];
+    let mut seq = 0u64;
+
+    c.benchmark_group("journal").bench_function("try_claim_commit", |b| {
+        b.iter(|| {
+            seq += 1;
+            let mut claim = w
+                .try_claim(FixHeader { seq, timestamp: seq }, payload.len())
+                .unwrap();
+            claim.as_mut_slice().copy_from_slice(&payload);
+            claim.commit();
+        });
+    });
+
+    drop((w, _r));
+    cleanup(&base);
+}
+
+fn bench_read(c: &mut Criterion) {
+    let base = std::env::temp_dir().join(format!("nexus-journal-bench-r-{}", std::process::id()));
+    cleanup(&base);
+
+    const N: u64 = 1000;
+    {
+        let (mut w, _r) = Journal::<FixHeader>::open(&base, cfg(1 << 20)).unwrap();
+        let payload = [0u8; 32];
+        for seq in 1..=N {
+            let mut claim = w
+                .try_claim(FixHeader { seq, timestamp: seq }, payload.len())
+                .unwrap();
+            claim.as_mut_slice().copy_from_slice(&payload);
+            claim.commit();
+        }
+    }
+
+    let mut group = c.benchmark_group("journal");
+    group.throughput(Throughput::Elements(N));
+    group.bench_function("next_record_drain", |b| {
+        b.iter_batched(
+            || Journal::<FixHeader>::open(&base, cfg(1 << 20)).unwrap(),
+            |(w, mut r)| {
+                while let Some(rec) = r.next_record() {
+                    black_box(rec.payload());
+                }
+                drop((w, r));
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+
+    cleanup(&base);
+}
+
+criterion_group!(benches, bench_write, bench_read);
+criterion_main!(benches);

--- a/nexus-shm/benches/journal.rs
+++ b/nexus-shm/benches/journal.rs
@@ -26,16 +26,23 @@ fn bench_write(c: &mut Criterion) {
     let payload = [0u8; 32];
     let mut seq = 0u64;
 
-    c.benchmark_group("journal").bench_function("try_claim_commit", |b| {
-        b.iter(|| {
-            seq += 1;
-            let mut claim = w
-                .try_claim(FixHeader { seq, timestamp: seq }, payload.len())
-                .unwrap();
-            claim.as_mut_slice().copy_from_slice(&payload);
-            claim.commit();
+    c.benchmark_group("journal")
+        .bench_function("try_claim_commit", |b| {
+            b.iter(|| {
+                seq += 1;
+                let mut claim = w
+                    .try_claim(
+                        FixHeader {
+                            seq,
+                            timestamp: seq,
+                        },
+                        payload.len(),
+                    )
+                    .unwrap();
+                claim.as_mut_slice().copy_from_slice(&payload);
+                claim.commit();
+            });
         });
-    });
 
     drop((w, _r));
     cleanup(&base);
@@ -51,7 +58,13 @@ fn bench_read(c: &mut Criterion) {
         let payload = [0u8; 32];
         for seq in 1..=N {
             let mut claim = w
-                .try_claim(FixHeader { seq, timestamp: seq }, payload.len())
+                .try_claim(
+                    FixHeader {
+                        seq,
+                        timestamp: seq,
+                    },
+                    payload.len(),
+                )
                 .unwrap();
             claim.as_mut_slice().copy_from_slice(&payload);
             claim.commit();

--- a/nexus-shm/src/journal/error.rs
+++ b/nexus-shm/src/journal/error.rs
@@ -20,7 +20,7 @@ impl fmt::Display for JournalError {
                     "record frame {frame} exceeds segment capacity {capacity}"
                 )
             }
-            Self::EmptyRecord => write!(f, "record frames to zero bytes"),
+            Self::EmptyRecord => write!(f, "empty record"),
             Self::Shm(e) => write!(f, "{e}"),
             Self::Os(e) => write!(f, "{e}"),
         }

--- a/nexus-shm/src/journal/error.rs
+++ b/nexus-shm/src/journal/error.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+
+use crate::error::ShmError;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum JournalError {
+    RecordTooLarge { frame: usize, capacity: usize },
+    EmptyRecord,
+    Shm(ShmError),
+    Os(std::io::Error),
+}
+
+impl fmt::Display for JournalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RecordTooLarge { frame, capacity } => {
+                write!(f, "record frame {frame} exceeds segment capacity {capacity}")
+            }
+            Self::EmptyRecord => write!(f, "record frames to zero bytes"),
+            Self::Shm(e) => write!(f, "{e}"),
+            Self::Os(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for JournalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Shm(e) => Some(e),
+            Self::Os(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<ShmError> for JournalError {
+    fn from(e: ShmError) -> Self {
+        Self::Shm(e)
+    }
+}
+
+impl From<std::io::Error> for JournalError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Os(e)
+    }
+}

--- a/nexus-shm/src/journal/error.rs
+++ b/nexus-shm/src/journal/error.rs
@@ -15,7 +15,10 @@ impl fmt::Display for JournalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::RecordTooLarge { frame, capacity } => {
-                write!(f, "record frame {frame} exceeds segment capacity {capacity}")
+                write!(
+                    f,
+                    "record frame {frame} exceeds segment capacity {capacity}"
+                )
             }
             Self::EmptyRecord => write!(f, "record frames to zero bytes"),
             Self::Shm(e) => write!(f, "{e}"),

--- a/nexus-shm/src/journal/frame.rs
+++ b/nexus-shm/src/journal/frame.rs
@@ -1,18 +1,36 @@
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 
-pub(crate) const LEN_SIZE: usize = size_of::<i32>();
+pub(crate) const FRAME_HEADER: usize = 8;
 pub(crate) const ALIGN: usize = 8;
+
+pub(crate) const TYPE_DATA: u16 = 0;
+pub(crate) const TYPE_PAD: u16 = 1;
 
 pub(crate) const fn align_up(n: usize) -> usize {
     (n + ALIGN - 1) & !(ALIGN - 1)
 }
 
 pub(crate) const fn footprint(body: usize) -> usize {
-    LEN_SIZE + align_up(body)
+    FRAME_HEADER + align_up(body)
 }
 
-pub(crate) unsafe fn marker<'a>(ptr: *mut u8) -> &'a AtomicI32 {
-    // SAFETY: caller guarantees alignment, initialization, and liveness for 'a;
-    // AtomicI32 shares i32's layout.
-    unsafe { AtomicI32::from_ptr(ptr.cast()) }
+pub(crate) unsafe fn commit_len<'a>(ptr: *mut u8) -> &'a AtomicU32 {
+    // SAFETY: caller guarantees ptr is 8-byte-aligned, initialized, and live for
+    // 'a; AtomicU32 shares u32's layout.
+    unsafe { AtomicU32::from_ptr(ptr.cast()) }
+}
+
+pub(crate) unsafe fn write_kind(ptr: *mut u8, frame_type: u16) {
+    // SAFETY: caller guarantees the 8-byte frame header at ptr is within a live
+    // mapping reserved for this record.
+    unsafe {
+        std::ptr::write_unaligned(ptr.add(4).cast::<u16>(), frame_type);
+        std::ptr::write_unaligned(ptr.add(6).cast::<u16>(), 0);
+    }
+}
+
+pub(crate) unsafe fn read_kind(ptr: *mut u8) -> u16 {
+    // SAFETY: caller guarantees the frame header is published (read after an
+    // Acquire load of commit_len) and within a live mapping.
+    unsafe { std::ptr::read_unaligned(ptr.add(4).cast::<u16>()) }
 }

--- a/nexus-shm/src/journal/frame.rs
+++ b/nexus-shm/src/journal/frame.rs
@@ -1,0 +1,18 @@
+use std::sync::atomic::AtomicI32;
+
+pub(crate) const LEN_SIZE: usize = size_of::<i32>();
+pub(crate) const ALIGN: usize = 8;
+
+pub(crate) const fn align_up(n: usize) -> usize {
+    (n + ALIGN - 1) & !(ALIGN - 1)
+}
+
+pub(crate) const fn footprint(body: usize) -> usize {
+    LEN_SIZE + align_up(body)
+}
+
+pub(crate) unsafe fn marker<'a>(ptr: *mut u8) -> &'a AtomicI32 {
+    // SAFETY: caller guarantees alignment, initialization, and liveness for 'a;
+    // AtomicI32 shares i32's layout.
+    unsafe { AtomicI32::from_ptr(ptr.cast()) }
+}

--- a/nexus-shm/src/journal/header.rs
+++ b/nexus-shm/src/journal/header.rs
@@ -1,13 +1,19 @@
 use crate::pod::Pod;
 
+/// Per-record metadata the journal frames but never interprets. Any [`Pod`] is a
+/// valid header; `()` gives a position-only log at zero overhead.
 pub trait RecordHeader: Pod {}
 
 impl<T: Pod> RecordHeader for T {}
 
+/// A header carrying a monotonic sequence number, enabling [`read_range`].
+///
+/// [`read_range`]: super::Reader::read_range
 pub trait SeqHeader: RecordHeader {
     fn seq(&self) -> u64;
 }
 
+/// Reference header for FIX journaling: sequence number plus timestamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct FixHeader {

--- a/nexus-shm/src/journal/header.rs
+++ b/nexus-shm/src/journal/header.rs
@@ -1,0 +1,26 @@
+use crate::pod::Pod;
+
+pub trait RecordHeader: Pod {}
+
+impl<T: Pod> RecordHeader for T {}
+
+pub trait SeqHeader: RecordHeader {
+    fn seq(&self) -> u64;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct FixHeader {
+    pub seq: u64,
+    pub timestamp: u64,
+}
+
+// SAFETY: repr(C) over two u64 — fixed layout, no pointers, no Drop, valid for
+// every bit pattern.
+unsafe impl Pod for FixHeader {}
+
+impl SeqHeader for FixHeader {
+    fn seq(&self) -> u64 {
+        self.seq
+    }
+}

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -1,0 +1,113 @@
+mod error;
+mod frame;
+mod header;
+mod reader;
+#[cfg(test)]
+mod tests;
+mod writer;
+
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+
+use crate::region::MapOptions;
+use crate::segment::Segment;
+
+pub use error::JournalError;
+pub use header::{FixHeader, RecordHeader, SeqHeader};
+pub use reader::{ReadRange, ReadRecord, Reader};
+pub use writer::{WriteClaim, Writer};
+
+use frame::{LEN_SIZE, align_up, footprint, marker};
+
+const MIN_SEGMENT: usize = 64;
+
+#[derive(Clone, Copy)]
+pub struct JournalConfig {
+    pub segment_size: usize,
+    pub map: MapOptions,
+}
+
+impl Default for JournalConfig {
+    fn default() -> Self {
+        Self {
+            segment_size: 64 * 1024 * 1024,
+            map: MapOptions::default(),
+        }
+    }
+}
+
+pub struct Journal<H>(PhantomData<H>);
+
+impl<H: RecordHeader> Journal<H> {
+    pub fn open(
+        base: impl AsRef<Path>,
+        cfg: JournalConfig,
+    ) -> Result<(Writer<H>, Reader<H>), JournalError> {
+        let base = base.as_ref().to_path_buf();
+        let segment_size = align_up(cfg.segment_size.max(MIN_SEGMENT));
+
+        let mut last = None;
+        let mut i = 0u64;
+        while segment_path(&base, i).exists() {
+            last = Some(i);
+            i += 1;
+        }
+
+        let index = last.unwrap_or(0);
+        let active = Segment::create(&segment_path(&base, index), segment_size, cfg.map)?;
+        let tail = recover_tail::<H>(&active, segment_size);
+
+        let writer = Writer {
+            base: base.clone(),
+            segment_size,
+            map: cfg.map,
+            active,
+            index,
+            tail,
+            _marker: PhantomData,
+        };
+
+        let seg0 = Segment::attach(&segment_path(&base, 0), cfg.map)?;
+        let reader = Reader {
+            base,
+            segment_size,
+            map: cfg.map,
+            segments: vec![seg0],
+            seg_idx: 0,
+            cursor: 0,
+            _marker: PhantomData,
+        };
+
+        Ok((writer, reader))
+    }
+}
+
+fn recover_tail<H: RecordHeader>(seg: &Segment, segment_size: usize) -> usize {
+    let data = seg.data();
+    let hsize = size_of::<H>();
+    let mut cur = 0;
+    while cur + LEN_SIZE <= segment_size {
+        // SAFETY: `cur` is a 4-aligned offset within the mapped data region.
+        let v = unsafe { marker(data.add(cur)) }.load(Ordering::Acquire);
+        if v == 0 {
+            break;
+        }
+        if v < 0 {
+            cur += LEN_SIZE + (-v) as usize;
+            continue;
+        }
+        let body = v as usize;
+        if body < hsize || cur + footprint(body) > segment_size {
+            break;
+        }
+        cur += footprint(body);
+    }
+    cur
+}
+
+fn segment_path(base: &Path, index: u64) -> PathBuf {
+    let mut p = base.as_os_str().to_owned();
+    p.push(format!(".{index}"));
+    PathBuf::from(p)
+}

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -18,10 +18,11 @@ pub use header::{FixHeader, RecordHeader, SeqHeader};
 pub use reader::{ReadRange, ReadRecord, Reader};
 pub use writer::{WriteClaim, Writer};
 
-use frame::{LEN_SIZE, align_up, footprint, marker};
+use frame::{FRAME_HEADER, TYPE_PAD, align_up, commit_len, footprint, read_kind};
 
 const MIN_SEGMENT: usize = 64;
 
+/// Configuration for opening a journal.
 #[derive(Clone, Copy)]
 pub struct JournalConfig {
     pub segment_size: usize,
@@ -37,9 +38,11 @@ impl Default for JournalConfig {
     }
 }
 
+/// Entry point for opening a journal over `{base}.{index}` segment files.
 pub struct Journal<H>(PhantomData<H>);
 
 impl<H: RecordHeader> Journal<H> {
+    /// Open (or recover) a journal, returning its [`Writer`] and [`Reader`].
     pub fn open(
         base: impl AsRef<Path>,
         cfg: JournalConfig,
@@ -87,17 +90,18 @@ fn recover_tail<H: RecordHeader>(seg: &Segment, segment_size: usize) -> usize {
     let data = seg.data();
     let hsize = size_of::<H>();
     let mut cur = 0;
-    while cur + LEN_SIZE <= segment_size {
-        // SAFETY: `cur` is a 4-aligned offset within the mapped data region.
-        let v = unsafe { marker(data.add(cur)) }.load(Ordering::Acquire);
-        if v == 0 {
+    while cur + FRAME_HEADER <= segment_size {
+        // SAFETY: `cur` is an 8-aligned offset within the mapped data region.
+        let cl = unsafe { commit_len(data.add(cur)) }.load(Ordering::Acquire);
+        if cl == 0 {
             break;
         }
-        if v < 0 {
-            cur += LEN_SIZE + (-v) as usize;
+        // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
+        if unsafe { read_kind(data.add(cur)) } == TYPE_PAD {
+            cur += align_up(cl as usize);
             continue;
         }
-        let body = v as usize;
+        let body = cl as usize;
         if body < hsize || cur + footprint(body) > segment_size {
             break;
         }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -1,0 +1,181 @@
+use std::marker::PhantomData;
+use std::ops::RangeBounds;
+use std::sync::atomic::Ordering;
+
+use crate::segment::Segment;
+
+use super::error::JournalError;
+use super::frame::{LEN_SIZE, footprint, marker};
+use super::header::{RecordHeader, SeqHeader};
+
+pub struct Reader<H: RecordHeader> {
+    pub(super) base: std::path::PathBuf,
+    pub(super) segment_size: usize,
+    pub(super) map: crate::region::MapOptions,
+    pub(super) segments: Vec<Segment>,
+    pub(super) seg_idx: usize,
+    pub(super) cursor: usize,
+    pub(super) _marker: PhantomData<H>,
+}
+
+impl<H: RecordHeader> Reader<H> {
+    pub fn next_record(&mut self) -> Option<ReadRecord<'_, H>> {
+        loop {
+            if self.cursor + LEN_SIZE > self.segment_size {
+                if self.advance_segment() {
+                    continue;
+                }
+                return None;
+            }
+            let data = self.segments[self.seg_idx].data();
+            // SAFETY: cursor is a 4-aligned offset within the mapped data.
+            let v = unsafe { marker(data.add(self.cursor)) }.load(Ordering::Acquire);
+            if v == 0 {
+                return None;
+            }
+            if v < 0 {
+                self.cursor += LEN_SIZE + (-v) as usize;
+                if self.cursor + LEN_SIZE > self.segment_size && !self.advance_segment() {
+                    return None;
+                }
+                continue;
+            }
+            let body = v as usize;
+            let hsize = size_of::<H>();
+            if body < hsize {
+                return None;
+            }
+            let off = self.cursor;
+            // SAFETY: the committed frame holds `H` at `off + LEN_SIZE`; `H: Pod`
+            // so an unaligned read is valid.
+            let header = unsafe { std::ptr::read_unaligned(data.add(off + LEN_SIZE).cast::<H>()) };
+            // SAFETY: the payload lies within the committed frame and the mapping
+            // outlives the borrow held through `&mut self`.
+            let payload = unsafe {
+                std::slice::from_raw_parts(data.add(off + LEN_SIZE + hsize), body - hsize)
+            };
+            self.cursor = off + footprint(body);
+            return Some(ReadRecord { header, payload });
+        }
+    }
+
+    fn advance_segment(&mut self) -> bool {
+        if self.seg_idx + 1 >= self.segments.len() && !self.load_next() {
+            return false;
+        }
+        self.seg_idx += 1;
+        self.cursor = 0;
+        true
+    }
+
+    fn load_next(&mut self) -> bool {
+        let next = self.segments.len() as u64;
+        let path = super::segment_path(&self.base, next);
+        match Segment::attach(&path, self.map) {
+            Ok(seg) => {
+                self.segments.push(seg);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    pub fn read_range<R>(&mut self, range: R) -> Result<ReadRange<'_, H>, JournalError>
+    where
+        H: SeqHeader,
+        R: RangeBounds<u64>,
+    {
+        while self.load_next() {}
+        let lo = match range.start_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n.saturating_add(1),
+            std::ops::Bound::Unbounded => 0,
+        };
+        let hi = match range.end_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n.saturating_sub(1),
+            std::ops::Bound::Unbounded => u64::MAX,
+        };
+        Ok(ReadRange {
+            segments: &self.segments,
+            segment_size: self.segment_size,
+            seg_idx: 0,
+            cursor: 0,
+            lo,
+            hi,
+            _marker: PhantomData,
+        })
+    }
+}
+
+pub struct ReadRecord<'a, H: RecordHeader> {
+    header: H,
+    payload: &'a [u8],
+}
+
+impl<H: RecordHeader> ReadRecord<'_, H> {
+    pub fn header(&self) -> H {
+        self.header
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        self.payload
+    }
+}
+
+pub struct ReadRange<'a, H: SeqHeader> {
+    segments: &'a [Segment],
+    segment_size: usize,
+    seg_idx: usize,
+    cursor: usize,
+    lo: u64,
+    hi: u64,
+    _marker: PhantomData<H>,
+}
+
+impl<'a, H: SeqHeader> Iterator for ReadRange<'a, H> {
+    type Item = ReadRecord<'a, H>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.seg_idx >= self.segments.len() {
+                return None;
+            }
+            if self.cursor + LEN_SIZE > self.segment_size {
+                self.seg_idx += 1;
+                self.cursor = 0;
+                continue;
+            }
+            let data = self.segments[self.seg_idx].data();
+            // SAFETY: cursor is a 4-aligned offset within the mapped data.
+            let v = unsafe { marker(data.add(self.cursor)) }.load(Ordering::Acquire);
+            if v == 0 {
+                self.seg_idx += 1;
+                self.cursor = 0;
+                continue;
+            }
+            if v < 0 {
+                self.cursor += LEN_SIZE + (-v) as usize;
+                continue;
+            }
+            let body = v as usize;
+            let hsize = size_of::<H>();
+            if body < hsize {
+                return None;
+            }
+            let off = self.cursor;
+            self.cursor = off + footprint(body);
+            // SAFETY: the committed frame holds `H` at `off + LEN_SIZE`; `H: Pod`.
+            let header = unsafe { std::ptr::read_unaligned(data.add(off + LEN_SIZE).cast::<H>()) };
+            if header.seq() < self.lo || header.seq() > self.hi {
+                continue;
+            }
+            // SAFETY: the payload lies within the committed frame and `segments`
+            // outlives `'a`.
+            let payload = unsafe {
+                std::slice::from_raw_parts(data.add(off + LEN_SIZE + hsize), body - hsize)
+            };
+            return Some(ReadRecord { header, payload });
+        }
+    }
+}

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -2,12 +2,14 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::sync::atomic::Ordering;
 
+use crate::error::ShmError;
 use crate::segment::Segment;
 
 use super::error::JournalError;
-use super::frame::{LEN_SIZE, footprint, marker};
+use super::frame::{FRAME_HEADER, TYPE_PAD, align_up, commit_len, footprint, read_kind};
 use super::header::{RecordHeader, SeqHeader};
 
+/// Read half of a journal: walks committed records across segments in order.
 pub struct Reader<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
@@ -19,73 +21,80 @@ pub struct Reader<H: RecordHeader> {
 }
 
 impl<H: RecordHeader> Reader<H> {
-    pub fn next_record(&mut self) -> Option<ReadRecord<'_, H>> {
+    /// Yield the next committed record, or `Ok(None)` once caught up to the
+    /// write tail. Real I/O failures while opening a rolled segment surface as
+    /// `Err` rather than being mistaken for end-of-log.
+    pub fn next_record(&mut self) -> Result<Option<ReadRecord<'_, H>>, JournalError> {
         loop {
-            if self.cursor + LEN_SIZE > self.segment_size {
-                if self.advance_segment() {
+            if self.cursor + FRAME_HEADER > self.segment_size {
+                if self.advance_segment()? {
                     continue;
                 }
-                return None;
+                return Ok(None);
             }
             let data = self.segments[self.seg_idx].data();
-            // SAFETY: cursor is a 4-aligned offset within the mapped data.
-            let v = unsafe { marker(data.add(self.cursor)) }.load(Ordering::Acquire);
-            if v == 0 {
-                return None;
+            // SAFETY: cursor is an 8-aligned offset within the mapped data.
+            let cl = unsafe { commit_len(data.add(self.cursor)) }.load(Ordering::Acquire);
+            if cl == 0 {
+                return Ok(None);
             }
-            if v < 0 {
-                self.cursor += LEN_SIZE + (-v) as usize;
-                if self.cursor + LEN_SIZE > self.segment_size && !self.advance_segment() {
-                    return None;
+            // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
+            if unsafe { read_kind(data.add(self.cursor)) } == TYPE_PAD {
+                self.cursor += align_up(cl as usize);
+                if self.cursor + FRAME_HEADER > self.segment_size && !self.advance_segment()? {
+                    return Ok(None);
                 }
                 continue;
             }
-            let body = v as usize;
+            let body = cl as usize;
             let hsize = size_of::<H>();
             if body < hsize {
-                return None;
+                return Ok(None);
             }
             let off = self.cursor;
-            // SAFETY: the committed frame holds `H` at `off + LEN_SIZE`; `H: Pod`
-            // so an unaligned read is valid.
-            let header = unsafe { std::ptr::read_unaligned(data.add(off + LEN_SIZE).cast::<H>()) };
+            // SAFETY: the committed frame holds `H` at `off + FRAME_HEADER`;
+            // `H: Pod`, so an unaligned read is valid.
+            let header =
+                unsafe { std::ptr::read_unaligned(data.add(off + FRAME_HEADER).cast::<H>()) };
             // SAFETY: the payload lies within the committed frame and the mapping
             // outlives the borrow held through `&mut self`.
             let payload = unsafe {
-                std::slice::from_raw_parts(data.add(off + LEN_SIZE + hsize), body - hsize)
+                std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize)
             };
             self.cursor = off + footprint(body);
-            return Some(ReadRecord { header, payload });
+            return Ok(Some(ReadRecord { header, payload }));
         }
     }
 
-    fn advance_segment(&mut self) -> bool {
-        if self.seg_idx + 1 >= self.segments.len() && !self.load_next() {
-            return false;
+    fn advance_segment(&mut self) -> Result<bool, JournalError> {
+        if self.seg_idx + 1 >= self.segments.len() && !self.load_next()? {
+            return Ok(false);
         }
         self.seg_idx += 1;
         self.cursor = 0;
-        true
+        Ok(true)
     }
 
-    fn load_next(&mut self) -> bool {
+    fn load_next(&mut self) -> Result<bool, JournalError> {
         let next = self.segments.len() as u64;
         let path = super::segment_path(&self.base, next);
         match Segment::attach(&path, self.map) {
             Ok(seg) => {
                 self.segments.push(seg);
-                true
+                Ok(true)
             }
-            Err(_) => false,
+            Err(ShmError::Os(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e.into()),
         }
     }
 
+    /// Iterate committed records whose header sequence falls in `range`.
     pub fn read_range<R>(&mut self, range: R) -> Result<ReadRange<'_, H>, JournalError>
     where
         H: SeqHeader,
         R: RangeBounds<u64>,
     {
-        while self.load_next() {}
+        while self.load_next()? {}
         let lo = match range.start_bound() {
             std::ops::Bound::Included(&n) => n,
             std::ops::Bound::Excluded(&n) => n.saturating_add(1),
@@ -108,6 +117,7 @@ impl<H: RecordHeader> Reader<H> {
     }
 }
 
+/// A committed record: a copy of the header and a zero-copy view of the payload.
 pub struct ReadRecord<'a, H: RecordHeader> {
     header: H,
     payload: &'a [u8],
@@ -123,6 +133,7 @@ impl<H: RecordHeader> ReadRecord<'_, H> {
     }
 }
 
+/// Borrowing iterator over a sequence range, returned by [`Reader::read_range`].
 pub struct ReadRange<'a, H: SeqHeader> {
     segments: &'a [Segment],
     segment_size: usize,
@@ -141,39 +152,39 @@ impl<'a, H: SeqHeader> Iterator for ReadRange<'a, H> {
             if self.seg_idx >= self.segments.len() {
                 return None;
             }
-            if self.cursor + LEN_SIZE > self.segment_size {
+            if self.cursor + FRAME_HEADER > self.segment_size {
                 self.seg_idx += 1;
                 self.cursor = 0;
                 continue;
             }
             let data = self.segments[self.seg_idx].data();
-            // SAFETY: cursor is a 4-aligned offset within the mapped data.
-            let v = unsafe { marker(data.add(self.cursor)) }.load(Ordering::Acquire);
-            if v == 0 {
-                self.seg_idx += 1;
-                self.cursor = 0;
+            // SAFETY: cursor is an 8-aligned offset within the mapped data.
+            let cl = unsafe { commit_len(data.add(self.cursor)) }.load(Ordering::Acquire);
+            if cl == 0 {
+                return None;
+            }
+            // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
+            if unsafe { read_kind(data.add(self.cursor)) } == TYPE_PAD {
+                self.cursor += align_up(cl as usize);
                 continue;
             }
-            if v < 0 {
-                self.cursor += LEN_SIZE + (-v) as usize;
-                continue;
-            }
-            let body = v as usize;
+            let body = cl as usize;
             let hsize = size_of::<H>();
             if body < hsize {
                 return None;
             }
             let off = self.cursor;
             self.cursor = off + footprint(body);
-            // SAFETY: the committed frame holds `H` at `off + LEN_SIZE`; `H: Pod`.
-            let header = unsafe { std::ptr::read_unaligned(data.add(off + LEN_SIZE).cast::<H>()) };
+            // SAFETY: the committed frame holds `H` at `off + FRAME_HEADER`; `H: Pod`.
+            let header =
+                unsafe { std::ptr::read_unaligned(data.add(off + FRAME_HEADER).cast::<H>()) };
             if header.seq() < self.lo || header.seq() > self.hi {
                 continue;
             }
             // SAFETY: the payload lies within the committed frame and `segments`
             // outlives `'a`.
             let payload = unsafe {
-                std::slice::from_raw_parts(data.add(off + LEN_SIZE + hsize), body - hsize)
+                std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize)
             };
             return Some(ReadRecord { header, payload });
         }

--- a/nexus-shm/src/journal/tests.rs
+++ b/nexus-shm/src/journal/tests.rs
@@ -1,0 +1,188 @@
+use std::path::{Path, PathBuf};
+
+use crate::MapOptions;
+
+use super::{FixHeader, Journal, JournalConfig, JournalError};
+
+fn base_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("nexus-journal-{}-{}", std::process::id(), name))
+}
+
+fn cleanup(base: &Path) {
+    for i in 0..32u64 {
+        let mut p = base.as_os_str().to_owned();
+        p.push(format!(".{i}"));
+        let _ = std::fs::remove_file(PathBuf::from(p));
+    }
+}
+
+fn fix(seq: u64) -> FixHeader {
+    FixHeader {
+        seq,
+        timestamp: seq * 1000,
+    }
+}
+
+fn cfg(segment_size: usize) -> JournalConfig {
+    JournalConfig {
+        segment_size,
+        map: MapOptions::default(),
+    }
+}
+
+#[test]
+fn roundtrip_fix() {
+    let base = base_path("roundtrip");
+    cleanup(&base);
+
+    let (mut w, mut r) = Journal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+    for seq in 1..=3u64 {
+        let payload = vec![seq as u8; seq as usize * 4];
+        let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
+        claim.as_mut_slice().copy_from_slice(&payload);
+        claim.commit();
+    }
+
+    for seq in 1..=3u64 {
+        let rec = r.next_record().unwrap();
+        assert_eq!(rec.header(), fix(seq));
+        assert_eq!(rec.payload(), &vec![seq as u8; seq as usize * 4][..]);
+    }
+    assert!(r.next_record().is_none());
+
+    drop((w, r));
+    cleanup(&base);
+}
+
+#[test]
+fn unit_header_zero_overhead() {
+    let base = base_path("unit");
+    cleanup(&base);
+
+    let (mut w, mut r) = Journal::<()>::open(&base, cfg(1 << 16)).unwrap();
+    let mut claim = w.try_claim((), 5).unwrap();
+    claim.as_mut_slice().copy_from_slice(b"hello");
+    claim.commit();
+
+    let rec = r.next_record().unwrap();
+    assert_eq!(rec.payload(), b"hello");
+    assert!(r.next_record().is_none());
+
+    drop((w, r));
+    cleanup(&base);
+}
+
+#[test]
+fn empty_unit_record_rejected() {
+    let base = base_path("empty");
+    cleanup(&base);
+
+    let (mut w, _r) = Journal::<()>::open(&base, cfg(1 << 16)).unwrap();
+    assert!(matches!(w.try_claim((), 0), Err(JournalError::EmptyRecord)));
+
+    drop(w);
+    cleanup(&base);
+}
+
+#[test]
+fn record_too_large_rejected() {
+    let base = base_path("toolarge");
+    cleanup(&base);
+
+    let (mut w, _r) = Journal::<FixHeader>::open(&base, cfg(256)).unwrap();
+    assert!(matches!(
+        w.try_claim(fix(1), 4096),
+        Err(JournalError::RecordTooLarge { .. })
+    ));
+
+    drop(w);
+    cleanup(&base);
+}
+
+#[test]
+fn multi_segment_roll() {
+    let base = base_path("roll");
+    cleanup(&base);
+
+    let (mut w, mut r) = Journal::<FixHeader>::open(&base, cfg(128)).unwrap();
+    for seq in 1..=20u64 {
+        let payload = (seq as u32).to_le_bytes();
+        let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
+        claim.as_mut_slice().copy_from_slice(&payload);
+        claim.commit();
+    }
+
+    let mut seen = 0u64;
+    for seq in 1..=20u64 {
+        let rec = r.next_record().unwrap();
+        assert_eq!(rec.header().seq, seq);
+        assert_eq!(rec.payload(), &(seq as u32).to_le_bytes());
+        seen += 1;
+    }
+    assert_eq!(seen, 20);
+    assert!(r.next_record().is_none());
+    assert!(super::segment_path(&base, 1).exists());
+
+    drop((w, r));
+    cleanup(&base);
+}
+
+#[test]
+fn recovery_stops_at_uncommitted_tail() {
+    let base = base_path("recovery");
+    cleanup(&base);
+
+    {
+        let (mut w, _r) = Journal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+        for seq in 1..=2u64 {
+            let payload = (seq as u32).to_le_bytes();
+            let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
+            claim.as_mut_slice().copy_from_slice(&payload);
+            claim.commit();
+        }
+        {
+            let mut claim = w.try_claim(fix(3), 4).unwrap();
+            claim.as_mut_slice().copy_from_slice(&7u32.to_le_bytes());
+        }
+        drop(w);
+    }
+
+    let (mut w, mut r) = Journal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+    let payload = 99u32.to_le_bytes();
+    let mut claim = w.try_claim(fix(3), payload.len()).unwrap();
+    claim.as_mut_slice().copy_from_slice(&payload);
+    claim.commit();
+
+    assert_eq!(r.next_record().unwrap().header().seq, 1);
+    assert_eq!(r.next_record().unwrap().header().seq, 2);
+    let third = r.next_record().unwrap();
+    assert_eq!(third.header().seq, 3);
+    assert_eq!(third.payload(), &99u32.to_le_bytes());
+    assert!(r.next_record().is_none());
+
+    drop((w, r));
+    cleanup(&base);
+}
+
+#[test]
+fn read_range_by_seq() {
+    let base = base_path("range");
+    cleanup(&base);
+
+    let (mut w, mut r) = Journal::<FixHeader>::open(&base, cfg(128)).unwrap();
+    for seq in 1..=10u64 {
+        let payload = (seq as u32).to_le_bytes();
+        let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
+        claim.as_mut_slice().copy_from_slice(&payload);
+        claim.commit();
+    }
+
+    let got: Vec<u64> = r.read_range(3..=6).unwrap().map(|rec| rec.header().seq).collect();
+    assert_eq!(got, vec![3, 4, 5, 6]);
+
+    let got: Vec<u64> = r.read_range(8..).unwrap().map(|rec| rec.header().seq).collect();
+    assert_eq!(got, vec![8, 9, 10]);
+
+    drop((w, r));
+    cleanup(&base);
+}

--- a/nexus-shm/src/journal/tests.rs
+++ b/nexus-shm/src/journal/tests.rs
@@ -44,11 +44,11 @@ fn roundtrip_fix() {
     }
 
     for seq in 1..=3u64 {
-        let rec = r.next_record().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
         assert_eq!(rec.header(), fix(seq));
         assert_eq!(rec.payload(), &vec![seq as u8; seq as usize * 4][..]);
     }
-    assert!(r.next_record().is_none());
+    assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
     cleanup(&base);
@@ -64,9 +64,9 @@ fn unit_header_zero_overhead() {
     claim.as_mut_slice().copy_from_slice(b"hello");
     claim.commit();
 
-    let rec = r.next_record().unwrap();
+    let rec = r.next_record().unwrap().unwrap();
     assert_eq!(rec.payload(), b"hello");
-    assert!(r.next_record().is_none());
+    assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
     cleanup(&base);
@@ -114,14 +114,43 @@ fn multi_segment_roll() {
 
     let mut seen = 0u64;
     for seq in 1..=20u64 {
-        let rec = r.next_record().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
         assert_eq!(rec.header().seq, seq);
         assert_eq!(rec.payload(), &(seq as u32).to_le_bytes());
         seen += 1;
     }
     assert_eq!(seen, 20);
-    assert!(r.next_record().is_none());
+    assert!(r.next_record().unwrap().is_none());
     assert!(super::segment_path(&base, 1).exists());
+
+    drop((w, r));
+    cleanup(&base);
+}
+
+#[test]
+fn pad_at_frame_header_boundary() {
+    let base = base_path("pad-boundary");
+    cleanup(&base);
+
+    // segment_size 64, () header. Payloads 8,8,16 give footprints 16,16,24,
+    // leaving tail=56 and exactly FRAME_HEADER (8) bytes free — the case that
+    // collided with the uncommitted sentinel under the old i32 marker. The next
+    // claim must PAD those 8 bytes and roll, leaving all records reachable.
+    let (mut w, mut r) = Journal::<()>::open(&base, cfg(64)).unwrap();
+    let lens = [8usize, 8, 16, 8, 8];
+    for (i, &len) in lens.iter().enumerate() {
+        let payload = vec![i as u8 + 1; len];
+        let mut claim = w.try_claim((), len).unwrap();
+        claim.as_mut_slice().copy_from_slice(&payload);
+        claim.commit();
+    }
+    assert!(super::segment_path(&base, 1).exists());
+
+    for (i, &len) in lens.iter().enumerate() {
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(rec.payload(), &vec![i as u8 + 1; len][..]);
+    }
+    assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
     cleanup(&base);
@@ -153,12 +182,12 @@ fn recovery_stops_at_uncommitted_tail() {
     claim.as_mut_slice().copy_from_slice(&payload);
     claim.commit();
 
-    assert_eq!(r.next_record().unwrap().header().seq, 1);
-    assert_eq!(r.next_record().unwrap().header().seq, 2);
-    let third = r.next_record().unwrap();
+    assert_eq!(r.next_record().unwrap().unwrap().header().seq, 1);
+    assert_eq!(r.next_record().unwrap().unwrap().header().seq, 2);
+    let third = r.next_record().unwrap().unwrap();
     assert_eq!(third.header().seq, 3);
     assert_eq!(third.payload(), &99u32.to_le_bytes());
-    assert!(r.next_record().is_none());
+    assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
     cleanup(&base);

--- a/nexus-shm/src/journal/tests.rs
+++ b/nexus-shm/src/journal/tests.rs
@@ -177,10 +177,18 @@ fn read_range_by_seq() {
         claim.commit();
     }
 
-    let got: Vec<u64> = r.read_range(3..=6).unwrap().map(|rec| rec.header().seq).collect();
+    let got: Vec<u64> = r
+        .read_range(3..=6)
+        .unwrap()
+        .map(|rec| rec.header().seq)
+        .collect();
     assert_eq!(got, vec![3, 4, 5, 6]);
 
-    let got: Vec<u64> = r.read_range(8..).unwrap().map(|rec| rec.header().seq).collect();
+    let got: Vec<u64> = r
+        .read_range(8..)
+        .unwrap()
+        .map(|rec| rec.header().seq)
+        .collect();
     assert_eq!(got, vec![8, 9, 10]);
 
     drop((w, r));

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -4,9 +4,10 @@ use std::sync::atomic::Ordering;
 use crate::segment::Segment;
 
 use super::error::JournalError;
-use super::frame::{LEN_SIZE, footprint, marker};
+use super::frame::{FRAME_HEADER, TYPE_DATA, TYPE_PAD, commit_len, footprint, write_kind};
 use super::header::RecordHeader;
 
+/// Append half of a journal: claims and commits records to the active segment.
 pub struct Writer<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
@@ -18,6 +19,8 @@ pub struct Writer<H: RecordHeader> {
 }
 
 impl<H: RecordHeader> Writer<H> {
+    /// Reserve space for a record carrying `header` and `payload_len` bytes,
+    /// rolling to a new segment if it does not fit the current one.
     pub fn try_claim(
         &mut self,
         header: H,
@@ -28,7 +31,7 @@ impl<H: RecordHeader> Writer<H> {
             return Err(JournalError::EmptyRecord);
         }
         let foot = footprint(body);
-        if body > i32::MAX as usize || foot > self.segment_size {
+        if body > u32::MAX as usize || foot > self.segment_size {
             return Err(JournalError::RecordTooLarge {
                 frame: foot,
                 capacity: self.segment_size,
@@ -49,11 +52,13 @@ impl<H: RecordHeader> Writer<H> {
 
     fn roll(&mut self) -> Result<(), JournalError> {
         let remaining = self.segment_size - self.tail;
-        if remaining >= LEN_SIZE {
+        if remaining >= FRAME_HEADER {
             let data = self.active.data();
-            // SAFETY: tail is a 4-aligned offset within the mapped data region.
-            let m = unsafe { marker(data.add(self.tail)) };
-            m.store(-((remaining - LEN_SIZE) as i32), Ordering::Release);
+            // SAFETY: tail is an 8-aligned offset within the mapped data region.
+            unsafe {
+                write_kind(data.add(self.tail), TYPE_PAD);
+                commit_len(data.add(self.tail)).store(remaining as u32, Ordering::Release);
+            }
         }
         self.index += 1;
         let path = super::segment_path(&self.base, self.index);
@@ -63,6 +68,9 @@ impl<H: RecordHeader> Writer<H> {
     }
 }
 
+/// A reserved, not-yet-published record. Fill the payload, then [`commit`].
+///
+/// [`commit`]: WriteClaim::commit
 pub struct WriteClaim<'a, H: RecordHeader> {
     writer: &'a mut Writer<H>,
     off: usize,
@@ -73,30 +81,34 @@ pub struct WriteClaim<'a, H: RecordHeader> {
 }
 
 impl<H: RecordHeader> WriteClaim<'_, H> {
+    /// The payload region to fill before committing.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        let start = self.off + LEN_SIZE + size_of::<H>();
+        let start = self.off + FRAME_HEADER + size_of::<H>();
         let data = self.writer.active.data();
         // SAFETY: the region is reserved for this claim, lies within the mapped
         // data, and is exclusively borrowed through `&mut self`.
         unsafe { std::slice::from_raw_parts_mut(data.add(start), self.payload_len) }
     }
 
+    /// Publish the record: write the header and frame kind, then release the
+    /// commit length so readers observe a fully-written record.
     pub fn commit(self) {
         let data = self.writer.active.data();
         // SAFETY: the header slot is reserved for this claim and within the
         // mapped data; `H: Pod`, so an unaligned byte write is valid.
-        unsafe { std::ptr::write_unaligned(data.add(self.off + LEN_SIZE).cast::<H>(), self.header) }
-
-        let next = self.off + self.foot;
-        if next + LEN_SIZE <= self.writer.segment_size {
-            // SAFETY: `next` is a 4-aligned offset within the mapped data.
-            let m = unsafe { marker(data.add(next)) };
-            m.store(0, Ordering::Relaxed);
+        unsafe {
+            std::ptr::write_unaligned(data.add(self.off + FRAME_HEADER).cast::<H>(), self.header);
+            write_kind(data.add(self.off), TYPE_DATA);
         }
 
-        // SAFETY: the marker slot is 4-aligned and within the mapped data.
-        let m = unsafe { marker(data.add(self.off)) };
-        m.store(self.body as i32, Ordering::Release);
+        let next = self.off + self.foot;
+        if next + FRAME_HEADER <= self.writer.segment_size {
+            // SAFETY: `next` is an 8-aligned offset within the mapped data.
+            unsafe { commit_len(data.add(next)).store(0, Ordering::Relaxed) }
+        }
+
+        // SAFETY: the commit-length slot is 8-aligned and within the mapped data.
+        unsafe { commit_len(data.add(self.off)).store(self.body as u32, Ordering::Release) }
         self.writer.tail = next;
     }
 }

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -1,0 +1,102 @@
+use std::marker::PhantomData;
+use std::sync::atomic::Ordering;
+
+use crate::segment::Segment;
+
+use super::error::JournalError;
+use super::frame::{LEN_SIZE, footprint, marker};
+use super::header::RecordHeader;
+
+pub struct Writer<H: RecordHeader> {
+    pub(super) base: std::path::PathBuf,
+    pub(super) segment_size: usize,
+    pub(super) map: crate::region::MapOptions,
+    pub(super) active: Segment,
+    pub(super) index: u64,
+    pub(super) tail: usize,
+    pub(super) _marker: PhantomData<H>,
+}
+
+impl<H: RecordHeader> Writer<H> {
+    pub fn try_claim(
+        &mut self,
+        header: H,
+        payload_len: usize,
+    ) -> Result<WriteClaim<'_, H>, JournalError> {
+        let body = size_of::<H>() + payload_len;
+        if body == 0 {
+            return Err(JournalError::EmptyRecord);
+        }
+        let foot = footprint(body);
+        if body > i32::MAX as usize || foot > self.segment_size {
+            return Err(JournalError::RecordTooLarge {
+                frame: foot,
+                capacity: self.segment_size,
+            });
+        }
+        if self.tail + foot > self.segment_size {
+            self.roll()?;
+        }
+        Ok(WriteClaim {
+            off: self.tail,
+            body,
+            foot,
+            header,
+            payload_len,
+            writer: self,
+        })
+    }
+
+    fn roll(&mut self) -> Result<(), JournalError> {
+        let remaining = self.segment_size - self.tail;
+        if remaining >= LEN_SIZE {
+            let data = self.active.data();
+            // SAFETY: tail is a 4-aligned offset within the mapped data region.
+            let m = unsafe { marker(data.add(self.tail)) };
+            m.store(-((remaining - LEN_SIZE) as i32), Ordering::Release);
+        }
+        self.index += 1;
+        let path = super::segment_path(&self.base, self.index);
+        self.active = Segment::create(&path, self.segment_size, self.map)?;
+        self.tail = 0;
+        Ok(())
+    }
+}
+
+pub struct WriteClaim<'a, H: RecordHeader> {
+    writer: &'a mut Writer<H>,
+    off: usize,
+    body: usize,
+    foot: usize,
+    header: H,
+    payload_len: usize,
+}
+
+impl<H: RecordHeader> WriteClaim<'_, H> {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        let start = self.off + LEN_SIZE + size_of::<H>();
+        let data = self.writer.active.data();
+        // SAFETY: the region is reserved for this claim, lies within the mapped
+        // data, and is exclusively borrowed through `&mut self`.
+        unsafe { std::slice::from_raw_parts_mut(data.add(start), self.payload_len) }
+    }
+
+    pub fn commit(self) {
+        let data = self.writer.active.data();
+        // SAFETY: the header slot is reserved for this claim and within the
+        // mapped data; `H: Pod`, so an unaligned byte write is valid.
+        unsafe { std::ptr::write_unaligned(data.add(self.off + LEN_SIZE).cast::<H>(), self.header) }
+
+        let next = self.off + self.foot;
+        if next + LEN_SIZE <= self.writer.segment_size {
+            // SAFETY: `next` is a 4-aligned offset within the mapped data.
+            let m = unsafe { marker(data.add(next)) };
+            m.store(0, Ordering::Relaxed);
+        }
+
+        // SAFETY: the marker slot is 4-aligned and within the mapped data.
+        let m = unsafe { marker(data.add(self.off)) };
+        m.store(self.body as i32, Ordering::Release);
+        self.writer.tail = next;
+    }
+}

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -6,12 +6,17 @@
 
 pub(crate) mod control;
 mod error;
+mod journal;
 mod lock;
 mod pod;
 mod region;
 mod segment;
 
 pub use error::ShmError;
+pub use journal::{
+    FixHeader, Journal, JournalConfig, JournalError, ReadRange, ReadRecord, Reader, RecordHeader,
+    SeqHeader, WriteClaim, Writer,
+};
 pub use lock::Liveness;
 pub use pod::Pod;
 pub use region::MapOptions;

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -21,3 +21,7 @@ impl_pod!(
 // SAFETY: an array of `Pod` is a contiguous run of `Pod` values with no added
 // layout, pointers, or Drop, so it inherits every requirement of the trait.
 unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}
+
+// SAFETY: zero-sized, stable layout, no pointers, no Drop, valid for its single
+// bit pattern.
+unsafe impl Pod for () {}


### PR DESCRIPTION
Implements #391. Design in #414 (approved); review feedback folded in.

## What

Append-only durable log over mmap segments on the #390 foundation. Aeron Archive model.

- `Journal<H>` — `open` returns `(Writer<H>, Reader<H>)`, SPSC.
- Pluggable `Pod` header: `()` for position-only logs at zero per-record overhead, `FixHeader { seq, timestamp }` for FIX. `read_range` is gated behind `H: SeqHeader`.
- `frame_len` i32 commit marker, **unpadded** (header + payload), sign-as-sentinel: `0` uncommitted/stop, `>0` committed, `<0` PAD. Reader advances `4 + align_8(frame_len)`.
- Write: reserve (marker stays 0) → `as_mut_slice()` → `commit()` writes header, zeroes the next marker slot, then Release-stores the marker.
- Read: Acquire-load marker, skip PAD, yield zero-copy payload.
- Forward-scan recovery to the first uncommitted tail; PAD-over segment roll; cross-process segment discovery via `{base}.{N+1}` filename probe.

## Verification

16 tests (roundtrip, `()` header, multi-segment roll, uncommitted-tail recovery, range query, too-large/empty rejection), clippy clean under `-D warnings`. Criterion bench: `try_claim`+`commit` ~135 ns, `next_record` drain ~21 M/s (unpinned dev box, indicative only).

## Two deviations from the design doc — want your call

1. **No checksum.** The reviewed frame layout has no checksum field, and a config flag that does nothing violates the no-dead-code bar. Dropped it; recovery relies on the commit marker alone, which the doc already states fully covers the crash case. Checksum can come as a follow-up with its own layout (trailing CRC, `frame_len` accounting) for review.
2. **`ReadRecord::header()` returns `H` by value, not `&H`.** With an i32 marker the header sits at a 4-aligned offset, so `&H` would be unaligned UB for `FixHeader` (align 8). `H: Pod: Copy` and headers are tiny; payload stays zero-copy `&[u8]`. The alternative is an 8-byte marker cell, which I avoided to keep the Aeron i32 convention you confirmed.

Out of scope (noted in the doc): O(1) ring index, MPSC, fsync policy.
