### PR TITLE
fix: replace EventRateF64 with integer-timestamp EventRateU64/I64

### DIFF
--- a/docs/cookbook-market-data-gateway.md
+++ b/docs/cookbook-market-data-gateway.md
@@ -92,7 +92,7 @@ All allocation happens here. After this point no hot-path code calls
 use nexus_logbuf::spsc as logbuf_spsc;
 use nexus_queue::spmc;
 use nexus_slot::spsc as slot_spsc;
-use nexus_stats::{monitoring::EventRateF64, statistics::PercentileF64};
+use nexus_stats::{monitoring::EventRateU64, statistics::PercentileF64};
 
 pub struct Gateway {
     // Archival — raw WS frames, off the hot path, for replay/compliance.
@@ -111,7 +111,7 @@ pub struct Gateway {
 
     // Health metrics. Updated by reader task.
     inter_arrival: PercentileF64,
-    msg_rate: EventRateF64,
+    msg_rate: EventRateU64,
 }
 
 impl Gateway {
@@ -133,9 +133,7 @@ impl Gateway {
             trade_fanout,
             trade_rx,
             inter_arrival: PercentileF64::new(0.999).unwrap(),
-            // fixed: EventRateF64 uses a builder and takes an alpha smoothing
-            // factor; it does not accept a Duration.
-            msg_rate: EventRateF64::builder().alpha(0.1).build().unwrap(),
+            msg_rate: EventRateU64::builder().span(15).build().unwrap(),
         }
     }
 }
