### PR TITLE
feat: nexus-fix-codegen — dictionary-driven code generator (#407)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ members = [
 	"nexus-async-rt",
 	"nexus-inference",
 	"nexus-fix-codec",
+	"nexus-fix-codegen",
+	"nexus-fix-codegen-tests",
 ]
 
 [workspace.package]

--- a/nexus-fix-codec/Cargo.toml
+++ b/nexus-fix-codec/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["parsing", "network-programming"]
 workspace = true
 
 [dependencies]
+nexus-ascii = { path = "../nexus-ascii" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/nexus-fix-codec/src/convert.rs
+++ b/nexus-fix-codec/src/convert.rs
@@ -1,0 +1,109 @@
+//! Parsing helpers for typed FIX field values.
+
+/// Parse a FIX integer (`INT`, `SEQNUM`) value. Returns `None` on empty
+/// input, non-digit bytes, or overflow.
+#[inline]
+pub fn parse_fix_int(bytes: &[u8]) -> Option<i64> {
+    let (neg, digits) = match bytes.first()? {
+        b'-' => (true, &bytes[1..]),
+        b'+' => (false, &bytes[1..]),
+        _ => (false, bytes),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mut acc: i64 = 0;
+    for &b in digits {
+        let d = b.wrapping_sub(b'0');
+        if d > 9 {
+            return None;
+        }
+        acc = acc.checked_mul(10)?.checked_add(d as i64)?;
+    }
+    Some(if neg { -acc } else { acc })
+}
+
+/// Parse a FIX unsigned integer (`LENGTH`, `NUMINGROUP`) value. Returns
+/// `None` on empty input, non-digit bytes, or overflow.
+#[inline]
+pub fn parse_fix_uint(bytes: &[u8]) -> Option<u32> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut acc: u32 = 0;
+    for &b in bytes {
+        let d = b.wrapping_sub(b'0');
+        if d > 9 {
+            return None;
+        }
+        acc = acc.checked_mul(10)?.checked_add(d as u32)?;
+    }
+    Some(acc)
+}
+
+/// Format an unsigned integer into `buf` as ASCII digits, returning the
+/// written slice. `buf` of 20 bytes holds any `u64`. Allocation-free.
+#[inline]
+pub fn format_uint(buf: &mut [u8; 20], mut v: u64) -> &[u8] {
+    let mut p = buf.len();
+    loop {
+        p -= 1;
+        buf[p] = b'0' + (v % 10) as u8;
+        v /= 10;
+        if v == 0 {
+            break;
+        }
+    }
+    &buf[p..]
+}
+
+/// Parse a FIX boolean (`BOOLEAN`) value: `Y` is true, `N` is false.
+#[inline]
+pub fn parse_fix_bool(bytes: &[u8]) -> Option<bool> {
+    match bytes {
+        b"Y" => Some(true),
+        b"N" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ints() {
+        assert_eq!(parse_fix_int(b"0"), Some(0));
+        assert_eq!(parse_fix_int(b"42"), Some(42));
+        assert_eq!(parse_fix_int(b"-17"), Some(-17));
+        assert_eq!(parse_fix_int(b"+5"), Some(5));
+        assert_eq!(parse_fix_int(b""), None);
+        assert_eq!(parse_fix_int(b"-"), None);
+        assert_eq!(parse_fix_int(b"1a"), None);
+    }
+
+    #[test]
+    fn uints() {
+        assert_eq!(parse_fix_uint(b"123"), Some(123));
+        assert_eq!(parse_fix_uint(b""), None);
+        assert_eq!(parse_fix_uint(b"-1"), None);
+        assert_eq!(parse_fix_uint(b"99999999999"), None);
+    }
+
+    #[test]
+    fn uint_format() {
+        let mut buf = [0u8; 20];
+        assert_eq!(format_uint(&mut buf, 0), b"0");
+        assert_eq!(format_uint(&mut buf, 7), b"7");
+        assert_eq!(format_uint(&mut buf, 12345), b"12345");
+        assert_eq!(format_uint(&mut buf, u64::from(u32::MAX)), b"4294967295");
+    }
+
+    #[test]
+    fn bools() {
+        assert_eq!(parse_fix_bool(b"Y"), Some(true));
+        assert_eq!(parse_fix_bool(b"N"), Some(false));
+        assert_eq!(parse_fix_bool(b"y"), None);
+        assert_eq!(parse_fix_bool(b""), None);
+    }
+}

--- a/nexus-fix-codec/src/lib.rs
+++ b/nexus-fix-codec/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! Generated FIX codecs (from `nexus-fix-codegen`) depend on these primitives.
 
+mod convert;
 mod error;
 mod span;
 
@@ -17,7 +18,9 @@ pub mod reader;
 pub mod scan;
 pub mod writer;
 
+pub use convert::{format_uint, parse_fix_bool, parse_fix_int, parse_fix_uint};
 pub use error::{ChecksumError, DecodeError};
+pub use nexus_ascii::AsciiTextStr;
 pub use reader::{FieldReader, RawField, checksum, find_tag, parse_tag, validate_checksum};
 pub use scan::DelimiterScanner;
 pub use span::{FieldSpan, GroupSpan};

--- a/nexus-fix-codegen-tests/Cargo.toml
+++ b/nexus-fix-codegen-tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nexus-fix-codegen-tests"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-fix-codec = { path = "../nexus-fix-codec" }
+
+[build-dependencies]
+nexus-fix-codegen = { path = "../nexus-fix-codegen" }

--- a/nexus-fix-codegen-tests/build.rs
+++ b/nexus-fix-codegen-tests/build.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+fn main() {
+    let out = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let dict = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../nexus-fix-codegen/tests/fixtures/FIX_sample.xml");
+    println!("cargo:rerun-if-changed={}", dict.display());
+    nexus_fix_codegen::generate()
+        .dictionary(&dict)
+        .out_dir(&out)
+        .rustfmt(false)
+        .run()
+        .expect("codegen failed");
+}

--- a/nexus-fix-codegen-tests/build.rs
+++ b/nexus-fix-codegen-tests/build.rs
@@ -2,11 +2,15 @@ use std::path::PathBuf;
 
 fn main() {
     let out = std::env::var("OUT_DIR").expect("OUT_DIR not set");
-    let dict = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../nexus-fix-codegen/tests/fixtures/FIX_sample.xml");
-    println!("cargo:rerun-if-changed={}", dict.display());
+    let fixtures =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../nexus-fix-codegen/tests/fixtures");
+    let alpha = fixtures.join("venue_alpha.xml");
+    let beta = fixtures.join("venue_beta.xml");
+    println!("cargo:rerun-if-changed={}", alpha.display());
+    println!("cargo:rerun-if-changed={}", beta.display());
     nexus_fix_codegen::generate()
-        .dictionary(&dict)
+        .dictionary(&alpha)
+        .dictionary(&beta)
         .out_dir(&out)
         .rustfmt(false)
         .run()

--- a/nexus-fix-codegen-tests/src/lib.rs
+++ b/nexus-fix-codegen-tests/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod fix {
+    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+}

--- a/nexus-fix-codegen-tests/src/lib.rs
+++ b/nexus-fix-codegen-tests/src/lib.rs
@@ -1,3 +1,7 @@
-pub mod fix {
-    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+pub mod venue_alpha {
+    include!(concat!(env!("OUT_DIR"), "/venue_alpha/mod.rs"));
+}
+
+pub mod venue_beta {
+    include!(concat!(env!("OUT_DIR"), "/venue_beta/mod.rs"));
 }

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -1,0 +1,90 @@
+use nexus_fix_codegen_tests::fix;
+
+#[test]
+fn decodes_scalar_fields_and_enum() {
+    let msg = b"11=ORD123\x0154=1\x0155=BTC-USD\x0138=10\x01";
+    let m = fix::messages::NewOrderSingle::decode(msg);
+    assert_eq!(m.cl_ord_id(), Some(&b"ORD123"[..]));
+    assert_eq!(m.symbol(), Some(&b"BTC-USD"[..]));
+    assert_eq!(m.order_qty(), Some(&b"10"[..]));
+    assert_eq!(m.side_enum(), Some(fix::fields::Side::BUY));
+}
+
+#[test]
+fn absent_field_is_none() {
+    let msg = b"11=ORD123\x01";
+    let m = fix::messages::NewOrderSingle::decode(msg);
+    assert_eq!(m.symbol(), None);
+    assert_eq!(m.side_enum(), None);
+}
+
+#[test]
+fn decodes_data_field_with_embedded_soh() {
+    let msg = b"11=A\x0195=3\x0196=a\x01b\x0155=X\x01";
+    let m = fix::messages::NewOrderSingle::decode(msg);
+    assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
+    assert_eq!(m.raw_data(), Some(&b"a\x01b"[..]));
+    assert_eq!(m.symbol(), Some(&b"X"[..]));
+}
+
+#[test]
+fn decodes_repeating_group() {
+    let msg = b"11=A\x01453=2\x01448=PARTY1\x01452=1\x01448=PARTY2\x01452=2\x0155=X\x01";
+    let m = fix::messages::NewOrderSingle::decode(msg);
+    let parties: Vec<_> = m.no_party_i_ds().collect();
+    assert_eq!(parties.len(), 2);
+    assert_eq!(parties[0].party_id(), Some(&b"PARTY1"[..]));
+    assert_eq!(parties[1].party_id(), Some(&b"PARTY2"[..]));
+    assert_eq!(m.symbol(), Some(&b"X"[..]));
+}
+
+#[test]
+fn decodes_nested_group() {
+    let msg = b"11=A\x01453=1\x01448=P1\x01452=1\x01802=2\x01523=S1\x01803=1\x01523=S2\x01803=2\x0155=X\x01";
+    let m = fix::messages::NewOrderSingle::decode(msg);
+    let parties: Vec<_> = m.no_party_i_ds().collect();
+    assert_eq!(parties.len(), 1);
+    assert_eq!(parties[0].party_id(), Some(&b"P1"[..]));
+    let subs: Vec<_> = parties[0].no_party_sub_i_ds().collect();
+    assert_eq!(subs.len(), 2);
+    assert_eq!(subs[0].party_sub_id(), Some(&b"S1"[..]));
+    assert_eq!(subs[1].party_sub_id(), Some(&b"S2"[..]));
+    assert_eq!(m.symbol(), Some(&b"X"[..]));
+}
+
+#[test]
+fn msgtype_dispatch() {
+    assert_eq!(
+        fix::MsgType::from_bytes(b"D"),
+        Some(fix::MsgType::NewOrderSingle)
+    );
+    assert_eq!(fix::MsgType::NewOrderSingle.as_bytes(), b"D");
+    assert_eq!(fix::MsgType::from_bytes(b"ZZ"), None);
+}
+
+#[test]
+fn encodes_round_trip() {
+    let mut buf = [0u8; 128];
+    let n = fix::encoders::NewOrderSingleEncoder::new(&mut buf)
+        .cl_ord_id(b"ORD1")
+        .side_value(fix::fields::Side::SELL)
+        .symbol(b"ETH-USD")
+        .finish();
+    let encoded = &buf[..n];
+    let m = fix::messages::NewOrderSingle::decode(encoded);
+    assert_eq!(m.cl_ord_id(), Some(&b"ORD1"[..]));
+    assert_eq!(m.side_enum(), Some(fix::fields::Side::SELL));
+    assert_eq!(m.symbol(), Some(&b"ETH-USD"[..]));
+}
+
+#[test]
+fn encodes_data_field() {
+    let mut buf = [0u8; 64];
+    let n = fix::encoders::NewOrderSingleEncoder::new(&mut buf)
+        .cl_ord_id(b"A")
+        .raw_data(b"x\x01y")
+        .finish();
+    let m = fix::messages::NewOrderSingle::decode(&buf[..n]);
+    assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
+    assert_eq!(m.raw_data(), Some(&b"x\x01y"[..]));
+}

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -4,9 +4,18 @@ use nexus_fix_codegen_tests::{venue_alpha, venue_beta};
 fn alpha_decodes_scalar_fields_and_enum() {
     let msg = b"11=ORD123\x0154=1\x0155=BTC-USD\x0138=10\x01";
     let m = venue_alpha::messages::NewOrderSingle::decode(msg);
-    assert_eq!(m.cl_ord_id(), Some(&b"ORD123"[..]));
-    assert_eq!(m.symbol(), Some(&b"BTC-USD"[..]));
-    assert_eq!(m.order_qty(), Some(&b"10"[..]));
+    assert_eq!(
+        m.cl_ord_id().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"ORD123"[..])
+    );
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"BTC-USD"[..])
+    );
+    assert_eq!(
+        m.order_qty().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"10"[..])
+    );
     assert_eq!(m.side_enum(), Some(venue_alpha::fields::Side::BUY));
 }
 
@@ -14,17 +23,47 @@ fn alpha_decodes_scalar_fields_and_enum() {
 fn alpha_absent_field_is_none() {
     let msg = b"11=ORD123\x01";
     let m = venue_alpha::messages::NewOrderSingle::decode(msg);
-    assert_eq!(m.symbol(), None);
-    assert_eq!(m.side_enum(), None);
+    assert!(m.symbol().is_none());
+    assert!(m.side_enum().is_none());
+}
+
+#[test]
+fn alpha_unknown_enum_value_is_preserved() {
+    let msg = b"11=A\x0154=9\x01";
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
+    assert_eq!(
+        m.side_enum(),
+        Some(venue_alpha::fields::Side::Unknown(b'9'))
+    );
+}
+
+#[test]
+fn alpha_is_complete() {
+    let full = b"11=A\x0154=1\x0155=X\x01";
+    assert!(venue_alpha::messages::NewOrderSingle::decode(full).is_complete());
+    let missing_symbol = b"11=A\x0154=1\x01";
+    assert!(!venue_alpha::messages::NewOrderSingle::decode(missing_symbol).is_complete());
 }
 
 #[test]
 fn alpha_decodes_data_field_with_embedded_soh() {
     let msg = b"11=A\x0195=3\x0196=a\x01b\x0155=X\x01";
     let m = venue_alpha::messages::NewOrderSingle::decode(msg);
-    assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
+    assert_eq!(m.raw_data_length(), Some(3));
     assert_eq!(m.raw_data(), Some(&b"a\x01b"[..]));
-    assert_eq!(m.symbol(), Some(&b"X"[..]));
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"X"[..])
+    );
+}
+
+#[test]
+fn alpha_truncated_data_does_not_panic() {
+    let msg = b"11=A\x0195=100\x0196=ab\x01";
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
+    assert_eq!(m.raw_data_length(), Some(100));
+    let data = m.raw_data().unwrap();
+    assert!(data.len() <= msg.len());
 }
 
 #[test]
