### PR TITLE
improvements to seglog + session multiplexing + sequential scanning

### DIFF
--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -21,5 +21,5 @@ pub use journal::{
 pub use lock::Liveness;
 pub use pod::Pod;
 pub use region::MapOptions;
-pub use seglog::{LogOffset, SegmentedLog, SegmentedLogError};
+pub use seglog::{Frame, LogOffset, SegmentedLog, SegmentedLogError};
 pub use segment::{Segment, Status};

--- a/nexus-shm/src/seglog.rs
+++ b/nexus-shm/src/seglog.rs
@@ -34,10 +34,11 @@ fn session_id_ptr(ptr: *mut u8) -> *mut u32 {
 ///
 /// Provides access to the session tag, global offset, and payload bytes
 /// without copying from the underlying mmap'd segment.
+#[repr(C)]
 pub struct Frame<'buf> {
-    session_id: u32,
-    offset: u64,
     payload: &'buf [u8],
+    offset: u64,
+    session_id: u32,
 }
 
 impl<'buf> Frame<'buf> {

--- a/nexus-shm/src/seglog.rs
+++ b/nexus-shm/src/seglog.rs
@@ -142,6 +142,32 @@ unsafe impl Send for Slot {}
 /// active becomes readable, clean standby becomes active. The hot-path append
 /// never blocks on cleaning; the conductor must finish before the *next*
 /// rotation (size segments with enough headroom for the expected message rate).
+///
+/// # Global offset addressing
+///
+/// Sequential reads use a monotonically increasing `u64` position that spans
+/// all segments. The physical slot is derived via modular arithmetic:
+///
+/// ```text
+/// segment_number = pos / segment_size
+/// local_offset   = pos % segment_size
+/// slot_index     = segment_number % 3
+/// ```
+///
+/// This works because the init order (`current=0, prev=2, standby=1`) is
+/// chosen so that the rotation cycle (`current→prev, standby→current,
+/// old_prev→standby`) visits slots in order 0 → 1 → 2 → 0 → …:
+///
+/// ```text
+/// epoch 0: current=0  prev=2  standby=1
+/// epoch 1: current=1  prev=0  standby=2
+/// epoch 2: current=2  prev=1  standby=0
+/// epoch 3: current=0  prev=2  standby=1   (cycle repeats)
+/// ```
+///
+/// At any point, only the current (`epoch`) and previous (`epoch − 1`)
+/// segments are readable. Older segments have been handed to the conductor
+/// for cleaning.
 pub struct SegmentedLog {
     // conductor is dropped first (joins thread), then slots (unmaps memory).
     conductor: ConductorHandle,
@@ -212,8 +238,8 @@ impl SegmentedLog {
             slots: [s0, s1, s2],
             segment_size: size,
             current: 0,
-            prev: 1,
-            standby: 2,
+            prev: 2,
+            standby: 1,
             cursor: 0,
             epoch: 0,
             // Slot 0 is current at generation 0. Slots 1 and 2 hold no valid
@@ -293,6 +319,70 @@ impl SegmentedLog {
             if off + FRAME_HDR + body > self.segment_size {
                 return None;
             }
+            Some(std::slice::from_raw_parts(ptr.add(FRAME_HDR), body))
+        }
+    }
+
+    /// Monotonically increasing global offset at the current write position.
+    pub fn write_pos(&self) -> u64 {
+        self.epoch as u64 * self.segment_size as u64 + self.cursor as u64
+    }
+
+    /// Global offset at the start of the oldest readable segment.
+    pub fn read_start(&self) -> u64 {
+        if self.epoch == 0 {
+            0
+        } else {
+            (self.epoch as u64 - 1) * self.segment_size as u64
+        }
+    }
+
+    /// Read the next committed record at `pos`, advancing past it.
+    ///
+    /// Returns `None` when caught up to the writer or when `pos` references
+    /// an evicted segment. The slot is determined by `pos / segment_size % 3`;
+    /// the init order guarantees this maps directly to the physical slot index.
+    pub fn read_next(&self, pos: &mut u64) -> Option<&[u8]> {
+        let seg_size = self.segment_size as u64;
+        let seg = *pos / seg_size;
+        let local = (*pos % seg_size) as usize;
+        let epoch = self.epoch as u64;
+
+        if seg > epoch || (epoch > 0 && seg + 1 < epoch) {
+            return None;
+        }
+
+        let slot = (seg % 3) as usize;
+
+        if local + FRAME_HDR > self.segment_size {
+            if seg < epoch {
+                *pos = (seg + 1) * seg_size;
+                return self.read_next(pos);
+            }
+            return None;
+        }
+
+        let data = self.slots[slot].data;
+        // SAFETY: `slot` is `seg % 3` where `seg` is either `epoch` (current) or
+        // `epoch - 1` (prev), both live mmap'd segments. `local` is bounded by
+        // `segment_size` via the modulo. The `local + FRAME_HDR` check above ensures
+        // we don't read past the segment for the header. The `local + FRAME_HDR + body`
+        // check below prevents reading past the segment for the payload.
+        unsafe {
+            let ptr = data.add(local);
+            let stored = (*commit_len_ptr(ptr)).load(Ordering::Acquire);
+            if stored == 0 {
+                if seg < epoch {
+                    *pos = (seg + 1) * seg_size;
+                    return self.read_next(pos);
+                }
+                return None;
+            }
+            let body = (stored - 1) as usize;
+            if local + FRAME_HDR + body > self.segment_size {
+                return None;
+            }
+            *pos += footprint(body) as u64;
             Some(std::slice::from_raw_parts(ptr.add(FRAME_HDR), body))
         }
     }
@@ -398,17 +488,17 @@ mod tests {
             log.append(&[0u8; 8]).unwrap();
         }
         // rotation 1 triggered by the first of the next 4 appends:
-        //   slot 0 → prev, slot 2 → current, slot 1 → standby (conductor cleaning slot 1)
+        //   slot 0 → prev, slot 1 → current, slot 2 → standby (conductor cleaning slot 2)
         for _ in 0..4 {
             log.append(&[0u8; 8]).unwrap();
         }
-        // wait for conductor to finish cleaning slot 1 before triggering rotation 2
+        // wait for conductor to finish cleaning slot 2 before triggering rotation 2
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while !log.conductor.ready.load(Ordering::Acquire) {
             assert!(std::time::Instant::now() < deadline, "conductor timed out");
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
-        // rotation 2: slot 2 → prev, slot 1 → current, slot 0 → standby
+        // rotation 2: slot 1 → prev, slot 2 → current, slot 0 → standby
         log.append(&[0u8; 1]).unwrap();
         // slot 0 is standby → no longer readable
         assert_eq!(log.read(o0), None);
@@ -426,7 +516,7 @@ mod tests {
         for _ in 0..3 {
             log.append(&[0u8; 8]).unwrap();
         }
-        // Rotation 1: slot 2 → current (gen 1), slot 0 → prev
+        // Rotation 1: slot 1 → current (gen 1), slot 0 → prev
         for _ in 0..4 {
             log.append(&[0u8; 8]).unwrap();
         }
@@ -435,7 +525,7 @@ mod tests {
             assert!(std::time::Instant::now() < deadline, "conductor timed out");
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
-        // Rotation 2: slot 1 → current (gen 2), slot 2 → prev, slot 0 → standby
+        // Rotation 2: slot 2 → current (gen 2), slot 1 → prev, slot 0 → standby
         for _ in 0..4 {
             log.append(&[0u8; 8]).unwrap();
         }
@@ -444,7 +534,7 @@ mod tests {
             assert!(std::time::Instant::now() < deadline, "conductor timed out");
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
-        // Rotation 3: slot 0 → current (gen 3), slot 1 → prev, slot 2 → standby.
+        // Rotation 3: slot 0 → current (gen 3), slot 2 → prev, slot 1 → standby.
         // Slot 0 is current again — same slot index as `stale` — but gen 3 != gen 0.
         log.append(&[0u8; 8]).unwrap();
         assert_eq!(log.read(stale), None);
@@ -468,6 +558,253 @@ mod tests {
         let mut log = open(&b, 1 << 16);
         let off = log.append(&[]).unwrap();
         assert_eq!(log.read(off), Some(b"".as_ref()));
+        cleanup(&b);
+    }
+
+    // ── sequential scan tests ────────────────────────────────────────────
+
+    #[test]
+    fn scan_single_segment() {
+        let b = base("scan1");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(b"aaa").unwrap();
+        log.append(b"bb").unwrap();
+        log.append(b"cccc").unwrap();
+
+        let mut pos = log.read_start();
+        assert_eq!(log.read_next(&mut pos), Some(b"aaa".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"bb".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"cccc".as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_across_rotation() {
+        let b = base("scanrot");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment; segment_size = 64
+        let mut log = open(&b, 64);
+        log.append(&[1u8; 8]).unwrap();
+        log.append(&[2u8; 8]).unwrap();
+        log.append(&[3u8; 8]).unwrap();
+        log.append(&[4u8; 8]).unwrap();
+        // segment full, next append triggers rotation
+        log.append(&[5u8; 8]).unwrap();
+        log.append(&[6u8; 8]).unwrap();
+
+        let mut pos = log.read_start();
+        assert_eq!(log.read_next(&mut pos), Some([1u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some([2u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some([3u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some([4u8; 8].as_ref()));
+        // crosses into current segment
+        assert_eq!(log.read_next(&mut pos), Some([5u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some([6u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_resumes_after_append() {
+        let b = base("scanresume");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(b"first").unwrap();
+
+        let mut pos = log.read_start();
+        assert_eq!(log.read_next(&mut pos), Some(b"first".as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+
+        log.append(b"second").unwrap();
+        assert_eq!(log.read_next(&mut pos), Some(b"second".as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_evicted_returns_none() {
+        let b = base("scanevict");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment; segment_size = 64
+        let mut log = open(&b, 64);
+        let start = log.read_start();
+        // fill segment 0
+        for _ in 0..4 {
+            log.append(&[0u8; 8]).unwrap();
+        }
+        // rotation 1
+        for _ in 0..4 {
+            log.append(&[0u8; 8]).unwrap();
+        }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !log.conductor.ready.load(Ordering::Acquire) {
+            assert!(std::time::Instant::now() < deadline, "conductor timed out");
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        // rotation 2 — segment 0 is now standby, evicted
+        log.append(&[0u8; 8]).unwrap();
+
+        let mut pos = start;
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn write_pos_increases_monotonically() {
+        let b = base("wpos");
+        cleanup(&b);
+        // Large segment so no rotation needed for this test.
+        let mut log = open(&b, 1 << 16);
+        let mut prev_pos = log.write_pos();
+        assert_eq!(prev_pos, 0);
+        for _ in 0..12 {
+            log.append(&[0u8; 8]).unwrap();
+            let wp = log.write_pos();
+            assert!(wp > prev_pos, "write_pos must increase: {wp} <= {prev_pos}");
+            prev_pos = wp;
+        }
+        cleanup(&b);
+    }
+
+    #[test]
+    fn write_pos_increases_across_rotation() {
+        let b = base("wposrot");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment
+        let mut log = open(&b, 64);
+        let mut prev_pos = 0u64;
+        for i in 0..4 {
+            log.append(&[i as u8; 8]).unwrap();
+            let wp = log.write_pos();
+            assert!(wp > prev_pos, "write_pos must increase: {wp} <= {prev_pos}");
+            prev_pos = wp;
+        }
+        // triggers rotation
+        log.append(&[4u8; 8]).unwrap();
+        let wp = log.write_pos();
+        assert!(wp > prev_pos, "write_pos must increase after rotation: {wp} <= {prev_pos}");
+        cleanup(&b);
+    }
+
+    #[test]
+    fn slot_order_is_sequential() {
+        let b = base("slotord");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment; segment_size = 64
+        let mut log = open(&b, 64);
+        assert_eq!(log.current, 0);
+        // fill and rotate
+        for _ in 0..4 { log.append(&[0u8; 8]).unwrap(); }
+        log.append(&[0u8; 8]).unwrap();
+        assert_eq!(log.current, 1);
+        // fill and rotate again
+        for _ in 0..3 { log.append(&[0u8; 8]).unwrap(); }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !log.conductor.ready.load(Ordering::Acquire) {
+            assert!(std::time::Instant::now() < deadline, "conductor timed out");
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        log.append(&[0u8; 8]).unwrap();
+        assert_eq!(log.current, 2);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_empty_log() {
+        let b = base("scanempty");
+        cleanup(&b);
+        let log = open(&b, 1 << 16);
+        let mut pos = log.read_start();
+        assert_eq!(pos, 0);
+        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.write_pos(), 0);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_empty_payloads() {
+        let b = base("scanemptypay");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(&[]).unwrap();
+        log.append(&[]).unwrap();
+        log.append(b"x").unwrap();
+
+        let mut pos = log.read_start();
+        assert_eq!(log.read_next(&mut pos), Some(b"".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"x".as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_variable_size_records() {
+        let b = base("scanvar");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(b"a").unwrap();
+        log.append(b"bb").unwrap();
+        log.append(b"ccccccccc").unwrap(); // 9 bytes, aligns up to 16
+        log.append(b"dd").unwrap();
+
+        let mut pos = log.read_start();
+        assert_eq!(log.read_next(&mut pos), Some(b"a".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"bb".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"ccccccccc".as_ref()));
+        assert_eq!(log.read_next(&mut pos), Some(b"dd".as_ref()));
+        assert_eq!(log.read_next(&mut pos), None);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_cursor_matches_write_pos_after_drain() {
+        let b = base("scandrain");
+        cleanup(&b);
+        let mut log = open(&b, 64);
+        log.append(&[1u8; 8]).unwrap();
+        log.append(&[2u8; 8]).unwrap();
+        log.append(&[3u8; 8]).unwrap();
+
+        let mut pos = log.read_start();
+        while log.read_next(&mut pos).is_some() {}
+        assert_eq!(pos, log.write_pos());
+
+        // also holds after rotation
+        log.append(&[4u8; 8]).unwrap(); // fills segment
+        log.append(&[5u8; 8]).unwrap(); // triggers rotation
+        while log.read_next(&mut pos).is_some() {}
+        assert_eq!(pos, log.write_pos());
+        cleanup(&b);
+    }
+
+    #[test]
+    fn read_start_advances_after_rotation() {
+        let b = base("readstart");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment; segment_size = 64
+        let mut log = open(&b, 64);
+        assert_eq!(log.read_start(), 0);
+
+        // fill segment 0, trigger rotation
+        for _ in 0..4 { log.append(&[0u8; 8]).unwrap(); }
+        log.append(&[0u8; 8]).unwrap();
+        // epoch 1: prev = segment 0, current = segment 1
+        assert_eq!(log.read_start(), 0);
+
+        // fill segment 1, trigger rotation
+        for _ in 0..3 { log.append(&[0u8; 8]).unwrap(); }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !log.conductor.ready.load(Ordering::Acquire) {
+            assert!(std::time::Instant::now() < deadline, "conductor timed out");
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        log.append(&[0u8; 8]).unwrap();
+        // epoch 2: prev = segment 1, current = segment 2
+        // segment 0 is evicted; read_start should be at segment 1
+        assert_eq!(log.read_start(), 64);
         cleanup(&b);
     }
 }

--- a/nexus-shm/src/seglog.rs
+++ b/nexus-shm/src/seglog.rs
@@ -24,6 +24,36 @@ fn commit_len_ptr(ptr: *mut u8) -> *mut AtomicU32 {
     ptr.cast()
 }
 
+// Returns a `*mut u32` pointing at the session_id field (bytes 4..8) of a frame header.
+fn session_id_ptr(ptr: *mut u8) -> *mut u32 {
+    // SAFETY: ptr is frame-aligned (>= 4-byte), so ptr+4 is also 4-byte aligned.
+    unsafe { ptr.add(4).cast() }
+}
+
+/// Zero-copy view of a committed record in the log.
+///
+/// Provides access to the session tag, global offset, and payload bytes
+/// without copying from the underlying mmap'd segment.
+pub struct Frame<'buf> {
+    session_id: u32,
+    offset: u64,
+    payload: &'buf [u8],
+}
+
+impl<'buf> Frame<'buf> {
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    pub fn payload(&self) -> &'buf [u8] {
+        self.payload
+    }
+}
+
 /// Opaque position handle returned by [`SegmentedLog::append`], passed to
 /// [`SegmentedLog::read`]. Valid until the slot it references is rotated out.
 ///
@@ -42,6 +72,10 @@ impl Default for LogOffset {
 impl LogOffset {
     fn new(slot: u8, local_off: usize, epoch: u32) -> Self {
         Self((epoch as u64) << 34 | (slot as u64) << 32 | local_off as u64)
+    }
+
+    fn global_offset(self, segment_size: usize) -> u64 {
+        self.epoch() as u64 * segment_size as u64 + self.local_off() as u64
     }
 
     fn slot(self) -> usize {
@@ -177,7 +211,7 @@ pub struct SegmentedLog {
     prev: usize,
     standby: usize,
     cursor: usize,
-    epoch: u32,
+    epoch: u64,
     slot_gen: [u32; 3],
 }
 
@@ -252,11 +286,15 @@ impl SegmentedLog {
         self.segment_size
     }
 
-    /// Append `payload` to the active segment.
+    /// Append `payload` to the active segment, tagged with `session_id`.
     ///
     /// Returns a [`LogOffset`] valid for reads until the slot is rotated out
     /// (two rotations after this write).
-    pub fn append(&mut self, payload: &[u8]) -> Result<LogOffset, SegmentedLogError> {
+    pub fn append(
+        &mut self,
+        session_id: u32,
+        payload: &[u8],
+    ) -> Result<LogOffset, SegmentedLogError> {
         let body = payload.len();
         let foot = footprint(body);
         if foot > self.segment_size {
@@ -277,6 +315,7 @@ impl SegmentedLog {
         unsafe {
             let ptr = data.add(off);
             std::ptr::copy_nonoverlapping(payload.as_ptr(), ptr.add(FRAME_HDR), body);
+            *session_id_ptr(ptr) = session_id;
             let next = off + foot;
             if next + FRAME_HDR <= self.segment_size {
                 (*commit_len_ptr(data.add(next))).store(0, Ordering::Relaxed);
@@ -293,9 +332,9 @@ impl SegmentedLog {
         ))
     }
 
-    /// Return the payload stored at `offset`, or `None` if the slot has been
+    /// Return the frame stored at `offset`, or `None` if the slot has been
     /// rotated out and is no longer readable.
-    pub fn read(&self, offset: LogOffset) -> Option<&[u8]> {
+    pub fn read(&self, offset: LogOffset) -> Option<Frame<'_>> {
         let slot = offset.slot();
         if slot != self.current && slot != self.prev {
             return None;
@@ -319,13 +358,17 @@ impl SegmentedLog {
             if off + FRAME_HDR + body > self.segment_size {
                 return None;
             }
-            Some(std::slice::from_raw_parts(ptr.add(FRAME_HDR), body))
+            Some(Frame {
+                session_id: *session_id_ptr(ptr),
+                offset: offset.global_offset(self.segment_size),
+                payload: std::slice::from_raw_parts(ptr.add(FRAME_HDR), body),
+            })
         }
     }
 
     /// Monotonically increasing global offset at the current write position.
     pub fn write_pos(&self) -> u64 {
-        self.epoch as u64 * self.segment_size as u64 + self.cursor as u64
+        self.epoch * self.segment_size as u64 + self.cursor as u64
     }
 
     /// Global offset at the start of the oldest readable segment.
@@ -333,20 +376,28 @@ impl SegmentedLog {
         if self.epoch == 0 {
             0
         } else {
-            (self.epoch as u64 - 1) * self.segment_size as u64
+            (self.epoch - 1) * self.segment_size as u64
         }
     }
 
-    /// Read the next committed record at `pos`, advancing past it.
+    /// Read the next committed frame at `pos`, advancing past it.
     ///
     /// Returns `None` when caught up to the writer or when `pos` references
     /// an evicted segment. The slot is determined by `pos / segment_size % 3`;
     /// the init order guarantees this maps directly to the physical slot index.
-    pub fn read_next(&self, pos: &mut u64) -> Option<&[u8]> {
+    ///
+    /// `pos` must be frame-aligned (a multiple of 8). Values obtained from
+    /// [`read_start`] and advanced by this method satisfy this invariant.
+    pub fn read_next(&self, pos: &mut u64) -> Option<Frame<'_>> {
+        debug_assert!(
+            (*pos).is_multiple_of(ALIGN as u64),
+            "pos must be frame-aligned (got {pos})",
+            pos = *pos,
+        );
         let seg_size = self.segment_size as u64;
         let seg = *pos / seg_size;
         let local = (*pos % seg_size) as usize;
-        let epoch = self.epoch as u64;
+        let epoch = self.epoch;
 
         if seg > epoch || (epoch > 0 && seg + 1 < epoch) {
             return None;
@@ -382,8 +433,13 @@ impl SegmentedLog {
             if local + FRAME_HDR + body > self.segment_size {
                 return None;
             }
+            let frame_offset = *pos;
             *pos += footprint(body) as u64;
-            Some(std::slice::from_raw_parts(ptr.add(FRAME_HDR), body))
+            Some(Frame {
+                session_id: *session_id_ptr(ptr),
+                offset: frame_offset,
+                payload: std::slice::from_raw_parts(ptr.add(FRAME_HDR), body),
+            })
         }
     }
 
@@ -396,8 +452,8 @@ impl SegmentedLog {
         self.current = self.standby;
         self.standby = old_prev;
         self.cursor = 0;
-        self.epoch = self.epoch.wrapping_add(1);
-        self.slot_gen[self.current] = self.epoch;
+        self.epoch += 1;
+        self.slot_gen[self.current] = self.epoch as u32;
         // TODO: if the conductor gains fallible work (archival, compression), add
         // error propagation here — the current `let _ =` would silently swallow
         // conductor failures. A flush-on-exit signal (distinct from channel close)
@@ -432,13 +488,23 @@ mod tests {
         SegmentedLog::open(base, size, MapOptions::default()).unwrap()
     }
 
+    fn wait_conductor(log: &SegmentedLog) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !log.conductor.ready.load(Ordering::Acquire) {
+            assert!(std::time::Instant::now() < deadline, "conductor timed out");
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+
     #[test]
     fn roundtrip() {
         let b = base("rt");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        let off = log.append(b"hello").unwrap();
-        assert_eq!(log.read(off), Some(b"hello".as_ref()));
+        let off = log.append(0, b"hello").unwrap();
+        let frame = log.read(off).unwrap();
+        assert_eq!(frame.payload(), b"hello");
+        assert_eq!(frame.session_id(), 0);
         cleanup(&b);
     }
 
@@ -447,12 +513,12 @@ mod tests {
         let b = base("multi");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        let o1 = log.append(b"aaa").unwrap();
-        let o2 = log.append(b"bb").unwrap();
-        let o3 = log.append(b"cccc").unwrap();
-        assert_eq!(log.read(o1), Some(b"aaa".as_ref()));
-        assert_eq!(log.read(o2), Some(b"bb".as_ref()));
-        assert_eq!(log.read(o3), Some(b"cccc".as_ref()));
+        let o1 = log.append(0, b"aaa").unwrap();
+        let o2 = log.append(0, b"bb").unwrap();
+        let o3 = log.append(0, b"cccc").unwrap();
+        assert_eq!(log.read(o1).unwrap().payload(), b"aaa");
+        assert_eq!(log.read(o2).unwrap().payload(), b"bb");
+        assert_eq!(log.read(o3).unwrap().payload(), b"cccc");
         cleanup(&b);
     }
 
@@ -462,17 +528,17 @@ mod tests {
         cleanup(&b);
         // footprint(8) = 16; 4 records = 64 bytes; segment_size = 64
         let mut log = open(&b, 64);
-        let o0 = log.append(&[0u8; 8]).unwrap();
-        let _o1 = log.append(&[1u8; 8]).unwrap();
-        let _o2 = log.append(&[2u8; 8]).unwrap();
-        let o3 = log.append(&[3u8; 8]).unwrap();
+        let o0 = log.append(0, &[0u8; 8]).unwrap();
+        let _o1 = log.append(0, &[1u8; 8]).unwrap();
+        let _o2 = log.append(0, &[2u8; 8]).unwrap();
+        let o3 = log.append(0, &[3u8; 8]).unwrap();
         // cursor now == 64 == segment_size → next append triggers rotation
-        let o4 = log.append(&[4u8; 8]).unwrap();
+        let o4 = log.append(0, &[4u8; 8]).unwrap();
         // slot 0 (prev) still readable
-        assert_eq!(log.read(o0), Some([0u8; 8].as_ref()));
-        assert_eq!(log.read(o3), Some([3u8; 8].as_ref()));
+        assert_eq!(log.read(o0).unwrap().payload(), &[0u8; 8]);
+        assert_eq!(log.read(o3).unwrap().payload(), &[3u8; 8]);
         // slot 1 (current) readable
-        assert_eq!(log.read(o4), Some([4u8; 8].as_ref()));
+        assert_eq!(log.read(o4).unwrap().payload(), &[4u8; 8]);
         cleanup(&b);
     }
 
@@ -482,26 +548,22 @@ mod tests {
         cleanup(&b);
         // footprint(8) = 16; 4 records per segment; segment_size = 64
         let mut log = open(&b, 64);
-        let o0 = log.append(&[0u8; 8]).unwrap();
+        let o0 = log.append(0, &[0u8; 8]).unwrap();
         // fill slot 0
         for _ in 0..3 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
         // rotation 1 triggered by the first of the next 4 appends:
         //   slot 0 → prev, slot 1 → current, slot 2 → standby (conductor cleaning slot 2)
         for _ in 0..4 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
         // wait for conductor to finish cleaning slot 2 before triggering rotation 2
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
+        wait_conductor(&log);
         // rotation 2: slot 1 → prev, slot 2 → current, slot 0 → standby
-        log.append(&[0u8; 1]).unwrap();
+        log.append(0, &[0u8; 1]).unwrap();
         // slot 0 is standby → no longer readable
-        assert_eq!(log.read(o0), None);
+        assert!(log.read(o0).is_none());
         cleanup(&b);
     }
 
@@ -512,32 +574,24 @@ mod tests {
         // footprint(8) = 16; 4 records per segment; segment_size = 64
         let mut log = open(&b, 64);
         // Write to slot 0 (gen 0)
-        let stale = log.append(&[0u8; 8]).unwrap();
+        let stale = log.append(0, &[0u8; 8]).unwrap();
         for _ in 0..3 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
         // Rotation 1: slot 1 → current (gen 1), slot 0 → prev
         for _ in 0..4 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
+        wait_conductor(&log);
         // Rotation 2: slot 2 → current (gen 2), slot 1 → prev, slot 0 → standby
         for _ in 0..4 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
+        wait_conductor(&log);
         // Rotation 3: slot 0 → current (gen 3), slot 2 → prev, slot 1 → standby.
         // Slot 0 is current again — same slot index as `stale` — but gen 3 != gen 0.
-        log.append(&[0u8; 8]).unwrap();
-        assert_eq!(log.read(stale), None);
+        log.append(0, &[0u8; 8]).unwrap();
+        assert!(log.read(stale).is_none());
         cleanup(&b);
     }
 
@@ -546,7 +600,7 @@ mod tests {
         let b = base("large");
         cleanup(&b);
         let mut log = open(&b, 64);
-        assert!(log.append(&[0u8; 1024]).is_err());
+        assert!(log.append(0, &[0u8; 1024]).is_err());
         cleanup(&b);
     }
 
@@ -556,8 +610,67 @@ mod tests {
         let b = base("empty");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        let off = log.append(&[]).unwrap();
-        assert_eq!(log.read(off), Some(b"".as_ref()));
+        let off = log.append(0, &[]).unwrap();
+        assert_eq!(log.read(off).unwrap().payload(), b"");
+        cleanup(&b);
+    }
+
+    // ── session_id tests ────────────────────────────────────────────────
+
+    #[test]
+    fn session_id_roundtrip() {
+        let b = base("sessrt");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        let o1 = log.append(42, b"hello").unwrap();
+        let o2 = log.append(99, b"world").unwrap();
+        let f1 = log.read(o1).unwrap();
+        let f2 = log.read(o2).unwrap();
+        assert_eq!(f1.session_id(), 42);
+        assert_eq!(f1.payload(), b"hello");
+        assert_eq!(f2.session_id(), 99);
+        assert_eq!(f2.payload(), b"world");
+        cleanup(&b);
+    }
+
+    #[test]
+    fn session_id_survives_rotation() {
+        let b = base("sessrot");
+        cleanup(&b);
+        // footprint(8) = 16; 4 records per segment; segment_size = 64
+        let mut log = open(&b, 64);
+        let o0 = log.append(10, &[0u8; 8]).unwrap();
+        for _ in 0..3 {
+            log.append(0, &[0u8; 8]).unwrap();
+        }
+        // triggers rotation
+        log.append(20, &[1u8; 8]).unwrap();
+        // o0 is in prev segment, still readable
+        let f = log.read(o0).unwrap();
+        assert_eq!(f.session_id(), 10);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn scan_returns_session_id() {
+        let b = base("scansess");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(1, b"aaa").unwrap();
+        log.append(2, b"bbb").unwrap();
+        log.append(1, b"ccc").unwrap();
+
+        let mut pos = log.read_start();
+        let f1 = log.read_next(&mut pos).unwrap();
+        assert_eq!(f1.session_id(), 1);
+        assert_eq!(f1.payload(), b"aaa");
+        let f2 = log.read_next(&mut pos).unwrap();
+        assert_eq!(f2.session_id(), 2);
+        assert_eq!(f2.payload(), b"bbb");
+        let f3 = log.read_next(&mut pos).unwrap();
+        assert_eq!(f3.session_id(), 1);
+        assert_eq!(f3.payload(), b"ccc");
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -568,15 +681,15 @@ mod tests {
         let b = base("scan1");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        log.append(b"aaa").unwrap();
-        log.append(b"bb").unwrap();
-        log.append(b"cccc").unwrap();
+        log.append(0, b"aaa").unwrap();
+        log.append(0, b"bb").unwrap();
+        log.append(0, b"cccc").unwrap();
 
         let mut pos = log.read_start();
-        assert_eq!(log.read_next(&mut pos), Some(b"aaa".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"bb".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"cccc".as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"aaa");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"bb");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"cccc");
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -586,23 +699,23 @@ mod tests {
         cleanup(&b);
         // footprint(8) = 16; 4 records per segment; segment_size = 64
         let mut log = open(&b, 64);
-        log.append(&[1u8; 8]).unwrap();
-        log.append(&[2u8; 8]).unwrap();
-        log.append(&[3u8; 8]).unwrap();
-        log.append(&[4u8; 8]).unwrap();
+        log.append(0, &[1u8; 8]).unwrap();
+        log.append(0, &[2u8; 8]).unwrap();
+        log.append(0, &[3u8; 8]).unwrap();
+        log.append(0, &[4u8; 8]).unwrap();
         // segment full, next append triggers rotation
-        log.append(&[5u8; 8]).unwrap();
-        log.append(&[6u8; 8]).unwrap();
+        log.append(0, &[5u8; 8]).unwrap();
+        log.append(0, &[6u8; 8]).unwrap();
 
         let mut pos = log.read_start();
-        assert_eq!(log.read_next(&mut pos), Some([1u8; 8].as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some([2u8; 8].as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some([3u8; 8].as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some([4u8; 8].as_ref()));
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[1u8; 8]);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[2u8; 8]);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[3u8; 8]);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[4u8; 8]);
         // crosses into current segment
-        assert_eq!(log.read_next(&mut pos), Some([5u8; 8].as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some([6u8; 8].as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[5u8; 8]);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), &[6u8; 8]);
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -611,15 +724,15 @@ mod tests {
         let b = base("scanresume");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        log.append(b"first").unwrap();
+        log.append(0, b"first").unwrap();
 
         let mut pos = log.read_start();
-        assert_eq!(log.read_next(&mut pos), Some(b"first".as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"first");
+        assert!(log.read_next(&mut pos).is_none());
 
-        log.append(b"second").unwrap();
-        assert_eq!(log.read_next(&mut pos), Some(b"second".as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        log.append(0, b"second").unwrap();
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"second");
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -632,22 +745,18 @@ mod tests {
         let start = log.read_start();
         // fill segment 0
         for _ in 0..4 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
         // rotation 1
         for _ in 0..4 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
         }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
+        wait_conductor(&log);
         // rotation 2 — segment 0 is now standby, evicted
-        log.append(&[0u8; 8]).unwrap();
+        log.append(0, &[0u8; 8]).unwrap();
 
         let mut pos = start;
-        assert_eq!(log.read_next(&mut pos), None);
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -660,7 +769,7 @@ mod tests {
         let mut prev_pos = log.write_pos();
         assert_eq!(prev_pos, 0);
         for _ in 0..12 {
-            log.append(&[0u8; 8]).unwrap();
+            log.append(0, &[0u8; 8]).unwrap();
             let wp = log.write_pos();
             assert!(wp > prev_pos, "write_pos must increase: {wp} <= {prev_pos}");
             prev_pos = wp;
@@ -676,15 +785,18 @@ mod tests {
         let mut log = open(&b, 64);
         let mut prev_pos = 0u64;
         for i in 0..4 {
-            log.append(&[i as u8; 8]).unwrap();
+            log.append(0, &[i as u8; 8]).unwrap();
             let wp = log.write_pos();
             assert!(wp > prev_pos, "write_pos must increase: {wp} <= {prev_pos}");
             prev_pos = wp;
         }
         // triggers rotation
-        log.append(&[4u8; 8]).unwrap();
+        log.append(0, &[4u8; 8]).unwrap();
         let wp = log.write_pos();
-        assert!(wp > prev_pos, "write_pos must increase after rotation: {wp} <= {prev_pos}");
+        assert!(
+            wp > prev_pos,
+            "write_pos must increase after rotation: {wp} <= {prev_pos}"
+        );
         cleanup(&b);
     }
 
@@ -696,17 +808,17 @@ mod tests {
         let mut log = open(&b, 64);
         assert_eq!(log.current, 0);
         // fill and rotate
-        for _ in 0..4 { log.append(&[0u8; 8]).unwrap(); }
-        log.append(&[0u8; 8]).unwrap();
+        for _ in 0..4 {
+            log.append(0, &[0u8; 8]).unwrap();
+        }
+        log.append(0, &[0u8; 8]).unwrap();
         assert_eq!(log.current, 1);
         // fill and rotate again
-        for _ in 0..3 { log.append(&[0u8; 8]).unwrap(); }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
+        for _ in 0..3 {
+            log.append(0, &[0u8; 8]).unwrap();
         }
-        log.append(&[0u8; 8]).unwrap();
+        wait_conductor(&log);
+        log.append(0, &[0u8; 8]).unwrap();
         assert_eq!(log.current, 2);
         cleanup(&b);
     }
@@ -718,7 +830,7 @@ mod tests {
         let log = open(&b, 1 << 16);
         let mut pos = log.read_start();
         assert_eq!(pos, 0);
-        assert_eq!(log.read_next(&mut pos), None);
+        assert!(log.read_next(&mut pos).is_none());
         assert_eq!(log.write_pos(), 0);
         cleanup(&b);
     }
@@ -728,15 +840,15 @@ mod tests {
         let b = base("scanemptypay");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        log.append(&[]).unwrap();
-        log.append(&[]).unwrap();
-        log.append(b"x").unwrap();
+        log.append(0, &[]).unwrap();
+        log.append(0, &[]).unwrap();
+        log.append(0, b"x").unwrap();
 
         let mut pos = log.read_start();
-        assert_eq!(log.read_next(&mut pos), Some(b"".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"x".as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"x");
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -745,17 +857,17 @@ mod tests {
         let b = base("scanvar");
         cleanup(&b);
         let mut log = open(&b, 1 << 16);
-        log.append(b"a").unwrap();
-        log.append(b"bb").unwrap();
-        log.append(b"ccccccccc").unwrap(); // 9 bytes, aligns up to 16
-        log.append(b"dd").unwrap();
+        log.append(0, b"a").unwrap();
+        log.append(0, b"bb").unwrap();
+        log.append(0, b"ccccccccc").unwrap(); // 9 bytes, aligns up to 16
+        log.append(0, b"dd").unwrap();
 
         let mut pos = log.read_start();
-        assert_eq!(log.read_next(&mut pos), Some(b"a".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"bb".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"ccccccccc".as_ref()));
-        assert_eq!(log.read_next(&mut pos), Some(b"dd".as_ref()));
-        assert_eq!(log.read_next(&mut pos), None);
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"a");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"bb");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"ccccccccc");
+        assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"dd");
+        assert!(log.read_next(&mut pos).is_none());
         cleanup(&b);
     }
 
@@ -764,17 +876,17 @@ mod tests {
         let b = base("scandrain");
         cleanup(&b);
         let mut log = open(&b, 64);
-        log.append(&[1u8; 8]).unwrap();
-        log.append(&[2u8; 8]).unwrap();
-        log.append(&[3u8; 8]).unwrap();
+        log.append(0, &[1u8; 8]).unwrap();
+        log.append(0, &[2u8; 8]).unwrap();
+        log.append(0, &[3u8; 8]).unwrap();
 
         let mut pos = log.read_start();
         while log.read_next(&mut pos).is_some() {}
         assert_eq!(pos, log.write_pos());
 
         // also holds after rotation
-        log.append(&[4u8; 8]).unwrap(); // fills segment
-        log.append(&[5u8; 8]).unwrap(); // triggers rotation
+        log.append(0, &[4u8; 8]).unwrap(); // fills segment
+        log.append(0, &[5u8; 8]).unwrap(); // triggers rotation
         while log.read_next(&mut pos).is_some() {}
         assert_eq!(pos, log.write_pos());
         cleanup(&b);
@@ -789,22 +901,38 @@ mod tests {
         assert_eq!(log.read_start(), 0);
 
         // fill segment 0, trigger rotation
-        for _ in 0..4 { log.append(&[0u8; 8]).unwrap(); }
-        log.append(&[0u8; 8]).unwrap();
+        for _ in 0..4 {
+            log.append(0, &[0u8; 8]).unwrap();
+        }
+        log.append(0, &[0u8; 8]).unwrap();
         // epoch 1: prev = segment 0, current = segment 1
         assert_eq!(log.read_start(), 0);
 
         // fill segment 1, trigger rotation
-        for _ in 0..3 { log.append(&[0u8; 8]).unwrap(); }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while !log.conductor.ready.load(Ordering::Acquire) {
-            assert!(std::time::Instant::now() < deadline, "conductor timed out");
-            std::thread::sleep(std::time::Duration::from_millis(1));
+        for _ in 0..3 {
+            log.append(0, &[0u8; 8]).unwrap();
         }
-        log.append(&[0u8; 8]).unwrap();
+        wait_conductor(&log);
+        log.append(0, &[0u8; 8]).unwrap();
         // epoch 2: prev = segment 1, current = segment 2
         // segment 0 is evicted; read_start should be at segment 1
         assert_eq!(log.read_start(), 64);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn frame_offset_matches_global_position() {
+        let b = base("frmoff");
+        cleanup(&b);
+        let mut log = open(&b, 1 << 16);
+        log.append(0, b"aaa").unwrap();
+        log.append(0, b"bbb").unwrap();
+
+        let mut pos = log.read_start();
+        let f1 = log.read_next(&mut pos).unwrap();
+        assert_eq!(f1.offset(), 0);
+        let f2 = log.read_next(&mut pos).unwrap();
+        assert_eq!(f2.offset(), footprint(3) as u64);
         cleanup(&b);
     }
 }


### PR DESCRIPTION
## Summary

- **`Frame<'buf>`**: zero-copy view of a committed record with `session_id()`, `offset()`, `payload()` — enables session multiplexing in the journal
- **Session-tagged writes**: `append(session_id, payload)` stores session_id in the frame header (bytes 4..8, previously reserved)
- **Sequential scan API**: `write_pos()`, `read_start()`, `read_next()` for monotonically increasing global offset scanning across segment rotations
- **Slot init order fix**: `(current=0, prev=2, standby=1)` so rotation visits slots 0→1→2→0, enabling clean `segment_number % 3` mapping
- **Epoch widened to u64**: prevents `write_pos()` wrapping (slot_gen stays u32 for LogOffset validation)
- **Alignment debug_assert in `read_next`**: documents the frame-alignment invariant

## Design notes

Frame header layout is now `[commit_len: u32][session_id: u32][payload...]`. SegmentedLog remains single-threaded SPSC — session_id is a tag for demuxing on the read side, not a concurrency mechanism. A single owner thread writes all sessions; a separate logger/archiver thread tails via `read_next()`.

See discussion #457 for the revised FIX engine architecture where the journal is an archival side-channel (not on the message read path), and #464 for the FixFramer design that replaces the framing half of the original FixReader concept.

## Test plan

- [x] Session ID roundtrip (write + read preserves session_id)
- [x] Session ID survives rotation
- [x] Sequential scan returns session_id per frame
- [x] Frame offset matches global position
- [x] Single segment scan, cross-rotation scan, resume after append
- [x] Evicted segment returns None
- [x] write_pos monotonicity (single segment + across rotation)
- [x] Slot ordering is sequential (0→1→2)
- [x] Edge cases: empty log, empty payloads, variable-size records
- [x] Cursor matches write_pos after full drain
- [x] read_start advances after rotation
- [x] All 40 nexus-shm tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)