### PR TITLE
feat(fix-engine): Message<D> enum, FixAdminMsg trait, admin codegen

### DIFF
--- a/nexus-fix-codec/src/dict.rs
+++ b/nexus-fix-codec/src/dict.rs
@@ -10,7 +10,7 @@ use nexus_ascii::AsciiTextStr;
 /// typed accessor methods to read fields.
 pub trait FixAdminMsg<'buf>: Sized {
     /// Construct the decoder from a raw FIX message buffer.
-    fn decode(buf: &'buf [u8]) -> Self;
+    fn decode(buf: &'buf [u8]) -> Result<Self, crate::DecodeError>;
 }
 
 /// Dictionary-level knowledge for a specific FIX version.

--- a/nexus-fix-codec/src/dict.rs
+++ b/nexus-fix-codec/src/dict.rs
@@ -2,11 +2,22 @@ use crate::field::FieldView;
 use crate::types::FixTimestamp;
 use nexus_ascii::AsciiTextStr;
 
+/// Zero-copy decoder for a session-level admin message.
+///
+/// Implemented by every generated admin message type in `admin::*`.
+/// The session framework calls `decode` to construct the decoder and hands it
+/// to the caller via [`Message`](crate::Message); the caller then uses the
+/// typed accessor methods to read fields.
+pub trait FixAdminMsg<'buf>: Sized {
+    /// Construct the decoder from a raw FIX message buffer.
+    fn decode(buf: &'buf [u8]) -> Self;
+}
+
 /// Dictionary-level knowledge for a specific FIX version.
 ///
 /// Generated per dictionary (FIX 4.2, FIX 4.4, etc.) by `nexus-fix-codegen`.
 /// The implementing type is a zero-sized struct — all information is
-/// compile-time. The future `Session` is generic over this trait, so
+/// compile-time. The `Session` is generic over this trait, so
 /// FIX-version dispatch monomorphizes away with no vtable or runtime branching.
 pub trait FixDictionary {
     /// The dictionary's message-type enum (generated, closed set).
@@ -14,6 +25,21 @@ pub trait FixDictionary {
 
     /// The dictionary's generated header decoder type.
     type Header<'buf>: FixHeader<'buf>;
+
+    /// Decoder for Logon (35=A).
+    type Logon<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for Logout (35=5).
+    type Logout<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for Heartbeat (35=0).
+    type Heartbeat<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for TestRequest (35=1).
+    type TestRequest<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for ResendRequest (35=2).
+    type ResendRequest<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for SequenceReset (35=4).
+    type SequenceReset<'buf>: FixAdminMsg<'buf>;
+    /// Decoder for Reject (35=3).
+    type Reject<'buf>: FixAdminMsg<'buf>;
 
     /// The `BeginString` value for this FIX version (e.g. `b"FIX.4.4"`).
     const BEGIN_STRING: &'static [u8];

--- a/nexus-fix-codec/src/lib.rs
+++ b/nexus-fix-codec/src/lib.rs
@@ -27,7 +27,7 @@ pub mod reader;
 pub mod scan;
 pub mod writer;
 
-pub use dict::{FixDictionary, FixHeader};
+pub use dict::{FixAdminMsg, FixDictionary, FixHeader};
 pub use error::{ChecksumError, DecodeError, EncodeError, FixValueError};
 pub use field::{FieldView, FromFixValue};
 pub use nexus_ascii::{AsciiChar, AsciiText, AsciiTextStr};

--- a/nexus-fix-codegen/src/emit/admin.rs
+++ b/nexus-fix-codegen/src/emit/admin.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use super::{HEADER, RField, RMessage, emit_value_accessor};
+use super::{HEADER, RField, RMember, RMessage, emit_value_accessor, snake};
 
 /// (tag, snake_field_name, rust_return_type)
 type ProtocolField = (u32, &'static str, &'static str);
@@ -61,6 +61,26 @@ pub fn emit(messages: &[RMessage]) -> String {
     s
 }
 
+fn extra_fields<'a>(
+    messages: &'a [RMessage],
+    msgtype: &str,
+    proto_tags: &HashSet<u32>,
+) -> Vec<&'a RField> {
+    messages
+        .iter()
+        .find(|m| m.is_admin && m.msgtype == msgtype)
+        .map(|msg| {
+            msg.members
+                .iter()
+                .filter_map(|mem| match mem {
+                    RMember::Field(f) if !proto_tags.contains(&f.number) => Some(f),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn emit_admin_type(
     s: &mut String,
     name: &str,
@@ -68,42 +88,89 @@ fn emit_admin_type(
     proto_fields: &[ProtocolField],
     messages: &[RMessage],
 ) {
+    let proto_tags: HashSet<u32> = proto_fields.iter().map(|&(tag, _, _)| tag).collect();
+    let extra = extra_fields(messages, msgtype, &proto_tags);
+
+    // Struct
     let _ = writeln!(s, "pub struct {name}<'buf> {{");
-    s.push_str("    buf: &'buf [u8],\n}\n\n");
+    s.push_str("    header: super::header::HeaderDecoder<'buf>,\n");
+    for &(_, field_name, _) in proto_fields {
+        let _ = writeln!(s, "    {field_name}: nexus_fix_codec::FieldSpan,");
+    }
+    for f in &extra {
+        let _ = writeln!(s, "    {}: nexus_fix_codec::FieldSpan,", snake(&f.name));
+    }
+    s.push_str("    checksum: nexus_fix_codec::FieldSpan,\n}\n\n");
 
     // FixAdminMsg impl
     let _ = writeln!(
         s,
         "impl<'buf> nexus_fix_codec::FixAdminMsg<'buf> for {name}<'buf> {{"
     );
-    s.push_str("    fn decode(buf: &'buf [u8]) -> Self {\n        Self { buf }\n    }\n}\n\n");
+    s.push_str(
+        "    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> { Self::decode(buf) }\n}\n\n",
+    );
 
-    // Protocol-required accessors
+    // inherent impl
     let _ = writeln!(s, "impl<'buf> {name}<'buf> {{");
-    let proto_tags: HashSet<u32> = proto_fields.iter().map(|&(tag, _, _)| tag).collect();
-    for &(tag, field_name, rust_type) in proto_fields {
+
+    // wrap_unchecked
+    s.push_str("    pub fn wrap_unchecked(header: super::header::HeaderDecoder<'buf>) -> Result<Self, nexus_fix_codec::DecodeError> {\n");
+    s.push_str("        let mut m = Self {\n            header,\n");
+    for &(_, field_name, _) in proto_fields {
+        let _ = writeln!(
+            s,
+            "            {field_name}: nexus_fix_codec::FieldSpan::EMPTY,"
+        );
+    }
+    for f in &extra {
+        let _ = writeln!(
+            s,
+            "            {}: nexus_fix_codec::FieldSpan::EMPTY,",
+            snake(&f.name)
+        );
+    }
+    s.push_str("            checksum: nexus_fix_codec::FieldSpan::EMPTY,\n        };\n");
+    s.push_str("        while let Some(f) = m.header.reader.next_field() {\n            match f.tag {\n");
+    for &(tag, field_name, _) in proto_fields {
+        let _ = writeln!(s, "                {tag} => {{ m.{field_name} = f.value; }}");
+    }
+    for f in &extra {
+        let _ = writeln!(
+            s,
+            "                {} => {{ m.{} = f.value; }}",
+            f.number,
+            snake(&f.name)
+        );
+    }
+    s.push_str(
+        "                10 => { m.checksum = f.value; break; }\n                _ => {}\n            }\n        }\n        Ok(m)\n    }\n\n",
+    );
+
+    // decode
+    s.push_str("    pub fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {\n");
+    s.push_str(
+        "        Self::wrap_unchecked(super::header::HeaderDecoder::decode(buf))\n    }\n\n",
+    );
+
+    // header()
+    s.push_str(
+        "    pub fn header(&self) -> &super::header::HeaderDecoder<'buf> { &self.header }\n\n",
+    );
+
+    // protocol field accessors
+    for &(_, field_name, rust_type) in proto_fields {
         let _ = write!(
             s,
             "    pub fn {field_name}(&self) -> Option<nexus_fix_codec::FieldView<'buf, {rust_type}>> {{\n        \
-             nexus_fix_codec::find_tag(self.buf, 0, {tag})\n            \
-             .and_then(|s| nexus_fix_codec::FieldView::new(s, self.buf))\n    \
+             nexus_fix_codec::FieldView::new(self.{field_name}, self.header.reader.buf())\n    \
              }}\n\n"
         );
     }
 
-    // Venue-specific fields from the XML (non-group, not already in proto set)
-    if let Some(msg) = messages.iter().find(|m| m.is_admin && m.msgtype == msgtype) {
-        let extra: Vec<&RField> = msg
-            .members
-            .iter()
-            .filter_map(|mem| match mem {
-                super::RMember::Field(f) if !proto_tags.contains(&f.number) => Some(f),
-                _ => None,
-            })
-            .collect();
-        for f in extra {
-            emit_value_accessor(s, f, "self.buf");
-        }
+    // venue-specific accessors
+    for f in &extra {
+        emit_value_accessor(s, f, "self.header.reader.buf()");
     }
 
     s.push_str("}\n\n");

--- a/nexus-fix-codegen/src/emit/admin.rs
+++ b/nexus-fix-codegen/src/emit/admin.rs
@@ -1,0 +1,117 @@
+use std::collections::HashSet;
+use std::fmt::Write;
+
+use super::{HEADER, RField, RMessage, emit_value_accessor};
+
+/// (tag, snake_field_name, rust_return_type)
+type ProtocolField = (u32, &'static str, &'static str);
+
+/// (struct_name, msgtype_byte, protocol_required_fields)
+const SPECS: &[(&str, &str, &[ProtocolField])] = &[
+    (
+        "Logon",
+        "A",
+        &[
+            (108, "heart_bt_int", "u32"),
+            (98, "encrypt_method", "u32"),
+            (141, "reset_seq_num_flag", "bool"),
+        ],
+    ),
+    (
+        "Logout",
+        "5",
+        &[(58, "text", "&'buf nexus_fix_codec::AsciiTextStr")],
+    ),
+    (
+        "Heartbeat",
+        "0",
+        &[(112, "test_req_id", "&'buf nexus_fix_codec::AsciiTextStr")],
+    ),
+    (
+        "TestRequest",
+        "1",
+        &[(112, "test_req_id", "&'buf nexus_fix_codec::AsciiTextStr")],
+    ),
+    (
+        "ResendRequest",
+        "2",
+        &[(7, "begin_seq_no", "u64"), (16, "end_seq_no", "u64")],
+    ),
+    (
+        "SequenceReset",
+        "4",
+        &[(36, "new_seq_no", "u64"), (123, "gap_fill_flag", "bool")],
+    ),
+    (
+        "Reject",
+        "3",
+        &[
+            (45, "ref_seq_num", "u64"),
+            (58, "text", "&'buf nexus_fix_codec::AsciiTextStr"),
+        ],
+    ),
+];
+
+pub fn emit(messages: &[RMessage]) -> String {
+    let mut s = String::new();
+    s.push_str(HEADER);
+    for &(name, msgtype, proto_fields) in SPECS {
+        emit_admin_type(&mut s, name, msgtype, proto_fields, messages);
+    }
+    s
+}
+
+fn emit_admin_type(
+    s: &mut String,
+    name: &str,
+    msgtype: &str,
+    proto_fields: &[ProtocolField],
+    messages: &[RMessage],
+) {
+    let _ = writeln!(s, "pub struct {name}<'buf> {{");
+    s.push_str("    buf: &'buf [u8],\n}\n\n");
+
+    // FixAdminMsg impl
+    let _ = writeln!(
+        s,
+        "impl<'buf> nexus_fix_codec::FixAdminMsg<'buf> for {name}<'buf> {{"
+    );
+    s.push_str("    fn decode(buf: &'buf [u8]) -> Self {\n        Self { buf }\n    }\n}\n\n");
+
+    // Protocol-required accessors
+    let _ = writeln!(s, "impl<'buf> {name}<'buf> {{");
+    let proto_tags: HashSet<u32> = proto_fields.iter().map(|&(tag, _, _)| tag).collect();
+    for &(tag, field_name, rust_type) in proto_fields {
+        let _ = write!(
+            s,
+            "    pub fn {field_name}(&self) -> Option<nexus_fix_codec::FieldView<'buf, {rust_type}>> {{\n        \
+             nexus_fix_codec::find_tag(self.buf, 0, {tag})\n            \
+             .and_then(|s| nexus_fix_codec::FieldView::new(s, self.buf))\n    \
+             }}\n\n"
+        );
+    }
+
+    // Venue-specific fields from the XML (non-group, not already in proto set)
+    if let Some(msg) = messages.iter().find(|m| m.is_admin && m.msgtype == msgtype) {
+        let extra: Vec<&RField> = msg
+            .members
+            .iter()
+            .filter_map(|mem| match mem {
+                super::RMember::Field(f) if !proto_tags.contains(&f.number) => Some(f),
+                _ => None,
+            })
+            .collect();
+        for f in extra {
+            emit_value_accessor(s, f, "self.buf");
+        }
+    }
+
+    s.push_str("}\n\n");
+}
+
+/// The 7 associated type assignments for the `FixDictionary` impl.
+pub fn emit_dict_assoc_types(s: &mut String) {
+    for &(name, _, _) in SPECS {
+        let _ = writeln!(s, "    type {name}<'buf> = admin::{name}<'buf>;");
+    }
+}

--- a/nexus-fix-codegen/src/emit/admin.rs
+++ b/nexus-fix-codegen/src/emit/admin.rs
@@ -131,9 +131,14 @@ fn emit_admin_type(
         );
     }
     s.push_str("            checksum: nexus_fix_codec::FieldSpan::EMPTY,\n        };\n");
-    s.push_str("        while let Some(f) = m.header.reader.next_field() {\n            match f.tag {\n");
+    s.push_str(
+        "        while let Some(f) = m.header.reader.next_field() {\n            match f.tag {\n",
+    );
     for &(tag, field_name, _) in proto_fields {
-        let _ = writeln!(s, "                {tag} => {{ m.{field_name} = f.value; }}");
+        let _ = writeln!(
+            s,
+            "                {tag} => {{ m.{field_name} = f.value; }}"
+        );
     }
     for f in &extra {
         let _ = writeln!(
@@ -148,7 +153,9 @@ fn emit_admin_type(
     );
 
     // decode
-    s.push_str("    pub fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {\n");
+    s.push_str(
+        "    pub fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {\n",
+    );
     s.push_str(
         "        Self::wrap_unchecked(super::header::HeaderDecoder::decode(buf))\n    }\n\n",
     );

--- a/nexus-fix-codegen/src/emit/mod.rs
+++ b/nexus-fix-codegen/src/emit/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod encoders;
 mod fields;
 mod groups;
@@ -114,6 +115,10 @@ pub fn generate(dict: &Dictionary) -> Result<Vec<GeneratedFile>, EmitError> {
         GeneratedFile {
             name: "encoders.rs".to_string(),
             source: encoders::emit(&messages, &header_fields),
+        },
+        GeneratedFile {
+            name: "admin.rs".to_string(),
+            source: admin::emit(&messages),
         },
         GeneratedFile {
             name: "mod.rs".to_string(),
@@ -373,7 +378,8 @@ fn emit_mod(messages: &[RMessage], major: &str, minor: &str) -> String {
     s.push_str("pub mod header { include!(\"header.rs\"); }\n");
     s.push_str("pub mod messages { include!(\"messages.rs\"); }\n");
     s.push_str("pub mod groups { include!(\"groups.rs\"); }\n");
-    s.push_str("pub mod encoders { include!(\"encoders.rs\"); }\n\n");
+    s.push_str("pub mod encoders { include!(\"encoders.rs\"); }\n");
+    s.push_str("pub mod admin { include!(\"admin.rs\"); }\n\n");
 
     let begin_string = if !major.is_empty() && !minor.is_empty() {
         format!("FIX.{major}.{minor}")
@@ -418,6 +424,7 @@ fn emit_mod(messages: &[RMessage], major: &str, minor: &str) -> String {
     s.push_str("impl nexus_fix_codec::FixDictionary for Dict {\n");
     s.push_str("    type MsgType = MsgType;\n");
     s.push_str("    type Header<'buf> = header::HeaderDecoder<'buf>;\n");
+    admin::emit_dict_assoc_types(&mut s);
     let _ = writeln!(
         s,
         "    const BEGIN_STRING: &'static [u8] = {};",

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -54,6 +54,8 @@ pub enum SessionError {
     MissingField { tag: u32 },
     /// A field is present but fails to parse.
     MalformedField { tag: u32 },
+    /// Admin message decoder failed.
+    MalformedMessage,
 }
 
 impl core::fmt::Display for SessionError {
@@ -63,6 +65,7 @@ impl core::fmt::Display for SessionError {
             Self::MissingMsgSeqNum => write!(f, "tag 34 (MsgSeqNum) missing"),
             Self::MissingField { tag } => write!(f, "required tag {tag} missing"),
             Self::MalformedField { tag } => write!(f, "tag {tag} malformed"),
+            Self::MalformedMessage => write!(f, "admin message malformed"),
         }
     }
 }
@@ -178,7 +181,8 @@ impl<D: FixDictionary> Session<D> {
                 let send_reply = !was_logon_sent;
                 self.state
                     .on_logon(seq, heart_bt_int, reset, send_reply, now);
-                let msg = D::Logon::decode(buf);
+                let msg = D::Logon::decode(buf)
+                    .map_err(|_| SessionError::MalformedMessage)?;
                 Ok(if was_logon_sent {
                     Message::LogonAcknowledged { msg }
                 } else {
@@ -188,7 +192,8 @@ impl<D: FixDictionary> Session<D> {
             Some(b"5") => {
                 let was_logout_pending = self.state.state() == State::LogoutPending;
                 self.state.on_logout(seq, poss_dup, now);
-                let msg = D::Logout::decode(buf);
+                let msg = D::Logout::decode(buf)
+                    .map_err(|_| SessionError::MalformedMessage)?;
                 Ok(if was_logout_pending {
                     Message::LogoutAcknowledged { msg }
                 } else {
@@ -198,7 +203,8 @@ impl<D: FixDictionary> Session<D> {
             Some(b"0") => {
                 self.state.on_heartbeat(seq, poss_dup, now);
                 Ok(Message::Heartbeat {
-                    msg: D::Heartbeat::decode(buf),
+                    msg: D::Heartbeat::decode(buf)
+                        .map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"1") => {
@@ -206,7 +212,8 @@ impl<D: FixDictionary> Session<D> {
                     find_tag(buf, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(buf));
                 self.state.on_test_request(seq, poss_dup, test_req_id, now);
                 Ok(Message::TestRequest {
-                    msg: D::TestRequest::decode(buf),
+                    msg: D::TestRequest::decode(buf)
+                        .map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"2") => {
@@ -220,7 +227,8 @@ impl<D: FixDictionary> Session<D> {
                     as u32;
                 self.state.on_resend_request(seq, poss_dup, begin, end, now);
                 Ok(Message::ResendRequest {
-                    msg: D::ResendRequest::decode(buf),
+                    msg: D::ResendRequest::decode(buf)
+                        .map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"4") => {
@@ -233,7 +241,8 @@ impl<D: FixDictionary> Session<D> {
                     .unwrap_or(false);
                 self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
                 Ok(Message::SequenceReset {
-                    msg: D::SequenceReset::decode(buf),
+                    msg: D::SequenceReset::decode(buf)
+                        .map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"3") => {
@@ -243,7 +252,8 @@ impl<D: FixDictionary> Session<D> {
                     as u32;
                 self.state.on_reject(seq, poss_dup, ref_seq, now);
                 Ok(Message::Reject {
-                    msg: D::Reject::decode(buf),
+                    msg: D::Reject::decode(buf)
+                        .map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(_) => {

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -2,10 +2,11 @@ use core::marker::PhantomData;
 use std::time::Instant;
 
 use nexus_fix_codec::{
-    FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
+    FixAdminMsg, FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum,
+    parse_fix_uint,
 };
 
-use crate::{Out, SessionState, State};
+use crate::{DisconnectReason, SessionState, State};
 
 const COMP_ID_CAP: usize = 20;
 
@@ -68,15 +69,43 @@ impl core::fmt::Display for SessionError {
 
 impl core::error::Error for SessionError {}
 
+/// Typed inbound message returned by [`Session::on_message`].
+///
+/// Admin messages carry the dictionary's zero-copy decoder for the message type
+/// so callers can read any field — protocol-required or venue-specific — without
+/// re-parsing. App messages surface the decoded header so the caller can route
+/// by `MsgType` and decode the body independently.
+pub enum Message<'buf, D: FixDictionary> {
+    /// Counterparty initiated a Logon (acceptor role). Send your own Logon back.
+    LogonRequest { msg: D::Logon<'buf> },
+    /// Counterparty acknowledged our Logon (initiator role). Session is live.
+    LogonAcknowledged { msg: D::Logon<'buf> },
+    /// Counterparty initiated a Logout. Send a Logout acknowledgement.
+    LogoutRequest { msg: D::Logout<'buf> },
+    /// Counterparty acknowledged our Logout. Session is done.
+    LogoutAcknowledged { msg: D::Logout<'buf> },
+    /// Heartbeat (35=0). No reply required unless it carries a TestReqID.
+    Heartbeat { msg: D::Heartbeat<'buf> },
+    /// TestRequest (35=1). Echo the `TestReqID` in a Heartbeat reply.
+    TestRequest { msg: D::TestRequest<'buf> },
+    /// ResendRequest (35=2). Re-send or gap-fill the requested range.
+    ResendRequest { msg: D::ResendRequest<'buf> },
+    /// SequenceReset (35=4). State updated internally; inspect if needed.
+    SequenceReset { msg: D::SequenceReset<'buf> },
+    /// Reject (35=3). State updated internally; inspect if needed.
+    Reject { msg: D::Reject<'buf> },
+    /// Business message. Route by `header.raw_msg_type()` and decode the body.
+    Application { header: D::Header<'buf> },
+    /// Session disconnected (CompID mismatch, timeout, or protocol violation).
+    Disconnected { reason: DisconnectReason },
+}
+
 /// Dictionary-powered FIX session router.
 ///
 /// Wraps [`SessionState`] with a codec layer: decodes the header via
 /// `D::Header::decode`, validates CompIDs, routes by raw `MsgType` bytes, and
-/// dispatches to the appropriate typed [`SessionState`] handler.
-///
-/// Admin messages (`A`, `5`, `0`, `1`, `2`, `4`, `3`) are consumed internally.
-/// App messages are returned as `(Out, Some(header))` so the caller can decode
-/// the full message body.
+/// dispatches to the appropriate [`SessionState`] handler. Returns a typed
+/// [`Message`] so the caller owns both encoding and venue-specific logic.
 pub struct Session<D: FixDictionary> {
     state: SessionState,
     config: SessionConfig,
@@ -103,17 +132,16 @@ impl<D: FixDictionary> Session<D> {
     /// Route an inbound message.
     ///
     /// Decodes the header, validates CompIDs, and dispatches to the matching
-    /// [`SessionState`] handler. Returns the [`Out`] from the handler plus
-    /// the decoded header for app messages; `None` for admin messages (consumed
-    /// internally).
+    /// [`SessionState`] handler. Returns a [`Message`] carrying either the
+    /// decoded admin message or the application header.
     pub fn on_message<'buf>(
         &mut self,
         buf: &'buf [u8],
         now: Instant,
-    ) -> Result<(Out, Option<D::Header<'buf>>), SessionError> {
+    ) -> Result<Message<'buf, D>, SessionError> {
         let header = D::Header::decode(buf);
 
-        // CompID validation — mismatch triggers a disconnect via SessionState.
+        // CompID validation — mismatch → disconnect.
         let sender_ok = header
             .sender_comp_id()
             .is_some_and(|v| v.as_bytes() == self.config.target.as_bytes());
@@ -121,7 +149,10 @@ impl<D: FixDictionary> Session<D> {
             .target_comp_id()
             .is_some_and(|v| v.as_bytes() == self.config.sender.as_bytes());
         if !sender_ok || !target_ok {
-            return Ok((self.state.on_comp_id_mismatch(now), None));
+            self.state.on_comp_id_mismatch(now);
+            return Ok(Message::Disconnected {
+                reason: DisconnectReason::CompIdMismatch,
+            });
         }
 
         let seq = header
@@ -143,23 +174,40 @@ impl<D: FixDictionary> Session<D> {
                 let reset = find_tag(buf, 0, 141)
                     .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
                     .unwrap_or(false);
-                // Acceptor replies with its own Logon; initiator already sent one.
-                let send_reply = self.state.state() != State::LogonSent;
-                Ok((
-                    self.state
-                        .on_logon(seq, heart_bt_int, reset, send_reply, now),
-                    None,
-                ))
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                let send_reply = !was_logon_sent;
+                self.state
+                    .on_logon(seq, heart_bt_int, reset, send_reply, now);
+                let msg = D::Logon::decode(buf);
+                Ok(if was_logon_sent {
+                    Message::LogonAcknowledged { msg }
+                } else {
+                    Message::LogonRequest { msg }
+                })
             }
-            Some(b"5") => Ok((self.state.on_logout(seq, poss_dup, now), None)),
-            Some(b"0") => Ok((self.state.on_heartbeat(seq, poss_dup, now), None)),
+            Some(b"5") => {
+                let was_logout_pending = self.state.state() == State::LogoutPending;
+                self.state.on_logout(seq, poss_dup, now);
+                let msg = D::Logout::decode(buf);
+                Ok(if was_logout_pending {
+                    Message::LogoutAcknowledged { msg }
+                } else {
+                    Message::LogoutRequest { msg }
+                })
+            }
+            Some(b"0") => {
+                self.state.on_heartbeat(seq, poss_dup, now);
+                Ok(Message::Heartbeat {
+                    msg: D::Heartbeat::decode(buf),
+                })
+            }
             Some(b"1") => {
                 let test_req_id =
                     find_tag(buf, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(buf));
-                Ok((
-                    self.state.on_test_request(seq, poss_dup, test_req_id, now),
-                    None,
-                ))
+                self.state.on_test_request(seq, poss_dup, test_req_id, now);
+                Ok(Message::TestRequest {
+                    msg: D::TestRequest::decode(buf),
+                })
             }
             Some(b"2") => {
                 let begin = find_tag(buf, 0, 7).ok_or(SessionError::MissingField { tag: 7 })?;
@@ -170,10 +218,10 @@ impl<D: FixDictionary> Session<D> {
                 let end = parse_fix_seqnum(end.slice(buf))
                     .map_err(|_| SessionError::MalformedField { tag: 16 })?
                     as u32;
-                Ok((
-                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
-                    None,
-                ))
+                self.state.on_resend_request(seq, poss_dup, begin, end, now);
+                Ok(Message::ResendRequest {
+                    msg: D::ResendRequest::decode(buf),
+                })
             }
             Some(b"4") => {
                 let new_seq = find_tag(buf, 0, 36).ok_or(SessionError::MissingField { tag: 36 })?;
@@ -183,21 +231,24 @@ impl<D: FixDictionary> Session<D> {
                 let gap_fill = find_tag(buf, 0, 123)
                     .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
                     .unwrap_or(false);
-                Ok((
-                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
-                    None,
-                ))
+                self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
+                Ok(Message::SequenceReset {
+                    msg: D::SequenceReset::decode(buf),
+                })
             }
             Some(b"3") => {
                 let ref_seq = find_tag(buf, 0, 45).ok_or(SessionError::MissingField { tag: 45 })?;
                 let ref_seq = parse_fix_seqnum(ref_seq.slice(buf))
                     .map_err(|_| SessionError::MalformedField { tag: 45 })?
                     as u32;
-                Ok((self.state.on_reject(seq, poss_dup, ref_seq, now), None))
+                self.state.on_reject(seq, poss_dup, ref_seq, now);
+                Ok(Message::Reject {
+                    msg: D::Reject::decode(buf),
+                })
             }
             Some(_) => {
-                let out = self.state.on_app(seq, poss_dup, now);
-                Ok((out, Some(header)))
+                self.state.on_app(seq, poss_dup, now);
+                Ok(Message::Application { header })
             }
             None => Err(SessionError::MissingMsgType),
         }

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -181,8 +181,7 @@ impl<D: FixDictionary> Session<D> {
                 let send_reply = !was_logon_sent;
                 self.state
                     .on_logon(seq, heart_bt_int, reset, send_reply, now);
-                let msg = D::Logon::decode(buf)
-                    .map_err(|_| SessionError::MalformedMessage)?;
+                let msg = D::Logon::decode(buf).map_err(|_| SessionError::MalformedMessage)?;
                 Ok(if was_logon_sent {
                     Message::LogonAcknowledged { msg }
                 } else {
@@ -192,8 +191,7 @@ impl<D: FixDictionary> Session<D> {
             Some(b"5") => {
                 let was_logout_pending = self.state.state() == State::LogoutPending;
                 self.state.on_logout(seq, poss_dup, now);
-                let msg = D::Logout::decode(buf)
-                    .map_err(|_| SessionError::MalformedMessage)?;
+                let msg = D::Logout::decode(buf).map_err(|_| SessionError::MalformedMessage)?;
                 Ok(if was_logout_pending {
                     Message::LogoutAcknowledged { msg }
                 } else {
@@ -203,8 +201,7 @@ impl<D: FixDictionary> Session<D> {
             Some(b"0") => {
                 self.state.on_heartbeat(seq, poss_dup, now);
                 Ok(Message::Heartbeat {
-                    msg: D::Heartbeat::decode(buf)
-                        .map_err(|_| SessionError::MalformedMessage)?,
+                    msg: D::Heartbeat::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"1") => {
@@ -212,8 +209,7 @@ impl<D: FixDictionary> Session<D> {
                     find_tag(buf, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(buf));
                 self.state.on_test_request(seq, poss_dup, test_req_id, now);
                 Ok(Message::TestRequest {
-                    msg: D::TestRequest::decode(buf)
-                        .map_err(|_| SessionError::MalformedMessage)?,
+                    msg: D::TestRequest::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(b"2") => {
@@ -252,8 +248,7 @@ impl<D: FixDictionary> Session<D> {
                     as u32;
                 self.state.on_reject(seq, poss_dup, ref_seq, now);
                 Ok(Message::Reject {
-                    msg: D::Reject::decode(buf)
-                        .map_err(|_| SessionError::MalformedMessage)?,
+                    msg: D::Reject::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
                 })
             }
             Some(_) => {

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -14,5 +14,5 @@ mod session;
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
 };
-pub use framework::{CompId, Session, SessionConfig, SessionError};
+pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -18,8 +18,8 @@ struct AdminDecoder<'buf> {
 }
 
 impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
-    fn decode(buf: &'buf [u8]) -> Self {
-        Self { buf }
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { buf })
     }
 }
 

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{FieldView, FixDictionary, FixHeader, FixTimestamp, find_tag};
-use nexus_fix_engine::{AdminMsg, CompId, Event, Out, Session, SessionConfig, SessionState, State};
+use nexus_fix_codec::{FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, Message, Session, SessionConfig, SessionState, State,
+};
 
 // ── minimal mock dictionary ──────────────────────────────────────────────────
 
@@ -10,9 +12,49 @@ struct MockDict;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum MockMsgType {}
 
+// Minimal find_tag-based admin decoder used for all 7 types in the mock.
+struct AdminDecoder<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+}
+
+impl<'buf> AdminDecoder<'buf> {
+    fn heart_bt_int(&self) -> Option<FieldView<'buf, u32>> {
+        find_tag(self.buf, 0, 108).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn test_req_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 112).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn begin_seq_no(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 7).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn end_seq_no(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 16).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn new_seq_no(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 36).and_then(|s| FieldView::new(s, self.buf))
+    }
+}
+
 impl FixDictionary for MockDict {
     type MsgType = MockMsgType;
     type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
     const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
     fn is_admin(_: MockMsgType) -> bool {
         false
@@ -66,11 +108,6 @@ fn session() -> Session<MockDict> {
     Session::new(state, config)
 }
 
-fn admin_msgs(out: Out) -> Vec<AdminMsg> {
-    out.admin_messages().collect()
-}
-
-// Minimal valid Logon buffer — tags needed by Session<MockDict>.on_message.
 // 49=TARGET (their sender = our target), 56=SENDER (their target = our sender).
 fn logon(seq: u32, hbi: u32) -> Vec<u8> {
     let mut v = Vec::new();
@@ -120,19 +157,12 @@ fn app_msg(seq: u32) -> Vec<u8> {
 fn acceptor_logon() {
     let mut s = session();
     let msg = logon(1, 30);
-    let (out, hdr) = s.on_message(&msg, Instant::now()).unwrap();
-    assert!(hdr.is_none());
+    let m = s.on_message(&msg, Instant::now()).unwrap();
+    assert!(matches!(m, Message::LogonRequest { .. }));
     assert_eq!(s.state().state(), State::Active);
-    assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
-    let admins = admin_msgs(out);
-    assert_eq!(admins.len(), 1);
-    assert!(matches!(
-        admins[0],
-        AdminMsg::Logon {
-            seq: 1,
-            heart_bt_int_s: 30
-        }
-    ));
+    if let Message::LogonRequest { msg } = m {
+        assert_eq!(msg.heart_bt_int().and_then(|v| v.checked().ok()), Some(30));
+    }
 }
 
 #[test]
@@ -143,33 +173,21 @@ fn initiator_logon_reply() {
     assert_eq!(s.state().state(), State::LogonSent);
 
     let msg = logon(1, 30);
-    let (out, hdr) = s.on_message(&msg, now).unwrap();
-    assert!(hdr.is_none());
+    let m = s.on_message(&msg, now).unwrap();
+    assert!(matches!(m, Message::LogonAcknowledged { .. }));
     assert_eq!(s.state().state(), State::Active);
-    assert_eq!(admin_msgs(out).len(), 0);
 }
 
 #[test]
 fn logout_round_trip() {
     let mut s = session();
     let now = Instant::now();
-    let msg = logon(1, 30);
-    s.on_message(&msg, now).unwrap();
+    s.on_message(&logon(1, 30), now).unwrap();
 
     let msg = logout(2);
-    let (out, _) = s.on_message(&msg, now).unwrap();
+    let m = s.on_message(&msg, now).unwrap();
+    assert!(matches!(m, Message::LogoutRequest { .. }));
     assert_eq!(s.state().state(), State::Disconnected);
-    assert_eq!(
-        out.event(),
-        Some(Event::Disconnected {
-            reason: nexus_fix_engine::DisconnectReason::Logout,
-        })
-    );
-    assert!(
-        admin_msgs(out)
-            .iter()
-            .any(|a| matches!(a, AdminMsg::Logout { .. }))
-    );
 }
 
 #[test]
@@ -178,36 +196,32 @@ fn heartbeat_is_handled() {
     let now = Instant::now();
     s.on_message(&logon(1, 30), now).unwrap();
 
-    let msg = heartbeat(2);
-    let (out, hdr) = s.on_message(&msg, now).unwrap();
-    assert!(hdr.is_none());
-    assert_eq!(admin_msgs(out).len(), 0);
+    let hb = heartbeat(2);
+    let m = s.on_message(&hb, now).unwrap();
+    assert!(matches!(m, Message::Heartbeat { .. }));
 }
 
 #[test]
-fn test_request_echoed_as_heartbeat() {
+fn test_request_surfaces_id() {
     let mut s = session();
     let now = Instant::now();
     s.on_message(&logon(1, 30), now).unwrap();
 
     let msg = test_request(2, "PROBE1");
-    let (out, hdr) = s.on_message(&msg, now).unwrap();
-    assert!(hdr.is_none());
-    let admins = admin_msgs(out);
-    assert_eq!(admins.len(), 1);
-    match admins[0] {
-        AdminMsg::Heartbeat {
-            echo: Some((id, len)),
-            ..
-        } => {
-            assert_eq!(&id[..len as usize], b"PROBE1");
-        }
-        _ => panic!("expected Heartbeat with echo"),
+    let m = s.on_message(&msg, now).unwrap();
+    if let Message::TestRequest { msg } = m {
+        let id = msg
+            .test_req_id()
+            .and_then(|v| v.checked().ok())
+            .map(nexus_fix_codec::AsciiTextStr::as_bytes);
+        assert_eq!(id, Some(b"PROBE1".as_ref()));
+    } else {
+        panic!("expected TestRequest");
     }
 }
 
 #[test]
-fn resend_request_triggers_gap_fill() {
+fn resend_request_fields() {
     let mut s = session();
     let now = Instant::now();
     s.on_message(&logon(1, 30), now).unwrap();
@@ -215,16 +229,14 @@ fn resend_request_triggers_gap_fill() {
     s.state_mut().allocate_seq(now); // seq 3
 
     let msg = resend_request(2, 2, 3);
-    let (out, _) = s.on_message(&msg, now).unwrap();
-    assert!(matches!(
-        out.event(),
-        Some(Event::ResendRange { begin: 2, end: 3 })
-    ));
-    assert!(
-        admin_msgs(out)
-            .iter()
-            .any(|a| matches!(a, AdminMsg::SequenceReset { .. }))
-    );
+    let m = s.on_message(&msg, now).unwrap();
+    if let Message::ResendRequest { msg } = m {
+        assert_eq!(msg.begin_seq_no().and_then(|v| v.checked().ok()), Some(2));
+        assert_eq!(msg.end_seq_no().and_then(|v| v.checked().ok()), Some(3));
+    } else {
+        panic!("expected ResendRequest");
+    }
+    assert_eq!(s.state().state(), State::Active);
 }
 
 #[test]
@@ -234,15 +246,18 @@ fn sequence_reset_gap_fill() {
     s.on_message(&logon(1, 30), now).unwrap();
 
     // trigger a gap
-    let msg = app_msg(5);
-    s.on_message(&msg, now).unwrap();
+    s.on_message(&app_msg(5), now).unwrap();
     assert_eq!(s.state().state(), State::Resending);
 
     let msg = sequence_reset(2, 6, true);
-    let (out, _) = s.on_message(&msg, now).unwrap();
+    let m = s.on_message(&msg, now).unwrap();
+    if let Message::SequenceReset { msg } = m {
+        assert_eq!(msg.new_seq_no().and_then(|v| v.checked().ok()), Some(6));
+    } else {
+        panic!("expected SequenceReset");
+    }
     assert_eq!(s.state().next_inbound_seq(), 6);
     assert_eq!(s.state().state(), State::Active);
-    assert_eq!(out.event(), Some(Event::SequenceReset { new_seq: 6 }));
 }
 
 #[test]
@@ -252,15 +267,8 @@ fn app_message_surfaces_header() {
     s.on_message(&logon(1, 30), now).unwrap();
 
     let msg = app_msg(2);
-    let (out, hdr) = s.on_message(&msg, now).unwrap();
-    assert!(hdr.is_some());
-    assert_eq!(
-        out.event(),
-        Some(Event::App {
-            seq_num: 2,
-            poss_dup: false
-        })
-    );
+    let m = s.on_message(&msg, now).unwrap();
+    assert!(matches!(m, Message::Application { .. }));
 }
 
 #[test]
@@ -269,14 +277,13 @@ fn comp_id_mismatch_disconnects() {
     let now = Instant::now();
     s.on_message(&logon(1, 30), now).unwrap();
 
-    // Wrong SenderCompID
     let msg = b"34=2\x0135=0\x0149=WRONG\x0156=SENDER\x01";
-    let (out, _) = s.on_message(msg, now).unwrap();
-    assert_eq!(s.state().state(), State::Disconnected);
+    let m = s.on_message(msg, now).unwrap();
     assert!(matches!(
-        out.event(),
-        Some(Event::Disconnected {
-            reason: nexus_fix_engine::DisconnectReason::CompIdMismatch
-        })
+        m,
+        Message::Disconnected {
+            reason: DisconnectReason::CompIdMismatch
+        }
     ));
+    assert_eq!(s.state().state(), State::Disconnected);
 }


### PR DESCRIPTION
Closes #460.

Replaces `(Out, Option<Header>)` with a typed `Message<'buf, D>` enum. Callers own encoding; the engine owns protocol state.

**nexus-fix-codec**
- `FixAdminMsg<'buf>` trait: `fn decode(buf: &'buf [u8]) -> Self`
- `FixDictionary` extended with 7 GATs: `Logon`, `Logout`, `Heartbeat`, `TestRequest`, `ResendRequest`, `SequenceReset`, `Reject` — each bound on `FixAdminMsg`

**nexus-fix-codegen**
- New `admin.rs` emitter — always generates 7 admin decoder structs per dictionary
- Protocol-required fields hardcoded; venue-specific fields from XML merged in
- `emit_mod` wires in `pub mod admin` and sets all 7 associated types on `Dict`

**nexus-fix-engine**
- `Message<'buf, D>` enum: 10 variants (`LogonRequest`, `LogonAcknowledged`, `LogoutRequest`, `LogoutAcknowledged`, `Heartbeat`, `TestRequest`, `ResendRequest`, `SequenceReset`, `Reject`, `Application`, `Disconnected`)
- `Session::on_message` returns `Result<Message<'buf, D>, SessionError>`
- `Out`/`AdminMsg` remain on `SessionState` for direct state-machine users

9 framework tests updated to match the new API.