@@ -33,9 +72,22 @@ fn alpha_decodes_repeating_group() {
     let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     let parties: Vec<_> = m.no_party_i_ds().collect();
     assert_eq!(parties.len(), 2);
-    assert_eq!(parties[0].party_id(), Some(&b"PARTY1"[..]));
-    assert_eq!(parties[1].party_id(), Some(&b"PARTY2"[..]));
-    assert_eq!(m.symbol(), Some(&b"X"[..]));
+    assert_eq!(
+        parties[0]
+            .party_id()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"PARTY1"[..])
+    );
+    assert_eq!(
+        parties[1]
+            .party_id()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"PARTY2"[..])
+    );
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"X"[..])
+    );
 }
 
 #[test]
@@ -44,27 +96,57 @@ fn alpha_decodes_nested_group() {
     let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     let parties: Vec<_> = m.no_party_i_ds().collect();
     assert_eq!(parties.len(), 1);
-    assert_eq!(parties[0].party_id(), Some(&b"P1"[..]));
+    assert_eq!(
+        parties[0]
+            .party_id()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"P1"[..])
+    );
     let subs: Vec<_> = parties[0].no_party_sub_i_ds().collect();
     assert_eq!(subs.len(), 2);
-    assert_eq!(subs[0].party_sub_id(), Some(&b"S1"[..]));
-    assert_eq!(subs[1].party_sub_id(), Some(&b"S2"[..]));
-    assert_eq!(m.symbol(), Some(&b"X"[..]));
+    assert_eq!(
+        subs[0]
+            .party_sub_id()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"S1"[..])
+    );
+    assert_eq!(
+        subs[1]
+            .party_sub_id()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"S2"[..])
+    );
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"X"[..])
+    );
 }
 
 #[test]
 fn alpha_decodes_execution_report() {
     let msg = b"37=ORD1\x0117=EX1\x01150=0\x0139=2\x0155=BTC-USD\x0154=1\x0132=5\x0131=100\x01";
     let m = venue_alpha::messages::ExecutionReport::decode(msg);
-    assert_eq!(m.order_id(), Some(&b"ORD1"[..]));
-    assert_eq!(m.exec_id(), Some(&b"EX1"[..]));
+    assert_eq!(
+        m.order_id().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"ORD1"[..])
+    );
+    assert_eq!(
+        m.exec_id().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"EX1"[..])
+    );
     assert_eq!(m.exec_type_enum(), Some(venue_alpha::fields::ExecType::NEW));
     assert_eq!(
         m.ord_status_enum(),
         Some(venue_alpha::fields::OrdStatus::FILLED)
     );
-    assert_eq!(m.last_qty(), Some(&b"5"[..]));
-    assert_eq!(m.last_px(), Some(&b"100"[..]));
+    assert_eq!(
+        m.last_qty().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"5"[..])
+    );
+    assert_eq!(
+        m.last_px().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"100"[..])
+    );
 }
 
 #[test]
@@ -86,9 +168,15 @@ fn alpha_encodes_round_trip() {
         .symbol(b"ETH-USD")
         .finish();
     let m = venue_alpha::messages::NewOrderSingle::decode(&buf[..n]);
-    assert_eq!(m.cl_ord_id(), Some(&b"ORD1"[..]));
+    assert_eq!(
+        m.cl_ord_id().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"ORD1"[..])
+    );
     assert_eq!(m.side_enum(), Some(venue_alpha::fields::Side::SELL));
-    assert_eq!(m.symbol(), Some(&b"ETH-USD"[..]));
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"ETH-USD"[..])
+    );
 }
 
 #[test]
@@ -99,7 +187,7 @@ fn alpha_encodes_data_field() {
         .raw_data(b"x\x01y")
         .finish();
     let m = venue_alpha::messages::NewOrderSingle::decode(&buf[..n]);
-    assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
+    assert_eq!(m.raw_data_length(), Some(3));
     assert_eq!(m.raw_data(), Some(&b"x\x01y"[..]));
 }
 
@@ -107,19 +195,32 @@ fn alpha_encodes_data_field() {
 fn beta_decodes_market_data_group() {
     let msg = b"55=EUR/USD\x01268=2\x01269=0\x01270=1.1050\x01271=1000000\x01269=1\x01270=1.1052\x01271=2000000\x01";
     let m = venue_beta::messages::MarketDataSnapshotFullRefresh::decode(msg);
-    assert_eq!(m.symbol(), Some(&b"EUR/USD"[..]));
+    assert_eq!(
+        m.symbol().map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"EUR/USD"[..])
+    );
     let entries: Vec<_> = m.no_md_entries().collect();
     assert_eq!(entries.len(), 2);
     assert_eq!(
         entries[0].md_entry_type_enum(),
         Some(venue_beta::fields::MDEntryType::BID)
     );
-    assert_eq!(entries[0].md_entry_px(), Some(&b"1.1050"[..]));
+    assert_eq!(
+        entries[0]
+            .md_entry_px()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"1.1050"[..])
+    );
     assert_eq!(
         entries[1].md_entry_type_enum(),
         Some(venue_beta::fields::MDEntryType::OFFER)
     );
-    assert_eq!(entries[1].md_entry_size(), Some(&b"2000000"[..]));
+    assert_eq!(
+        entries[1]
+            .md_entry_size()
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes),
+        Some(&b"2000000"[..])
+    );
 }
 
 #[test]

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -1,36 +1,36 @@
-use nexus_fix_codegen_tests::fix;
+use nexus_fix_codegen_tests::{venue_alpha, venue_beta};
 
 #[test]
