### PR TITLE
feat(fix-engine): FrameReader + FrameWriter, rename FrameWriter → FrameFormatter

### DIFF
--- a/nexus-fix-codec/examples/perf_scan.rs
+++ b/nexus-fix-codec/examples/perf_scan.rs
@@ -20,7 +20,7 @@ mod _bench_utils;
 use _bench_utils::{BATCH, WARMUP, percentile, print_intro, rdtsc_fenced_end, rdtsc_fenced_start};
 use nexus_fix_codec::reader::{FieldReader, checksum};
 use nexus_fix_codec::scan;
-use nexus_fix_codec::writer::{FieldWriter, FrameWriter};
+use nexus_fix_codec::writer::{FieldWriter, FrameFormatter};
 use std::hint::black_box;
 
 /// Number of batches sampled per benchmark. Each batch averages `BATCH`
@@ -309,13 +309,13 @@ fn main() {
     );
 
     // =========================================================================
-    // FrameWriter: encode + frame a full NewOrderSingle (the generated-encoder
+    // FrameFormatter: encode + frame a full NewOrderSingle (the generated-encoder
     // hot path: body fields + real 8=/9=/35=/10= framing)
     // =========================================================================
 
-    println!("\n=== FrameWriter: encode + frame NewOrderSingle ===\n");
+    println!("\n=== FrameFormatter: encode + frame NewOrderSingle ===\n");
 
-    // FrameWriter owns 8=, 9= (canonical BodyLength, right-aligned at finish),
+    // FrameFormatter owns 8=, 9= (canonical BodyLength, right-aligned at finish),
     // 35=, and 10= (checksum), so only the body fields are written here. Same
     // 15-field message as the FieldWriter case above — the delta is the real
     // framing work that produces a *valid* message (FieldWriter wrote a
@@ -336,21 +336,22 @@ fn main() {
     ];
     let mut fbuf = [0u8; 256];
     let (p50_fr, p99_fr, p999_fr) = benchmark(|| {
-        let mut f = FrameWriter::new(&mut fbuf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut fbuf, b"FIX.4.4", b"D");
         for &(tag, val) in black_box(body_fields) {
             f.field(tag, val);
         }
-        black_box(f.finish().unwrap()).len()
+        let (_, len) = f.finish().unwrap();
+        black_box(len)
     });
     let frame_len = {
-        let mut f = FrameWriter::new(&mut fbuf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut fbuf, b"FIX.4.4", b"D");
         for &(tag, val) in body_fields {
             f.field(tag, val);
         }
-        f.finish().unwrap().len()
+        f.finish().unwrap().1
     };
 
