### PR TITLE
feat(fix-engine): Session<D: FixDictionary> routing layer

### DIFF
--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -1,7 +1,9 @@
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use nexus_fix_codec::{FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint};
+use nexus_fix_codec::{
+    FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
+};
 
 use crate::{Out, SessionState, State};
 
@@ -20,7 +22,10 @@ impl CompId {
         }
         let mut bytes = [0u8; COMP_ID_CAP];
         bytes[..s.len()].copy_from_slice(s);
-        Some(Self { bytes, len: s.len() as u8 })
+        Some(Self {
+            bytes,
+            len: s.len() as u8,
+        })
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -80,7 +85,11 @@ pub struct Session<D: FixDictionary> {
 
 impl<D: FixDictionary> Session<D> {
     pub fn new(state: SessionState, config: SessionConfig) -> Self {
-        Self { state, config, _dict: PhantomData }
+        Self {
+            state,
+            config,
+            _dict: PhantomData,
+        }
     }
 
     pub fn state(&self) -> &SessionState {
@@ -128,8 +137,7 @@ impl<D: FixDictionary> Session<D> {
 
         match header.raw_msg_type().map(|v| v.as_bytes()) {
             Some(b"A") => {
-                let hbi = find_tag(buf, 0, 108)
-                    .ok_or(SessionError::MissingField { tag: 108 })?;
+                let hbi = find_tag(buf, 0, 108).ok_or(SessionError::MissingField { tag: 108 })?;
                 let heart_bt_int = parse_fix_uint(hbi.slice(buf))
                     .map_err(|_| SessionError::MalformedField { tag: 108 })?;
                 let reset = find_tag(buf, 0, 141)
@@ -137,41 +145,54 @@ impl<D: FixDictionary> Session<D> {
                     .unwrap_or(false);
                 // Acceptor replies with its own Logon; initiator already sent one.
                 let send_reply = self.state.state() != State::LogonSent;
-                Ok((self.state.on_logon(seq, heart_bt_int, reset, send_reply, now), None))
+                Ok((
+                    self.state
+                        .on_logon(seq, heart_bt_int, reset, send_reply, now),
+                    None,
+                ))
             }
             Some(b"5") => Ok((self.state.on_logout(seq, poss_dup, now), None)),
             Some(b"0") => Ok((self.state.on_heartbeat(seq, poss_dup, now), None)),
             Some(b"1") => {
-                let test_req_id = find_tag(buf, 0, 112)
-                    .map_or_else(|| b"".as_ref(), |s| s.slice(buf));
-                Ok((self.state.on_test_request(seq, poss_dup, test_req_id, now), None))
+                let test_req_id =
+                    find_tag(buf, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(buf));
+                Ok((
+                    self.state.on_test_request(seq, poss_dup, test_req_id, now),
+                    None,
+                ))
             }
             Some(b"2") => {
-                let begin = find_tag(buf, 0, 7)
-                    .ok_or(SessionError::MissingField { tag: 7 })?;
+                let begin = find_tag(buf, 0, 7).ok_or(SessionError::MissingField { tag: 7 })?;
                 let begin = parse_fix_seqnum(begin.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 7 })? as u32;
-                let end = find_tag(buf, 0, 16)
-                    .ok_or(SessionError::MissingField { tag: 16 })?;
+                    .map_err(|_| SessionError::MalformedField { tag: 7 })?
+                    as u32;
+                let end = find_tag(buf, 0, 16).ok_or(SessionError::MissingField { tag: 16 })?;
                 let end = parse_fix_seqnum(end.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 16 })? as u32;
-                Ok((self.state.on_resend_request(seq, poss_dup, begin, end, now), None))
+                    .map_err(|_| SessionError::MalformedField { tag: 16 })?
+                    as u32;
+                Ok((
+                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
+                    None,
+                ))
             }
             Some(b"4") => {
-                let new_seq = find_tag(buf, 0, 36)
-                    .ok_or(SessionError::MissingField { tag: 36 })?;
+                let new_seq = find_tag(buf, 0, 36).ok_or(SessionError::MissingField { tag: 36 })?;
                 let new_seq = parse_fix_seqnum(new_seq.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 36 })? as u32;
+                    .map_err(|_| SessionError::MalformedField { tag: 36 })?
+                    as u32;
                 let gap_fill = find_tag(buf, 0, 123)
                     .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
                     .unwrap_or(false);
-                Ok((self.state.on_sequence_reset(seq, new_seq, gap_fill, now), None))
+                Ok((
+                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
+                    None,
+                ))
             }
             Some(b"3") => {
-                let ref_seq = find_tag(buf, 0, 45)
-                    .ok_or(SessionError::MissingField { tag: 45 })?;
+                let ref_seq = find_tag(buf, 0, 45).ok_or(SessionError::MissingField { tag: 45 })?;
                 let ref_seq = parse_fix_seqnum(ref_seq.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 45 })? as u32;
+                    .map_err(|_| SessionError::MalformedField { tag: 45 })?
+                    as u32;
                 Ok((self.state.on_reject(seq, poss_dup, ref_seq, now), None))
             }
             Some(_) => {

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -1,0 +1,184 @@
+use core::marker::PhantomData;
+use std::time::Instant;
+
+use nexus_fix_codec::{FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint};
+
+use crate::{Out, SessionState, State};
+
+const COMP_ID_CAP: usize = 20;
+
+#[derive(Clone, Copy, Debug)]
+pub struct CompId {
+    bytes: [u8; COMP_ID_CAP],
+    len: u8,
+}
+
+impl CompId {
+    pub fn new(s: &[u8]) -> Option<Self> {
+        if s.len() > COMP_ID_CAP {
+            return None;
+        }
+        let mut bytes = [0u8; COMP_ID_CAP];
+        bytes[..s.len()].copy_from_slice(s);
+        Some(Self { bytes, len: s.len() as u8 })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+}
+
+/// Session configuration: CompID pair used for inbound header validation.
+#[derive(Clone, Copy, Debug)]
+pub struct SessionConfig {
+    /// Our own SenderCompID — must match incoming TargetCompID (tag 56).
+    pub sender: CompId,
+    /// Counterparty SenderCompID — must match incoming SenderCompID (tag 49).
+    pub target: CompId,
+}
+
+/// Error returned by [`Session::on_message`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionError {
+    /// Tag 35 (MsgType) absent.
+    MissingMsgType,
+    /// Tag 34 (MsgSeqNum) absent.
+    MissingMsgSeqNum,
+    /// A required field for this message type is absent.
+    MissingField { tag: u32 },
+    /// A field is present but fails to parse.
+    MalformedField { tag: u32 },
+}
+
+impl core::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingMsgType => write!(f, "tag 35 (MsgType) missing"),
+            Self::MissingMsgSeqNum => write!(f, "tag 34 (MsgSeqNum) missing"),
+            Self::MissingField { tag } => write!(f, "required tag {tag} missing"),
+            Self::MalformedField { tag } => write!(f, "tag {tag} malformed"),
+        }
+    }
+}
+
+impl core::error::Error for SessionError {}
+
+/// Dictionary-powered FIX session router.
+///
+/// Wraps [`SessionState`] with a codec layer: decodes the header via
+/// `D::Header::decode`, validates CompIDs, routes by raw `MsgType` bytes, and
+/// dispatches to the appropriate typed [`SessionState`] handler.
+///
+/// Admin messages (`A`, `5`, `0`, `1`, `2`, `4`, `3`) are consumed internally.
+/// App messages are returned as `(Out, Some(header))` so the caller can decode
+/// the full message body.
+pub struct Session<D: FixDictionary> {
+    state: SessionState,
+    config: SessionConfig,
+    _dict: PhantomData<D>,
+}
+
+impl<D: FixDictionary> Session<D> {
+    pub fn new(state: SessionState, config: SessionConfig) -> Self {
+        Self { state, config, _dict: PhantomData }
+    }
+
+    pub fn state(&self) -> &SessionState {
+        &self.state
+    }
+
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        &mut self.state
+    }
+
+    /// Route an inbound message.
+    ///
+    /// Decodes the header, validates CompIDs, and dispatches to the matching
+    /// [`SessionState`] handler. Returns the [`Out`] from the handler plus
+    /// the decoded header for app messages; `None` for admin messages (consumed
+    /// internally).
+    pub fn on_message<'buf>(
+        &mut self,
+        buf: &'buf [u8],
+        now: Instant,
+    ) -> Result<(Out, Option<D::Header<'buf>>), SessionError> {
+        let header = D::Header::decode(buf);
+
+        // CompID validation — mismatch triggers a disconnect via SessionState.
+        let sender_ok = header
+            .sender_comp_id()
+            .is_some_and(|v| v.as_bytes() == self.config.target.as_bytes());
+        let target_ok = header
+            .target_comp_id()
+            .is_some_and(|v| v.as_bytes() == self.config.sender.as_bytes());
+        if !sender_ok || !target_ok {
+            return Ok((self.state.on_comp_id_mismatch(now), None));
+        }
+
+        let seq = header
+            .msg_seq_num()
+            .ok_or(SessionError::MissingMsgSeqNum)?
+            .checked()
+            .map_err(|_| SessionError::MalformedField { tag: 34 })? as u32;
+
+        let poss_dup = header
+            .poss_dup_flag()
+            .and_then(|v| v.checked().ok())
+            .unwrap_or(false);
+
+        match header.raw_msg_type().map(|v| v.as_bytes()) {
+            Some(b"A") => {
+                let hbi = find_tag(buf, 0, 108)
+                    .ok_or(SessionError::MissingField { tag: 108 })?;
+                let heart_bt_int = parse_fix_uint(hbi.slice(buf))
+                    .map_err(|_| SessionError::MalformedField { tag: 108 })?;
+                let reset = find_tag(buf, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
+                    .unwrap_or(false);
+                // Acceptor replies with its own Logon; initiator already sent one.
+                let send_reply = self.state.state() != State::LogonSent;
+                Ok((self.state.on_logon(seq, heart_bt_int, reset, send_reply, now), None))
+            }
+            Some(b"5") => Ok((self.state.on_logout(seq, poss_dup, now), None)),
+            Some(b"0") => Ok((self.state.on_heartbeat(seq, poss_dup, now), None)),
+            Some(b"1") => {
+                let test_req_id = find_tag(buf, 0, 112)
+                    .map_or_else(|| b"".as_ref(), |s| s.slice(buf));
+                Ok((self.state.on_test_request(seq, poss_dup, test_req_id, now), None))
+            }
+            Some(b"2") => {
+                let begin = find_tag(buf, 0, 7)
+                    .ok_or(SessionError::MissingField { tag: 7 })?;
+                let begin = parse_fix_seqnum(begin.slice(buf))
+                    .map_err(|_| SessionError::MalformedField { tag: 7 })? as u32;
+                let end = find_tag(buf, 0, 16)
+                    .ok_or(SessionError::MissingField { tag: 16 })?;
+                let end = parse_fix_seqnum(end.slice(buf))
+                    .map_err(|_| SessionError::MalformedField { tag: 16 })? as u32;
+                Ok((self.state.on_resend_request(seq, poss_dup, begin, end, now), None))
+            }
+            Some(b"4") => {
+                let new_seq = find_tag(buf, 0, 36)
+                    .ok_or(SessionError::MissingField { tag: 36 })?;
+                let new_seq = parse_fix_seqnum(new_seq.slice(buf))
+                    .map_err(|_| SessionError::MalformedField { tag: 36 })? as u32;
+                let gap_fill = find_tag(buf, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
+                    .unwrap_or(false);
+                Ok((self.state.on_sequence_reset(seq, new_seq, gap_fill, now), None))
+            }
+            Some(b"3") => {
+                let ref_seq = find_tag(buf, 0, 45)
+                    .ok_or(SessionError::MissingField { tag: 45 })?;
+                let ref_seq = parse_fix_seqnum(ref_seq.slice(buf))
+                    .map_err(|_| SessionError::MalformedField { tag: 45 })? as u32;
+                Ok((self.state.on_reject(seq, poss_dup, ref_seq, now), None))
+            }
+            Some(_) => {
+                let out = self.state.on_app(seq, poss_dup, now);
+                Ok((out, Some(header)))
+            }
+            None => Err(SessionError::MissingMsgType),
+        }
+    }
+}

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -7,6 +7,8 @@
 //! session event. The framework layer above encodes those messages and drives
 //! the transport.
 
+mod framework;
 mod session;
 
+pub use framework::{CompId, Session, SessionConfig, SessionError};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -87,23 +87,19 @@ fn logon(seq: u32, hbi: u32) -> Vec<u8> {
 }
 
 fn logout(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=5\x0149=TARGET\x0156=SENDER\x01")
-        .into_bytes()
+    format!("34={seq}\x0135=5\x0149=TARGET\x0156=SENDER\x01").into_bytes()
 }
 
 fn heartbeat(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=0\x0149=TARGET\x0156=SENDER\x01")
-        .into_bytes()
+    format!("34={seq}\x0135=0\x0149=TARGET\x0156=SENDER\x01").into_bytes()
 }
 
 fn test_request(seq: u32, id: &str) -> Vec<u8> {
-    format!("34={seq}\x0135=1\x0149=TARGET\x0156=SENDER\x01112={id}\x01")
-        .into_bytes()
+    format!("34={seq}\x0135=1\x0149=TARGET\x0156=SENDER\x01112={id}\x01").into_bytes()
 }
 
 fn resend_request(seq: u32, begin: u32, end: u32) -> Vec<u8> {
-    format!("34={seq}\x017={begin}\x0116={end}\x0135=2\x0149=TARGET\x0156=SENDER\x01")
-        .into_bytes()
+    format!("34={seq}\x017={begin}\x0116={end}\x0135=2\x0149=TARGET\x0156=SENDER\x01").into_bytes()
 }
 
 fn sequence_reset(seq: u32, new_seq: u32, gap_fill: bool) -> Vec<u8> {
@@ -115,8 +111,7 @@ fn sequence_reset(seq: u32, new_seq: u32, gap_fill: bool) -> Vec<u8> {
 }
 
 fn app_msg(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=D\x0149=TARGET\x0156=SENDER\x01")
-        .into_bytes()
+    format!("34={seq}\x0135=D\x0149=TARGET\x0156=SENDER\x01").into_bytes()
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
@@ -131,7 +126,13 @@ fn acceptor_logon() {
     assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
     let admins = admin_msgs(out);
     assert_eq!(admins.len(), 1);
-    assert!(matches!(admins[0], AdminMsg::Logon { seq: 1, heart_bt_int_s: 30 }));
+    assert!(matches!(
+        admins[0],
+        AdminMsg::Logon {
+            seq: 1,
+            heart_bt_int_s: 30
+        }
+    ));
 }
 
 #[test]
@@ -158,10 +159,17 @@ fn logout_round_trip() {
     let msg = logout(2);
     let (out, _) = s.on_message(&msg, now).unwrap();
     assert_eq!(s.state().state(), State::Disconnected);
-    assert_eq!(out.event(), Some(Event::Disconnected {
-        reason: nexus_fix_engine::DisconnectReason::Logout,
-    }));
-    assert!(admin_msgs(out).iter().any(|a| matches!(a, AdminMsg::Logout { .. })));
+    assert_eq!(
+        out.event(),
+        Some(Event::Disconnected {
+            reason: nexus_fix_engine::DisconnectReason::Logout,
+        })
+    );
+    assert!(
+        admin_msgs(out)
+            .iter()
+            .any(|a| matches!(a, AdminMsg::Logout { .. }))
+    );
 }
 
 #[test]
@@ -188,7 +196,10 @@ fn test_request_echoed_as_heartbeat() {
     let admins = admin_msgs(out);
     assert_eq!(admins.len(), 1);
     match admins[0] {
-        AdminMsg::Heartbeat { echo: Some((id, len)), .. } => {
+        AdminMsg::Heartbeat {
+            echo: Some((id, len)),
+            ..
+        } => {
             assert_eq!(&id[..len as usize], b"PROBE1");
         }
         _ => panic!("expected Heartbeat with echo"),
@@ -209,7 +220,11 @@ fn resend_request_triggers_gap_fill() {
         out.event(),
         Some(Event::ResendRange { begin: 2, end: 3 })
     ));
-    assert!(admin_msgs(out).iter().any(|a| matches!(a, AdminMsg::SequenceReset { .. })));
+    assert!(
+        admin_msgs(out)
+            .iter()
+            .any(|a| matches!(a, AdminMsg::SequenceReset { .. }))
+    );
 }
 
 #[test]
@@ -239,7 +254,13 @@ fn app_message_surfaces_header() {
     let msg = app_msg(2);
     let (out, hdr) = s.on_message(&msg, now).unwrap();
     assert!(hdr.is_some());
-    assert_eq!(out.event(), Some(Event::App { seq_num: 2, poss_dup: false }));
+    assert_eq!(
+        out.event(),
+        Some(Event::App {
+            seq_num: 2,
+            poss_dup: false
+        })
+    );
 }
 
 #[test]
@@ -254,6 +275,8 @@ fn comp_id_mismatch_disconnects() {
     assert_eq!(s.state().state(), State::Disconnected);
     assert!(matches!(
         out.event(),
-        Some(Event::Disconnected { reason: nexus_fix_engine::DisconnectReason::CompIdMismatch })
+        Some(Event::Disconnected {
+            reason: nexus_fix_engine::DisconnectReason::CompIdMismatch
+        })
     ));
 }

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -1,0 +1,259 @@
+use std::time::{Duration, Instant};
+
+use nexus_fix_codec::{FieldView, FixDictionary, FixHeader, FixTimestamp, find_tag};
+use nexus_fix_engine::{AdminMsg, CompId, Event, Out, Session, SessionConfig, SessionState, State};
+
+// ── minimal mock dictionary ──────────────────────────────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const HB: Duration = Duration::from_secs(30);
+
+fn session() -> Session<MockDict> {
+    let state = SessionState::new(HB);
+    let config = SessionConfig {
+        sender: CompId::new(b"SENDER").unwrap(),
+        target: CompId::new(b"TARGET").unwrap(),
+    };
+    Session::new(state, config)
+}
+
+fn admin_msgs(out: Out) -> Vec<AdminMsg> {
+    out.admin_messages().collect()
+}
+
+// Minimal valid Logon buffer — tags needed by Session<MockDict>.on_message.
+// 49=TARGET (their sender = our target), 56=SENDER (their target = our sender).
+fn logon(seq: u32, hbi: u32) -> Vec<u8> {
+    let mut v = Vec::new();
+    for part in [
+        format!("34={seq}\x01"),
+        "35=A\x01".to_string(),
+        "49=TARGET\x01".to_string(),
+        "56=SENDER\x01".to_string(),
+        format!("108={hbi}\x01"),
+    ] {
+        v.extend_from_slice(part.as_bytes());
+    }
+    v
+}
+
+fn logout(seq: u32) -> Vec<u8> {
+    format!("34={seq}\x0135=5\x0149=TARGET\x0156=SENDER\x01")
+        .into_bytes()
+}
+
+fn heartbeat(seq: u32) -> Vec<u8> {
+    format!("34={seq}\x0135=0\x0149=TARGET\x0156=SENDER\x01")
+        .into_bytes()
+}
+
+fn test_request(seq: u32, id: &str) -> Vec<u8> {
+    format!("34={seq}\x0135=1\x0149=TARGET\x0156=SENDER\x01112={id}\x01")
+        .into_bytes()
+}
+
+fn resend_request(seq: u32, begin: u32, end: u32) -> Vec<u8> {
+    format!("34={seq}\x017={begin}\x0116={end}\x0135=2\x0149=TARGET\x0156=SENDER\x01")
+        .into_bytes()
+}
+
+fn sequence_reset(seq: u32, new_seq: u32, gap_fill: bool) -> Vec<u8> {
+    format!(
+        "34={seq}\x0135=4\x0149=TARGET\x0156=SENDER\x0136={new_seq}\x01123={}\x01",
+        if gap_fill { "Y" } else { "N" }
+    )
+    .into_bytes()
+}
+
+fn app_msg(seq: u32) -> Vec<u8> {
+    format!("34={seq}\x0135=D\x0149=TARGET\x0156=SENDER\x01")
+        .into_bytes()
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn acceptor_logon() {
+    let mut s = session();
+    let msg = logon(1, 30);
+    let (out, hdr) = s.on_message(&msg, Instant::now()).unwrap();
+    assert!(hdr.is_none());
+    assert_eq!(s.state().state(), State::Active);
+    assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
+    let admins = admin_msgs(out);
+    assert_eq!(admins.len(), 1);
+    assert!(matches!(admins[0], AdminMsg::Logon { seq: 1, heart_bt_int_s: 30 }));
+}
+
+#[test]
+fn initiator_logon_reply() {
+    let mut s = session();
+    let now = Instant::now();
+    s.state_mut().connect(now);
+    assert_eq!(s.state().state(), State::LogonSent);
+
+    let msg = logon(1, 30);
+    let (out, hdr) = s.on_message(&msg, now).unwrap();
+    assert!(hdr.is_none());
+    assert_eq!(s.state().state(), State::Active);
+    assert_eq!(admin_msgs(out).len(), 0);
+}
+
+#[test]
+fn logout_round_trip() {
+    let mut s = session();
+    let now = Instant::now();
+    let msg = logon(1, 30);
+    s.on_message(&msg, now).unwrap();
+
+    let msg = logout(2);
+    let (out, _) = s.on_message(&msg, now).unwrap();
+    assert_eq!(s.state().state(), State::Disconnected);
+    assert_eq!(out.event(), Some(Event::Disconnected {
+        reason: nexus_fix_engine::DisconnectReason::Logout,
+    }));
+    assert!(admin_msgs(out).iter().any(|a| matches!(a, AdminMsg::Logout { .. })));
+}
+
+#[test]
+fn heartbeat_is_handled() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+
+    let msg = heartbeat(2);
+    let (out, hdr) = s.on_message(&msg, now).unwrap();
+    assert!(hdr.is_none());
+    assert_eq!(admin_msgs(out).len(), 0);
+}
+
+#[test]
+fn test_request_echoed_as_heartbeat() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+
+    let msg = test_request(2, "PROBE1");
+    let (out, hdr) = s.on_message(&msg, now).unwrap();
+    assert!(hdr.is_none());
+    let admins = admin_msgs(out);
+    assert_eq!(admins.len(), 1);
+    match admins[0] {
+        AdminMsg::Heartbeat { echo: Some((id, len)), .. } => {
+            assert_eq!(&id[..len as usize], b"PROBE1");
+        }
+        _ => panic!("expected Heartbeat with echo"),
+    }
+}
+
+#[test]
+fn resend_request_triggers_gap_fill() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+    s.state_mut().allocate_seq(now); // seq 2
+    s.state_mut().allocate_seq(now); // seq 3
+
+    let msg = resend_request(2, 2, 3);
+    let (out, _) = s.on_message(&msg, now).unwrap();
+    assert!(matches!(
+        out.event(),
+        Some(Event::ResendRange { begin: 2, end: 3 })
+    ));
+    assert!(admin_msgs(out).iter().any(|a| matches!(a, AdminMsg::SequenceReset { .. })));
+}
+
+#[test]
+fn sequence_reset_gap_fill() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+
+    // trigger a gap
+    let msg = app_msg(5);
+    s.on_message(&msg, now).unwrap();
+    assert_eq!(s.state().state(), State::Resending);
+
+    let msg = sequence_reset(2, 6, true);
+    let (out, _) = s.on_message(&msg, now).unwrap();
+    assert_eq!(s.state().next_inbound_seq(), 6);
+    assert_eq!(s.state().state(), State::Active);
+    assert_eq!(out.event(), Some(Event::SequenceReset { new_seq: 6 }));
+}
+
+#[test]
+fn app_message_surfaces_header() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+
+    let msg = app_msg(2);
+    let (out, hdr) = s.on_message(&msg, now).unwrap();
+    assert!(hdr.is_some());
+    assert_eq!(out.event(), Some(Event::App { seq_num: 2, poss_dup: false }));
+}
+
+#[test]
+fn comp_id_mismatch_disconnects() {
+    let mut s = session();
+    let now = Instant::now();
+    s.on_message(&logon(1, 30), now).unwrap();
+
+    // Wrong SenderCompID
+    let msg = b"34=2\x0135=0\x0149=WRONG\x0156=SENDER\x01";
+    let (out, _) = s.on_message(msg, now).unwrap();
+    assert_eq!(s.state().state(), State::Disconnected);
+    assert!(matches!(
+        out.event(),
+        Some(Event::Disconnected { reason: nexus_fix_engine::DisconnectReason::CompIdMismatch })
+    ));
+}


### PR DESCRIPTION
Adds `Session<D: FixDictionary>` — a thin codec-aware wrapper over `SessionState`.

- Decodes inbound buffer via `D::Header::decode`
- Validates SenderCompID / TargetCompID against `SessionConfig`; disconnects on mismatch
- Routes by raw MsgType bytes to typed `SessionState` handlers (Logon, Logout, Heartbeat, TestRequest, ResendRequest, SequenceReset, Reject)
- Returns `(Out, Some(header))` for app messages so callers can decode the body
- Determines acceptor vs initiator from `state != LogonSent` (no separate flag)

9 integration tests using a minimal `MockDict` / `MockHeader`.

Closes #458 prep. Related: #459 (FixReader/FixWriter), #460 (encoding context).