@@ -224,8 +222,7 @@ async fn reader_task(
         //    p999 of inter-arrival catches stalls before the feed
         //    stops entirely.
         gw.inter_arrival.update((now_ns as f64) / 1e9).ok();
-        // fixed: EventRateF64::update takes an f64 timestamp.
-        gw.msg_rate.update(now_ns as f64 / 1e9).ok();
+        gw.msg_rate.update(now_ns);
 
         // 4. Publish to SPMC. If the queue is full, we drop — a slow
         //    downstream does not block the reader.
@@ -353,7 +350,6 @@ pub struct GatewayHealth {
 impl Gateway {
     pub fn health(&self) -> GatewayHealth {
         GatewayHealth {
-            // fixed: EventRateF64::rate() returns Option<f64>.
             msg_rate_per_sec: self.msg_rate.rate().unwrap_or(0.0),
             // fixed: PercentileF64 query is `.percentile()`, not `.value()`.
             inter_arrival_p999_ms: self

--- a/nexus-stats-core/CHANGELOG.md
+++ b/nexus-stats-core/CHANGELOG.md
@@ -8,6 +8,12 @@ with the project-specific allowance that a minor bump may carry small,
 narrowly-scoped breaking changes when external blast radius is
 contained.
 
+## [3.0.1] — 2026-06-04
+
+### Changed
+
+- **Breaking:** Replaced `EventRateF64` / `EventRateI64` with `EventRateU64` / `EventRateI64` using integer timestamps and bit-shift EMA (same pattern as `LivenessI64`). The old `EventRateF64` incorrectly used `f64` timestamps; the new types use `u64` / `i64` timestamps with fixed-point `i128` accumulator and `span()` builder instead of `alpha()`.
+
 ## [3.0.0] — 2026-05-28
 
 ### Removed

--- a/nexus-stats-core/Cargo.toml
+++ b/nexus-stats-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-stats-core"
-version = "3.0.0"
+version = "3.0.1"
 description = "Core types and utilities shared across nexus-stats subcrates"
 readme = "README.md"
 edition.workspace = true

--- a/nexus-stats-core/src/monitoring/event_rate.rs
+++ b/nexus-stats-core/src/monitoring/event_rate.rs
@@ -1,95 +1,94 @@
-use crate::math::MulAdd;
-
-/// Smoothed event rate tracker.
+/// Smoothed event rate tracker (unsigned integer timestamps).
 ///
-/// Uses an EMA of inter-arrival times, inverted on query to produce
-/// a rate (events per unit time). The rate adapts smoothly to changes
-/// in event frequency.
+/// Uses a fixed-point bit-shift EMA of inter-arrival times, inverted
+/// on query to produce a rate (events per unit time). Timestamps are
+/// unsigned ticks (e.g. nanoseconds from `Instant`).
 ///
 /// # Use Cases
 /// - Message throughput monitoring
 /// - Order rate tracking
 /// - Adaptive rate limiting input
 #[derive(Debug, Clone)]
-pub struct EventRateF64 {
-    alpha: f64,
-    one_minus_alpha: f64,
-    interval: f64,
-    last_timestamp: f64,
+pub struct EventRateU64 {
+    acc: i128,
+    shift: u32,
+    span: u64,
+    last_timestamp: u64,
     count: u64,
     min_samples: u64,
+    initialized: bool,
 }
 
-/// Builder for [`EventRateF64`].
+/// Builder for [`EventRateU64`].
 #[derive(Debug, Clone)]
-pub struct EventRateF64Builder {
-    alpha: Option<f64>,
+pub struct EventRateU64Builder {
+    span: Option<u64>,
     min_samples: u64,
 }
 
-impl EventRateF64 {
+impl EventRateU64 {
     /// Creates a builder.
     #[inline]
     #[must_use]
-    pub fn builder() -> EventRateF64Builder {
-        EventRateF64Builder {
-            alpha: None,
+    pub fn builder() -> EventRateU64Builder {
+        EventRateU64Builder {
+            span: None,
             min_samples: 2,
         }
     }
 
-    /// Updates with an event at the given timestamp.
-    ///
-    /// If two events share a timestamp, the interval is zero and
-    /// `rate()` returns `None` until a non-zero interval is observed.
-    ///
-    /// # Errors
-    ///
-    /// Returns `DataError::NotANumber` if the timestamp is NaN, or
-    /// `DataError::Infinite` if the timestamp is infinite.
+    /// Updates with an event at the given tick.
     #[inline]
-    pub fn update(&mut self, timestamp: f64) -> Result<(), crate::DataError> {
-        check_finite!(timestamp);
+    pub fn update(&mut self, timestamp: u64) {
         self.count += 1;
 
         if self.count == 1 {
             self.last_timestamp = timestamp;
-            return Ok(());
+            return;
         }
 
-        let dt = timestamp - self.last_timestamp;
+        let dt = timestamp.wrapping_sub(self.last_timestamp) as i64;
         self.last_timestamp = timestamp;
 
-        if self.count == 2 {
-            self.interval = dt;
+        if self.initialized {
+            let dt_shifted = (dt as i128) << self.shift;
+            self.acc += (dt_shifted - self.acc) >> self.shift;
         } else {
-            self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
+            self.acc = (dt as i128) << self.shift;
+            self.initialized = true;
         }
-        Ok(())
     }
 
     /// Current smoothed event rate (events per unit time).
     ///
-    /// Returns `None` if not primed or if interval is zero.
+    /// Returns `None` if not primed or if the smoothed interval is zero.
     #[inline]
     #[must_use]
     pub fn rate(&self) -> Option<f64> {
-        if self.count < self.min_samples || self.interval <= 0.0 {
+        let interval = self.interval()?;
+        if interval == 0 {
             None
         } else {
-            Some(1.0 / self.interval)
+            Some(1.0 / interval as f64)
         }
     }
 
-    /// Current smoothed inter-event interval, or `None` if < 2 events.
+    /// Current smoothed inter-event interval in ticks, or `None` if < 2 events.
     #[inline]
     #[must_use]
-    pub fn interval(&self) -> Option<f64> {
-        if self.count >= 2 {
-            Some(self.interval)
+    pub fn interval(&self) -> Option<u64> {
+        if self.count >= self.min_samples && self.initialized {
+            Some((self.acc >> self.shift) as u64)
         } else {
             None
         }
+    }
+
+    /// Effective span after rounding to `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn effective_span(&self) -> u64 {
+        self.span
     }
 
     /// Number of events recorded.
@@ -109,38 +108,19 @@ impl EventRateF64 {
     /// Resets to uninitialized state.
     #[inline]
     pub fn reset(&mut self) {
-        self.interval = 0.0;
-        self.last_timestamp = 0.0;
+        self.acc = 0;
+        self.last_timestamp = 0;
         self.count = 0;
+        self.initialized = false;
     }
 }
 
-impl EventRateF64Builder {
-    /// Direct smoothing factor for interval EMA.
-    #[inline]
-    #[must_use]
-    pub fn alpha(mut self, alpha: f64) -> Self {
-        self.alpha = Some(alpha);
-        self
-    }
-
-    /// Halflife for interval smoothing.
-    #[inline]
-    #[must_use]
-    #[cfg(any(feature = "std", feature = "libm"))]
-    pub fn halflife(mut self, halflife: f64) -> Self {
-        let ln2 = core::f64::consts::LN_2;
-        let alpha = 1.0 - crate::math::exp(-ln2 / halflife);
-        self.alpha = Some(alpha);
-        self
-    }
-
-    /// Span for interval smoothing.
+impl EventRateU64Builder {
+    /// Smoothing span. Rounded up to next `2^k - 1`.
     #[inline]
     #[must_use]
     pub fn span(mut self, n: u64) -> Self {
-        let alpha = 2.0 / (n as f64 + 1.0);
-        self.alpha = Some(alpha);
+        self.span = Some(n);
         self
     }
 
@@ -156,24 +136,181 @@ impl EventRateF64Builder {
     ///
     /// # Errors
     ///
-    /// - Alpha must have been set.
-    /// - Alpha must be in (0, 1) exclusive.
+    /// - Span must have been set and >= 1.
     #[inline]
-    pub fn build(self) -> Result<EventRateF64, crate::ConfigError> {
-        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-        if !(alpha > 0.0 && alpha < 1.0) {
-            return Err(crate::ConfigError::Invalid(
-                "EventRate alpha must be in (0, 1)",
-            ));
+    pub fn build(self) -> Result<EventRateU64, crate::ConfigError> {
+        let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
+        if requested < 1 {
+            return Err(crate::ConfigError::Invalid("EventRate span must be >= 1"));
         }
 
-        Ok(EventRateF64 {
-            alpha,
-            one_minus_alpha: 1.0 - alpha,
-            interval: 0.0,
-            last_timestamp: 0.0,
+        let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
+        let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
+
+        Ok(EventRateU64 {
+            acc: 0,
+            shift,
+            span: effective,
+            last_timestamp: 0,
             count: 0,
             min_samples: self.min_samples,
+            initialized: false,
+        })
+    }
+}
+
+/// Smoothed event rate tracker (signed integer timestamps).
+///
+/// Identical to [`EventRateU64`] but accepts `i64` timestamps for
+/// compatibility with signed time representations (e.g. offsets,
+/// relative ticks).
+#[derive(Debug, Clone)]
+pub struct EventRateI64 {
+    acc: i128,
+    shift: u32,
+    span: u64,
+    last_timestamp: i64,
+    count: u64,
+    min_samples: u64,
+    initialized: bool,
+}
+
+/// Builder for [`EventRateI64`].
+#[derive(Debug, Clone)]
+pub struct EventRateI64Builder {
+    span: Option<u64>,
+    min_samples: u64,
+}
+
+impl EventRateI64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> EventRateI64Builder {
+        EventRateI64Builder {
+            span: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Updates with an event at the given tick.
+    #[inline]
+    pub fn update(&mut self, timestamp: i64) {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_timestamp = timestamp;
+            return;
+        }
+
+        let dt = timestamp - self.last_timestamp;
+        self.last_timestamp = timestamp;
+
+        if self.initialized {
+            let dt_shifted = (dt as i128) << self.shift;
+            self.acc += (dt_shifted - self.acc) >> self.shift;
+        } else {
+            self.acc = (dt as i128) << self.shift;
+            self.initialized = true;
+        }
+    }
+
+    /// Current smoothed event rate (events per unit time).
+    ///
+    /// Returns `None` if not primed or if the smoothed interval is zero.
+    #[inline]
+    #[must_use]
+    pub fn rate(&self) -> Option<f64> {
+        let interval = self.interval()?;
+        if interval == 0 {
+            None
+        } else {
+            Some(1.0 / interval as f64)
+        }
+    }
+
+    /// Current smoothed inter-event interval in ticks, or `None` if < 2 events.
+    #[inline]
+    #[must_use]
+    pub fn interval(&self) -> Option<i64> {
+        if self.count >= self.min_samples && self.initialized {
+            Some((self.acc >> self.shift) as i64)
+        } else {
+            None
+        }
+    }
+
+    /// Effective span after rounding to `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn effective_span(&self) -> u64 {
+        self.span
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the tracker has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.acc = 0;
+        self.last_timestamp = 0;
+        self.count = 0;
+        self.initialized = false;
+    }
+}
+
+impl EventRateI64Builder {
+    /// Smoothing span. Rounded up to next `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.span = Some(n);
+        self
+    }
+
+    /// Minimum events before rate is valid. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the event rate tracker.
+    ///
+    /// # Errors
+    ///
+    /// - Span must have been set and >= 1.
+    #[inline]
+    pub fn build(self) -> Result<EventRateI64, crate::ConfigError> {
+        let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
+        if requested < 1 {
+            return Err(crate::ConfigError::Invalid("EventRate span must be >= 1"));
+        }
+
+        let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
+        let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
+
+        Ok(EventRateI64 {
+            acc: 0,
+            shift,
+            span: effective,
+            last_timestamp: 0,
+            count: 0,
+            min_samples: self.min_samples,
+            initialized: false,
         })
     }
 }
@@ -183,31 +320,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn constant_rate() {
-        let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
+    fn constant_rate_u64() {
+        let mut er = EventRateU64::builder().span(15).build().unwrap();
 
-        // Events every 10 units -> rate should converge to 0.1
-        for i in 0..100 {
-            er.update(i as f64 * 10.0).unwrap();
+        for i in 0..100u64 {
+            er.update(i * 10);
         }
 
+        let interval = er.interval().unwrap();
+        assert_eq!(interval, 10, "interval should converge to 10");
         let rate = er.rate().unwrap();
-        assert!((rate - 0.1).abs() < 0.01, "rate should be ~0.1, got {rate}");
+        assert!(
+            (rate - 0.1).abs() < 0.001,
+            "rate should be ~0.1, got {rate}"
+        );
+    }
+
+    #[test]
+    fn constant_rate_i64() {
+        let mut er = EventRateI64::builder().span(15).build().unwrap();
+
+        for i in 0..100i64 {
+            er.update(i * 10);
+        }
+
+        let interval = er.interval().unwrap();
+        assert_eq!(interval, 10, "interval should converge to 10");
+        let rate = er.rate().unwrap();
+        assert!(
+            (rate - 0.1).abs() < 0.001,
+            "rate should be ~0.1, got {rate}"
+        );
     }
 
     #[test]
     fn burst_increases_rate() {
-        let mut er = EventRateF64::builder().alpha(0.5).build().unwrap();
+        let mut er = EventRateU64::builder().span(7).build().unwrap();
 
-        // Normal rate: every 10 units
-        for i in 0..20 {
-            er.update(i as f64 * 10.0).unwrap();
+        for i in 0..20u64 {
+            er.update(i * 1000);
         }
         let normal_rate = er.rate().unwrap();
 
-        // Burst: events every 1 unit
-        for i in 0..20 {
-            er.update(200.0 + i as f64).unwrap();
+        for i in 0..20u64 {
+            er.update(20_000 + i * 100);
         }
         let burst_rate = er.rate().unwrap();
 
@@ -219,25 +375,38 @@ mod tests {
 
     #[test]
     fn priming() {
-        let mut er = EventRateF64::builder()
-            .alpha(0.3)
+        let mut er = EventRateU64::builder()
+            .span(7)
             .min_samples(5)
             .build()
             .unwrap();
 
-        for i in 0..4 {
-            er.update(i as f64 * 10.0).unwrap();
+        for i in 0..4u64 {
+            er.update(i * 10);
+            assert!(!er.is_primed());
             assert!(er.rate().is_none());
         }
-        er.update(40.0).unwrap();
+        er.update(40);
+        assert!(er.is_primed());
         assert!(er.rate().is_some());
     }
 
     #[test]
-    fn reset() {
-        let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
-        for i in 0..10 {
-            er.update(i as f64 * 10.0).unwrap();
+    fn reset_u64() {
+        let mut er = EventRateU64::builder().span(7).build().unwrap();
+        for i in 0..10u64 {
+            er.update(i * 10);
+        }
+        er.reset();
+        assert_eq!(er.count(), 0);
+        assert!(er.rate().is_none());
+    }
+
+    #[test]
+    fn reset_i64() {
+        let mut er = EventRateI64::builder().span(7).build().unwrap();
+        for i in 0..10i64 {
+            er.update(i * 10);
         }
         er.reset();
         assert_eq!(er.count(), 0);
@@ -246,32 +415,21 @@ mod tests {
 
     #[test]
     fn zero_interval_returns_none() {
-        let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
-        er.update(100.0).unwrap();
-        er.update(100.0).unwrap(); // same timestamp -> interval = 0
-        // rate() should return None (division by zero guard)
-        assert!(
-            er.rate().is_none(),
-            "rate should be None with zero interval"
-        );
+        let mut er = EventRateU64::builder().span(7).build().unwrap();
+        er.update(100);
+        er.update(100);
+        assert!(er.rate().is_none());
     }
 
     #[test]
-    fn errors_without_alpha() {
-        let result = EventRateF64::builder().build();
-        assert!(matches!(result, Err(crate::ConfigError::Missing("alpha"))));
+    fn errors_without_span() {
+        let result = EventRateU64::builder().build();
+        assert!(matches!(result, Err(crate::ConfigError::Missing("span"))));
     }
 
     #[test]
-    fn rejects_nan_and_inf() {
-        let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
-        assert!(matches!(
-            er.update(f64::NAN),
-            Err(crate::DataError::NotANumber)
-        ));
-        assert!(matches!(
-            er.update(f64::INFINITY),
-            Err(crate::DataError::Infinite)
-        ));
+    fn effective_span_rounds_up() {
+        let er = EventRateU64::builder().span(10).build().unwrap();
+        assert_eq!(er.effective_span(), 15);
     }
 }

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -135,7 +135,7 @@ for deep-dives on each algorithm.
 | `PeakHoldF64` | Peak envelope with hold + decay | 7 |
 | `MaxGaugeF64` | Reset-on-read maximum (Netflix pattern) | 5 |
 | `LivenessF64` | Source alive/dead detection | 6 |
-| `EventRateF64` | Smoothed events per unit time | 6 |
+| `EventRateU64` | Smoothed events per unit time | 6 |
 | `CoDelI64` | Queue backpressure detection (CoDel-inspired) | 7 |
 | `SaturationF64` | Resource utilization threshold (USE method) | 6 |
 | `ErrorRateF64` | Failure rate with weighted severity | 6 |

--- a/nexus-stats/docs/algorithms/event-rate.md
+++ b/nexus-stats/docs/algorithms/event-rate.md
@@ -7,25 +7,24 @@ per second is this source producing?"
 |----------|-------|
 | Update cost | ~6 cycles |
 | Memory | ~32 bytes |
-| Types | `EventRateF64`, `EventRateF32`, `EventRateI64`, `EventRateI32` |
+| Types | `EventRateU64`, `EventRateI64` |
 
 ## API
 
 ```rust
-let mut rate = EventRateF64::builder().span(20).build().unwrap();
+let mut rate = EventRateU64::builder().span(15).build().unwrap();
 
-rate.tick(timestamp);  // record an event
+rate.update(timestamp_ns);  // record an event
 if let Some(r) = rate.rate() {
     println!("{r} events per time unit");
 }
 ```
 
-Internally: EMA of time between events, rate = 1 / smoothed_interval.
+Internally: bit-shift EMA of inter-arrival times (i128 accumulator,
+shift-based smoothing), rate = 1.0 / interval. Same pattern as `LivenessI64`.
 
-**Note:** Integer variants (`EventRateI64`, `EventRateI32`) provide
-`tick()` and `interval()` only — no `rate()` method, since `1 / interval`
-truncates to zero for integer intervals > 1. Use float variants if you
-need the rate directly, or compute it yourself with appropriate scaling.
+`EventRateU64` takes `u64` timestamps (e.g. nanoseconds from `Instant`).
+`EventRateI64` takes `i64` timestamps for signed time representations.
 
 ## When to Use Something Else
 

--- a/nexus-stats/docs/reference/performance.md
+++ b/nexus-stats/docs/reference/performance.md
@@ -38,7 +38,7 @@ pinned to a single core.
 | PeakHoldF64 | 7 | 9 | compare + decay |
 | MaxGaugeF64 | ~5 | ~5 | compare-and-swap |
 | LivenessF64 | 6 | 20 | EMA + deadline |
-| EventRateF64 | 6 | 9 | EMA + inversion |
+| EventRateU64 | 6 | 9 | bit-shift EMA + inversion |
 | CoDelI64 | 7 | 10 | WindowedMin + threshold |
 | SaturationF64 | ~6 | ~8 | EMA + threshold |
 | ErrorRateF64 | ~6 | ~8 | EMA of outcomes |

--- a/nexus-stats/docs/use-cases/rate-management.md
+++ b/nexus-stats/docs/use-cases/rate-management.md
@@ -9,10 +9,10 @@ lives in the `nexus-rate` crate. This covers the *measurement* side.
 
 ```rust
 use nexus_stats::Condition;
-use nexus_stats::monitoring::{EventRateF64, SaturationF64};
+use nexus_stats::monitoring::{EventRateU64, SaturationF64};
 
 // Track our own order rate
-let mut order_rate = EventRateF64::builder().span(20).build().unwrap();
+let mut order_rate = EventRateU64::builder().span(15).build().unwrap();
 
 // Detect if we're approaching the limit
 let mut limit_sat = SaturationF64::builder()
@@ -21,7 +21,7 @@ let mut limit_sat = SaturationF64::builder()
     .build().unwrap();
 
 // On each order sent:
-order_rate.tick(now);
+order_rate.update(now_ns);
 
 if let Some(rate) = order_rate.rate() {
     let utilization = rate / exchange_rate_limit;
@@ -35,16 +35,16 @@ if let Some(rate) = order_rate.rate() {
 
 ```rust
 use nexus_stats::Direction;
-use nexus_stats::monitoring::EventRateF64;
+use nexus_stats::monitoring::EventRateU64;
 use nexus_stats::detection::CusumF64;
 
-let mut rate = EventRateF64::builder().span(30).build().unwrap();
+let mut rate = EventRateU64::builder().span(31).build().unwrap();
 let mut cusum = CusumF64::builder(expected_rate)
     .slack(expected_rate * 0.1)
     .threshold(expected_rate * 2.0)
     .build().unwrap();
 
-rate.tick(now);
+rate.update(now_ns);
 if let Some(r) = rate.rate() {
     if let Some(shift) = cusum.update(r) {
         match shift {

--- a/nexus-stats/examples/perf_stats.rs
+++ b/nexus-stats/examples/perf_stats.rs
@@ -14,7 +14,7 @@ use nexus_stats::{
     frequency::TopK,
     learning::{EpsilonGreedyF64, Exp3F64, ThompsonBetaF64, ThompsonGammaF64, Ucb1F64},
     monitoring::{
-        CoDelI64, DrawdownF64, EventRateF64, LivenessF64, PeakHoldF64, RunningMaxF64,
+        CoDelI64, DrawdownF64, EventRateU64, LivenessF64, PeakHoldF64, RunningMaxF64,
         RunningMinF64, WindowedMaxF64, WindowedMinF64,
     },
     signal::{AutocorrelationF64, CrossCorrelationF64, EntropyF64, TransferEntropyF64},
@@ -406,19 +406,19 @@ fn bench_running_max_f64(samples: &mut [u64]) {
     }
 }
 
-fn bench_event_rate_f64(samples: &mut [u64]) {
-    let mut er = EventRateF64::builder().alpha(0.3).build().unwrap();
+fn bench_event_rate_u64(samples: &mut [u64]) {
+    let mut er = EventRateU64::builder().span(15).build().unwrap();
     let mut rng = 12345u64;
-    let mut t = 0.0f64;
+    let mut t = 0u64;
     for _ in 0..WARMUP {
-        t += 10.0 + (next_val(&mut rng) % 5) as f64;
-        let _ = er.update(t);
+        t += 10 + next_val(&mut rng) % 5;
+        er.update(t);
     }
     for s in samples.iter_mut() {
         let start = rdtsc_start();
         for _ in 0..BATCH {
-            t += 10.0 + (next_val(&mut rng) % 5) as f64;
-            let _ = er.update(t);
+            t += 10 + next_val(&mut rng) % 5;
+            er.update(t);
         }
         let end = rdtsc_end();
         black_box(er.rate());
@@ -989,8 +989,8 @@ fn main() {
     print_row("RunningMinF64::update", &mut buf);
     bench_running_max_f64(&mut buf);
     print_row("RunningMaxF64::update", &mut buf);
-    bench_event_rate_f64(&mut buf);
-    print_row("EventRateF64::update", &mut buf);
+    bench_event_rate_u64(&mut buf);
+    print_row("EventRateU64::update", &mut buf);
     bench_codel_i64(&mut buf);
     print_row("CoDelI64::update", &mut buf);
 


### PR DESCRIPTION
## Summary

`EventRateF64` incorrectly used `f64` timestamps — the actual use case is integer ticks (nanoseconds, rdtsc cycles). Replaced with:

- **`EventRateU64`** — unsigned `u64` timestamps (e.g. nanoseconds from `Instant`)
- **`EventRateI64`** — signed `i64` timestamps (e.g. offsets, relative ticks)

Both use bit-shift EMA with `i128` accumulator and shift-based smoothing, matching the `LivenessI64` pattern. Builder uses `span()` instead of `alpha()`.

Bumps nexus-stats-core to 3.0.1.

## Changes

- `nexus-stats-core/src/monitoring/event_rate.rs` — full rewrite
- `nexus-stats-core/Cargo.toml` — version 3.0.0 → 3.0.1
- `nexus-stats-core/CHANGELOG.md` — documented breaking change
- `nexus-stats/examples/perf_stats.rs` — updated benchmark
- Docs updated across 5 files (README, algorithm doc, use-case recipes, perf reference, cookbook)

## Test plan

- [x] All 396 nexus-stats-core tests pass (9 new EventRate tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No stale `EventRateF64` references remain outside CHANGELOG

Closes #447