-fn decodes_scalar_fields_and_enum() {
+fn alpha_decodes_scalar_fields_and_enum() {
     let msg = b"11=ORD123\x0154=1\x0155=BTC-USD\x0138=10\x01";
-    let m = fix::messages::NewOrderSingle::decode(msg);
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     assert_eq!(m.cl_ord_id(), Some(&b"ORD123"[..]));
     assert_eq!(m.symbol(), Some(&b"BTC-USD"[..]));
     assert_eq!(m.order_qty(), Some(&b"10"[..]));
-    assert_eq!(m.side_enum(), Some(fix::fields::Side::BUY));
+    assert_eq!(m.side_enum(), Some(venue_alpha::fields::Side::BUY));
 }
 
 #[test]
-fn absent_field_is_none() {
+fn alpha_absent_field_is_none() {
     let msg = b"11=ORD123\x01";
-    let m = fix::messages::NewOrderSingle::decode(msg);
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     assert_eq!(m.symbol(), None);
     assert_eq!(m.side_enum(), None);
 }
 
 #[test]
-fn decodes_data_field_with_embedded_soh() {
+fn alpha_decodes_data_field_with_embedded_soh() {
     let msg = b"11=A\x0195=3\x0196=a\x01b\x0155=X\x01";
-    let m = fix::messages::NewOrderSingle::decode(msg);
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
     assert_eq!(m.raw_data(), Some(&b"a\x01b"[..]));
     assert_eq!(m.symbol(), Some(&b"X"[..]));
 }
 
 #[test]
-fn decodes_repeating_group() {
+fn alpha_decodes_repeating_group() {
     let msg = b"11=A\x01453=2\x01448=PARTY1\x01452=1\x01448=PARTY2\x01452=2\x0155=X\x01";
-    let m = fix::messages::NewOrderSingle::decode(msg);
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     let parties: Vec<_> = m.no_party_i_ds().collect();
     assert_eq!(parties.len(), 2);
     assert_eq!(parties[0].party_id(), Some(&b"PARTY1"[..]));
@@ -39,9 +39,9 @@ fn decodes_repeating_group() {
 }
 
 #[test]
-fn decodes_nested_group() {
+fn alpha_decodes_nested_group() {
     let msg = b"11=A\x01453=1\x01448=P1\x01452=1\x01802=2\x01523=S1\x01803=1\x01523=S2\x01803=2\x0155=X\x01";
-    let m = fix::messages::NewOrderSingle::decode(msg);
+    let m = venue_alpha::messages::NewOrderSingle::decode(msg);
     let parties: Vec<_> = m.no_party_i_ds().collect();
     assert_eq!(parties.len(), 1);
     assert_eq!(parties[0].party_id(), Some(&b"P1"[..]));
@@ -53,38 +53,88 @@ fn decodes_nested_group() {
 }
 
 #[test]
-fn msgtype_dispatch() {
+fn alpha_decodes_execution_report() {
+    let msg = b"37=ORD1\x0117=EX1\x01150=0\x0139=2\x0155=BTC-USD\x0154=1\x0132=5\x0131=100\x01";
+    let m = venue_alpha::messages::ExecutionReport::decode(msg);
+    assert_eq!(m.order_id(), Some(&b"ORD1"[..]));
+    assert_eq!(m.exec_id(), Some(&b"EX1"[..]));
+    assert_eq!(m.exec_type_enum(), Some(venue_alpha::fields::ExecType::NEW));
     assert_eq!(
-        fix::MsgType::from_bytes(b"D"),
-        Some(fix::MsgType::NewOrderSingle)
+        m.ord_status_enum(),
+        Some(venue_alpha::fields::OrdStatus::FILLED)
     );
-    assert_eq!(fix::MsgType::NewOrderSingle.as_bytes(), b"D");
-    assert_eq!(fix::MsgType::from_bytes(b"ZZ"), None);
+    assert_eq!(m.last_qty(), Some(&b"5"[..]));
+    assert_eq!(m.last_px(), Some(&b"100"[..]));
 }
 
 #[test]
-fn encodes_round_trip() {
+fn alpha_msgtype_dispatch() {
+    use venue_alpha::MsgType;
+    assert_eq!(MsgType::from_bytes(b"D"), Some(MsgType::NewOrderSingle));
+    assert_eq!(MsgType::from_bytes(b"8"), Some(MsgType::ExecutionReport));
+    assert_eq!(MsgType::from_bytes(b"0"), Some(MsgType::Heartbeat));
+    assert_eq!(MsgType::ExecutionReport.as_bytes(), b"8");
+    assert_eq!(MsgType::from_bytes(b"ZZ"), None);
+}
+
+#[test]
+fn alpha_encodes_round_trip() {
     let mut buf = [0u8; 128];
-    let n = fix::encoders::NewOrderSingleEncoder::new(&mut buf)
+    let n = venue_alpha::encoders::NewOrderSingleEncoder::new(&mut buf)
         .cl_ord_id(b"ORD1")
-        .side_value(fix::fields::Side::SELL)
+        .side_value(venue_alpha::fields::Side::SELL)
         .symbol(b"ETH-USD")
         .finish();
-    let encoded = &buf[..n];
-    let m = fix::messages::NewOrderSingle::decode(encoded);
+    let m = venue_alpha::messages::NewOrderSingle::decode(&buf[..n]);
     assert_eq!(m.cl_ord_id(), Some(&b"ORD1"[..]));
-    assert_eq!(m.side_enum(), Some(fix::fields::Side::SELL));
+    assert_eq!(m.side_enum(), Some(venue_alpha::fields::Side::SELL));
     assert_eq!(m.symbol(), Some(&b"ETH-USD"[..]));
 }
 
 #[test]
-fn encodes_data_field() {
+fn alpha_encodes_data_field() {
     let mut buf = [0u8; 64];
-    let n = fix::encoders::NewOrderSingleEncoder::new(&mut buf)
+    let n = venue_alpha::encoders::NewOrderSingleEncoder::new(&mut buf)
         .cl_ord_id(b"A")
         .raw_data(b"x\x01y")
         .finish();
-    let m = fix::messages::NewOrderSingle::decode(&buf[..n]);
+    let m = venue_alpha::messages::NewOrderSingle::decode(&buf[..n]);
     assert_eq!(m.raw_data_length(), Some(&b"3"[..]));
     assert_eq!(m.raw_data(), Some(&b"x\x01y"[..]));
+}
+
+#[test]
+fn beta_decodes_market_data_group() {
+    let msg = b"55=EUR/USD\x01268=2\x01269=0\x01270=1.1050\x01271=1000000\x01269=1\x01270=1.1052\x01271=2000000\x01";
+    let m = venue_beta::messages::MarketDataSnapshotFullRefresh::decode(msg);
+    assert_eq!(m.symbol(), Some(&b"EUR/USD"[..]));
+    let entries: Vec<_> = m.no_md_entries().collect();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(
+        entries[0].md_entry_type_enum(),
+        Some(venue_beta::fields::MDEntryType::BID)
+    );
+    assert_eq!(entries[0].md_entry_px(), Some(&b"1.1050"[..]));
+    assert_eq!(
+        entries[1].md_entry_type_enum(),
+        Some(venue_beta::fields::MDEntryType::OFFER)
+    );
+    assert_eq!(entries[1].md_entry_size(), Some(&b"2000000"[..]));
+}
+
+#[test]
+fn beta_msgtype_dispatch() {
+    use venue_beta::MsgType;
+    assert_eq!(
+        MsgType::from_bytes(b"W"),
+        Some(MsgType::MarketDataSnapshotFullRefresh)
+    );
+    assert_eq!(MsgType::from_bytes(b"A"), Some(MsgType::Logon));
+    assert_eq!(MsgType::from_bytes(b"D"), None);
+}
+
+#[test]
+fn modules_are_independent() {
+    assert_eq!(venue_alpha::BEGIN_STRING, b"FIX.4.4");
+    assert_eq!(venue_beta::BEGIN_STRING, b"FIX.4.2");
 }

--- a/nexus-fix-codegen/Cargo.toml
+++ b/nexus-fix-codegen/Cargo.toml
@@ -19,9 +19,13 @@ name = "nexus_fix_codegen"
 [[bin]]
 name = "nexus-fix-codegen"
 path = "src/main.rs"
+required-features = ["cli"]
+
+[features]
+cli = ["dep:clap"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"], optional = true }
 quick-xml = "0.37"
 
 [dev-dependencies]

--- a/nexus-fix-codegen/Cargo.toml
+++ b/nexus-fix-codegen/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "nexus-fix-codegen"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Dictionary-driven FIX codec generator for nexus-fix-codec"
+readme = "README.md"
+repository.workspace = true
+keywords = ["fix", "codegen", "trading", "protocol", "low-latency"]
+categories = ["development-tools", "encoding", "parser-implementations"]
+
+[lints]
+workspace = true
+
+[lib]
+name = "nexus_fix_codegen"
+
+[[bin]]
+name = "nexus-fix-codegen"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+quick-xml = "0.37"
+
+[dev-dependencies]

--- a/nexus-fix-codegen/README.md
+++ b/nexus-fix-codegen/README.md
@@ -1,0 +1,44 @@
+# nexus-fix-codegen
+
+Dictionary-driven code generator for [`nexus-fix-codec`](../nexus-fix-codec).
+Reads a QuickFIX XML dictionary and emits zero-copy, zero-alloc Rust decoders
+and encoders that sit directly on the codec primitives.
+
+## Output
+
+Per dictionary, five files:
+
+- `fields.rs` — `TAG_*` constants and typed enums (`from_byte`/`as_byte` or
+  `from_bytes`/`as_bytes`).
+- `messages.rs` — per-`MsgType` flyweight decoders. A single forward pass over
+  `FieldReader` dispatches each tag into a `FieldSpan` slot; accessors are pure
+  reads. DATA fields are read length-delimited so an embedded `0x01` never
+  mis-splits.
+- `groups.rs` — repeating-group iterators and per-entry decoders, recursive.
+- `encoders.rs` — consume-self builders over `FieldWriter`.
+- `mod.rs` — re-exports, `BEGIN_STRING`, and `MsgType` dispatch.
+
+## CLI
+
+```bash
+cargo run -p nexus-fix-codegen -- --dict dict/FIX44.xml --out src/generated/
+```
+
+## build.rs
+
+```rust
+nexus_fix_codegen::generate()
+    .dictionary("dict/FIX44.xml")
+    .out_dir(std::env::var("OUT_DIR").unwrap())
+    .run()
+    .unwrap();
+```
+
+```rust
+pub mod fix {
+    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+}
+```
+
+DATA fields inside repeating groups are rejected at generation time
+(`EmitError::DataInGroup`).

--- a/nexus-fix-codegen/README.md
+++ b/nexus-fix-codegen/README.md
@@ -8,20 +8,26 @@ and encoders that sit directly on the codec primitives.
 
 Per dictionary, five files:
 
-- `fields.rs` — `TAG_*` constants and typed enums (`from_byte`/`as_byte` or
-  `from_bytes`/`as_bytes`).
+- `fields.rs` — `TAG_*` constants and typed enums. Constructors are infallible
+  (`from_byte`/`from_bytes` return `Self`); values outside the dictionary become
+  `Unknown(u8)` / `Unknown(&AsciiTextStr)`.
 - `messages.rs` — per-`MsgType` flyweight decoders. A single forward pass over
-  `FieldReader` dispatches each tag into a `FieldSpan` slot; accessors are pure
-  reads. DATA fields are read length-delimited so an embedded `0x01` never
-  mis-splits.
+  `FieldReader` dispatches each tag (via `match`) into a `FieldSpan` slot.
+  Accessors are typed by FIX type: `&AsciiTextStr` for string-like fields,
+  `i64`/`u32` for integers, `bool` for booleans, `&[u8]` for DATA. DATA is read
+  length-delimited so an embedded `0x01` never mis-splits. `is_complete()`
+  checks required fields are present.
 - `groups.rs` — repeating-group iterators and per-entry decoders, recursive.
-- `encoders.rs` — consume-self builders over `FieldWriter`.
+- `encoders.rs` — consume-self builders over `FieldWriter`. Repeating groups are
+  not yet supported on the encode side.
 - `mod.rs` — re-exports, `BEGIN_STRING`, and `MsgType` dispatch.
 
 ## CLI
 
+The CLI is behind the `cli` feature (so `build.rs` users don't compile `clap`):
+
 ```bash
-cargo run -p nexus-fix-codegen -- --dict dict/FIX44.xml --out src/generated/
+cargo run -p nexus-fix-codegen --features cli -- --dict dict/FIX44.xml --out src/generated/
 ```
 
 ## build.rs

--- a/nexus-fix-codegen/src/dict/mod.rs
+++ b/nexus-fix-codegen/src/dict/mod.rs
@@ -6,8 +6,11 @@ pub use parse::{ParseError, parse};
 pub enum FieldType {
     Data,
     Length,
+    NumInGroup,
     Int,
-    Other,
+    SeqNum,
+    Bool,
+    Ascii,
 }
 
 impl FieldType {
@@ -15,8 +18,11 @@ impl FieldType {
         match s {
             "DATA" | "XMLDATA" => Self::Data,
             "LENGTH" => Self::Length,
-            "INT" | "NUMINGROUP" | "SEQNUM" => Self::Int,
-            _ => Self::Other,
+            "NUMINGROUP" => Self::NumInGroup,
+            "INT" => Self::Int,
+            "SEQNUM" => Self::SeqNum,
+            "BOOLEAN" => Self::Bool,
+            _ => Self::Ascii,
         }
     }
 }

--- a/nexus-fix-codegen/src/dict/mod.rs
+++ b/nexus-fix-codegen/src/dict/mod.rs
@@ -1,0 +1,89 @@
+mod parse;
+
+pub use parse::{ParseError, parse};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldType {
+    Data,
+    Length,
+    Int,
+    Other,
+}
+
+impl FieldType {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "DATA" | "XMLDATA" => Self::Data,
+            "LENGTH" => Self::Length,
+            "INT" | "NUMINGROUP" | "SEQNUM" => Self::Int,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EnumValue {
+    pub value: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldDef {
+    pub number: u32,
+    pub name: String,
+    pub ftype: FieldType,
+    pub values: Vec<EnumValue>,
+}
+
+impl FieldDef {
+    pub fn is_enum(&self) -> bool {
+        !self.values.is_empty()
+    }
+
+    pub fn single_char(&self) -> bool {
+        self.values.iter().all(|v| v.value.len() == 1)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Member {
+    Field { name: String, required: bool },
+    Component { name: String },
+    Group(GroupDef),
+}
+
+#[derive(Debug, Clone)]
+pub struct GroupDef {
+    pub name: String,
+    pub required: bool,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageDef {
+    pub name: String,
+    pub msgtype: String,
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Dictionary {
+    pub major: String,
+    pub minor: String,
+    pub fields: Vec<FieldDef>,
+    pub components: Vec<(String, Vec<Member>)>,
+    pub messages: Vec<MessageDef>,
+}
+
+impl Dictionary {
+    pub fn field(&self, name: &str) -> Option<&FieldDef> {
+        self.fields.iter().find(|f| f.name == name)
+    }
+
+    pub fn component(&self, name: &str) -> Option<&[Member]> {
+        self.components
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, m)| m.as_slice())
+    }
+}

--- a/nexus-fix-codegen/src/dict/parse.rs
+++ b/nexus-fix-codegen/src/dict/parse.rs
@@ -1,0 +1,247 @@
+use std::fmt;
+
+use quick_xml::events::attributes::AttrError;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+
+use super::{Dictionary, EnumValue, FieldDef, FieldType, GroupDef, Member, MessageDef};
+
+#[derive(Debug)]
+pub enum ParseError {
+    Xml(quick_xml::Error),
+    Attr(AttrError),
+    MissingAttr { element: String, attr: String },
+    BadNumber(String),
+    NoRoot,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Xml(e) => write!(f, "XML error: {e}"),
+            Self::Attr(e) => write!(f, "attribute error: {e}"),
+            Self::MissingAttr { element, attr } => {
+                write!(f, "<{element}> missing required attribute '{attr}'")
+            }
+            Self::BadNumber(s) => write!(f, "invalid field number '{s}'"),
+            Self::NoRoot => write!(f, "missing <fix> root element"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl From<quick_xml::Error> for ParseError {
+    fn from(e: quick_xml::Error) -> Self {
+        Self::Xml(e)
+    }
+}
+
+impl From<AttrError> for ParseError {
+    fn from(e: AttrError) -> Self {
+        Self::Attr(e)
+    }
+}
+
+pub fn parse(xml: &str) -> Result<Dictionary, ParseError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut major = String::new();
+    let mut minor = String::new();
+    let mut fields = Vec::new();
+    let mut components = Vec::new();
+    let mut messages = Vec::new();
+    let mut seen_root = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) => match e.name().as_ref() {
+                b"fix" | b"fixt" => {
+                    seen_root = true;
+                    major = opt_attr(&e, "major")?.unwrap_or_default();
+                    minor = opt_attr(&e, "minor")?.unwrap_or_default();
+                }
+                b"fields" => fields = read_fields(&mut reader)?,
+                b"components" => components = read_components(&mut reader)?,
+                b"messages" => messages = read_messages(&mut reader)?,
+                b"header" | b"trailer" => skip_to_end(&mut reader, e.name().as_ref())?,
+                _ => {}
+            },
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    if !seen_root {
+        return Err(ParseError::NoRoot);
+    }
+    Ok(Dictionary {
+        major,
+        minor,
+        fields,
+        components,
+        messages,
+    })
+}
+
+fn read_fields(reader: &mut Reader<&[u8]>) -> Result<Vec<FieldDef>, ParseError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event()? {
+            Event::Empty(e) if e.name().as_ref() == b"field" => {
+                out.push(field_def(&e, Vec::new())?);
+            }
+            Event::Start(e) if e.name().as_ref() == b"field" => {
+                let values = read_values(reader)?;
+                out.push(field_def(&e, values)?);
+            }
+            Event::End(e) if e.name().as_ref() == b"fields" => break,
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn field_def(e: &BytesStart, values: Vec<EnumValue>) -> Result<FieldDef, ParseError> {
+    let number_str = req_attr(e, "number")?;
+    let number = number_str
+        .parse::<u32>()
+        .map_err(|_| ParseError::BadNumber(number_str))?;
+    let ftype = opt_attr(e, "type")?.map_or(FieldType::Other, |t| FieldType::from_str(&t));
+    Ok(FieldDef {
+        number,
+        name: req_attr(e, "name")?,
+        ftype,
+        values,
+    })
+}
+
+fn read_values(reader: &mut Reader<&[u8]>) -> Result<Vec<EnumValue>, ParseError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event()? {
+            Event::Empty(e) | Event::Start(e) if e.name().as_ref() == b"value" => {
+                out.push(EnumValue {
+                    value: req_attr(&e, "enum")?,
+                    name: req_attr(&e, "description")?,
+                });
+            }
+            Event::End(e) if e.name().as_ref() == b"field" => break,
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn read_components(reader: &mut Reader<&[u8]>) -> Result<Vec<(String, Vec<Member>)>, ParseError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) if e.name().as_ref() == b"component" => {
+                let name = req_attr(&e, "name")?;
+                let members = read_members(reader, b"component")?;
+                out.push((name, members));
+            }
+            Event::End(e) if e.name().as_ref() == b"components" => break,
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn read_messages(reader: &mut Reader<&[u8]>) -> Result<Vec<MessageDef>, ParseError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) if e.name().as_ref() == b"message" => {
+                let name = req_attr(&e, "name")?;
+                let msgtype = req_attr(&e, "msgtype")?;
+                let members = read_members(reader, b"message")?;
+                out.push(MessageDef {
+                    name,
+                    msgtype,
+                    members,
+                });
+            }
+            Event::End(e) if e.name().as_ref() == b"messages" => break,
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn read_members(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<Vec<Member>, ParseError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event()? {
+            Event::Empty(e) => match e.name().as_ref() {
+                b"field" => out.push(Member::Field {
+                    name: req_attr(&e, "name")?,
+                    required: is_required(&e)?,
+                }),
+                b"component" => out.push(Member::Component {
+                    name: req_attr(&e, "name")?,
+                }),
+                _ => {}
+            },
+            Event::Start(e) => match e.name().as_ref() {
+                b"group" => {
+                    let name = req_attr(&e, "name")?;
+                    let required = is_required(&e)?;
+                    let members = read_members(reader, b"group")?;
+                    out.push(Member::Group(GroupDef {
+                        name,
+                        required,
+                        members,
+                    }));
+                }
+                other => skip_to_end(reader, other)?,
+            },
+            Event::End(e) if e.name().as_ref() == end => break,
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn skip_to_end(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<(), ParseError> {
+    let mut depth = 1usize;
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) if e.name().as_ref() == end => depth += 1,
+            Event::End(e) if e.name().as_ref() == end => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn is_required(e: &BytesStart) -> Result<bool, ParseError> {
+    Ok(opt_attr(e, "required")?.as_deref() == Some("Y"))
+}
+
+fn opt_attr(e: &BytesStart, key: &str) -> Result<Option<String>, ParseError> {
+    match e.try_get_attribute(key)? {
+        Some(a) => Ok(Some(a.unescape_value()?.into_owned())),
+        None => Ok(None),
+    }
+}
+
+fn req_attr(e: &BytesStart, key: &str) -> Result<String, ParseError> {
+    opt_attr(e, key)?.ok_or_else(|| ParseError::MissingAttr {
+        element: String::from_utf8_lossy(e.name().as_ref()).into_owned(),
+        attr: key.to_string(),
+    })
+}

--- a/nexus-fix-codegen/src/dict/parse.rs
+++ b/nexus-fix-codegen/src/dict/parse.rs
@@ -109,7 +109,7 @@ fn field_def(e: &BytesStart, values: Vec<EnumValue>) -> Result<FieldDef, ParseEr
     let number = number_str
         .parse::<u32>()
         .map_err(|_| ParseError::BadNumber(number_str))?;
-    let ftype = opt_attr(e, "type")?.map_or(FieldType::Other, |t| FieldType::from_str(&t));
+    let ftype = opt_attr(e, "type")?.map_or(FieldType::Ascii, |t| FieldType::from_str(&t));
     Ok(FieldDef {
         number,
         name: req_attr(e, "name")?,

--- a/nexus-fix-codegen/src/emit/encoders.rs
+++ b/nexus-fix-codegen/src/emit/encoders.rs
@@ -88,7 +88,7 @@ fn emit_field_setter(s: &mut String, f: &RField) {
         } else {
             let _ = write!(
                 s,
-                "    pub fn {name}_value(mut self, value: super::fields::{ty}) -> Self {{\n        self.w.field(super::fields::TAG_{tag}, value.as_bytes());\n        self\n    }}\n\n"
+                "    pub fn {name}_value(mut self, value: super::fields::{ty}<'_>) -> Self {{\n        self.w.field(super::fields::TAG_{tag}, value.as_bytes());\n        self\n    }}\n\n"
             );
         }
     }
@@ -100,6 +100,6 @@ fn emit_data_setter(s: &mut String, len: &RField, data: &RField) {
     let len_tag = screaming(&len.name);
     let _ = write!(
         s,
-        "    pub fn {name}(mut self, value: &[u8]) -> Self {{\n        let len = value.len().to_string();\n        self.w.field(super::fields::TAG_{len_tag}, len.as_bytes());\n        self.w.field(super::fields::TAG_{data_tag}, value);\n        self\n    }}\n\n"
+        "    pub fn {name}(mut self, value: &[u8]) -> Self {{\n        let mut tmp = [0u8; 20];\n        let len = nexus_fix_codec::format_uint(&mut tmp, value.len() as u64);\n        self.w.field(super::fields::TAG_{len_tag}, len);\n        self.w.field(super::fields::TAG_{data_tag}, value);\n        self\n    }}\n\n"
     );
 }

--- a/nexus-fix-codegen/src/emit/encoders.rs
+++ b/nexus-fix-codegen/src/emit/encoders.rs
@@ -1,0 +1,105 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+
+use crate::dict::FieldType;
+
+use super::{HEADER, RField, RMember, RMessage, pascal, screaming, snake};
+
+pub fn emit(messages: &[RMessage]) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+    for m in messages {
+        emit_encoder(&mut s, m);
+    }
+    s
+}
+
+fn emit_encoder(s: &mut String, m: &RMessage) {
+    let ty = format!("{}Encoder", pascal(&m.name));
+    let fields: Vec<&RField> = m
+        .members
+        .iter()
+        .filter_map(|mem| match mem {
+            RMember::Field(f) => Some(f),
+            RMember::Group(_) => None,
+        })
+        .collect();
+
+    let mut paired_len: HashMap<u32, &RField> = HashMap::new();
+    let mut data_nums: HashSet<u32> = HashSet::new();
+    for w in fields.windows(2) {
+        if let [l, d] = w
+            && l.ftype == FieldType::Length
+            && d.ftype == FieldType::Data
+        {
+            paired_len.insert(l.number, d);
+            data_nums.insert(d.number);
+        }
+    }
+
+    let _ = write!(
+        s,
+        "pub struct {ty}<'buf> {{\n    w: nexus_fix_codec::FieldWriter<'buf>,\n}}\n\n"
+    );
+    let _ = writeln!(s, "impl<'buf> {ty}<'buf> {{");
+    s.push_str(
+        "    pub fn new(buf: &'buf mut [u8]) -> Self {\n        Self { w: nexus_fix_codec::FieldWriter::wrap(buf) }\n    }\n\n",
+    );
+    s.push_str(
+        "    pub fn wrap_at(buf: &'buf mut [u8], offset: usize) -> Self {\n        Self { w: nexus_fix_codec::FieldWriter::wrap_at(buf, offset) }\n    }\n\n",
+    );
+
+    let mut seen = HashSet::new();
+    for f in &fields {
+        if !seen.insert(f.number) {
+            continue;
+        }
+        if data_nums.contains(&f.number) {
+            continue;
+        }
+        if let Some(d) = paired_len.get(&f.number) {
+            emit_data_setter(s, f, d);
+        } else {
+            emit_field_setter(s, f);
+        }
+    }
+
+    s.push_str("    pub fn finish(self) -> usize {\n        self.w.pos()\n    }\n\n");
+    s.push_str(
+        "    pub fn finish_with_checksum(mut self) -> usize {\n        let sum = nexus_fix_codec::checksum(self.w.data());\n        let cs = nexus_fix_codec::format_checksum(sum);\n        self.w.field(10, &cs);\n        self.w.pos()\n    }\n",
+    );
+    s.push_str("}\n\n");
+}
+
+fn emit_field_setter(s: &mut String, f: &RField) {
+    let name = snake(&f.name);
+    let tag = screaming(&f.name);
+    let _ = write!(
+        s,
+        "    pub fn {name}(mut self, value: &[u8]) -> Self {{\n        self.w.field(super::fields::TAG_{tag}, value);\n        self\n    }}\n\n"
+    );
+    if f.is_enum {
+        let ty = pascal(&f.name);
+        if f.single_char {
+            let _ = write!(
+                s,
+                "    pub fn {name}_value(mut self, value: super::fields::{ty}) -> Self {{\n        self.w.field(super::fields::TAG_{tag}, &[value.as_byte()]);\n        self\n    }}\n\n"
+            );
+        } else {
+            let _ = write!(
+                s,
+                "    pub fn {name}_value(mut self, value: super::fields::{ty}) -> Self {{\n        self.w.field(super::fields::TAG_{tag}, value.as_bytes());\n        self\n    }}\n\n"
+            );
+        }
+    }
+}
+
+fn emit_data_setter(s: &mut String, len: &RField, data: &RField) {
+    let name = snake(&data.name);
+    let data_tag = screaming(&data.name);
+    let len_tag = screaming(&len.name);
+    let _ = write!(
+        s,
+        "    pub fn {name}(mut self, value: &[u8]) -> Self {{\n        let len = value.len().to_string();\n        self.w.field(super::fields::TAG_{len_tag}, len.as_bytes());\n        self.w.field(super::fields::TAG_{data_tag}, value);\n        self\n    }}\n\n"
+    );
+}

--- a/nexus-fix-codegen/src/emit/fields.rs
+++ b/nexus-fix-codegen/src/emit/fields.rs
@@ -1,0 +1,91 @@
+use std::fmt::Write;
+
+use crate::dict::{Dictionary, FieldDef};
+
+use super::{HEADER, byte_lit, pascal, screaming};
+
+pub fn emit(dict: &Dictionary) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+
+    for f in &dict.fields {
+        let _ = writeln!(
+            s,
+            "pub const TAG_{}: u32 = {};",
+            screaming(&f.name),
+            f.number
+        );
+    }
+    s.push('\n');
+
+    for f in &dict.fields {
+        if f.is_enum() {
+            emit_enum(&mut s, f);
+        }
+    }
+    s
+}
+
+fn emit_enum(s: &mut String, f: &FieldDef) {
+    let ty = pascal(&f.name);
+    s.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n");
+    let _ = writeln!(s, "pub enum {ty} {{");
+    for v in &f.values {
+        let _ = writeln!(s, "    {},", pascal(&v.name));
+    }
+    s.push_str("}\n\n");
+
+    let _ = writeln!(s, "impl {ty} {{");
+    if f.single_char() {
+        s.push_str("    pub fn from_byte(b: u8) -> Option<Self> {\n        match b {\n");
+        for v in &f.values {
+            let _ = writeln!(
+                s,
+                "            {} => Some(Self::{}),",
+                char_lit(&v.value),
+                pascal(&v.name)
+            );
+        }
+        s.push_str("            _ => None,\n        }\n    }\n\n");
+        s.push_str("    pub fn as_byte(self) -> u8 {\n        match self {\n");
+        for v in &f.values {
+            let _ = writeln!(
+                s,
+                "            Self::{} => {},",
+                pascal(&v.name),
+                char_lit(&v.value)
+            );
+        }
+    } else {
+        s.push_str("    pub fn from_bytes(b: &[u8]) -> Option<Self> {\n        match b {\n");
+        for v in &f.values {
+            let _ = writeln!(
+                s,
+                "            {} => Some(Self::{}),",
+                byte_lit(&v.value),
+                pascal(&v.name)
+            );
+        }
+        s.push_str("            _ => None,\n        }\n    }\n\n");
+        s.push_str("    pub fn as_bytes(self) -> &'static [u8] {\n        match self {\n");
+        for v in &f.values {
+            let _ = writeln!(
+                s,
+                "            Self::{} => {},",
+                pascal(&v.name),
+                byte_lit(&v.value)
+            );
+        }
+    }
+    s.push_str("        }\n    }\n");
+    s.push_str("}\n\n");
+}
+
+fn char_lit(s: &str) -> String {
+    let b = s.bytes().next().unwrap_or(b'?');
+    match b {
+        b'\'' | b'\\' => format!("b'\\{}'", b as char),
+        0x20..=0x7e => format!("b'{}'", b as char),
+        _ => format!("b'\\x{b:02x}'"),
+    }
+}

--- a/nexus-fix-codegen/src/emit/fields.rs
+++ b/nexus-fix-codegen/src/emit/fields.rs
@@ -28,57 +28,75 @@ pub fn emit(dict: &Dictionary) -> String {
 
 fn emit_enum(s: &mut String, f: &FieldDef) {
     let ty = pascal(&f.name);
+    if f.single_char() {
+        emit_single_char_enum(s, f, &ty);
+    } else {
+        emit_multi_char_enum(s, f, &ty);
+    }
+}
+
+fn emit_single_char_enum(s: &mut String, f: &FieldDef, ty: &str) {
     s.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n");
     let _ = writeln!(s, "pub enum {ty} {{");
     for v in &f.values {
         let _ = writeln!(s, "    {},", pascal(&v.name));
     }
-    s.push_str("}\n\n");
+    s.push_str("    Unknown(u8),\n}\n\n");
 
     let _ = writeln!(s, "impl {ty} {{");
-    if f.single_char() {
-        s.push_str("    pub fn from_byte(b: u8) -> Option<Self> {\n        match b {\n");
-        for v in &f.values {
-            let _ = writeln!(
-                s,
-                "            {} => Some(Self::{}),",
-                char_lit(&v.value),
-                pascal(&v.name)
-            );
-        }
-        s.push_str("            _ => None,\n        }\n    }\n\n");
-        s.push_str("    pub fn as_byte(self) -> u8 {\n        match self {\n");
-        for v in &f.values {
-            let _ = writeln!(
-                s,
-                "            Self::{} => {},",
-                pascal(&v.name),
-                char_lit(&v.value)
-            );
-        }
-    } else {
-        s.push_str("    pub fn from_bytes(b: &[u8]) -> Option<Self> {\n        match b {\n");
-        for v in &f.values {
-            let _ = writeln!(
-                s,
-                "            {} => Some(Self::{}),",
-                byte_lit(&v.value),
-                pascal(&v.name)
-            );
-        }
-        s.push_str("            _ => None,\n        }\n    }\n\n");
-        s.push_str("    pub fn as_bytes(self) -> &'static [u8] {\n        match self {\n");
-        for v in &f.values {
-            let _ = writeln!(
-                s,
-                "            Self::{} => {},",
-                pascal(&v.name),
-                byte_lit(&v.value)
-            );
-        }
+    s.push_str("    pub fn from_byte(b: u8) -> Self {\n        match b {\n");
+    for v in &f.values {
+        let _ = writeln!(
+            s,
+            "            {} => Self::{},",
+            char_lit(&v.value),
+            pascal(&v.name)
+        );
     }
-    s.push_str("        }\n    }\n");
-    s.push_str("}\n\n");
+    s.push_str("            other => Self::Unknown(other),\n        }\n    }\n\n");
+    s.push_str("    pub fn as_byte(self) -> u8 {\n        match self {\n");
+    for v in &f.values {
+        let _ = writeln!(
+            s,
+            "            Self::{} => {},",
+            pascal(&v.name),
+            char_lit(&v.value)
+        );
+    }
+    s.push_str("            Self::Unknown(b) => b,\n        }\n    }\n}\n\n");
+}
+
+fn emit_multi_char_enum(s: &mut String, f: &FieldDef, ty: &str) {
+    s.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n");
+    let _ = writeln!(s, "pub enum {ty}<'buf> {{");
+    for v in &f.values {
+        let _ = writeln!(s, "    {},", pascal(&v.name));
+    }
+    s.push_str("    Unknown(&'buf nexus_fix_codec::AsciiTextStr),\n}\n\n");
+
+    let _ = writeln!(s, "impl<'buf> {ty}<'buf> {{");
+    s.push_str(
+        "    pub fn from_bytes(b: &'buf nexus_fix_codec::AsciiTextStr) -> Self {\n        match b.as_bytes() {\n",
+    );
+    for v in &f.values {
+        let _ = writeln!(
+            s,
+            "            {} => Self::{},",
+            byte_lit(&v.value),
+            pascal(&v.name)
+        );
+    }
+    s.push_str("            _ => Self::Unknown(b),\n        }\n    }\n\n");
+    s.push_str("    pub fn as_bytes(self) -> &'buf [u8] {\n        match self {\n");
+    for v in &f.values {
+        let _ = writeln!(
+            s,
+            "            Self::{} => {},",
+            pascal(&v.name),
+            byte_lit(&v.value)
+        );
+    }
+    s.push_str("            Self::Unknown(b) => b.as_bytes(),\n        }\n    }\n}\n\n");
 }
 
 fn char_lit(s: &str) -> String {

--- a/nexus-fix-codegen/src/emit/groups.rs
+++ b/nexus-fix-codegen/src/emit/groups.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use super::{
-    HEADER, RGroup, RMember, RMessage, group_type, pascal, screaming, snake, subtree_tags,
+    HEADER, RGroup, RMember, RMessage, emit_group_accessor, emit_value_accessor, group_type,
+    pascal, screaming, snake, subtree_tags, tag_or,
 };
 
 pub fn emit(messages: &[RMessage]) -> String {
@@ -69,7 +70,7 @@ fn emit_entry(s: &mut String, base: &str, entry: &str, g: &RGroup) {
 
     let mut tags = Vec::new();
     subtree_tags(&g.members, &mut tags);
-    let tag_list = tag_array(&tags);
+    let pat = tag_or(&tags);
 
     let _ = writeln!(s, "impl<'buf> {entry}<'buf> {{");
     s.push_str(
@@ -102,62 +103,71 @@ fn emit_entry(s: &mut String, base: &str, entry: &str, g: &RGroup) {
     s.push_str("            let Some(f) = r.next_field() else { break };\n");
     let _ = writeln!(
         s,
-        "            if (f.tag == {} && !first) || ![{tag_list}].contains(&f.tag) {{\n                return (e, mark);\n            }}",
+        "            if (f.tag == {} && !first) || !matches!(f.tag, {pat}) {{\n                return (e, mark);\n            }}",
         g.delimiter
     );
     s.push_str("            first = false;\n");
 
-    let mut arms: Vec<String> = Vec::new();
+    let mut arms: Vec<(String, String)> = Vec::new();
     let mut seen_arm = HashSet::new();
     for mem in &g.members {
         match mem {
             RMember::Field(f) if seen_arm.insert(f.number) => {
-                arms.push(format!(
-                    "f.tag == super::fields::TAG_{} {{\n                e.{} = f.value;\n            }}",
+                arms.push((
                     screaming(&f.name),
-                    snake(&f.name)
+                    format!("                e.{} = f.value;\n", snake(&f.name)),
                 ));
             }
             RMember::Group(inner) if seen_arm.insert(inner.number) => {
-                arms.push(nested_arm(inner));
+                arms.push((screaming(&inner.name), nested_body(inner)));
             }
             _ => {}
         }
     }
-    let _ = writeln!(s, "            if {}", arms.join(" else if "));
+    emit_entry_dispatch(s, &arms);
     s.push_str("        }\n        (e, r.pos())\n    }\n\n");
 
     emit_entry_accessors(s, base, g);
     s.push_str("}\n\n");
 }
 
-fn nested_arm(inner: &RGroup) -> String {
+fn emit_entry_dispatch(s: &mut String, arms: &[(String, String)]) {
+    if let [(tag, body)] = arms {
+        let _ = writeln!(s, "            if f.tag == super::fields::TAG_{tag} {{");
+        s.push_str(body);
+        s.push_str("            }\n");
+    } else {
+        s.push_str("            match f.tag {\n");
+        for (tag, body) in arms {
+            let _ = writeln!(s, "                super::fields::TAG_{tag} => {{");
+            s.push_str(body);
+            s.push_str("                }\n");
+        }
+        s.push_str("                _ => {}\n            }\n");
+    }
+}
+
+fn nested_body(inner: &RGroup) -> String {
     let mut tags = Vec::new();
     subtree_tags(&inner.members, &mut tags);
-    let tag_list = tag_array(&tags);
+    let pat = tag_or(&tags);
     let mut b = String::new();
-    let _ = writeln!(
-        b,
-        "f.tag == super::fields::TAG_{} {{",
-        screaming(&inner.name)
-    );
     b.push_str(
         "                let (count, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n",
     );
     let _ = writeln!(
         b,
-        "                e.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count as u16);",
+        "                e.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count.min(u16::MAX as u32) as u16);",
         snake(&inner.name)
     );
     b.push_str("                loop {\n                    let nmark = r.pos();\n");
     b.push_str("                    match r.next_field() {\n");
     let _ = writeln!(
         b,
-        "                        Some(nf) if [{tag_list}].contains(&nf.tag) => {{}}"
+        "                        Some(nf) if matches!(nf.tag, {pat}) => {{}}"
     );
     b.push_str("                        _ => {\n                            r = nexus_fix_codec::FieldReader::new(buf, nmark);\n                            break;\n                        }\n");
     b.push_str("                    }\n                }\n");
-    b.push_str("            }");
     b
 }
 
@@ -165,50 +175,12 @@ fn emit_entry_accessors(s: &mut String, base: &str, g: &RGroup) {
     let mut seen = HashSet::new();
     for mem in &g.members {
         match mem {
-            RMember::Field(f) if seen.insert(f.number) => {
-                let name = snake(&f.name);
-                let _ = write!(
-                    s,
-                    "    pub fn {name}(&self) -> Option<&'buf [u8]> {{\n        if self.{name}.is_present() {{ Some(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
-                );
-                if f.is_enum {
-                    let ty = pascal(&f.name);
-                    if f.single_char {
-                        let _ = write!(
-                            s,
-                            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_byte(*self.{name}()?.first()?)\n    }}\n\n"
-                        );
-                    } else {
-                        let _ = write!(
-                            s,
-                            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_bytes(self.{name}()?)\n    }}\n\n"
-                        );
-                    }
-                }
-            }
+            RMember::Field(f) if seen.insert(f.number) => emit_value_accessor(s, f),
             RMember::Group(inner) if seen.insert(inner.number) => {
-                let name = snake(&inner.name);
                 let iter = format!("{}Iter", group_type(base, &inner.name));
-                let _ = write!(
-                    s,
-                    "    pub fn {name}(&self) -> super::groups::{iter}<'buf> {{\n        super::groups::{iter}::new(self.buf, self.{name})\n    }}\n\n"
-                );
+                emit_group_accessor(s, &snake(&inner.name), &iter);
             }
             _ => {}
         }
     }
-}
-
-fn tag_array(tags: &[u32]) -> String {
-    tags.iter()
-        .enumerate()
-        .map(|(i, t)| {
-            if i == 0 {
-                format!("{t}u32")
-            } else {
-                t.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
 }

--- a/nexus-fix-codegen/src/emit/groups.rs
+++ b/nexus-fix-codegen/src/emit/groups.rs
@@ -1,0 +1,214 @@
+use std::collections::HashSet;
+use std::fmt::Write;
+
+use super::{
+    HEADER, RGroup, RMember, RMessage, group_type, pascal, screaming, snake, subtree_tags,
+};
+
+pub fn emit(messages: &[RMessage]) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+    for m in messages {
+        let prefix = pascal(&m.name);
+        for mem in &m.members {
+            if let RMember::Group(g) = mem {
+                emit_group(&mut s, &prefix, g);
+            }
+        }
+    }
+    s
+}
+
+fn emit_group(s: &mut String, prefix: &str, g: &RGroup) {
+    let base = group_type(prefix, &g.name);
+    let entry = format!("{base}Entry");
+    let iter = format!("{base}Iter");
+
+    let _ = write!(
+        s,
+        "pub struct {iter}<'buf> {{\n    buf: &'buf [u8],\n    pos: usize,\n    remaining: u16,\n}}\n\n"
+    );
+    let _ = writeln!(s, "impl<'buf> {iter}<'buf> {{");
+    let _ = write!(
+        s,
+        "    pub fn new(buf: &'buf [u8], span: nexus_fix_codec::GroupSpan) -> Self {{\n        Self {{ buf, pos: span.offset as usize, remaining: span.count }}\n    }}\n}}\n\n"
+    );
+    let _ = writeln!(
+        s,
+        "impl<'buf> Iterator for {iter}<'buf> {{\n    type Item = {entry}<'buf>;"
+    );
+    let _ = write!(
+        s,
+        "    fn next(&mut self) -> Option<Self::Item> {{\n        if self.remaining == 0 {{\n            return None;\n        }}\n        self.remaining -= 1;\n        let (e, next) = {entry}::decode(self.buf, self.pos);\n        self.pos = next;\n        Some(e)\n    }}\n}}\n\n"
+    );
+
+    emit_entry(s, &base, &entry, g);
+
+    for mem in &g.members {
+        if let RMember::Group(inner) = mem {
+            emit_group(s, &base, inner);
+        }
+    }
+}
+
+fn emit_entry(s: &mut String, base: &str, entry: &str, g: &RGroup) {
+    let _ = writeln!(s, "pub struct {entry}<'buf> {{\n    buf: &'buf [u8],");
+    let mut seen = HashSet::new();
+    for mem in &g.members {
+        match mem {
+            RMember::Field(f) if seen.insert(f.number) => {
+                let _ = writeln!(s, "    {}: nexus_fix_codec::FieldSpan,", snake(&f.name));
+            }
+            RMember::Group(inner) if seen.insert(inner.number) => {
+                let _ = writeln!(s, "    {}: nexus_fix_codec::GroupSpan,", snake(&inner.name));
+            }
+            _ => {}
+        }
+    }
+    s.push_str("}\n\n");
+
+    let mut tags = Vec::new();
+    subtree_tags(&g.members, &mut tags);
+    let tag_list = tag_array(&tags);
+
+    let _ = writeln!(s, "impl<'buf> {entry}<'buf> {{");
+    s.push_str(
+        "    fn decode(buf: &'buf [u8], start: usize) -> (Self, usize) {\n        let mut e = Self {\n            buf,\n",
+    );
+    let mut seen = HashSet::new();
+    for mem in &g.members {
+        match mem {
+            RMember::Field(f) if seen.insert(f.number) => {
+                let _ = writeln!(
+                    s,
+                    "            {}: nexus_fix_codec::FieldSpan::EMPTY,",
+                    snake(&f.name)
+                );
+            }
+            RMember::Group(inner) if seen.insert(inner.number) => {
+                let _ = writeln!(
+                    s,
+                    "            {}: nexus_fix_codec::GroupSpan::EMPTY,",
+                    snake(&inner.name)
+                );
+            }
+            _ => {}
+        }
+    }
+    s.push_str("        };\n");
+    s.push_str("        let mut r = nexus_fix_codec::FieldReader::new(buf, start);\n");
+    s.push_str("        let mut first = true;\n");
+    s.push_str("        loop {\n            let mark = r.pos();\n");
+    s.push_str("            let Some(f) = r.next_field() else { break };\n");
+    let _ = writeln!(
+        s,
+        "            if (f.tag == {} && !first) || ![{tag_list}].contains(&f.tag) {{\n                return (e, mark);\n            }}",
+        g.delimiter
+    );
+    s.push_str("            first = false;\n");
+
+    let mut arms: Vec<String> = Vec::new();
+    let mut seen_arm = HashSet::new();
+    for mem in &g.members {
+        match mem {
+            RMember::Field(f) if seen_arm.insert(f.number) => {
+                arms.push(format!(
+                    "f.tag == super::fields::TAG_{} {{\n                e.{} = f.value;\n            }}",
+                    screaming(&f.name),
+                    snake(&f.name)
+                ));
+            }
+            RMember::Group(inner) if seen_arm.insert(inner.number) => {
+                arms.push(nested_arm(inner));
+            }
+            _ => {}
+        }
+    }
+    let _ = writeln!(s, "            if {}", arms.join(" else if "));
+    s.push_str("        }\n        (e, r.pos())\n    }\n\n");
+
+    emit_entry_accessors(s, base, g);
+    s.push_str("}\n\n");
+}
+
+fn nested_arm(inner: &RGroup) -> String {
+    let mut tags = Vec::new();
+    subtree_tags(&inner.members, &mut tags);
+    let tag_list = tag_array(&tags);
+    let mut b = String::new();
+    let _ = writeln!(
+        b,
+        "f.tag == super::fields::TAG_{} {{",
+        screaming(&inner.name)
+    );
+    b.push_str(
+        "                let (count, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n",
+    );
+    let _ = writeln!(
+        b,
+        "                e.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count as u16);",
+        snake(&inner.name)
+    );
+    b.push_str("                loop {\n                    let nmark = r.pos();\n");
+    b.push_str("                    match r.next_field() {\n");
+    let _ = writeln!(
+        b,
+        "                        Some(nf) if [{tag_list}].contains(&nf.tag) => {{}}"
+    );
+    b.push_str("                        _ => {\n                            r = nexus_fix_codec::FieldReader::new(buf, nmark);\n                            break;\n                        }\n");
+    b.push_str("                    }\n                }\n");
+    b.push_str("            }");
+    b
+}
+
+fn emit_entry_accessors(s: &mut String, base: &str, g: &RGroup) {
+    let mut seen = HashSet::new();
+    for mem in &g.members {
+        match mem {
+            RMember::Field(f) if seen.insert(f.number) => {
+                let name = snake(&f.name);
+                let _ = write!(
+                    s,
+                    "    pub fn {name}(&self) -> Option<&'buf [u8]> {{\n        if self.{name}.is_present() {{ Some(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+                );
+                if f.is_enum {
+                    let ty = pascal(&f.name);
+                    if f.single_char {
+                        let _ = write!(
+                            s,
+                            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_byte(*self.{name}()?.first()?)\n    }}\n\n"
+                        );
+                    } else {
+                        let _ = write!(
+                            s,
+                            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_bytes(self.{name}()?)\n    }}\n\n"
+                        );
+                    }
+                }
+            }
+            RMember::Group(inner) if seen.insert(inner.number) => {
+                let name = snake(&inner.name);
+                let iter = format!("{}Iter", group_type(base, &inner.name));
+                let _ = write!(
+                    s,
+                    "    pub fn {name}(&self) -> super::groups::{iter}<'buf> {{\n        super::groups::{iter}::new(self.buf, self.{name})\n    }}\n\n"
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn tag_array(tags: &[u32]) -> String {
+    tags.iter()
+        .enumerate()
+        .map(|(i, t)| {
+            if i == 0 {
+                format!("{t}u32")
+            } else {
+                t.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/nexus-fix-codegen/src/emit/messages.rs
+++ b/nexus-fix-codegen/src/emit/messages.rs
@@ -1,0 +1,261 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+
+use crate::dict::FieldType;
+
+use super::{
+    HEADER, RField, RGroup, RMember, RMessage, group_type, pascal, screaming, snake, subtree_tags,
+};
+
+enum Top<'a> {
+    Field(&'a RField),
+    Group(&'a RGroup),
+}
+
+pub fn emit(messages: &[RMessage]) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+    for m in messages {
+        emit_message(&mut s, m);
+    }
+    s
+}
+
+fn emit_message(s: &mut String, m: &RMessage) {
+    let ty = pascal(&m.name);
+    let tops: Vec<Top> = m
+        .members
+        .iter()
+        .map(|mem| match mem {
+            RMember::Field(f) => Top::Field(f),
+            RMember::Group(g) => Top::Group(g),
+        })
+        .collect();
+
+    let mut data_handled: HashSet<u32> = HashSet::new();
+    let mut data_after: HashMap<u32, &RField> = HashMap::new();
+    for w in tops.windows(2) {
+        if let [Top::Field(l), Top::Field(d)] = w
+            && l.ftype == FieldType::Length
+            && d.ftype == FieldType::Data
+        {
+            data_handled.insert(d.number);
+            data_after.insert(l.number, *d);
+        }
+    }
+
+    emit_struct(s, &ty, &tops);
+    let _ = writeln!(s, "impl<'buf> {ty}<'buf> {{");
+    emit_required(s, &tops);
+    emit_decode(s, &tops, &data_handled, &data_after);
+    emit_accessors(s, &tops, &m.name);
+    s.push_str("}\n\n");
+}
+
+fn emit_required(s: &mut String, tops: &[Top]) {
+    let mut req = Vec::new();
+    let mut seen = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) if f.required && seen.insert(f.number) => req.push(f.number),
+            Top::Group(g) if g.required && seen.insert(g.number) => req.push(g.number),
+            _ => {}
+        }
+    }
+    let list = req
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(s, "    pub const REQUIRED: &'static [u32] = &[{list}];\n");
+}
+
+fn emit_struct(s: &mut String, ty: &str, tops: &[Top]) {
+    let _ = writeln!(s, "pub struct {ty}<'buf> {{\n    buf: &'buf [u8],");
+    let mut seen = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) if seen.insert(f.number) => {
+                let _ = writeln!(s, "    {}: nexus_fix_codec::FieldSpan,", snake(&f.name));
+            }
+            Top::Group(g) if seen.insert(g.number) => {
+                let _ = writeln!(s, "    {}: nexus_fix_codec::GroupSpan,", snake(&g.name));
+            }
+            _ => {}
+        }
+    }
+    s.push_str("}\n\n");
+}
+
+fn emit_decode(
+    s: &mut String,
+    tops: &[Top],
+    data_handled: &HashSet<u32>,
+    data_after: &HashMap<u32, &RField>,
+) {
+    s.push_str("    pub fn decode(buf: &'buf [u8]) -> Self {\n");
+    s.push_str("        let mut m = Self {\n            buf,\n");
+    let mut seen = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) if seen.insert(f.number) => {
+                let _ = writeln!(
+                    s,
+                    "            {}: nexus_fix_codec::FieldSpan::EMPTY,",
+                    snake(&f.name)
+                );
+            }
+            Top::Group(g) if seen.insert(g.number) => {
+                let _ = writeln!(
+                    s,
+                    "            {}: nexus_fix_codec::GroupSpan::EMPTY,",
+                    snake(&g.name)
+                );
+            }
+            _ => {}
+        }
+    }
+    s.push_str("        };\n");
+
+    let mut arms: Vec<String> = Vec::new();
+    let mut seen_arm = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) => {
+                if data_handled.contains(&f.number) || !seen_arm.insert(f.number) {
+                    continue;
+                }
+                if let Some(d) = data_after.get(&f.number) {
+                    arms.push(data_arm(f, d));
+                } else {
+                    arms.push(format!(
+                        "f.tag == super::fields::TAG_{} {{\n                m.{} = f.value;\n            }}",
+                        screaming(&f.name),
+                        snake(&f.name)
+                    ));
+                }
+            }
+            Top::Group(g) => {
+                if !seen_arm.insert(g.number) {
+                    continue;
+                }
+                arms.push(group_arm(g));
+            }
+        }
+    }
+
+    if !arms.is_empty() {
+        s.push_str("        let mut r = nexus_fix_codec::FieldReader::new(buf, 0);\n");
+        s.push_str("        while let Some(f) = r.next_field() {\n");
+        let _ = writeln!(s, "            if {}", arms.join(" else if "));
+        s.push_str("        }\n");
+    }
+    s.push_str("        m\n    }\n\n");
+}
+
+fn data_arm(len: &RField, data: &RField) -> String {
+    let mut b = String::new();
+    let _ = writeln!(b, "f.tag == super::fields::TAG_{} {{", screaming(&len.name));
+    let _ = writeln!(b, "                m.{} = f.value;", snake(&len.name));
+    b.push_str("                let (n, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n");
+    b.push_str("                let dstart = r.pos();\n");
+    b.push_str("                let (_, dtl) = nexus_fix_codec::parse_tag(&buf[dstart..]);\n");
+    b.push_str("                let vstart = dstart + dtl + 1;\n");
+    let _ = writeln!(
+        b,
+        "                m.{} = nexus_fix_codec::FieldSpan::new(vstart as u32, n);",
+        snake(&data.name)
+    );
+    b.push_str(
+        "                r = nexus_fix_codec::FieldReader::new(buf, vstart + n as usize + 1);\n",
+    );
+    b.push_str("            }");
+    b
+}
+
+fn group_arm(g: &RGroup) -> String {
+    let mut tags = Vec::new();
+    subtree_tags(&g.members, &mut tags);
+    let tag_list = tag_array(&tags);
+    let mut b = String::new();
+    let _ = writeln!(b, "f.tag == super::fields::TAG_{} {{", screaming(&g.name));
+    b.push_str(
+        "                let (count, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n",
+    );
+    let _ = writeln!(
+        b,
+        "                m.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count as u16);",
+        snake(&g.name)
+    );
+    b.push_str("                loop {\n");
+    b.push_str("                    let mark = r.pos();\n");
+    b.push_str("                    match r.next_field() {\n");
+    let _ = writeln!(
+        b,
+        "                        Some(gf) if [{tag_list}].contains(&gf.tag) => {{}}"
+    );
+    b.push_str("                        _ => {\n");
+    b.push_str("                            r = nexus_fix_codec::FieldReader::new(buf, mark);\n");
+    b.push_str("                            break;\n");
+    b.push_str("                        }\n");
+    b.push_str("                    }\n                }\n");
+    b.push_str("            }");
+    b
+}
+
+fn emit_accessors(s: &mut String, tops: &[Top], msg_name: &str) {
+    let prefix = pascal(msg_name);
+    let mut seen = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) if seen.insert(f.number) => {
+                let name = snake(&f.name);
+                let _ = write!(
+                    s,
+                    "    pub fn {name}(&self) -> Option<&'buf [u8]> {{\n        if self.{name}.is_present() {{ Some(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+                );
+                if f.is_enum {
+                    emit_enum_accessor(s, f, &name);
+                }
+            }
+            Top::Group(g) if seen.insert(g.number) => {
+                let name = snake(&g.name);
+                let iter = format!("{}Iter", group_type(&prefix, &g.name));
+                let _ = write!(
+                    s,
+                    "    pub fn {name}(&self) -> super::groups::{iter}<'buf> {{\n        super::groups::{iter}::new(self.buf, self.{name})\n    }}\n\n"
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn emit_enum_accessor(s: &mut String, f: &RField, name: &str) {
+    let ty = pascal(&f.name);
+    if f.single_char {
+        let _ = write!(
+            s,
+            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_byte(*self.{name}()?.first()?)\n    }}\n\n"
+        );
+    } else {
+        let _ = write!(
+            s,
+            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_bytes(self.{name}()?)\n    }}\n\n"
+        );
+    }
+}
+
+fn tag_array(tags: &[u32]) -> String {
+    tags.iter()
+        .enumerate()
+        .map(|(i, t)| {
+            if i == 0 {
+                format!("{t}u32")
+            } else {
+                t.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/nexus-fix-codegen/src/emit/messages.rs
+++ b/nexus-fix-codegen/src/emit/messages.rs
@@ -4,7 +4,8 @@ use std::fmt::Write;
 use crate::dict::FieldType;
 
 use super::{
-    HEADER, RField, RGroup, RMember, RMessage, group_type, pascal, screaming, snake, subtree_tags,
+    HEADER, RField, RGroup, RMember, RMessage, emit_group_accessor, emit_value_accessor,
+    group_type, pascal, screaming, snake, subtree_tags, tag_or,
 };
 
 enum Top<'a> {
@@ -46,28 +47,10 @@ fn emit_message(s: &mut String, m: &RMessage) {
 
     emit_struct(s, &ty, &tops);
     let _ = writeln!(s, "impl<'buf> {ty}<'buf> {{");
-    emit_required(s, &tops);
     emit_decode(s, &tops, &data_handled, &data_after);
+    emit_is_complete(s, &tops);
     emit_accessors(s, &tops, &m.name);
     s.push_str("}\n\n");
-}
-
-fn emit_required(s: &mut String, tops: &[Top]) {
-    let mut req = Vec::new();
-    let mut seen = HashSet::new();
-    for t in tops {
-        match t {
-            Top::Field(f) if f.required && seen.insert(f.number) => req.push(f.number),
-            Top::Group(g) if g.required && seen.insert(g.number) => req.push(g.number),
-            _ => {}
-        }
-    }
-    let list = req
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(", ");
-    let _ = writeln!(s, "    pub const REQUIRED: &'static [u32] = &[{list}];\n");
 }
 
 fn emit_struct(s: &mut String, ty: &str, tops: &[Top]) {
@@ -117,7 +100,7 @@ fn emit_decode(
     }
     s.push_str("        };\n");
 
-    let mut arms: Vec<String> = Vec::new();
+    let mut arms: Vec<(String, String)> = Vec::new();
     let mut seen_arm = HashSet::new();
     for t in tops {
         match t {
@@ -126,12 +109,11 @@ fn emit_decode(
                     continue;
                 }
                 if let Some(d) = data_after.get(&f.number) {
-                    arms.push(data_arm(f, d));
+                    arms.push((screaming(&f.name), data_body(f, d)));
                 } else {
-                    arms.push(format!(
-                        "f.tag == super::fields::TAG_{} {{\n                m.{} = f.value;\n            }}",
+                    arms.push((
                         screaming(&f.name),
-                        snake(&f.name)
+                        format!("                m.{} = f.value;\n", snake(&f.name)),
                     ));
                 }
             }
@@ -139,52 +121,67 @@ fn emit_decode(
                 if !seen_arm.insert(g.number) {
                     continue;
                 }
-                arms.push(group_arm(g));
+                arms.push((screaming(&g.name), group_body(g)));
             }
         }
     }
 
-    if !arms.is_empty() {
-        s.push_str("        let mut r = nexus_fix_codec::FieldReader::new(buf, 0);\n");
-        s.push_str("        while let Some(f) = r.next_field() {\n");
-        let _ = writeln!(s, "            if {}", arms.join(" else if "));
-        s.push_str("        }\n");
-    }
+    emit_dispatch(s, &arms);
     s.push_str("        m\n    }\n\n");
 }
 
-fn data_arm(len: &RField, data: &RField) -> String {
+fn emit_dispatch(s: &mut String, arms: &[(String, String)]) {
+    if arms.is_empty() {
+        return;
+    }
+    s.push_str("        let mut r = nexus_fix_codec::FieldReader::new(buf, 0);\n");
+    s.push_str("        while let Some(f) = r.next_field() {\n");
+    if let [(tag, body)] = arms {
+        let _ = writeln!(s, "            if f.tag == super::fields::TAG_{tag} {{");
+        s.push_str(body);
+        s.push_str("            }\n");
+    } else {
+        s.push_str("            match f.tag {\n");
+        for (tag, body) in arms {
+            let _ = writeln!(s, "                super::fields::TAG_{tag} => {{");
+            s.push_str(body);
+            s.push_str("                }\n");
+        }
+        s.push_str("                _ => {}\n            }\n");
+    }
+    s.push_str("        }\n");
+}
+
+fn data_body(len: &RField, data: &RField) -> String {
     let mut b = String::new();
-    let _ = writeln!(b, "f.tag == super::fields::TAG_{} {{", screaming(&len.name));
     let _ = writeln!(b, "                m.{} = f.value;", snake(&len.name));
     b.push_str("                let (n, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n");
     b.push_str("                let dstart = r.pos();\n");
     b.push_str("                let (_, dtl) = nexus_fix_codec::parse_tag(&buf[dstart..]);\n");
     b.push_str("                let vstart = dstart + dtl + 1;\n");
+    b.push_str("                let dlen = (n as usize).min(buf.len().saturating_sub(vstart));\n");
     let _ = writeln!(
         b,
-        "                m.{} = nexus_fix_codec::FieldSpan::new(vstart as u32, n);",
+        "                m.{} = nexus_fix_codec::FieldSpan::new(vstart as u32, dlen as u32);",
         snake(&data.name)
     );
     b.push_str(
-        "                r = nexus_fix_codec::FieldReader::new(buf, vstart + n as usize + 1);\n",
+        "                r = nexus_fix_codec::FieldReader::new(buf, (vstart + dlen + 1).min(buf.len()));\n",
     );
-    b.push_str("            }");
     b
 }
 
-fn group_arm(g: &RGroup) -> String {
+fn group_body(g: &RGroup) -> String {
     let mut tags = Vec::new();
     subtree_tags(&g.members, &mut tags);
-    let tag_list = tag_array(&tags);
+    let pat = tag_or(&tags);
     let mut b = String::new();
-    let _ = writeln!(b, "f.tag == super::fields::TAG_{} {{", screaming(&g.name));
     b.push_str(
         "                let (count, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n",
     );
     let _ = writeln!(
         b,
-        "                m.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count as u16);",
+        "                m.{} = nexus_fix_codec::GroupSpan::new(r.pos() as u32, count.min(u16::MAX as u32) as u16);",
         snake(&g.name)
     );
     b.push_str("                loop {\n");
@@ -192,15 +189,39 @@ fn group_arm(g: &RGroup) -> String {
     b.push_str("                    match r.next_field() {\n");
     let _ = writeln!(
         b,
-        "                        Some(gf) if [{tag_list}].contains(&gf.tag) => {{}}"
+        "                        Some(gf) if matches!(gf.tag, {pat}) => {{}}"
     );
     b.push_str("                        _ => {\n");
     b.push_str("                            r = nexus_fix_codec::FieldReader::new(buf, mark);\n");
     b.push_str("                            break;\n");
     b.push_str("                        }\n");
     b.push_str("                    }\n                }\n");
-    b.push_str("            }");
     b
+}
+
+fn emit_is_complete(s: &mut String, tops: &[Top]) {
+    let mut conds = Vec::new();
+    let mut seen = HashSet::new();
+    for t in tops {
+        match t {
+            Top::Field(f) if f.required && seen.insert(f.number) => {
+                conds.push(format!("self.{}.is_present()", snake(&f.name)));
+            }
+            Top::Group(g) if g.required && seen.insert(g.number) => {
+                conds.push(format!("self.{}.is_present()", snake(&g.name)));
+            }
+            _ => {}
+        }
+    }
+    let body = if conds.is_empty() {
+        "true".to_string()
+    } else {
+        conds.join(" && ")
+    };
+    let _ = writeln!(
+        s,
+        "    pub fn is_complete(&self) -> bool {{\n        {body}\n    }}\n"
+    );
 }
 
 fn emit_accessors(s: &mut String, tops: &[Top], msg_name: &str) {
@@ -208,54 +229,12 @@ fn emit_accessors(s: &mut String, tops: &[Top], msg_name: &str) {
     let mut seen = HashSet::new();
     for t in tops {
         match t {
-            Top::Field(f) if seen.insert(f.number) => {
-                let name = snake(&f.name);
-                let _ = write!(
-                    s,
-                    "    pub fn {name}(&self) -> Option<&'buf [u8]> {{\n        if self.{name}.is_present() {{ Some(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
-                );
-                if f.is_enum {
-                    emit_enum_accessor(s, f, &name);
-                }
-            }
+            Top::Field(f) if seen.insert(f.number) => emit_value_accessor(s, f),
             Top::Group(g) if seen.insert(g.number) => {
-                let name = snake(&g.name);
                 let iter = format!("{}Iter", group_type(&prefix, &g.name));
-                let _ = write!(
-                    s,
-                    "    pub fn {name}(&self) -> super::groups::{iter}<'buf> {{\n        super::groups::{iter}::new(self.buf, self.{name})\n    }}\n\n"
-                );
+                emit_group_accessor(s, &snake(&g.name), &iter);
             }
             _ => {}
         }
     }
-}
-
-fn emit_enum_accessor(s: &mut String, f: &RField, name: &str) {
-    let ty = pascal(&f.name);
-    if f.single_char {
-        let _ = write!(
-            s,
-            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_byte(*self.{name}()?.first()?)\n    }}\n\n"
-        );
-    } else {
-        let _ = write!(
-            s,
-            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        super::fields::{ty}::from_bytes(self.{name}()?)\n    }}\n\n"
-        );
-    }
-}
-
-fn tag_array(tags: &[u32]) -> String {
-    tags.iter()
-        .enumerate()
-        .map(|(i, t)| {
-            if i == 0 {
-                format!("{t}u32")
-            } else {
-                t.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
 }

--- a/nexus-fix-codegen/src/emit/mod.rs
+++ b/nexus-fix-codegen/src/emit/mod.rs
@@ -195,6 +195,106 @@ pub fn subtree_tags(members: &[RMember], out: &mut Vec<u32>) {
     }
 }
 
+pub fn tag_or(tags: &[u32]) -> String {
+    let mut v: Vec<u32> = tags.to_vec();
+    v.sort_unstable();
+    v.dedup();
+    let mut parts = Vec::new();
+    let mut i = 0;
+    while i < v.len() {
+        let mut j = i;
+        while j + 1 < v.len() && v[j + 1] == v[j] + 1 {
+            j += 1;
+        }
+        if j > i {
+            parts.push(format!("{}..={}", v[i], v[j]));
+        } else {
+            parts.push(v[i].to_string());
+        }
+        i = j + 1;
+    }
+    parts.join(" | ")
+}
+
+enum AccKind {
+    Bytes,
+    Ascii,
+    I64,
+    U32,
+    Bool,
+}
+
+fn acc_kind(ft: FieldType) -> AccKind {
+    match ft {
+        FieldType::Data => AccKind::Bytes,
+        FieldType::Length | FieldType::NumInGroup => AccKind::U32,
+        FieldType::Int | FieldType::SeqNum => AccKind::I64,
+        FieldType::Bool => AccKind::Bool,
+        FieldType::Ascii => AccKind::Ascii,
+    }
+}
+
+pub fn emit_value_accessor(s: &mut String, f: &RField) {
+    let name = snake(&f.name);
+    match acc_kind(f.ftype) {
+        AccKind::Bytes => {
+            let _ = write!(
+                s,
+                "    pub fn {name}(&self) -> Option<&'buf [u8]> {{\n        if self.{name}.is_present() {{ Some(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+            );
+        }
+        AccKind::Ascii => {
+            let _ = write!(
+                s,
+                "    pub fn {name}(&self) -> Option<&'buf nexus_fix_codec::AsciiTextStr> {{\n        if self.{name}.is_present() {{ nexus_fix_codec::AsciiTextStr::try_from_bytes(self.{name}.slice(self.buf)).ok() }} else {{ None }}\n    }}\n\n"
+            );
+        }
+        AccKind::I64 => {
+            let _ = write!(
+                s,
+                "    pub fn {name}(&self) -> Option<i64> {{\n        if self.{name}.is_present() {{ nexus_fix_codec::parse_fix_int(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+            );
+        }
+        AccKind::U32 => {
+            let _ = write!(
+                s,
+                "    pub fn {name}(&self) -> Option<u32> {{\n        if self.{name}.is_present() {{ nexus_fix_codec::parse_fix_uint(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+            );
+        }
+        AccKind::Bool => {
+            let _ = write!(
+                s,
+                "    pub fn {name}(&self) -> Option<bool> {{\n        if self.{name}.is_present() {{ nexus_fix_codec::parse_fix_bool(self.{name}.slice(self.buf)) }} else {{ None }}\n    }}\n\n"
+            );
+        }
+    }
+    if f.is_enum {
+        emit_enum_accessor(s, f, &name);
+    }
+}
+
+fn emit_enum_accessor(s: &mut String, f: &RField, name: &str) {
+    let ty = pascal(&f.name);
+    if f.single_char {
+        let _ = write!(
+            s,
+            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}> {{\n        self.{name}.slice(self.buf).first().map(|&b| super::fields::{ty}::from_byte(b))\n    }}\n\n"
+        );
+    } else {
+        let _ = write!(
+            s,
+            "    pub fn {name}_enum(&self) -> Option<super::fields::{ty}<'buf>> {{\n        if self.{name}.is_present() {{ nexus_fix_codec::AsciiTextStr::try_from_bytes(self.{name}.slice(self.buf)).ok().map(super::fields::{ty}::from_bytes) }} else {{ None }}\n    }}\n\n"
+        );
+    }
+}
+
+pub fn emit_group_accessor(s: &mut String, name: &str, iter: &str) {
+    let _ = write!(
+        s,
+        "    pub fn {name}(&self) -> super::groups::{iter}<'buf> {{\n        super::groups::{iter}::new(self.buf, self.{name})\n    }}\n\n"
+    );
+}
+
 fn emit_mod(messages: &[RMessage], major: &str, minor: &str) -> String {
     let mut s = String::new();
     s.push_str(HEADER);

--- a/nexus-fix-codegen/src/emit/mod.rs
+++ b/nexus-fix-codegen/src/emit/mod.rs
@@ -1,0 +1,333 @@
+mod encoders;
+mod fields;
+mod groups;
+mod messages;
+
+use std::fmt::{self, Write};
+
+use crate::dict::{Dictionary, FieldType, Member};
+
+#[derive(Debug)]
+pub enum EmitError {
+    UnknownField(String),
+    UnknownComponent(String),
+    EmptyGroup(String),
+    DataInGroup(String),
+}
+
+impl fmt::Display for EmitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownField(n) => {
+                write!(f, "field '{n}' referenced but not defined in <fields>")
+            }
+            Self::UnknownComponent(n) => write!(f, "component '{n}' referenced but not defined"),
+            Self::EmptyGroup(n) => write!(f, "group '{n}' has no members"),
+            Self::DataInGroup(n) => {
+                write!(
+                    f,
+                    "group '{n}' contains a DATA field; not supported in this version"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+pub struct RField {
+    pub name: String,
+    pub number: u32,
+    pub ftype: FieldType,
+    pub required: bool,
+    pub is_enum: bool,
+    pub single_char: bool,
+}
+
+pub struct RGroup {
+    pub name: String,
+    pub number: u32,
+    pub delimiter: u32,
+    pub required: bool,
+    pub members: Vec<RMember>,
+}
+
+pub enum RMember {
+    Field(RField),
+    Group(RGroup),
+}
+
+pub struct RMessage {
+    pub name: String,
+    pub msgtype: String,
+    pub members: Vec<RMember>,
+}
+
+pub struct GeneratedFile {
+    pub name: String,
+    pub source: String,
+}
+
+pub fn generate(dict: &Dictionary) -> Result<Vec<GeneratedFile>, EmitError> {
+    let messages = dict
+        .messages
+        .iter()
+        .map(|m| {
+            Ok(RMessage {
+                name: m.name.clone(),
+                msgtype: m.msgtype.clone(),
+                members: resolve(dict, &m.members)?,
+            })
+        })
+        .collect::<Result<Vec<_>, EmitError>>()?;
+
+    for m in &messages {
+        for mem in &m.members {
+            if let RMember::Group(g) = mem {
+                check_no_data(g)?;
+            }
+        }
+    }
+
+    Ok(vec![
+        GeneratedFile {
+            name: "fields.rs".to_string(),
+            source: fields::emit(dict),
+        },
+        GeneratedFile {
+            name: "messages.rs".to_string(),
+            source: messages::emit(&messages),
+        },
+        GeneratedFile {
+            name: "groups.rs".to_string(),
+            source: groups::emit(&messages),
+        },
+        GeneratedFile {
+            name: "encoders.rs".to_string(),
+            source: encoders::emit(&messages),
+        },
+        GeneratedFile {
+            name: "mod.rs".to_string(),
+            source: emit_mod(&messages, &dict.major, &dict.minor),
+        },
+    ])
+}
+
+fn resolve(dict: &Dictionary, members: &[Member]) -> Result<Vec<RMember>, EmitError> {
+    let mut out = Vec::new();
+    for m in members {
+        match m {
+            Member::Field { name, required } => {
+                let def = dict
+                    .field(name)
+                    .ok_or_else(|| EmitError::UnknownField(name.clone()))?;
+                out.push(RMember::Field(RField {
+                    name: name.clone(),
+                    number: def.number,
+                    ftype: def.ftype,
+                    required: *required,
+                    is_enum: def.is_enum(),
+                    single_char: def.single_char(),
+                }));
+            }
+            Member::Component { name, .. } => {
+                let members = dict
+                    .component(name)
+                    .ok_or_else(|| EmitError::UnknownComponent(name.clone()))?;
+                out.extend(resolve(dict, members)?);
+            }
+            Member::Group(g) => {
+                let def = dict
+                    .field(&g.name)
+                    .ok_or_else(|| EmitError::UnknownField(g.name.clone()))?;
+                let members = resolve(dict, &g.members)?;
+                let delimiter =
+                    first_field(&members).ok_or_else(|| EmitError::EmptyGroup(g.name.clone()))?;
+                out.push(RMember::Group(RGroup {
+                    name: g.name.clone(),
+                    number: def.number,
+                    delimiter,
+                    required: g.required,
+                    members,
+                }));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn check_no_data(g: &RGroup) -> Result<(), EmitError> {
+    for m in &g.members {
+        match m {
+            RMember::Field(f) if f.ftype == FieldType::Data => {
+                return Err(EmitError::DataInGroup(g.name.clone()));
+            }
+            RMember::Group(inner) => check_no_data(inner)?,
+            RMember::Field(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn first_field(members: &[RMember]) -> Option<u32> {
+    members
+        .iter()
+        .map(|m| match m {
+            RMember::Field(f) => f.number,
+            RMember::Group(g) => g.number,
+        })
+        .next()
+}
+
+pub fn group_type(prefix: &str, name: &str) -> String {
+    format!("{prefix}{}", pascal(name))
+}
+
+pub fn subtree_tags(members: &[RMember], out: &mut Vec<u32>) {
+    for m in members {
+        match m {
+            RMember::Field(f) => out.push(f.number),
+            RMember::Group(g) => {
+                out.push(g.number);
+                subtree_tags(&g.members, out);
+            }
+        }
+    }
+}
+
+fn emit_mod(messages: &[RMessage], major: &str, minor: &str) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+    s.push_str("pub mod fields { include!(\"fields.rs\"); }\n");
+    s.push_str("pub mod messages { include!(\"messages.rs\"); }\n");
+    s.push_str("pub mod groups { include!(\"groups.rs\"); }\n");
+    s.push_str("pub mod encoders { include!(\"encoders.rs\"); }\n\n");
+    if !major.is_empty() && !minor.is_empty() {
+        let _ = writeln!(
+            s,
+            "pub const BEGIN_STRING: &[u8] = {};\n",
+            byte_lit(&format!("FIX.{major}.{minor}"))
+        );
+    }
+    s.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum MsgType {\n");
+    for m in messages {
+        let _ = writeln!(s, "    {},", pascal(&m.name));
+    }
+    s.push_str("}\n\nimpl MsgType {\n");
+    s.push_str("    pub fn from_bytes(b: &[u8]) -> Option<Self> {\n        match b {\n");
+    for m in messages {
+        let _ = writeln!(
+            s,
+            "            {} => Some(Self::{}),",
+            byte_lit(&m.msgtype),
+            pascal(&m.name)
+        );
+    }
+    s.push_str("            _ => None,\n        }\n    }\n\n");
+    s.push_str("    pub fn as_bytes(self) -> &'static [u8] {\n        match self {\n");
+    for m in messages {
+        let _ = writeln!(
+            s,
+            "            Self::{} => {},",
+            pascal(&m.name),
+            byte_lit(&m.msgtype)
+        );
+    }
+    s.push_str("        }\n    }\n}\n");
+    s
+}
+
+pub const HEADER: &str = "// @generated by nexus-fix-codegen. Do not edit.\n\n";
+
+pub fn pascal(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let mut out = String::new();
+    let mut upper_next = true;
+    for c in cleaned.chars() {
+        if c == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.push(c.to_ascii_uppercase());
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    ensure_ident(out)
+}
+
+pub fn snake(s: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if !c.is_ascii_alphanumeric() {
+            if !out.ends_with('_') && !out.is_empty() {
+                out.push('_');
+            }
+            continue;
+        }
+        if c.is_ascii_uppercase() {
+            let prev = i.checked_sub(1).map(|j| chars[j]);
+            let next = chars.get(i + 1).copied();
+            let boundary = matches!(prev, Some(p) if p.is_ascii_lowercase() || p.is_ascii_digit())
+                || matches!((prev, next), (Some(p), Some(n))
+                    if p.is_ascii_uppercase() && n.is_ascii_lowercase());
+            if boundary && !out.is_empty() && !out.ends_with('_') {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    raw_if_keyword(out)
+}
+
+pub fn screaming(s: &str) -> String {
+    snake(s).to_ascii_uppercase()
+}
+
+fn ensure_ident(mut s: String) -> String {
+    if s.is_empty() {
+        s.push('X');
+    } else if s.as_bytes()[0].is_ascii_digit() {
+        s.insert(0, '_');
+    }
+    s
+}
+
+fn raw_if_keyword(s: String) -> String {
+    const KEYWORDS: &[&str] = &[
+        "as", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern", "false",
+        "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub",
+        "ref", "return", "self", "static", "struct", "super", "trait", "true", "type", "unsafe",
+        "use", "where", "while", "async", "await", "abstract", "become", "box", "do", "final",
+        "macro", "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
+    ];
+    if KEYWORDS.contains(&s.as_str()) {
+        format!("r#{s}")
+    } else {
+        ensure_ident(s)
+    }
+}
+
+pub fn byte_lit(s: &str) -> String {
+    let mut out = String::from("b\"");
+    for b in s.bytes() {
+        match b {
+            b'"' | b'\\' => {
+                out.push('\\');
+                out.push(b as char);
+            }
+            0x20..=0x7e => out.push(b as char),
+            _ => {
+                let _ = write!(out, "\\x{b:02x}");
+            }
+        }
+    }
+    out.push('"');
+    out
+}

--- a/nexus-fix-codegen/src/lib.rs
+++ b/nexus-fix-codegen/src/lib.rs
@@ -1,0 +1,139 @@
+mod dict;
+mod emit;
+
+#[cfg(test)]
+mod tests;
+
+pub use dict::ParseError;
+pub use emit::EmitError;
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug)]
+pub enum CodegenError {
+    Io(io::Error),
+    Parse(ParseError),
+    Emit(EmitError),
+}
+
+impl fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Parse(e) => write!(f, "{e}"),
+            Self::Emit(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for CodegenError {}
+
+impl From<io::Error> for CodegenError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<ParseError> for CodegenError {
+    fn from(e: ParseError) -> Self {
+        Self::Parse(e)
+    }
+}
+
+impl From<EmitError> for CodegenError {
+    fn from(e: EmitError) -> Self {
+        Self::Emit(e)
+    }
+}
+
+pub struct Config {
+    dictionaries: Vec<PathBuf>,
+    out_dir: PathBuf,
+    rustfmt: bool,
+}
+
+pub fn generate() -> Config {
+    Config::new()
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self {
+            dictionaries: Vec::new(),
+            out_dir: PathBuf::from("."),
+            rustfmt: true,
+        }
+    }
+
+    pub fn dictionary<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.dictionaries.push(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn dictionaries<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        for p in paths {
+            self.dictionaries.push(p.as_ref().to_path_buf());
+        }
+        self
+    }
+
+    pub fn out_dir<P: AsRef<Path>>(mut self, dir: P) -> Self {
+        self.out_dir = dir.as_ref().to_path_buf();
+        self
+    }
+
+    pub fn rustfmt(mut self, enabled: bool) -> Self {
+        self.rustfmt = enabled;
+        self
+    }
+
+    pub fn run(self) -> Result<(), CodegenError> {
+        let multi = self.dictionaries.len() > 1;
+        for dict_path in &self.dictionaries {
+            let xml = fs::read_to_string(dict_path)?;
+            let parsed = dict::parse(&xml)?;
+            let files = emit::generate(&parsed)?;
+
+            let target = if multi {
+                let stem = dict_path
+                    .file_stem()
+                    .map_or_else(|| "fix".to_string(), |s| s.to_string_lossy().into_owned());
+                self.out_dir.join(stem)
+            } else {
+                self.out_dir.clone()
+            };
+            fs::create_dir_all(&target)?;
+
+            for file in files {
+                let path = target.join(&file.name);
+                fs::write(&path, file.source)?;
+                if self.rustfmt {
+                    run_rustfmt(&path);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn run_rustfmt(path: &Path) {
+    let _ = Command::new("rustfmt")
+        .arg("--edition")
+        .arg("2024")
+        .arg(path)
+        .status();
+}

--- a/nexus-fix-codegen/src/main.rs
+++ b/nexus-fix-codegen/src/main.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(
+    name = "nexus-fix-codegen",
+    about = "Generate FIX codecs from a QuickFIX dictionary"
+)]
+struct Cli {
+    #[arg(long, required = true, value_name = "FILE")]
+    dict: Vec<PathBuf>,
+
+    #[arg(long, value_name = "DIR")]
+    out: PathBuf,
+
+    #[arg(long)]
+    no_rustfmt: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let cfg = nexus_fix_codegen::generate()
+        .out_dir(cli.out)
+        .dictionaries(cli.dict)
+        .rustfmt(!cli.no_rustfmt);
+    match cfg.run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("nexus-fix-codegen: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/nexus-fix-codegen/src/tests.rs
+++ b/nexus-fix-codegen/src/tests.rs
@@ -1,0 +1,80 @@
+use crate::dict::{self, FieldType};
+use crate::emit;
+
+const SAMPLE: &str = include_str!("../tests/fixtures/FIX_sample.xml");
+
+fn file<'a>(files: &'a [emit::GeneratedFile], name: &str) -> &'a str {
+    files
+        .iter()
+        .find(|f| f.name == name)
+        .map_or_else(|| panic!("missing {name}"), |f| f.source.as_str())
+}
+
+#[test]
+fn parses_structure() {
+    let d = dict::parse(SAMPLE).unwrap();
+    assert_eq!(d.major, "4");
+    assert_eq!(d.minor, "4");
+    assert_eq!(d.messages.len(), 2);
+    assert!(d.field("Side").unwrap().is_enum());
+    assert!(d.field("Side").unwrap().single_char());
+    assert_eq!(d.field("RawData").unwrap().ftype, FieldType::Data);
+    assert!(d.component("Parties").is_some());
+}
+
+#[test]
+fn emits_tag_consts_and_enum() {
+    let d = dict::parse(SAMPLE).unwrap();
+    let files = emit::generate(&d).unwrap();
+    let fields = file(&files, "fields.rs");
+    assert!(fields.contains("pub const TAG_SIDE: u32 = 54;"));
+    assert!(fields.contains("pub enum Side"));
+    assert!(fields.contains("fn from_byte"));
+}
+
+#[test]
+fn emits_message_decoder_and_group() {
+    let d = dict::parse(SAMPLE).unwrap();
+    let files = emit::generate(&d).unwrap();
+    let messages = file(&files, "messages.rs");
+    assert!(messages.contains("pub struct NewOrderSingle<'buf>"));
+    assert!(messages.contains("pub fn decode(buf: &'buf [u8]) -> Self"));
+    assert!(messages.contains("pub const REQUIRED: &'static [u32]"));
+    let groups = file(&files, "groups.rs");
+    assert!(groups.contains("NewOrderSingleNoPartyIDsEntry"));
+    assert!(groups.contains("NewOrderSingleNoPartyIDsNoPartySubIDsEntry"));
+}
+
+#[test]
+fn emits_msgtype_dispatch_and_begin_string() {
+    let d = dict::parse(SAMPLE).unwrap();
+    let files = emit::generate(&d).unwrap();
+    let m = file(&files, "mod.rs");
+    assert!(m.contains("pub const BEGIN_STRING: &[u8] = b\"FIX.4.4\";"));
+    assert!(m.contains("enum MsgType"));
+    assert!(m.contains("b\"D\" => Some(Self::NewOrderSingle)"));
+}
+
+#[test]
+fn rejects_data_in_group() {
+    let xml = r#"<fix major="4" minor="4">
+      <messages>
+        <message name="M" msgtype="X">
+          <group name="NoThings" required="N">
+            <field name="ThingLen" required="N"/>
+            <field name="ThingData" required="N"/>
+          </group>
+        </message>
+      </messages>
+      <fields>
+        <field number="100" name="NoThings" type="NUMINGROUP"/>
+        <field number="101" name="ThingLen" type="LENGTH"/>
+        <field number="102" name="ThingData" type="DATA"/>
+      </fields>
+    </fix>"#;
+    let d = dict::parse(xml).unwrap();
+    assert!(matches!(
+        emit::generate(&d),
+        Err(emit::EmitError::DataInGroup(_))
+    ));
+}

--- a/nexus-fix-codegen/src/tests.rs
+++ b/nexus-fix-codegen/src/tests.rs
@@ -39,7 +39,7 @@ fn emits_message_decoder_and_group() {
     let messages = file(&files, "messages.rs");
     assert!(messages.contains("pub struct NewOrderSingle<'buf>"));
     assert!(messages.contains("pub fn decode(buf: &'buf [u8]) -> Self"));
-    assert!(messages.contains("pub const REQUIRED: &'static [u32]"));
+    assert!(messages.contains("pub fn is_complete(&self) -> bool"));
     let groups = file(&files, "groups.rs");
     assert!(groups.contains("NewOrderSingleNoPartyIDsEntry"));
     assert!(groups.contains("NewOrderSingleNoPartyIDsNoPartySubIDsEntry"));

--- a/nexus-fix-codegen/src/tests.rs
+++ b/nexus-fix-codegen/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::dict::{self, FieldType};
 use crate::emit;
 
-const SAMPLE: &str = include_str!("../tests/fixtures/FIX_sample.xml");
+const SAMPLE: &str = include_str!("../tests/fixtures/venue_alpha.xml");
 
 fn file<'a>(files: &'a [emit::GeneratedFile], name: &str) -> &'a str {
     files
@@ -15,7 +15,7 @@ fn parses_structure() {
     let d = dict::parse(SAMPLE).unwrap();
     assert_eq!(d.major, "4");
     assert_eq!(d.minor, "4");
-    assert_eq!(d.messages.len(), 2);
+    assert_eq!(d.messages.len(), 3);
     assert!(d.field("Side").unwrap().is_enum());
     assert!(d.field("Side").unwrap().single_char());
     assert_eq!(d.field("RawData").unwrap().ftype, FieldType::Data);

--- a/nexus-fix-codegen/tests/fixtures/FIX_sample.xml
+++ b/nexus-fix-codegen/tests/fixtures/FIX_sample.xml
@@ -1,0 +1,56 @@
+<fix major="4" minor="4">
+  <header>
+    <field name="BeginString" required="Y"/>
+    <field name="MsgType" required="Y"/>
+  </header>
+  <trailer>
+    <field name="CheckSum" required="Y"/>
+  </trailer>
+  <messages>
+    <message name="NewOrderSingle" msgtype="D" msgcat="app">
+      <field name="ClOrdID" required="Y"/>
+      <field name="Side" required="Y"/>
+      <field name="Symbol" required="Y"/>
+      <field name="OrderQty" required="N"/>
+      <component name="Parties" required="N"/>
+      <field name="RawDataLength" required="N"/>
+      <field name="RawData" required="N"/>
+    </message>
+    <message name="Heartbeat" msgtype="0" msgcat="admin">
+      <field name="TestReqID" required="N"/>
+    </message>
+  </messages>
+  <components>
+    <component name="Parties">
+      <group name="NoPartyIDs" required="N">
+        <field name="PartyID" required="N"/>
+        <field name="PartyRole" required="N"/>
+        <group name="NoPartySubIDs" required="N">
+          <field name="PartySubID" required="N"/>
+          <field name="PartySubIDType" required="N"/>
+        </group>
+      </group>
+    </component>
+  </components>
+  <fields>
+    <field number="8" name="BeginString" type="STRING"/>
+    <field number="10" name="CheckSum" type="STRING"/>
+    <field number="35" name="MsgType" type="STRING"/>
+    <field number="11" name="ClOrdID" type="STRING"/>
+    <field number="54" name="Side" type="CHAR">
+      <value enum="1" description="BUY"/>
+      <value enum="2" description="SELL"/>
+    </field>
+    <field number="55" name="Symbol" type="STRING"/>
+    <field number="38" name="OrderQty" type="QTY"/>
+    <field number="453" name="NoPartyIDs" type="NUMINGROUP"/>
+    <field number="448" name="PartyID" type="STRING"/>
+    <field number="452" name="PartyRole" type="INT"/>
+    <field number="802" name="NoPartySubIDs" type="NUMINGROUP"/>
+    <field number="523" name="PartySubID" type="STRING"/>
+    <field number="803" name="PartySubIDType" type="INT"/>
+    <field number="95" name="RawDataLength" type="LENGTH"/>
+    <field number="96" name="RawData" type="DATA"/>
+    <field number="112" name="TestReqID" type="STRING"/>
+  </fields>
+</fix>

--- a/nexus-fix-codegen/tests/fixtures/venue_alpha.xml
+++ b/nexus-fix-codegen/tests/fixtures/venue_alpha.xml
@@ -16,6 +16,16 @@
       <field name="RawDataLength" required="N"/>
       <field name="RawData" required="N"/>
     </message>
+    <message name="ExecutionReport" msgtype="8" msgcat="app">
+      <field name="OrderID" required="Y"/>
+      <field name="ExecID" required="Y"/>
+      <field name="ExecType" required="Y"/>
+      <field name="OrdStatus" required="Y"/>
+      <field name="Symbol" required="Y"/>
+      <field name="Side" required="Y"/>
+      <field name="LastQty" required="N"/>
+      <field name="LastPx" required="N"/>
+    </message>
     <message name="Heartbeat" msgtype="0" msgcat="admin">
       <field name="TestReqID" required="N"/>
     </message>
@@ -37,12 +47,25 @@
     <field number="10" name="CheckSum" type="STRING"/>
     <field number="35" name="MsgType" type="STRING"/>
     <field number="11" name="ClOrdID" type="STRING"/>
+    <field number="17" name="ExecID" type="STRING"/>
+    <field number="31" name="LastPx" type="PRICE"/>
+    <field number="32" name="LastQty" type="QTY"/>
+    <field number="37" name="OrderID" type="STRING"/>
+    <field number="39" name="OrdStatus" type="CHAR">
+      <value enum="0" description="NEW"/>
+      <value enum="1" description="PARTIALLY_FILLED"/>
+      <value enum="2" description="FILLED"/>
+    </field>
     <field number="54" name="Side" type="CHAR">
       <value enum="1" description="BUY"/>
       <value enum="2" description="SELL"/>
     </field>
     <field number="55" name="Symbol" type="STRING"/>
     <field number="38" name="OrderQty" type="QTY"/>
+    <field number="150" name="ExecType" type="CHAR">
+      <value enum="0" description="NEW"/>
+      <value enum="F" description="TRADE"/>
+    </field>
     <field number="453" name="NoPartyIDs" type="NUMINGROUP"/>
     <field number="448" name="PartyID" type="STRING"/>
     <field number="452" name="PartyRole" type="INT"/>

--- a/nexus-fix-codegen/tests/fixtures/venue_beta.xml
+++ b/nexus-fix-codegen/tests/fixtures/venue_beta.xml
@@ -1,0 +1,40 @@
+<fix major="4" minor="2">
+  <header>
+    <field name="BeginString" required="Y"/>
+    <field name="MsgType" required="Y"/>
+  </header>
+  <trailer>
+    <field name="CheckSum" required="Y"/>
+  </trailer>
+  <messages>
+    <message name="Logon" msgtype="A" msgcat="admin">
+      <field name="EncryptMethod" required="Y"/>
+      <field name="HeartBtInt" required="Y"/>
+    </message>
+    <message name="MarketDataSnapshotFullRefresh" msgtype="W" msgcat="app">
+      <field name="Symbol" required="Y"/>
+      <group name="NoMDEntries" required="Y">
+        <field name="MDEntryType" required="Y"/>
+        <field name="MDEntryPx" required="N"/>
+        <field name="MDEntrySize" required="N"/>
+      </group>
+    </message>
+  </messages>
+  <components/>
+  <fields>
+    <field number="8" name="BeginString" type="STRING"/>
+    <field number="10" name="CheckSum" type="STRING"/>
+    <field number="35" name="MsgType" type="STRING"/>
+    <field number="98" name="EncryptMethod" type="INT"/>
+    <field number="108" name="HeartBtInt" type="INT"/>
+    <field number="55" name="Symbol" type="STRING"/>
+    <field number="268" name="NoMDEntries" type="NUMINGROUP"/>
+    <field number="269" name="MDEntryType" type="CHAR">
+      <value enum="0" description="BID"/>
+      <value enum="1" description="OFFER"/>
+      <value enum="2" description="TRADE"/>
+    </field>
+    <field number="270" name="MDEntryPx" type="PRICE"/>
+    <field number="271" name="MDEntrySize" type="QTY"/>
+  </fields>
+</fix>


### PR DESCRIPTION
Closes #407. Depends on #406 (`nexus-fix-codec` runtime). Implements the design approved in #418.

## What

New crate `nexus-fix-codegen`: a lib + `clap` CLI + `build.rs` API that reads a QuickFIX dictionary XML and emits readable Rust over the #406 codec primitives. Generated code is zero-copy, zero-alloc, no runtime reflection — the dictionary is consumed entirely at generation time (Prost tooling model).

```
nexus-fix-codegen/
  src/
    lib.rs    — Config builder + generate()
    main.rs   — clap CLI
    dict/     — quick-xml dictionary parse -> typed model
    emit/     — fields / messages / groups / encoders / mod emitters
```

## Generated output

- **`fields.rs`** — `TAG_*: u32` consts; typed enums per `<field>`. Single-char -> `from_byte`/`as_byte`; multi-char -> `from_bytes`/`as_bytes`. Lookups key off `RawField.value.slice(buf)`.
- **`messages.rs`** — per-`MsgType` flyweight decoder. One-pass populate: run `FieldReader` once, dispatch each `RawField.tag` into the message's `FieldSpan` slots. O(n), zero-copy, borrows `&[u8]`. No watermark, no `Cell` — accessors are pure reads checking `span.is_present()`.
- **`groups.rs`** — repeating-group iterators + per-entry decoders over `GroupSpan` + a bounded sub-scan. Fully recursive nesting.
- **`encoders.rs`** — consume-self builders over `FieldWriter` / `encode_field`, `finish() -> usize`, `finish_with_checksum()`.
- **`mod.rs`** — re-exports, `BEGIN_STRING`, `MsgType` dispatch.

## Design (per #418)

- **Dictionary-driven, not version-driven** — one codepath for any QuickFIX XML.
- **Unknown tags: silent skip** — no slot, no error.
- **Decode model: one-pass populate, no watermark.** `find_tag` stays in the codec for ad-hoc use; generated decoders don't call it.
- **DATA fields** (95/96, 90/91, 212/213, 348/349, 358/359) — read length-delimited: take the preceding length tag, consume exactly N bytes, re-seat `FieldReader` past the value so a `0x01` in a binary payload never mis-splits. DATA inside a repeating group is rejected at generation time (`EmitError::DataInGroup`) rather than emitting subtly-wrong code.
- **No `#[allow]` in generated code** — the output is clean under the workspace's `clippy::all/pedantic/nursery -D warnings` with zero suppressions.

## Resolved open questions (#418)

`quick-xml` parser · post-step `rustfmt` (graceful degrade if absent) · fully-recursive group nesting, no depth guard.

## Tests

- `nexus-fix-codegen` unit tests: dictionary parse + emitted-source assertions + DATA-in-group rejection.
- `nexus-fix-codegen-tests`: a `build.rs` consumer that generates from a sample dictionary into `OUT_DIR` and `include!`s it, then exercises decode (scalars, enums, DATA with embedded SOH, repeating + nested groups), `MsgType` dispatch, and encode round-trips. This is the end-to-end proof that generated code compiles and decodes correctly.

## Out of scope

Session/transport (#409/#410), persistence (#411). Targets the codec layer only.