-    println!("  FrameWriter (encode + frame, 15 fields, incl. BodyLength + checksum):");
+    println!("  FrameFormatter (encode + frame, 15 fields, incl. BodyLength + checksum):");
     println!("    p50={} p99={} p999={} cycles", p50_fr, p99_fr, p999_fr);
     println!(
         "    {:.1} cycles/field, {:.2} cycles/byte",

--- a/nexus-fix-codec/src/lib.rs
+++ b/nexus-fix-codec/src/lib.rs
@@ -41,7 +41,7 @@ pub use types::{
     parse_fix_int, parse_fix_multi_char, parse_fix_multi_string, parse_fix_seqnum, parse_fix_text,
     parse_fix_uint,
 };
-pub use writer::{FieldWriter, FrameWriter, FromFrame, encode_field, format_checksum};
+pub use writer::{FieldWriter, FrameFormatter, FromFormatter, encode_field, format_checksum};
 
 #[cfg(feature = "nexus-decimal")]
 pub use types::DecimalConvError;

--- a/nexus-fix-codec/src/writer.rs
+++ b/nexus-fix-codec/src/writer.rs
@@ -626,10 +626,7 @@ mod tests {
         let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
         f.field(11, b"A");
         let (start, len) = f.finish().unwrap();
-        assert!(
-            start > 0,
-            "right-aligned prefix should start past offset 0"
-        );
+        assert!(start > 0, "right-aligned prefix should start past offset 0");
         let msg = &buf[start..start + len];
         assert!(crate::validate_checksum(msg).is_ok());
         assert!(msg.starts_with(b"8=FIX.4.4\x019="));

--- a/nexus-fix-codec/src/writer.rs
+++ b/nexus-fix-codec/src/writer.rs
@@ -9,9 +9,9 @@
 //!
 //! # Buffer-too-small policy
 //!
-//! Two layers, two behaviors. [`FrameWriter`] — the user-facing message builder
-//! — **never panics** on a small buffer: an overflowing field poisons the writer
-//! and [`finish`](FrameWriter::finish) returns [`EncodeError::BufferFull`], so
+//! Two layers, two behaviors. [`FrameFormatter`] — the user-facing message builder
+//! — **never panics** on a small buffer: an overflowing field poisons the formatter
+//! and [`finish`](FrameFormatter::finish) returns [`EncodeError::BufferFull`], so
 //! the caller owns the failure. The lower-level primitives ([`encode_field`] and
 //! the value-type `encode` methods like [`FixDecimal::encode`](crate::FixDecimal::encode))
 //! instead **assert** capacity up front — an internal contract that lets them
@@ -95,18 +95,19 @@ impl<'a> FieldWriter<'a> {
 /// # Example
 ///
 /// ```
-/// use nexus_fix_codec::FrameWriter;
+/// use nexus_fix_codec::FrameFormatter;
 ///
 /// let mut buf = [0u8; 128];
-/// let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"D"); // 8=, reserve 9=, 35=D
+/// let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D"); // 8=, reserve 9=, 35=D
 /// f.field(49, b"SENDER");
 /// f.field(56, b"TARGET");
 /// f.field(11, b"ORD-1");
-/// let msg = f.finish().unwrap();
+/// let (start, len) = f.finish().unwrap();
+/// let msg = &buf[start..start + len];
 /// assert!(msg.starts_with(b"8=FIX.4.4\x019="));
 /// assert!(nexus_fix_codec::validate_checksum(msg).is_ok());
 /// ```
-pub struct FrameWriter<'buf> {
+pub struct FrameFormatter<'buf> {
     buf: &'buf mut [u8],
     begin_string: &'static [u8],
     /// Start of the body-length-counted region (after the reserved prefix).
@@ -117,7 +118,7 @@ pub struct FrameWriter<'buf> {
     full: bool,
 }
 
-impl<'buf> FrameWriter<'buf> {
+impl<'buf> FrameFormatter<'buf> {
     /// Begin a message: reserve the front prefix and write `35=<msg_type>`.
     ///
     /// The reservation defaults to the widest the `8=…9=…` prefix could need
@@ -173,16 +174,15 @@ impl<'buf> FrameWriter<'buf> {
         self.full
     }
 
-    /// Finish the message: write `8=…9=<canonical>` and append the checksum,
-    /// returning the framed message slice.
+    /// Finish the message: write `8=…9=<canonical>` and append the checksum.
     ///
-    /// The returned slice may start a few bytes into `buf` (the prefix is
-    /// right-aligned), so transmit exactly the returned slice — not `&buf[..]`.
+    /// Returns `(start, len)` — the byte offset and length of the finished
+    /// message within the buffer. The message is at `buf[start..start + len]`.
     ///
     /// # Errors
     /// [`EncodeError::BufferFull`](crate::EncodeError::BufferFull) if any field,
     /// the prefix, or the checksum did not fit.
-    pub fn finish(mut self) -> Result<&'buf [u8], EncodeError> {
+    pub fn finish(mut self) -> Result<(usize, usize), EncodeError> {
         if self.full {
             return Err(EncodeError::BufferFull);
         }
@@ -222,20 +222,20 @@ impl<'buf> FrameWriter<'buf> {
         // Checksum covers everything from `8=` up to (not including) `10=`.
         let sum = crate::checksum(&self.buf[start..self.pos]);
         let end = encode_field(self.buf, self.pos, 10, &format_checksum(sum));
-        Ok(&self.buf[start..end])
+        Ok((start, end - start))
     }
 }
 
-/// Resume an encoder stage from an in-progress [`FrameWriter`].
+/// Resume an encoder stage from an in-progress [`FrameFormatter`].
 ///
 /// Generated message encoders implement this so the venue-shared header encoder
 /// can return control to the per-message body stage when its `end()` is called,
 /// without the header encoder needing to name the concrete message type. It's
 /// the typestate handoff: header writer → message body writer, carrying the
 /// buffer along.
-pub trait FromFrame<'buf> {
+pub trait FromFormatter<'buf> {
     /// Resume encoding from `frame`.
-    fn from_frame(frame: FrameWriter<'buf>) -> Self;
+    fn from_formatter(frame: FrameFormatter<'buf>) -> Self;
 }
 
 /// Widest the `8=…9=…` prefix can be for a buffer of `buf_len` bytes: the `8=`
@@ -575,16 +575,17 @@ mod tests {
         assert_eq!(buf[msg_end - 1], 0x01);
     }
 
-    // ---- FrameWriter ----
+    // ---- FrameFormatter ----
 
     #[test]
     fn frame_basic_roundtrips() {
         let mut buf = [0u8; 128];
-        let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
         f.field(49, b"SENDER");
         f.field(56, b"TARGET");
         f.field(11, b"ORD-1");
-        let msg = f.finish().unwrap();
+        let (start, len) = f.finish().unwrap();
+        let msg = &buf[start..start + len];
 
         assert!(msg.starts_with(b"8=FIX.4.4\x019="));
         assert!(crate::validate_checksum(msg).is_ok());
@@ -604,9 +605,10 @@ mod tests {
         // Small body → BodyLength has fewer digits than the reservation;
         // the value must still be canonical (no leading zeros).
         let mut buf = [0u8; 4096];
-        let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"0");
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"0");
         f.field(112, b"HB");
-        let msg = f.finish().unwrap();
+        let (start, len) = f.finish().unwrap();
+        let msg = &buf[start..start + len];
 
         let mut r = crate::FieldReader::new(msg, 0);
         let fields: Vec<_> = r.by_ref().collect();
@@ -621,15 +623,14 @@ mod tests {
         // into it, so the message starts a few bytes in (no shift, body never
         // moved). buf.len() has 4 digits, the body's BodyLength only 2.
         let mut buf = [0u8; 1024];
-        let base = buf.as_ptr() as usize;
-        let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
         f.field(11, b"A");
-        let msg = f.finish().unwrap();
-        let offset = msg.as_ptr() as usize - base;
+        let (start, len) = f.finish().unwrap();
         assert!(
-            offset > 0,
+            start > 0,
             "right-aligned prefix should start past offset 0"
         );
+        let msg = &buf[start..start + len];
         assert!(crate::validate_checksum(msg).is_ok());
         assert!(msg.starts_with(b"8=FIX.4.4\x019="));
     }
@@ -638,7 +639,7 @@ mod tests {
     fn frame_buffer_full_no_panic() {
         // Too small even for the prefix — must error, never panic.
         let mut buf = [0u8; 8];
-        let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
         f.field(49, b"SENDER");
         assert_eq!(f.finish(), Err(crate::EncodeError::BufferFull));
     }
@@ -647,7 +648,7 @@ mod tests {
     fn frame_field_overflow_poisons() {
         // The body overruns mid-write → poisoned → BufferFull at finish.
         let mut buf = [0u8; 32];
-        let mut f = FrameWriter::new(&mut buf, b"FIX.4.4", b"D");
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
         f.field(11, b"THIS-IS-A-VERY-LONG-CLORDID-THAT-WONT-FIT");
         assert!(f.is_full());
         assert_eq!(f.finish(), Err(crate::EncodeError::BufferFull));
@@ -658,10 +659,11 @@ mod tests {
         // Reserve room for a 1-digit BodyLength, then write a body that needs
         // two digits → finish() shifts the content to make prefix room.
         let mut buf = [0u8; 128];
-        let mut f = FrameWriter::with_reserved(&mut buf, b"FIX.4.4", b"D", 14);
+        let mut f = FrameFormatter::with_reserved(&mut buf, b"FIX.4.4", b"D", 14);
         f.field(49, b"SENDER");
         f.field(56, b"TARGET");
-        let msg = f.finish().unwrap();
+        let (start, len) = f.finish().unwrap();
+        let msg = &buf[start..start + len];
 
         assert!(crate::validate_checksum(msg).is_ok());
         let mut r = crate::FieldReader::new(msg, 0);

--- a/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
+++ b/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
@@ -64,7 +64,7 @@ fn measure<F: Fn() -> R, R>(name: &str, f: F) {
 fn build_alpha_nos_with_groups() -> Vec<u8> {
     let mut buf = [0u8; 512];
     let ts = nexus_fix_codec::FixTimestamp::parse(b"20260603-12:00:00").unwrap();
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"SENDER")
         .target_comp_id(b"TARGET")
@@ -87,13 +87,13 @@ fn build_alpha_nos_with_groups() -> Vec<u8> {
         .symbol(b"BTC-USD")
         .finish()
         .unwrap();
-    msg.to_vec()
+    buf[start..start + len].to_vec()
 }
 
 fn build_alpha_nos_no_groups() -> Vec<u8> {
     let mut buf = [0u8; 256];
     let ts = nexus_fix_codec::FixTimestamp::parse(b"20260603-12:00:00").unwrap();
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"SENDER")
         .target_comp_id(b"TARGET")
@@ -105,7 +105,7 @@ fn build_alpha_nos_no_groups() -> Vec<u8> {
         .symbol(b"BTC-USD")
         .finish()
         .unwrap();
-    msg.to_vec()
+    buf[start..start + len].to_vec()
 }
 
 fn build_beta_md_with_groups() -> Vec<u8> {
@@ -122,7 +122,7 @@ fn build_beta_md_with_groups() -> Vec<u8> {
         mantissa: 1_000_000,
         scale: 0,
     };
-    let msg = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)
+    let (start, len) = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)
         .header_encoder()
         .finish()
         .symbol(b"EUR/USD")
@@ -141,7 +141,7 @@ fn build_beta_md_with_groups() -> Vec<u8> {
         .unwrap()
         .finish()
         .unwrap();
-    msg.to_vec()
+    buf[start..start + len].to_vec()
 }
 
 fn main() {
@@ -219,7 +219,7 @@ fn main() {
 
     measure("alpha NOS encode  (no groups)", || {
         let mut buf = [0u8; 256];
-        let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(black_box(&mut buf))
+        let (_, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(black_box(&mut buf))
             .header_encoder()
             .sender_comp_id(b"SENDER")
             .target_comp_id(b"TARGET")
@@ -231,12 +231,12 @@ fn main() {
             .symbol(b"BTC-USD")
             .finish()
             .unwrap();
-        black_box(msg.len())
+        black_box(len)
     });
 
     measure("alpha NOS encode  (2 parties)", || {
         let mut buf = [0u8; 512];
-        let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(black_box(&mut buf))
+        let (_, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(black_box(&mut buf))
             .header_encoder()
             .sender_comp_id(b"SENDER")
             .target_comp_id(b"TARGET")
@@ -259,7 +259,7 @@ fn main() {
             .symbol(b"BTC-USD")
             .finish()
             .unwrap();
-        black_box(msg.len())
+        black_box(len)
     });
 
     let px_bid = nexus_fix_codec::FixDecimal {
@@ -276,7 +276,7 @@ fn main() {
     };
     measure("beta MD encode  (2 entries)", || {
         let mut buf = [0u8; 512];
-        let msg =
+        let (_, len) =
             venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(black_box(&mut buf))
                 .header_encoder()
                 .finish()
@@ -296,14 +296,14 @@ fn main() {
                 .unwrap()
                 .finish()
                 .unwrap();
-        black_box(msg.len())
+        black_box(len)
     });
 
     measure("alpha NOS encode  (shift path)", || {
         // Undersized prefix reservation → finish() shifts the content right to
         // make room for the canonical BodyLength.
         let mut buf = [0u8; 256];
-        let msg =
+        let (_, len) =
             venue_alpha::encoders::NewOrderSingleEncoder::wrap_reserved(black_box(&mut buf), 14)
                 .header_encoder()
                 .sender_comp_id(b"SENDER")
@@ -316,6 +316,6 @@ fn main() {
                 .symbol(b"BTC-USD")
                 .finish()
                 .unwrap();
-        black_box(msg.len())
+        black_box(len)
     });
 }

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -141,7 +141,7 @@ fn sending_time() -> nexus_fix_codec::FixTimestamp {
 #[test]
 fn alpha_encodes_round_trip() {
     let mut buf = [0u8; 256];
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"BUYSIDE")
         .target_comp_id(b"SELLSIDE")
@@ -153,6 +153,7 @@ fn alpha_encodes_round_trip() {
         .symbol(b"ETH-USD")
         .finish()
         .unwrap();
+    let msg = &buf[start..start + len];
 
     // A complete, valid FIX message — header, body, framing, checksum.
     assert!(msg.starts_with(b"8=FIX.4.4\x019="));
@@ -178,7 +179,7 @@ fn alpha_encodes_typed_decimal_and_optional_header() {
         scale: 1,
     };
     let mut buf = [0u8; 256];
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"S")
         .target_comp_id(b"T")
@@ -192,6 +193,7 @@ fn alpha_encodes_typed_decimal_and_optional_header() {
         .order_qty(qty) // typed FixDecimal in, encoded for us
         .finish()
         .unwrap();
+    let msg = &buf[start..start + len];
 
     let m = venue_alpha::messages::NewOrderSingle::decode(msg).unwrap();
     assert!(m.header().poss_dup_flag().unwrap().get());
@@ -201,7 +203,7 @@ fn alpha_encodes_typed_decimal_and_optional_header() {
 #[test]
 fn alpha_encodes_data_field() {
     let mut buf = [0u8; 128];
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"S")
         .target_comp_id(b"T")
@@ -212,6 +214,7 @@ fn alpha_encodes_data_field() {
         .raw_data(b"x\x01y")
         .finish()
         .unwrap();
+    let msg = &buf[start..start + len];
     assert!(nexus_fix_codec::validate_checksum(msg).is_ok());
     let m = venue_alpha::messages::NewOrderSingle::decode(msg).unwrap();
     assert_eq!(m.raw_data_length().unwrap().get(), 3);
@@ -523,7 +526,7 @@ fn alpha_encode_undersized_reservation_shifts_and_stays_valid() {
     // wrap_reserved with a prefix reservation too small for the BodyLength digits
     // forces finish() to shift the content right; the message must stay valid.
     let mut buf = [0u8; 256];
-    let msg = venue_alpha::encoders::NewOrderSingleEncoder::wrap_reserved(&mut buf, 14)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap_reserved(&mut buf, 14)
         .header_encoder()
         .sender_comp_id(b"SENDER")
         .target_comp_id(b"TARGET")
@@ -535,6 +538,7 @@ fn alpha_encode_undersized_reservation_shifts_and_stays_valid() {
         .symbol(b"BTC-USD")
         .finish()
         .unwrap();
+    let msg = &buf[start..start + len];
     assert!(msg.starts_with(b"8=FIX.4.4\x01"));
     assert!(nexus_fix_codec::validate_checksum(msg).is_ok());
     let m = venue_alpha::messages::NewOrderSingle::decode(msg).unwrap();
@@ -728,7 +732,7 @@ fn alpha_group_view_absent() {
 #[test]
 fn alpha_group_encode_round_trip() {
     let mut buf = [0u8; 512];
-    let full = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"S")
         .target_comp_id(b"T")
@@ -751,6 +755,7 @@ fn alpha_group_encode_round_trip() {
         .symbol(b"BTC")
         .finish()
         .unwrap();
+    let full = &buf[start..start + len];
 
     assert!(nexus_fix_codec::validate_checksum(full).is_ok());
 
@@ -769,7 +774,7 @@ fn alpha_group_encode_round_trip() {
 #[test]
 fn alpha_nested_group_encode_round_trip() {
     let mut buf = [0u8; 512];
-    let full = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
+    let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
         .sender_comp_id(b"S")
         .target_comp_id(b"T")
@@ -799,6 +804,7 @@ fn alpha_nested_group_encode_round_trip() {
         .symbol(b"BTC")
         .finish()
         .unwrap();
+    let full = &buf[start..start + len];
 
     assert!(nexus_fix_codec::validate_checksum(full).is_ok());
 
@@ -831,7 +837,7 @@ fn beta_group_encode_round_trip() {
     };
 
     let mut buf = [0u8; 512];
-    let full = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)
+    let (start, len) = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)
         .header_encoder()
         .finish()
         .symbol(b"EUR/USD")
@@ -850,6 +856,7 @@ fn beta_group_encode_round_trip() {
         .unwrap()
         .finish()
         .unwrap();
+    let full = &buf[start..start + len];
 
     assert!(nexus_fix_codec::validate_checksum(full).is_ok());
 

--- a/nexus-fix-codegen/src/emit/encoders.rs
+++ b/nexus-fix-codegen/src/emit/encoders.rs
@@ -258,7 +258,10 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
         s,
         "pub struct {enc}<'buf> {{\n    frame: nexus_fix_codec::FrameFormatter<'buf>,\n}}\n\n"
     );
-    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {enc}<'buf> {{");
+    let _ = writeln!(
+        s,
+        "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {enc}<'buf> {{"
+    );
     let _ = write!(
         s,
         "    /// Begin encoding into `buf` (writes `8=`, reserves `9=`, writes `35=`).\n    \
@@ -290,7 +293,10 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
          fn from_formatter(frame: nexus_fix_codec::FrameFormatter<'buf>) -> Self {{\n        \
          Self {{ frame }}\n    }}\n}}\n\n"
     );
-    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {body}<'buf> {{");
+    let _ = writeln!(
+        s,
+        "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {body}<'buf> {{"
+    );
 
     let prefix = pascal(&m.name);
     let mut seen = HashSet::new();
@@ -509,7 +515,10 @@ fn emit_group_encoder_set(
     s.push_str("}\n\n");
 
     // --- GroupEnc impl ---
-    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {group_enc}<'buf> {{");
+    let _ = writeln!(
+        s,
+        "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {group_enc}<'buf> {{"
+    );
 
     // entry()
     let _ = write!(
@@ -579,7 +588,10 @@ fn emit_group_encoder_set(
     s.push_str("}\n\n");
 
     // --- EntryEnc impl ---
-    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {entry_enc}<'buf> {{");
+    let _ = writeln!(
+        s,
+        "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {entry_enc}<'buf> {{"
+    );
 
     let mut seen = HashSet::new();
     for mem in &g.members {

--- a/nexus-fix-codegen/src/emit/encoders.rs
+++ b/nexus-fix-codegen/src/emit/encoders.rs
@@ -8,7 +8,7 @@ use super::{
     group_type, pascal, screaming, snake,
 };
 
-/// Tags owned by FrameWriter — excluded from the header encoder typestate.
+/// Tags owned by FrameFormatter — excluded from the header encoder typestate.
 const FRAME_TAGS: &[u32] = &[8, 9, 10, 35];
 
 // Scratch-buffer widths emitted into generated setters, sized to each kind's
@@ -108,7 +108,7 @@ fn emit_header_encoder(s: &mut String, fields: &[EncHeaderField]) {
     s.push('\n');
     s.push_str(
         "pub struct HeaderEncoder<'buf, S, B> {\n    \
-         frame: nexus_fix_codec::FrameWriter<'buf>,\n    \
+         frame: nexus_fix_codec::FrameFormatter<'buf>,\n    \
          _marker: PhantomData<(S, B)>,\n}\n\n",
     );
 
@@ -116,7 +116,7 @@ fn emit_header_encoder(s: &mut String, fields: &[EncHeaderField]) {
     s.push_str(
         "impl<'buf, B> HeaderEncoder<'buf, HeaderS0, B> {\n    \
          #[inline]\n    \
-         fn start(frame: nexus_fix_codec::FrameWriter<'buf>) -> Self {\n        \
+         fn start(frame: nexus_fix_codec::FrameFormatter<'buf>) -> Self {\n        \
          HeaderEncoder { frame, _marker: PhantomData }\n    }\n}\n\n",
     );
 
@@ -138,11 +138,11 @@ fn emit_header_encoder(s: &mut String, fields: &[EncHeaderField]) {
     let finish_impl = |s: &mut String, state: usize| {
         let _ = write!(
             s,
-            "impl<'buf, B: nexus_fix_codec::FromFrame<'buf>> HeaderEncoder<'buf, HeaderS{state}, B> {{\n    \
+            "impl<'buf, B: nexus_fix_codec::FromFormatter<'buf>> HeaderEncoder<'buf, HeaderS{state}, B> {{\n    \
              /// Finish the header and continue to the message body stage.\n    \
              #[inline]\n    \
              pub fn finish(self) -> B {{\n        \
-             B::from_frame(self.frame)\n    }}\n}}\n\n"
+             B::from_formatter(self.frame)\n    }}\n}}\n\n"
         );
     };
     for i in 0..=n {
@@ -256,20 +256,20 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
     // --- start stage: wrap / wrap_reserved / header_encoder ---
     let _ = write!(
         s,
-        "pub struct {enc}<'buf> {{\n    frame: nexus_fix_codec::FrameWriter<'buf>,\n}}\n\n"
+        "pub struct {enc}<'buf> {{\n    frame: nexus_fix_codec::FrameFormatter<'buf>,\n}}\n\n"
     );
     let _ = writeln!(s, "impl<'buf> {enc}<'buf> {{");
     let _ = write!(
         s,
         "    /// Begin encoding into `buf` (writes `8=`, reserves `9=`, writes `35=`).\n    \
          pub fn wrap(buf: &'buf mut [u8]) -> Self {{\n        \
-         Self {{ frame: nexus_fix_codec::FrameWriter::new(buf, super::BEGIN_STRING, {msgtype}) }}\n    }}\n\n"
+         Self {{ frame: nexus_fix_codec::FrameFormatter::new(buf, super::BEGIN_STRING, {msgtype}) }}\n    }}\n\n"
     );
     let _ = write!(
         s,
         "    /// As [`wrap`](Self::wrap) with an explicit `8=…9=…` prefix reservation.\n    \
          pub fn wrap_reserved(buf: &'buf mut [u8], reserved: usize) -> Self {{\n        \
-         Self {{ frame: nexus_fix_codec::FrameWriter::with_reserved(buf, super::BEGIN_STRING, {msgtype}, reserved) }}\n    }}\n\n"
+         Self {{ frame: nexus_fix_codec::FrameFormatter::with_reserved(buf, super::BEGIN_STRING, {msgtype}, reserved) }}\n    }}\n\n"
     );
     let _ = write!(
         s,
@@ -278,16 +278,16 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
          HeaderEncoder::start(self.frame)\n    }}\n}}\n\n"
     );
 
-    // --- body stage: FromFrame + typed setters + finish ---
+    // --- body stage: FromFormatter + typed setters + finish ---
     let _ = write!(
         s,
-        "pub struct {body}<'buf> {{\n    frame: nexus_fix_codec::FrameWriter<'buf>,\n}}\n\n"
+        "pub struct {body}<'buf> {{\n    frame: nexus_fix_codec::FrameFormatter<'buf>,\n}}\n\n"
     );
     let _ = write!(
         s,
-        "impl<'buf> nexus_fix_codec::FromFrame<'buf> for {body}<'buf> {{\n    \
+        "impl<'buf> nexus_fix_codec::FromFormatter<'buf> for {body}<'buf> {{\n    \
          #[inline]\n    \
-         fn from_frame(frame: nexus_fix_codec::FrameWriter<'buf>) -> Self {{\n        \
+         fn from_formatter(frame: nexus_fix_codec::FrameFormatter<'buf>) -> Self {{\n        \
          Self {{ frame }}\n    }}\n}}\n\n"
     );
     let _ = writeln!(s, "impl<'buf> {body}<'buf> {{");
@@ -316,14 +316,13 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
 
     s.push_str(
         "    /// Finish the message: write `8=`/`9=<canonical BodyLength>` and the\n    \
-         /// `10=<checksum>` trailer, returning the framed message slice.\n    \
+         /// `10=<checksum>` trailer.\n    \
          ///\n    \
-         /// The returned slice may start a few bytes into the buffer (the\n    \
-         /// `8=…9=…` prefix is right-aligned), so transmit exactly the returned\n    \
-         /// slice — not the whole buffer. Returns\n    \
-         /// [`EncodeError::BufferFull`](nexus_fix_codec::EncodeError) if any\n    \
+         /// Returns `(start, len)` — the byte offset and length of the finished\n    \
+         /// message within the buffer. The message is at `buf[start..start + len]`.\n    \
+         /// Returns [`EncodeError::BufferFull`](nexus_fix_codec::EncodeError) if any\n    \
          /// field, the prefix, or the checksum did not fit.\n    \
-         pub fn finish(self) -> Result<&'buf [u8], nexus_fix_codec::EncodeError> {\n        \
+         pub fn finish(self) -> Result<(usize, usize), nexus_fix_codec::EncodeError> {\n        \
          self.frame.finish()\n    }\n}\n\n",
     );
 
@@ -499,7 +498,7 @@ fn emit_group_encoder_set(
     let _ = write!(
         s,
         "pub struct {group_enc}<'buf> {{\n    \
-         frame: nexus_fix_codec::FrameWriter<'buf>,\n    \
+         frame: nexus_fix_codec::FrameFormatter<'buf>,\n    \
          declared: u16,\n    \
          written: u16,\n"
     );
@@ -569,7 +568,7 @@ fn emit_group_encoder_set(
     let _ = write!(
         s,
         "pub struct {entry_enc}<'buf> {{\n    \
-         frame: nexus_fix_codec::FrameWriter<'buf>,\n    \
+         frame: nexus_fix_codec::FrameFormatter<'buf>,\n    \
          group_declared: u16,\n    \
          group_written: u16,\n"
     );

--- a/nexus-fix-codegen/src/emit/encoders.rs
+++ b/nexus-fix-codegen/src/emit/encoders.rs
@@ -258,7 +258,7 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
         s,
         "pub struct {enc}<'buf> {{\n    frame: nexus_fix_codec::FrameFormatter<'buf>,\n}}\n\n"
     );
-    let _ = writeln!(s, "impl<'buf> {enc}<'buf> {{");
+    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {enc}<'buf> {{");
     let _ = write!(
         s,
         "    /// Begin encoding into `buf` (writes `8=`, reserves `9=`, writes `35=`).\n    \
@@ -290,7 +290,7 @@ fn emit_encoder(s: &mut String, m: &RMessage) {
          fn from_formatter(frame: nexus_fix_codec::FrameFormatter<'buf>) -> Self {{\n        \
          Self {{ frame }}\n    }}\n}}\n\n"
     );
-    let _ = writeln!(s, "impl<'buf> {body}<'buf> {{");
+    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {body}<'buf> {{");
 
     let prefix = pascal(&m.name);
     let mut seen = HashSet::new();
@@ -509,7 +509,7 @@ fn emit_group_encoder_set(
     s.push_str("}\n\n");
 
     // --- GroupEnc impl ---
-    let _ = writeln!(s, "impl<'buf> {group_enc}<'buf> {{");
+    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {group_enc}<'buf> {{");
 
     // entry()
     let _ = write!(
@@ -579,7 +579,7 @@ fn emit_group_encoder_set(
     s.push_str("}\n\n");
 
     // --- EntryEnc impl ---
-    let _ = writeln!(s, "impl<'buf> {entry_enc}<'buf> {{");
+    let _ = writeln!(s, "#[allow(clippy::elidable_lifetime_names)]\nimpl<'buf> {entry_enc}<'buf> {{");
 
     let mut seen = HashSet::new();
     for mem in &g.members {

--- a/nexus-fix-engine/Cargo.toml
+++ b/nexus-fix-engine/Cargo.toml
@@ -15,3 +15,4 @@ workspace = true
 
 [dependencies]
 nexus-fix-codec = { path = "../nexus-fix-codec" }
+nexus-net = { path = "../nexus-net" }

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -263,7 +263,10 @@ impl FrameReader {
         };
 
         let body_start = soh2 + 1;
-        let Some(message_end) = body_start.checked_add(body_len).and_then(|n| n.checked_add(CHECKSUM_LEN)) else {
+        let Some(message_end) = body_start
+            .checked_add(body_len)
+            .and_then(|n| n.checked_add(CHECKSUM_LEN))
+        else {
             return ParseResult::Garbage;
         };
 

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -808,10 +808,8 @@ mod tests {
 
     #[test]
     fn message_too_large_followed_by_valid() {
-        let big = new_order(b"VERY-LONG-ORDER-ID-THAT-IS-BIG");
+        let mut data = new_order(b"VERY-LONG-ORDER-ID-THAT-IS-BIG");
         let small = heartbeat();
-
-        let mut data = big.clone();
         data.extend_from_slice(&small);
 
         let mut reader = FrameReader::builder().max_message_size(50).build();

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -1,0 +1,938 @@
+//! FIX message framing over a TCP byte stream.
+//!
+//! [`FrameReader`] buffers inbound bytes and yields complete FIX messages
+//! as `&[u8]` slices. [`FrameWriter`] buffers outbound messages encoded by
+//! the codec. Both are dictionary-independent — using only the structural
+//! tags `8=` (BeginString), `9=` (BodyLength), and `10=` (CheckSum) that
+//! are invariant across all FIX versions.
+
+use nexus_net::buf::{ReadBuf, WriteBuf};
+
+const SOH: u8 = 0x01;
+
+/// Checksum trailer is always `10=XXX\x01` — 7 bytes.
+const CHECKSUM_LEN: usize = 7;
+
+/// Error from [`FrameReader::read`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadError {
+    /// ReadBuf cannot accept the incoming bytes.
+    BufferFull {
+        /// Bytes the caller tried to write.
+        needed: usize,
+        /// Bytes available in the spare region.
+        available: usize,
+    },
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BufferFull { needed, available } => {
+                write!(f, "buffer full: need {needed} bytes, {available} available")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReadError {}
+
+/// Error from [`FrameReader::next`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameError {
+    /// Invalid data was detected and discarded. `skipped` bytes were
+    /// advanced past to reach the next `8=` boundary (or end of buffer).
+    ///
+    /// The reader is ready for the next [`next`](FrameReader::next) call —
+    /// no manual recovery needed.
+    Garbage { skipped: usize },
+    /// Message exceeds the configured maximum size. The message was
+    /// skipped entirely.
+    MessageTooLarge { size: usize },
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Garbage { skipped } => {
+                write!(f, "discarded {skipped} bytes of invalid data")
+            }
+            Self::MessageTooLarge { size } => {
+                write!(f, "message size {size} exceeds configured maximum")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+/// FIX message boundary detector.
+///
+/// Buffers inbound TCP bytes and yields complete FIX messages. Each call
+/// to [`next`](Self::next) returns the next complete message as a raw
+/// `&[u8]` borrowing from the internal buffer, or `None` if more bytes
+/// are needed.
+///
+/// Invalid data is handled automatically: `next()` scans forward to
+/// the next `8=` boundary and returns [`FrameError::Garbage`] with the
+/// number of bytes discarded. The reader is always in a parseable state
+/// after returning — no manual recovery needed.
+///
+/// # Usage
+///
+/// ```
+/// use nexus_fix_engine::FrameReader;
+///
+/// let mut reader = FrameReader::builder()
+///     .buffer_capacity(65_536)
+///     .build();
+///
+/// // A complete Heartbeat message.
+/// let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+/// reader.read(msg).unwrap();
+///
+/// let frame = reader.next().unwrap().unwrap();
+/// assert_eq!(frame, msg.as_slice());
+/// assert!(reader.next().unwrap().is_none());
+/// ```
+pub struct FrameReader {
+    buf: ReadBuf,
+    buf_compact_at: usize,
+    max_message_size: usize,
+    pending_advance: usize,
+}
+
+/// Builder for [`FrameReader`].
+pub struct FrameReaderBuilder {
+    buffer_capacity: usize,
+    compact_at: f64,
+    max_message_size: usize,
+}
+
+enum ParseResult {
+    Complete(usize),
+    Incomplete,
+    Garbage,
+    TooLarge { size: usize, end: usize },
+}
+
+impl FrameReader {
+    /// Create a builder with sensible defaults.
+    #[must_use]
+    pub fn builder() -> FrameReaderBuilder {
+        FrameReaderBuilder {
+            buffer_capacity: 64 * 1024,
+            compact_at: 0.5,
+            max_message_size: 1024 * 1024,
+        }
+    }
+
+    /// Buffer wire bytes from a source slice.
+    pub fn read(&mut self, src: &[u8]) -> Result<(), ReadError> {
+        let mut spare = self.buf.spare();
+        if src.len() > spare.len() {
+            self.buf.compact();
+            spare = self.buf.spare();
+            if src.len() > spare.len() {
+                return Err(ReadError::BufferFull {
+                    needed: src.len(),
+                    available: spare.len(),
+                });
+            }
+        }
+        spare[..src.len()].copy_from_slice(src);
+        self.buf.filled(src.len());
+        Ok(())
+    }
+
+    /// Read bytes from a source directly into the internal buffer.
+    ///
+    /// Returns bytes read, or 0 on EOF.
+    pub fn read_from<R: std::io::Read>(&mut self, src: &mut R) -> std::io::Result<usize> {
+        let mut spare = self.buf.spare();
+        if spare.is_empty() {
+            self.buf.compact();
+            spare = self.buf.spare();
+            if spare.is_empty() {
+                return Err(std::io::Error::other("frame reader buffer full"));
+            }
+        }
+        let n = src.read(spare)?;
+        self.buf.filled(n);
+        Ok(n)
+    }
+
+    /// Writable region for direct socket reads.
+    #[inline]
+    pub fn spare(&mut self) -> &mut [u8] {
+        self.buf.spare()
+    }
+
+    /// Commit bytes written into [`spare()`](Self::spare).
+    #[inline]
+    pub fn filled(&mut self, n: usize) {
+        self.buf.filled(n);
+    }
+
+    /// Reclaim consumed buffer space.
+    #[inline]
+    pub fn compact(&mut self) {
+        self.buf.compact();
+    }
+
+    /// Whether the buffer should be compacted based on the configured threshold.
+    #[inline]
+    pub fn should_compact(&self) -> bool {
+        let consumed = self.buf.consumed();
+        consumed > 0 && consumed >= self.buf_compact_at && !self.buf.is_empty()
+    }
+
+    /// Bytes of buffer space remaining.
+    #[inline]
+    pub fn remaining(&self) -> usize {
+        self.buf.remaining()
+    }
+
+    /// Parse the next complete FIX message.
+    ///
+    /// Returns the full message bytes (`8=…` through `10=XXX\x01`) or
+    /// `None` if more data is needed. Call in a loop after each
+    /// [`read`](Self::read) to drain all complete messages from the buffer.
+    ///
+    /// On invalid data, scans forward to the next `8=` boundary and
+    /// returns [`FrameError::Garbage`]. The reader always makes progress
+    /// on error — the next call starts from the new position.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<&[u8]>, FrameError> {
+        if self.pending_advance > 0 {
+            self.buf.advance(self.pending_advance);
+            self.pending_advance = 0;
+        }
+
+        match self.try_parse() {
+            ParseResult::Complete(end) => {
+                self.pending_advance = end;
+                Ok(Some(&self.buf.data()[..end]))
+            }
+            ParseResult::Incomplete => Ok(None),
+            ParseResult::Garbage => {
+                let skipped = self.skip_to_next_header();
+                Err(FrameError::Garbage { skipped })
+            }
+            ParseResult::TooLarge { size, end } => {
+                if self.buf.data().len() >= end {
+                    self.buf.advance(end);
+                } else {
+                    self.skip_to_next_header();
+                }
+                Err(FrameError::MessageTooLarge { size })
+            }
+        }
+    }
+
+    /// Pure read-only parse: determines the message boundary or error
+    /// without mutating any state.
+    fn try_parse(&self) -> ParseResult {
+        let data = self.buf.data();
+        if data.len() < 2 {
+            return ParseResult::Incomplete;
+        }
+
+        if data[0] != b'8' || data[1] != b'=' {
+            return ParseResult::Garbage;
+        }
+
+        let Some(soh1) = find_soh(data, 2) else {
+            return ParseResult::Incomplete;
+        };
+
+        let tag9 = soh1 + 1;
+        if data.len() < tag9 + 3 {
+            return ParseResult::Incomplete;
+        }
+        if data[tag9] != b'9' || data[tag9 + 1] != b'=' {
+            return ParseResult::Garbage;
+        }
+
+        let digits_start = tag9 + 2;
+        let Some(soh2) = find_soh(data, digits_start) else {
+            return ParseResult::Incomplete;
+        };
+        let Ok(body_len) = parse_body_length(&data[digits_start..soh2]) else {
+            return ParseResult::Garbage;
+        };
+
+        let body_start = soh2 + 1;
+        let message_end = body_start + body_len + CHECKSUM_LEN;
+
+        if message_end > self.max_message_size {
+            return ParseResult::TooLarge {
+                size: message_end,
+                end: message_end,
+            };
+        }
+
+        if data.len() < message_end {
+            return ParseResult::Incomplete;
+        }
+
+        ParseResult::Complete(message_end)
+    }
+
+    /// Scan forward from byte 1 for the next `8=` and advance past
+    /// everything before it. Returns bytes discarded.
+    fn skip_to_next_header(&mut self) -> usize {
+        let data = self.buf.data();
+        for i in 1..data.len().saturating_sub(1) {
+            if data[i] == b'8' && data[i + 1] == b'=' {
+                self.buf.advance(i);
+                return i;
+            }
+        }
+        let len = data.len();
+        self.buf.advance(len);
+        len
+    }
+}
+
+impl FrameReaderBuilder {
+    /// Internal buffer capacity in bytes.
+    ///
+    /// Default: 64 KiB. The buffer is fixed-size — it never reallocates.
+    #[must_use]
+    pub fn buffer_capacity(mut self, cap: usize) -> Self {
+        self.buffer_capacity = cap;
+        self
+    }
+
+    /// Fraction of buffer that must be consumed before [`should_compact`](FrameReader::should_compact)
+    /// returns `true`. Default: 0.5 (50%).
+    #[must_use]
+    pub fn compact_at(mut self, ratio: f64) -> Self {
+        self.compact_at = ratio;
+        self
+    }
+
+    /// Maximum message size in bytes. Messages exceeding this return
+    /// [`FrameError::MessageTooLarge`]. Default: 1 MiB.
+    #[must_use]
+    pub fn max_message_size(mut self, max: usize) -> Self {
+        self.max_message_size = max;
+        self
+    }
+
+    /// Build the [`FrameReader`].
+    #[must_use]
+    pub fn build(self) -> FrameReader {
+        let buf = ReadBuf::with_capacity(self.buffer_capacity);
+        let buf_compact_at = (self.buffer_capacity as f64 * self.compact_at) as usize;
+        FrameReader {
+            buf,
+            buf_compact_at,
+            max_message_size: self.max_message_size,
+            pending_advance: 0,
+        }
+    }
+}
+
+/// Find the next SOH byte (`\x01`) starting at `from`.
+///
+/// SWAR (SIMD Within A Register): processes 8 bytes per iteration
+/// using u64 arithmetic. Sufficient for the short scans in header
+/// parsing (~8-12 bytes to first SOH).
+#[inline]
+fn find_soh(data: &[u8], from: usize) -> Option<usize> {
+    const HI: u64 = 0x8080_8080_8080_8080;
+    const LO: u64 = 0x0101_0101_0101_0101;
+
+    let bytes = data.get(from..)?;
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let splat = LO; // LO * 0x01 == LO
+    let mut i = 0;
+
+    while i + 8 <= bytes.len() {
+        // SAFETY: bounds checked by the while condition
+        let chunk: [u8; 8] = unsafe { bytes.as_ptr().add(i).cast::<[u8; 8]>().read_unaligned() };
+        let word = u64::from_ne_bytes(chunk);
+        let xored = word ^ splat;
+        let mask = xored.wrapping_sub(LO) & !xored & HI;
+        if mask != 0 {
+            let offset = (mask.trailing_zeros() / 8) as usize;
+            return Some(from + i + offset);
+        }
+        i += 8;
+    }
+
+    while i < bytes.len() {
+        if bytes[i] == SOH {
+            return Some(from + i);
+        }
+        i += 1;
+    }
+
+    None
+}
+
+/// Parse an ASCII decimal integer from a byte slice.
+fn parse_body_length(digits: &[u8]) -> Result<usize, ()> {
+    if digits.is_empty() {
+        return Err(());
+    }
+    let mut n: usize = 0;
+    for &b in digits {
+        if !b.is_ascii_digit() {
+            return Err(());
+        }
+        n = n
+            .checked_mul(10)
+            .and_then(|n| n.checked_add((b - b'0') as usize))
+            .ok_or(())?;
+    }
+    Ok(n)
+}
+
+// =============================================================================
+// FrameWriter
+// =============================================================================
+
+/// Outbound FIX message buffer.
+///
+/// Thin wrapper around [`WriteBuf`](nexus_net::buf::WriteBuf) providing
+/// symmetry with [`FrameReader`]. The codec (via
+/// [`FrameFormatter`](nexus_fix_codec::FrameFormatter)) handles all message
+/// encoding — FrameWriter just manages the write buffer.
+///
+/// # Usage
+///
+/// ```
+/// use nexus_fix_engine::FrameWriter;
+/// use nexus_fix_codec::FrameFormatter;
+///
+/// let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+///
+/// // Encode a Heartbeat into the writer's spare region.
+/// let spare = writer.spare();
+/// let mut fmt = FrameFormatter::new(spare, b"FIX.4.4", b"0");
+/// let (start, len) = fmt.finish().unwrap();
+///
+/// // Commit the encoded message.
+/// writer.commit(start, len);
+///
+/// // Data is ready for the socket.
+/// assert!(!writer.is_empty());
+/// assert!(writer.data().starts_with(b"8=FIX.4.4\x01"));
+/// ```
+pub struct FrameWriter(WriteBuf);
+
+/// Builder for [`FrameWriter`].
+pub struct FrameWriterBuilder {
+    buffer_capacity: usize,
+}
+
+impl FrameWriter {
+    /// Create a builder with sensible defaults.
+    #[must_use]
+    pub fn builder() -> FrameWriterBuilder {
+        FrameWriterBuilder {
+            buffer_capacity: 64 * 1024,
+        }
+    }
+
+    /// Writable region for encoding a message via
+    /// [`FrameFormatter`](nexus_fix_codec::FrameFormatter).
+    #[inline]
+    pub fn spare(&mut self) -> &mut [u8] {
+        self.0.spare()
+    }
+
+    /// Commit a finished message into the write buffer.
+    ///
+    /// `start` and `len` come from
+    /// [`FrameFormatter::finish()`](nexus_fix_codec::FrameFormatter::finish).
+    /// Closes the right-alignment gap (if any) so the message is contiguous
+    /// with any previously buffered data.
+    #[inline]
+    pub fn commit(&mut self, start: usize, len: usize) {
+        if start > 0 {
+            self.0.spare().copy_within(start..start + len, 0);
+        }
+        self.0.filled(len);
+    }
+
+    /// Pending bytes ready for socket write.
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        self.0.data()
+    }
+
+    /// Consume `n` bytes after a successful socket write.
+    ///
+    /// Auto-resets the buffer when fully drained.
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        self.0.advance(n);
+    }
+
+    /// Whether there are pending bytes to write.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Bytes of spare capacity remaining.
+    #[inline]
+    pub fn remaining(&self) -> usize {
+        self.0.tailroom()
+    }
+}
+
+impl FrameWriterBuilder {
+    /// Total buffer capacity in bytes. Default: 64 KiB.
+    #[must_use]
+    pub fn buffer_capacity(mut self, capacity: usize) -> Self {
+        self.buffer_capacity = capacity;
+        self
+    }
+
+    /// Build the [`FrameWriter`].
+    #[must_use]
+    pub fn build(self) -> FrameWriter {
+        FrameWriter(WriteBuf::new(self.buffer_capacity, 0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn heartbeat() -> Vec<u8> {
+        let mut buf = [0u8; 128];
+        let (start, len) = nexus_fix_codec::FrameFormatter::new(&mut buf, b"FIX.4.4", b"0")
+            .finish()
+            .unwrap();
+        buf[start..start + len].to_vec()
+    }
+
+    fn new_order(clord_id: &[u8]) -> Vec<u8> {
+        let mut buf = [0u8; 256];
+        let mut f = nexus_fix_codec::FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
+        f.field(49, b"SENDER");
+        f.field(56, b"TARGET");
+        f.field(11, clord_id);
+        let (start, len) = f.finish().unwrap();
+        buf[start..start + len].to_vec()
+    }
+
+    // ---- happy path ----
+
+    #[test]
+    fn single_message() {
+        let msg = heartbeat();
+        let mut reader = FrameReader::builder().build();
+        reader.read(&msg).unwrap();
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn two_messages_in_one_read() {
+        let mut data = heartbeat();
+        let second = new_order(b"ORD-1");
+        data.extend_from_slice(&second);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let f1 = reader.next().unwrap().unwrap().to_vec();
+        let f2 = reader.next().unwrap().unwrap().to_vec();
+        assert!(reader.next().unwrap().is_none());
+
+        assert_eq!(f1, heartbeat());
+        assert_eq!(f2, second);
+    }
+
+    #[test]
+    fn incomplete_then_complete() {
+        let msg = heartbeat();
+        let split = msg.len() / 2;
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&msg[..split]).unwrap();
+        assert!(reader.next().unwrap().is_none());
+
+        reader.read(&msg[split..]).unwrap();
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn byte_at_a_time() {
+        let msg = heartbeat();
+        let mut reader = FrameReader::builder().build();
+
+        for (i, &b) in msg.iter().enumerate() {
+            reader.read(&[b]).unwrap();
+            if i < msg.len() - 1 {
+                assert!(reader.next().unwrap().is_none());
+            }
+        }
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn three_messages_sequential() {
+        let m1 = new_order(b"A");
+        let m2 = new_order(b"BB");
+        let m3 = heartbeat();
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&m1).unwrap();
+        reader.read(&m2).unwrap();
+        reader.read(&m3).unwrap();
+
+        assert_eq!(reader.next().unwrap().unwrap(), m1.as_slice());
+        assert_eq!(reader.next().unwrap().unwrap(), m2.as_slice());
+        assert_eq!(reader.next().unwrap().unwrap(), m3.as_slice());
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn spare_and_filled() {
+        let msg = heartbeat();
+        let mut reader = FrameReader::builder().build();
+
+        let spare = reader.spare();
+        spare[..msg.len()].copy_from_slice(&msg);
+        reader.filled(msg.len());
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn read_from_io() {
+        let msg = heartbeat();
+        let mut cursor = std::io::Cursor::new(&msg);
+        let mut reader = FrameReader::builder().build();
+
+        let n = reader.read_from(&mut cursor).unwrap();
+        assert_eq!(n, msg.len());
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    // ---- garbage recovery ----
+
+    #[test]
+    fn garbage_prefix_skipped() {
+        let msg = heartbeat();
+        let mut data = b"GARBAGE".to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        // next() detects garbage, skips to 8=, returns error.
+        let err = reader.next().unwrap_err();
+        assert_eq!(err, FrameError::Garbage { skipped: 7 });
+
+        // Next call picks up the valid message.
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_missing_body_length() {
+        // 8= present but 9= missing — entire malformed start is garbage.
+        let garbage = b"8=FIX.4.4\x0135=0\x01";
+        let msg = heartbeat();
+        let mut data = garbage.to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert_eq!(
+            err,
+            FrameError::Garbage {
+                skipped: garbage.len()
+            }
+        );
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_invalid_body_length() {
+        let garbage = b"8=FIX.4.4\x019=abc\x01";
+        let msg = heartbeat();
+        let mut data = garbage.to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_body_length_overflow() {
+        let garbage = b"8=FIX.4.4\x019=99999999999999999999\x01";
+        let msg = heartbeat();
+        let mut data = garbage.to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_all_discarded_when_no_header() {
+        let mut reader = FrameReader::builder().build();
+        reader.read(b"no valid message here at all").unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert_eq!(err, FrameError::Garbage { skipped: 28 });
+
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn garbage_false_8_equals_keeps_scanning() {
+        // `8=` in garbage but not a valid message start. next() will
+        // land on it, detect garbage again, then find the real message.
+        let msg = heartbeat();
+        let mut data = b"XX8=junk\x01".to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        // First next(): skips XX, lands on false 8=.
+        let err = reader.next().unwrap_err();
+        assert_eq!(err, FrameError::Garbage { skipped: 2 });
+
+        // Second next(): false 8= has no valid 9=, skips to real 8=.
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        // Third next(): real message.
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_empty_body_length() {
+        let garbage = b"8=FIX.4.4\x019=\x01";
+        let msg = heartbeat();
+        let mut data = garbage.to_vec();
+        data.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    // ---- message too large ----
+
+    #[test]
+    fn message_too_large() {
+        let mut reader = FrameReader::builder().max_message_size(32).build();
+        let msg = new_order(b"ORD-1");
+        reader.read(&msg).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::MessageTooLarge { .. }));
+
+        // Reader advanced past the message.
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn message_too_large_followed_by_valid() {
+        let big = new_order(b"VERY-LONG-ORDER-ID-THAT-IS-BIG");
+        let small = heartbeat();
+
+        let mut data = big.clone();
+        data.extend_from_slice(&small);
+
+        let mut reader = FrameReader::builder().max_message_size(50).build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::MessageTooLarge { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, small.as_slice());
+    }
+
+    // ---- buffer management ----
+
+    #[test]
+    fn buffer_full() {
+        let mut reader = FrameReader::builder().buffer_capacity(16).build();
+        let msg = heartbeat();
+        let err = reader.read(&msg).unwrap_err();
+        assert!(matches!(err, ReadError::BufferFull { .. }));
+    }
+
+    #[test]
+    fn compact_reclaims_space() {
+        let msg = heartbeat();
+        let mut reader = FrameReader::builder()
+            .buffer_capacity(msg.len() + 8)
+            .build();
+
+        reader.read(&msg).unwrap();
+        let _ = reader.next().unwrap().unwrap();
+
+        assert!(reader.next().unwrap().is_none());
+        reader.compact();
+
+        reader.read(&msg).unwrap();
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn should_compact_threshold() {
+        let m1 = heartbeat();
+        let m2 = new_order(b"A");
+        let mut reader = FrameReader::builder()
+            .buffer_capacity((m1.len() + m2.len()) * 2)
+            .compact_at(0.1)
+            .build();
+
+        reader.read(&m1).unwrap();
+        reader.read(&m2).unwrap();
+        assert!(!reader.should_compact());
+
+        let _ = reader.next().unwrap().unwrap();
+        let _ = reader.next().unwrap().unwrap();
+        assert!(reader.should_compact());
+    }
+
+    // ---- FrameWriter ----
+
+    #[test]
+    fn writer_encode_and_read_back() {
+        let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len) = fmt.finish().unwrap();
+        writer.commit(start, len);
+
+        assert!(!writer.is_empty());
+        assert!(writer.data().starts_with(b"8=FIX.4.4\x01"));
+        assert_eq!(writer.data().len(), len);
+    }
+
+    #[test]
+    fn writer_multiple_messages() {
+        let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+
+        // First message.
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len1) = fmt.finish().unwrap();
+        writer.commit(start, len1);
+
+        // Second message.
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"D");
+        fmt.field(49, b"SENDER");
+        fmt.field(11, b"ORD-1");
+        let (start, len2) = fmt.finish().unwrap();
+        writer.commit(start, len2);
+
+        assert_eq!(writer.data().len(), len1 + len2);
+
+        // Both messages should be valid FIX.
+        let data = writer.data();
+        assert!(nexus_fix_codec::validate_checksum(&data[..len1]).is_ok());
+        assert!(nexus_fix_codec::validate_checksum(&data[len1..]).is_ok());
+    }
+
+    #[test]
+    fn writer_advance_drains() {
+        let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len) = fmt.finish().unwrap();
+        writer.commit(start, len);
+
+        assert!(!writer.is_empty());
+        writer.advance(len);
+        assert!(writer.is_empty());
+    }
+
+    #[test]
+    fn writer_partial_advance() {
+        let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len) = fmt.finish().unwrap();
+        writer.commit(start, len);
+
+        let half = len / 2;
+        writer.advance(half);
+        assert_eq!(writer.data().len(), len - half);
+    }
+
+    #[test]
+    fn writer_remaining_decreases() {
+        let mut writer = FrameWriter::builder().buffer_capacity(256).build();
+        let before = writer.remaining();
+
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len) = fmt.finish().unwrap();
+        writer.commit(start, len);
+
+        assert_eq!(writer.remaining(), before - len);
+    }
+
+    #[test]
+    fn writer_gap_is_closed() {
+        // Use a large buffer so the reservation is wider than needed,
+        // producing a nonzero start offset from finish().
+        let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
+
+        let spare = writer.spare();
+        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let (start, len) = fmt.finish().unwrap();
+        assert!(start > 0, "expected nonzero start from right-alignment");
+        writer.commit(start, len);
+
+        // data() should start right at the message — no gap.
+        assert!(writer.data().starts_with(b"8=FIX.4.4\x01"));
+        assert_eq!(writer.data().len(), len);
+    }
+}

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -263,7 +263,9 @@ impl FrameReader {
         };
 
         let body_start = soh2 + 1;
-        let message_end = body_start + body_len + CHECKSUM_LEN;
+        let Some(message_end) = body_start.checked_add(body_len).and_then(|n| n.checked_add(CHECKSUM_LEN)) else {
+            return ParseResult::Garbage;
+        };
 
         if message_end > self.max_message_size {
             return ParseResult::TooLarge {
@@ -309,6 +311,10 @@ impl FrameReaderBuilder {
     /// returns `true`. Default: 0.5 (50%).
     #[must_use]
     pub fn compact_at(mut self, ratio: f64) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&ratio),
+            "compact_at must be between 0.0 and 1.0, got {ratio}"
+        );
         self.compact_at = ratio;
         self
     }
@@ -706,6 +712,31 @@ mod tests {
     }
 
     #[test]
+    fn garbage_body_length_addition_overflow() {
+        // body_len parses successfully but body_start + body_len + CHECKSUM_LEN
+        // overflows usize — must be treated as garbage, not wrap around.
+        let val = (usize::MAX - 10).to_string();
+        let mut garbage = format!("8=FIX.4.4\x019={val}\x01").into_bytes();
+        let msg = heartbeat();
+        garbage.extend_from_slice(&msg);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&garbage).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    #[should_panic(expected = "compact_at must be between 0.0 and 1.0")]
+    fn compact_at_rejects_invalid() {
+        let _ = FrameReader::builder().compact_at(1.5).build();
+    }
+
+    #[test]
     fn garbage_all_discarded_when_no_header() {
         let mut reader = FrameReader::builder().build();
         reader.read(b"no valid message here at all").unwrap();
@@ -843,7 +874,7 @@ mod tests {
         let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
 
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len) = fmt.finish().unwrap();
         writer.commit(start, len);
 
@@ -858,7 +889,7 @@ mod tests {
 
         // First message.
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len1) = fmt.finish().unwrap();
         writer.commit(start, len1);
 
@@ -883,7 +914,7 @@ mod tests {
         let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
 
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len) = fmt.finish().unwrap();
         writer.commit(start, len);
 
@@ -897,7 +928,7 @@ mod tests {
         let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
 
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len) = fmt.finish().unwrap();
         writer.commit(start, len);
 
@@ -912,7 +943,7 @@ mod tests {
         let before = writer.remaining();
 
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len) = fmt.finish().unwrap();
         writer.commit(start, len);
 
@@ -926,7 +957,7 @@ mod tests {
         let mut writer = FrameWriter::builder().buffer_capacity(4096).build();
 
         let spare = writer.spare();
-        let mut fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
+        let fmt = nexus_fix_codec::FrameFormatter::new(spare, b"FIX.4.4", b"0");
         let (start, len) = fmt.finish().unwrap();
         assert!(start > 0, "expected nonzero start from right-alignment");
         writer.commit(start, len);

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -11,6 +11,8 @@ mod frame;
 mod framework;
 mod session;
 
-pub use frame::{FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError};
+pub use frame::{
+    FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
+};
 pub use framework::{CompId, Session, SessionConfig, SessionError};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -7,8 +7,10 @@
 //! session event. The framework layer above encodes those messages and drives
 //! the transport.
 
+mod frame;
 mod framework;
 mod session;
 
+pub use frame::{FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError};
 pub use framework::{CompId, Session, SessionConfig, SessionError};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};


### PR DESCRIPTION
## Summary

- **FrameReader** in `nexus-fix-engine`: dictionary-independent FIX message boundary detection over a TCP byte stream. Owns a `ReadBuf`, yields complete messages as `&[u8]` slices. Handles garbage data internally — `next()` scans to the next `8=` boundary and returns `FrameError::Garbage { skipped }`. SWAR-accelerated SOH scanning (8 bytes/iter).
- **FrameWriter** in `nexus-fix-engine`: thin newtype over `WriteBuf` for outbound message buffering. The codec encodes into `spare()`, caller commits with `(start, len)` from `FrameFormatter::finish()`. Closes the right-alignment gap on commit so messages are contiguous.
- **Rename** `FrameWriter` → `FrameFormatter` in `nexus-fix-codec` — it formats into `&mut [u8]`, not a socket writer. Updated across codec, codegen, and examples.
- **`FrameFormatter::finish()`** now returns `(usize, usize)` instead of `&[u8]` — avoids borrow conflicts when committing into a `WriteBuf`.

Closes #464.

## Test plan

- [x] `cargo test -p nexus-fix-codec -p nexus-fix-engine -p nexus-fix-codegen`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Verify codegen tests still pass (54 tests exercise generated encoder `finish()`)
- [x] Verify FrameReader garbage recovery (7 tests covering false headers, empty body length, pure garbage)
- [x] Verify FrameWriter gap closure (test with large buffer where `start > 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)