### PR TITLE
feat: FrameWriter owns WriteBuf (#467)

### DIFF
--- a/nexus-async-web/benches/perf_async_ws.rs
+++ b/nexus-async-web/benches/perf_async_ws.rs
@@ -349,7 +349,6 @@ fn bench_deser_only<T: for<'de> Deserialize<'de>>(json: &str, msg_count: u64) ->
 async fn bench_stream_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
     use futures_util::StreamExt;
     use nexus_async_web::ws::{WsReader, WsStream, WsWriter};
-    use nexus_net::buf::WriteBuf;
     use nexus_web::ws::{FrameReader, FrameWriter, Role};
 
     let conn = AsyncReadAdapter::new(MockAsyncReader { data: wire, pos: 0 });
@@ -360,8 +359,7 @@ async fn bench_stream_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
             .build(),
         usize::MAX,
     );
-    let writer =
-        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14));
+    let writer = WsWriter::from_raw_parts(FrameWriter::new(Role::Client, 65_536));
     let mut ws = WsStream::from_parts(reader, writer, conn);
 
     let start = Instant::now();
@@ -987,7 +985,7 @@ fn bench_blocking_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
         .role(Role::Client)
         .buffer_capacity(64 * 1024)
         .build();
-    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client));
+    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client, 65_536));
 
     let start = Instant::now();
     let mut received = 0u64;

--- a/nexus-async-web/benches/perf_async_ws_nexus.rs
+++ b/nexus-async-web/benches/perf_async_ws_nexus.rs
@@ -233,7 +233,7 @@ fn bench_blocking(wire: &[u8], msg_count: u64) -> (Duration, u64) {
         .role(Role::Client)
         .buffer_capacity(64 * 1024)
         .build();
-    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client));
+    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client, 65_536));
 
     let start = Instant::now();
     let mut received = 0u64;

--- a/nexus-async-web/benches/perf_ws_cycles_nexus.rs
+++ b/nexus-async-web/benches/perf_ws_cycles_nexus.rs
@@ -16,7 +16,6 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use nexus_async_rt::{AsyncRead, AsyncWrite};
 use nexus_async_web::NexusAsyncReadAdapter;
 use nexus_async_web::ws::{WsReader, WsWriter};
-use nexus_net::buf::WriteBuf;
 use nexus_web::ws::{FrameReader, FrameWriter, Role};
 
 // =============================================================================
@@ -207,7 +206,7 @@ fn make_parts(
         .build();
     (
         WsReader::from_raw_parts(reader, usize::MAX),
-        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14)),
+        WsWriter::from_raw_parts(FrameWriter::new(Role::Client, 65_536)),
         mock,
     )
 }

--- a/nexus-async-web/benches/perf_ws_cycles_tokio.rs
+++ b/nexus-async-web/benches/perf_ws_cycles_tokio.rs
@@ -14,7 +14,6 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use nexus_async_web::AsyncReadAdapter;
 use nexus_async_web::ws::{WsReader, WsWriter};
-use nexus_net::buf::WriteBuf;
 use nexus_web::ws::{FrameReader, FrameWriter, Role};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -206,7 +205,7 @@ fn make_parts(
         .build();
     (
         WsReader::from_raw_parts(reader, usize::MAX),
-        WsWriter::from_raw_parts(FrameWriter::new(Role::Client), WriteBuf::new(65_536, 14)),
+        WsWriter::from_raw_parts(FrameWriter::new(Role::Client, 65_536)),
         mock,
     )
 }

--- a/nexus-async-web/src/ws/nexus/stream.rs
+++ b/nexus-async-web/src/ws/nexus/stream.rs
@@ -8,7 +8,6 @@ use std::net::ToSocketAddrs;
 
 use nexus_async_rt::TcpStream;
 use nexus_net::WireStream;
-use nexus_net::buf::WriteBuf;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_web::http::HTTP_HANDSHAKE_BUFFER;
@@ -103,8 +102,7 @@ async fn connect_handshake<S: WireStream + Unpin>(
                         max_read_size,
                     },
                     WsWriter {
-                        writer: FrameWriter::new(Role::Client),
-                        write_buf: WriteBuf::new(write_cap, 14),
+                        writer: FrameWriter::new(Role::Client, write_cap),
                     },
                     stream,
                 ));
@@ -199,8 +197,7 @@ async fn accept_handshake<S: WireStream + Unpin>(
             max_read_size,
         },
         WsWriter {
-            writer: FrameWriter::new(Role::Server),
-            write_buf: WriteBuf::new(write_cap, 14),
+            writer: FrameWriter::new(Role::Server, write_cap),
         },
         stream,
     ))
@@ -624,15 +621,13 @@ mod tests {
     fn parts_from_bytes(data: Vec<u8>) -> (WsReader, WsWriter, NexusAsyncReadAdapter<MockStream>) {
         let mock = NexusAsyncReadAdapter::new(MockStream::from_bytes(data));
         let reader = FrameReader::builder().role(Role::Client).build();
-        let writer = FrameWriter::new(Role::Client);
         (
             WsReader {
                 reader,
                 max_read_size: usize::MAX,
             },
             WsWriter {
-                writer,
-                write_buf: WriteBuf::new(65_536, 14),
+                writer: FrameWriter::new(Role::Client, 65_536),
             },
             mock,
         )
@@ -846,8 +841,7 @@ mod tests {
     fn send_on_broken_stream_returns_error() {
         let mock = NexusAsyncReadAdapter::new(BrokenWriteStream(Cursor::new(Vec::new())));
         let mut writer = WsWriter {
-            writer: FrameWriter::new(Role::Client),
-            write_buf: WriteBuf::new(65_536, 14),
+            writer: FrameWriter::new(Role::Client, 65_536),
         };
         let mut conn = mock;
 

--- a/nexus-async-web/src/ws/parts.rs
+++ b/nexus-async-web/src/ws/parts.rs
@@ -7,7 +7,6 @@
 use std::io;
 use std::pin::Pin;
 
-use nexus_net::buf::WriteBuf;
 use nexus_net::{ParserSink, WireStream};
 use nexus_web::ws::{CloseCode, Error as WsError, FrameReader, FrameWriter, Message};
 
@@ -133,21 +132,19 @@ impl WsReader {
 
 /// Write half of a WebSocket connection.
 ///
-/// Owns the [`FrameWriter`] and [`WriteBuf`]. Encodes outgoing
-/// frames and flushes them through a transport connection passed
-/// to each send method.
+/// Owns the [`FrameWriter`]. Encodes outgoing frames and flushes them
+/// through a transport connection passed to each send method.
 pub struct WsWriter {
     pub(crate) writer: FrameWriter,
-    pub(crate) write_buf: WriteBuf,
 }
 
 impl WsWriter {
-    /// Construct from raw nexus-web types.
+    /// Construct from a [`FrameWriter`].
     ///
     /// For custom handshakes or testing. Prefer using
     /// [`WsStreamBuilder`](super::WsStreamBuilder) for normal connections.
-    pub fn from_raw_parts(writer: FrameWriter, write_buf: WriteBuf) -> Self {
-        Self { writer, write_buf }
+    pub fn from_raw_parts(writer: FrameWriter) -> Self {
+        Self { writer }
     }
 
     /// Send a text message.
@@ -156,9 +153,8 @@ impl WsWriter {
         conn: &mut S,
         text: &str,
     ) -> Result<(), WsError> {
-        self.writer
-            .encode_text_into(text.as_bytes(), &mut self.write_buf);
-        write_all_async(conn, self.write_buf.data()).await?;
+        self.writer.encode_text(text.as_bytes());
+        write_all_async(conn, self.writer.data()).await?;
         Ok(())
     }
 
@@ -168,8 +164,8 @@ impl WsWriter {
         conn: &mut S,
         data: &[u8],
     ) -> Result<(), WsError> {
-        self.writer.encode_binary_into(data, &mut self.write_buf);
-        write_all_async(conn, self.write_buf.data()).await?;
+        self.writer.encode_binary(data);
+        write_all_async(conn, self.writer.data()).await?;
         Ok(())
     }
 
@@ -179,10 +175,8 @@ impl WsWriter {
         conn: &mut S,
         data: &[u8],
     ) -> Result<(), WsError> {
-        self.writer
-            .encode_ping_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(conn, self.write_buf.data()).await?;
+        self.writer.encode_ping(data).map_err(WsError::Encode)?;
+        write_all_async(conn, self.writer.data()).await?;
         Ok(())
     }
 
@@ -192,10 +186,8 @@ impl WsWriter {
         conn: &mut S,
         data: &[u8],
     ) -> Result<(), WsError> {
-        self.writer
-            .encode_pong_into(data, &mut self.write_buf)
-            .map_err(WsError::Encode)?;
-        write_all_async(conn, self.write_buf.data()).await?;
+        self.writer.encode_pong(data).map_err(WsError::Encode)?;
+        write_all_async(conn, self.writer.data()).await?;
         Ok(())
     }
 
@@ -207,15 +199,13 @@ impl WsWriter {
         reason: &str,
     ) -> Result<(), WsError> {
         if code == CloseCode::NoStatus {
-            let mut dst = [0u8; 14];
-            let n = self.writer.encode_empty_close(&mut dst);
-            write_all_async(conn, &dst[..n]).await?;
+            self.writer.encode_empty_close();
         } else {
             self.writer
-                .encode_close_into(code.as_u16(), reason.as_bytes(), &mut self.write_buf)
+                .encode_close(code.as_u16(), reason.as_bytes())
                 .map_err(WsError::Encode)?;
-            write_all_async(conn, self.write_buf.data()).await?;
         }
+        write_all_async(conn, self.writer.data()).await?;
         Ok(())
     }
 

--- a/nexus-async-web/src/ws/tokio/stream.rs
+++ b/nexus-async-web/src/ws/tokio/stream.rs
@@ -6,7 +6,6 @@
 use std::pin::Pin;
 
 use nexus_net::WireStream;
-use nexus_net::buf::WriteBuf;
 #[cfg(feature = "tls")]
 use nexus_net::tls::TlsConfig;
 use nexus_web::http::HTTP_HANDSHAKE_BUFFER;
@@ -102,8 +101,7 @@ async fn connect_handshake<S: WireStream + Unpin>(
                         max_read_size,
                     },
                     WsWriter {
-                        writer: FrameWriter::new(Role::Client),
-                        write_buf: WriteBuf::new(write_cap, 14),
+                        writer: FrameWriter::new(Role::Client, write_cap),
                     },
                     stream,
                 ));
@@ -198,8 +196,7 @@ async fn accept_handshake<S: WireStream + Unpin>(
             max_read_size,
         },
         WsWriter {
-            writer: FrameWriter::new(Role::Server),
-            write_buf: WriteBuf::new(write_cap, 14),
+            writer: FrameWriter::new(Role::Server, write_cap),
         },
         stream,
     ))
@@ -231,7 +228,6 @@ pub struct WsStream<S> {
     stream: S,
     reader: FrameReader,
     writer: FrameWriter,
-    write_buf: WriteBuf,
     max_read_size: usize,
 }
 
@@ -245,7 +241,6 @@ impl<S> WsStream<S> {
             max_read_size: reader.max_read_size,
             reader: reader.reader,
             writer: writer.writer,
-            write_buf: writer.write_buf,
         }
     }
 
@@ -258,7 +253,6 @@ impl<S> WsStream<S> {
             },
             WsWriter {
                 writer: self.writer,
-                write_buf: self.write_buf,
             },
             self.stream,
         )
@@ -273,7 +267,6 @@ impl<S> WsStream<S> {
             stream,
             reader,
             writer,
-            write_buf: WriteBuf::new(65_536, 14),
             max_read_size: usize::MAX,
         }
     }
@@ -640,35 +633,23 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
         let this = self.get_mut();
         match &item {
             OwnedMessage::Text(s) => {
-                this.writer
-                    .encode_text_into(s.as_bytes(), &mut this.write_buf);
+                this.writer.encode_text(s.as_bytes());
             }
             OwnedMessage::Binary(b) => {
-                this.writer.encode_binary_into(b, &mut this.write_buf);
+                this.writer.encode_binary(b);
             }
             OwnedMessage::Ping(b) => {
-                this.writer
-                    .encode_ping_into(b, &mut this.write_buf)
-                    .map_err(WsError::Encode)?;
+                this.writer.encode_ping(b).map_err(WsError::Encode)?;
             }
             OwnedMessage::Pong(b) => {
-                this.writer
-                    .encode_pong_into(b, &mut this.write_buf)
-                    .map_err(WsError::Encode)?;
+                this.writer.encode_pong(b).map_err(WsError::Encode)?;
             }
             OwnedMessage::Close(cf) => {
                 if cf.code == CloseCode::NoStatus {
-                    let mut dst = [0u8; 14];
-                    let n = this.writer.encode_empty_close(&mut dst);
-                    this.write_buf.clear();
-                    this.write_buf.append(&dst[..n]);
+                    this.writer.encode_empty_close();
                 } else {
                     this.writer
-                        .encode_close_into(
-                            cf.code.as_u16(),
-                            cf.reason.as_bytes(),
-                            &mut this.write_buf,
-                        )
+                        .encode_close(cf.code.as_u16(), cf.reason.as_bytes())
                         .map_err(WsError::Encode)?;
                 }
             }
@@ -678,8 +659,8 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
-        while !this.write_buf.is_empty() {
-            let data = this.write_buf.data();
+        while !this.writer.data().is_empty() {
+            let data = this.writer.data();
             match Pin::new(&mut this.stream).poll_write(cx, data) {
                 Poll::Ready(Ok(0)) => {
                     return Poll::Ready(Err(WsError::Io(std::io::Error::new(
@@ -688,7 +669,7 @@ impl<S: WireStream + Unpin> Sink<OwnedMessage> for WsStream<S> {
                     ))));
                 }
                 Poll::Ready(Ok(n)) => {
-                    this.write_buf.advance(n);
+                    this.writer.advance(n);
                 }
                 Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
                 Poll::Pending => return Poll::Pending,
@@ -776,7 +757,7 @@ mod tests {
     fn parts_from_bytes(data: Vec<u8>) -> (WsReader, WsWriter, AsyncReadAdapter<MockStream>) {
         let mock = AsyncReadAdapter::new(MockStream(Cursor::new(data)));
         let reader = FrameReader::builder().role(Role::Client).build();
-        let writer = FrameWriter::new(Role::Client);
+        let writer = FrameWriter::new(Role::Client, 65_536);
         let ws = WsStream::from_raw_parts(mock, reader, writer);
         ws.into_parts()
     }
@@ -1035,7 +1016,7 @@ mod tests {
     async fn send_on_broken_stream_returns_error() {
         let mock = AsyncReadAdapter::new(BrokenWriteStream(Cursor::new(Vec::new())));
         let reader = FrameReader::builder().role(Role::Client).build();
-        let writer = FrameWriter::new(Role::Client);
+        let writer = FrameWriter::new(Role::Client, 65_536);
         let (_, mut ws_writer, mut conn) =
             WsStream::from_raw_parts(mock, reader, writer).into_parts();
 

--- a/nexus-web/benches/frame_writer.rs
+++ b/nexus-web/benches/frame_writer.rs
@@ -4,19 +4,18 @@
 //!   cargo bench -p nexus-web --bench frame_writer
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use nexus_web::buf::WriteBuf;
 use nexus_web::ws::{FrameWriter, Role};
 
 fn bench_encode_text_server(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_text_server");
     for size in [32, 128, 512, 2048, 4096] {
-        let mut writer = FrameWriter::new(Role::Server);
+        let mut writer = FrameWriter::new(Role::Server, size + 14);
         let payload = vec![b'x'; size];
         let mut dst = vec![0u8; writer.max_encoded_len(size)];
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |b, payload| {
             b.iter(|| {
-                let n = writer.encode_text(payload, &mut dst);
+                let n = writer.encode_text_raw(payload, &mut dst);
                 black_box(n);
             });
         });
@@ -27,13 +26,13 @@ fn bench_encode_text_server(c: &mut Criterion) {
 fn bench_encode_text_client(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_text_client");
     for size in [32, 128, 512, 2048, 4096] {
-        let mut writer = FrameWriter::new(Role::Client);
+        let mut writer = FrameWriter::new(Role::Client, size + 14);
         let payload = vec![b'x'; size];
         let mut dst = vec![0u8; writer.max_encoded_len(size)];
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |b, payload| {
             b.iter(|| {
-                let n = writer.encode_text(payload, &mut dst);
+                let n = writer.encode_text_raw(payload, &mut dst);
                 black_box(n);
             });
         });
@@ -44,14 +43,13 @@ fn bench_encode_text_client(c: &mut Criterion) {
 fn bench_encode_into_writebuf(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_into_writebuf");
     for size in [32, 128, 512, 2048, 4096] {
-        let mut writer = FrameWriter::new(Role::Server);
+        let mut writer = FrameWriter::new(Role::Server, size + 14);
         let payload = vec![b'x'; size];
-        let mut wbuf = WriteBuf::new(size + 14, 14);
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |b, payload| {
             b.iter(|| {
-                writer.encode_text_into(payload, &mut wbuf);
-                black_box(wbuf.data());
+                writer.encode_text(payload);
+                black_box(writer.data());
             });
         });
     }
@@ -61,19 +59,18 @@ fn bench_encode_into_writebuf(c: &mut Criterion) {
 fn bench_encode_writer(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_text_writer");
     for size in [32, 128, 512, 2048, 4096] {
-        let mut writer = FrameWriter::new(Role::Server);
+        let mut writer = FrameWriter::new(Role::Server, size + 14);
         let payload = vec![b'x'; size];
-        let mut wbuf = WriteBuf::new(size + 14, 14);
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |b, payload| {
             b.iter(|| {
                 writer
-                    .encode_text_writer(&mut wbuf, |w| {
+                    .encode_text_writer(|w| {
                         use std::io::Write;
                         w.write_all(payload)
                     })
                     .unwrap();
-                black_box(wbuf.data());
+                black_box(writer.data());
             });
         });
     }
@@ -83,16 +80,15 @@ fn bench_encode_writer(c: &mut Criterion) {
 fn bench_encode_fixed(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_text_fixed");
     for size in [32, 128, 512, 2048, 4096] {
-        let mut writer = FrameWriter::new(Role::Server);
+        let mut writer = FrameWriter::new(Role::Server, size + 14);
         let payload = vec![b'x'; size];
-        let mut wbuf = WriteBuf::new(size + 14, 14);
         group.throughput(Throughput::Bytes(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |b, payload| {
             b.iter(|| {
-                writer.encode_text_fixed(&mut wbuf, size, |buf| {
+                writer.encode_text_fixed(size, |buf| {
                     buf.copy_from_slice(payload);
                 });
-                black_box(wbuf.data());
+                black_box(writer.data());
             });
         });
     }

--- a/nexus-web/examples/perf_throughput.rs
+++ b/nexus-web/examples/perf_throughput.rs
@@ -189,7 +189,7 @@ fn bench_parse_nexus(wire: &[u8], msg_count: u64) -> (Duration, u64) {
         .role(Role::Client)
         .buffer_capacity(64 * 1024)
         .build();
-    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client));
+    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client, 65_536));
 
     let start = Instant::now();
     let mut received = 0u64;
@@ -245,7 +245,7 @@ fn bench_parse_deser_nexus<T: for<'de> Deserialize<'de>>(
         .role(Role::Client)
         .buffer_capacity(64 * 1024)
         .build();
-    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client));
+    let mut ws = Client::from_parts(cursor, reader, FrameWriter::new(Role::Client, 65_536));
 
     let start = Instant::now();
     let mut received = 0u64;

--- a/nexus-web/examples/perf_vs_tungstenite.rs
+++ b/nexus-web/examples/perf_vs_tungstenite.rs
@@ -265,7 +265,7 @@ fn main() {
 fn bench_nexus_write(label: &str, payload: &[u8], binary: bool) {
     use nexus_web::ws::{FrameWriter, Role};
 
-    let mut writer = FrameWriter::new(Role::Client); // Client = masked (harder case)
+    let mut writer = FrameWriter::new(Role::Client, payload.len() + 14); // Client = masked (harder case)
     let mut dst = vec![0u8; writer.max_encoded_len(payload.len())];
     let mut samples = vec![0u64; SAMPLES];
 
@@ -273,9 +273,9 @@ fn bench_nexus_write(label: &str, payload: &[u8], binary: bool) {
         let t0 = rdtsc_start();
         for _ in 0..BATCH {
             let n = if binary {
-                writer.encode_binary(payload, &mut dst)
+                writer.encode_binary_raw(payload, &mut dst)
             } else {
-                writer.encode_text(payload, &mut dst)
+                writer.encode_text_raw(payload, &mut dst)
             };
             black_box(n);
         }
@@ -286,16 +286,16 @@ fn bench_nexus_write(label: &str, payload: &[u8], binary: bool) {
     print_row(&format!("nexus-web  {label} (masked)"), &mut samples);
 
     // Also server (unmasked) — the market data relay path
-    let mut writer = FrameWriter::new(Role::Server);
+    let mut writer = FrameWriter::new(Role::Server, payload.len() + 14);
     let mut dst = vec![0u8; writer.max_encoded_len(payload.len())];
 
     for s in &mut samples {
         let t0 = rdtsc_start();
         for _ in 0..BATCH {
             let n = if binary {
-                writer.encode_binary(payload, &mut dst)
+                writer.encode_binary_raw(payload, &mut dst)
             } else {
-                writer.encode_text(payload, &mut dst)
+                writer.encode_text_raw(payload, &mut dst)
             };
             black_box(n);
         }

--- a/nexus-web/examples/perf_ws.rs
+++ b/nexus-web/examples/perf_ws.rs
@@ -6,7 +6,6 @@
 //!   cargo build --release -p nexus-web --example perf_ws
 //!   taskset -c 0 ./target/release/examples/perf_ws
 
-use nexus_web::buf::WriteBuf;
 use nexus_web::ws::{FrameReader, FrameWriter, Role, apply_mask};
 use std::hint::black_box;
 
@@ -207,25 +206,25 @@ fn bench_simdutf8_cycles(samples: &mut [u64], size: usize) {
 }
 
 fn bench_encode_cycles(samples: &mut [u64], size: usize, role: Role) {
-    let mut writer = FrameWriter::new(role);
+    let mut writer = FrameWriter::new(role, size + 14);
     let payload = vec![b'x'; size];
     let mut dst = vec![0u8; writer.max_encoded_len(size)];
 
     for _ in 0..10_000 {
-        writer.encode_text(&payload, &mut dst);
+        writer.encode_text_raw(&payload, &mut dst);
     }
 
     for s in samples.iter_mut() {
         let start = rdtsc_start();
         for _ in 0..BATCH {
-            let n = writer.encode_text(&payload, &mut dst);
+            let n = writer.encode_text_raw(&payload, &mut dst);
             black_box(n);
         }
         let end = rdtsc_end();
         *s = (end - start) / BATCH;
     }
     let label = format!(
-        "encode_text ({size}B, {})",
+        "encode_text_raw ({size}B, {})",
         if role == Role::Server {
             "server"
         } else {
@@ -236,24 +235,23 @@ fn bench_encode_cycles(samples: &mut [u64], size: usize, role: Role) {
 }
 
 fn bench_encode_into_cycles(samples: &mut [u64], size: usize) {
-    let mut writer = FrameWriter::new(Role::Server);
+    let mut writer = FrameWriter::new(Role::Server, size + 14);
     let payload = vec![b'x'; size];
-    let mut wbuf = WriteBuf::new(size + 14, 14);
 
     for _ in 0..10_000 {
-        writer.encode_text_into(&payload, &mut wbuf);
+        writer.encode_text(&payload);
     }
 
     for s in samples.iter_mut() {
         let start = rdtsc_start();
         for _ in 0..BATCH {
-            writer.encode_text_into(&payload, &mut wbuf);
-            black_box(wbuf.data());
+            writer.encode_text(&payload);
+            black_box(writer.data());
         }
         let end = rdtsc_end();
         *s = (end - start) / BATCH;
     }
-    print_row(&format!("encode_text_into ({size}B, server)"), samples);
+    print_row(&format!("encode_text ({size}B, server)"), samples);
 }
 
 fn bench_throughput_cycles(samples: &mut [u64], msg_count: usize) {
@@ -358,7 +356,7 @@ fn main() {
         bench_encode_cycles(&mut buf, size, Role::Client);
     }
 
-    section("FrameWriter — encode_into (WriteBuf)");
+    section("FrameWriter — encode (internal buf)");
     for size in [128, 512, 2048] {
         bench_encode_into_cycles(&mut buf, size);
     }

--- a/nexus-web/src/ws/connecting.rs
+++ b/nexus-web/src/ws/connecting.rs
@@ -7,8 +7,6 @@ use super::frame_reader::{FrameReader, FrameReaderBuilder};
 use super::frame_writer::FrameWriter;
 use super::handshake::{self, HandshakeError};
 use super::stream::{Client, ClientBuilder, Error, parse_ws_url};
-use nexus_net::buf::WriteBuf;
-
 #[cfg(feature = "tls")]
 use nexus_net::tls::{TlsCodec, TlsError};
 
@@ -48,7 +46,6 @@ pub struct Connecting<S> {
     tls: Option<TlsCodec>,
     reader_builder: FrameReaderBuilder,
     write_buf_capacity: usize,
-    write_buf_headroom: usize,
     // Handshake data
     ws_key: [u8; 24],
     req_buf: Vec<u8>,
@@ -125,7 +122,6 @@ impl ClientBuilder {
             tls,
             reader_builder: self.reader_builder,
             write_buf_capacity: self.write_buf_capacity,
-            write_buf_headroom: self.write_buf_headroom,
             ws_key,
             req_buf: Vec::new(),
             req_offset: 0,
@@ -391,8 +387,7 @@ impl<S: Read + Write> Connecting<S> {
         Ok(Client::from_parts_internal(
             stream,
             reader,
-            FrameWriter::new(Role::Client),
-            WriteBuf::new(self.write_buf_capacity, self.write_buf_headroom),
+            FrameWriter::new(Role::Client, self.write_buf_capacity),
         ))
     }
 

--- a/nexus-web/src/ws/frame_writer.rs
+++ b/nexus-web/src/ws/frame_writer.rs
@@ -552,7 +552,9 @@ mod tests {
     fn encode_close_code_round_trip() {
         use crate::ws::{CloseCode, FrameReader, Message};
         let mut writer = FrameWriter::new(Role::Server, 65_536);
-        writer.encode_close_code(CloseCode::Normal, "goodbye").unwrap();
+        writer
+            .encode_close_code(CloseCode::Normal, "goodbye")
+            .unwrap();
 
         let mut reader = FrameReader::builder().role(Role::Client).build();
         reader.read(writer.data()).unwrap();

--- a/nexus-web/src/ws/frame_writer.rs
+++ b/nexus-web/src/ws/frame_writer.rs
@@ -50,15 +50,19 @@ impl FrameHeader {
 /// Encodes messages into RFC 6455 wire format. If the role is Client,
 /// frames are masked with a random 4-byte key. If Server, no masking.
 ///
+/// Owns its output buffer — call [`data`](Self::data) after any `encode_*`
+/// call to get the pending bytes, and [`advance`](Self::advance) after a
+/// partial write. For a zero-copy raw-slice path use the `encode_*_raw`
+/// variants instead.
+///
 /// # Usage
 ///
 /// ```
 /// use nexus_web::ws::{FrameWriter, Role};
 ///
-/// let mut writer = FrameWriter::new(Role::Server);
-/// let mut dst = vec![0u8; writer.max_encoded_len(5)];
-/// let n = writer.encode_text(b"Hello", &mut dst);
-/// assert_eq!(&dst[..n], &[0x81, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F]);
+/// let mut writer = FrameWriter::new(Role::Server, 65_536);
+/// writer.encode_text(b"Hello");
+/// assert_eq!(&writer.data()[2..], b"Hello");
 /// ```
 pub struct FrameWriter {
     role: Role,
@@ -66,70 +70,151 @@ pub struct FrameWriter {
     /// OS randomness on first use, then produces mask keys at ~1 cycle
     /// instead of ~50-200 cycles per getrandom syscall.
     mask_rng: Option<ChaCha8Rng>,
+    write_buf: nexus_net::buf::WriteBuf,
 }
 
 impl FrameWriter {
-    /// Create a writer for the given role.
+    /// Create a writer for the given role with the given write buffer capacity.
     #[must_use]
-    pub fn new(role: Role) -> Self {
+    pub fn new(role: Role, capacity: usize) -> Self {
         Self {
             role,
             mask_rng: None,
+            write_buf: nexus_net::buf::WriteBuf::new(capacity, 14),
         }
     }
 
-    /// Encode a text message frame. Returns bytes written.
+    /// Encoded frame bytes, ready to write to the socket.
     ///
-    /// # Panics
-    /// Panics if `dst` is too small. Use [`max_encoded_len`](Self::max_encoded_len).
-    pub fn encode_text(&mut self, payload: &[u8], dst: &mut [u8]) -> usize {
-        self.encode(0x81, payload, dst) // FIN + Text
+    /// Valid after any `encode_*` call. Consumed by [`advance`](Self::advance).
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        self.write_buf.data()
     }
 
-    /// Encode a binary message frame. Returns bytes written.
-    pub fn encode_binary(&mut self, payload: &[u8], dst: &mut [u8]) -> usize {
-        self.encode(0x82, payload, dst) // FIN + Binary
+    /// Consume `n` bytes from the front after a partial write.
+    ///
+    /// On full drain, the buffer resets automatically — no `clear()` needed
+    /// between frames.
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        self.write_buf.advance(n);
     }
 
-    /// Encode a ping control frame. Returns bytes written.
+    /// Encode a text message frame into the internal buffer.
+    pub fn encode_text(&mut self, payload: &[u8]) {
+        self.encode_into(0x81, payload);
+    }
+
+    /// Encode a binary message frame into the internal buffer.
+    pub fn encode_binary(&mut self, payload: &[u8]) {
+        self.encode_into(0x82, payload);
+    }
+
+    /// Encode a ping control frame into the internal buffer.
     ///
     /// Returns `Err` if payload exceeds 125 bytes (RFC 6455 §5.5).
-    pub fn encode_ping(&mut self, payload: &[u8], dst: &mut [u8]) -> Result<usize, EncodeError> {
+    pub fn encode_ping(&mut self, payload: &[u8]) -> Result<(), EncodeError> {
         if payload.len() > 125 {
             return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
         }
-        Ok(self.encode(0x89, payload, dst)) // FIN + Ping
+        self.encode_into(0x89, payload);
+        Ok(())
     }
 
-    /// Encode a pong control frame. Returns bytes written.
+    /// Encode a pong control frame into the internal buffer.
     ///
     /// Returns `Err` if payload exceeds 125 bytes (RFC 6455 §5.5).
-    pub fn encode_pong(&mut self, payload: &[u8], dst: &mut [u8]) -> Result<usize, EncodeError> {
+    pub fn encode_pong(&mut self, payload: &[u8]) -> Result<(), EncodeError> {
         if payload.len() > 125 {
             return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
         }
-        Ok(self.encode(0x8A, payload, dst)) // FIN + Pong
+        self.encode_into(0x8A, payload);
+        Ok(())
     }
 
-    /// Encode a close frame. Returns bytes written.
+    /// Encode a close frame into the internal buffer.
     ///
     /// Returns `Err` if code + reason exceeds 125 bytes.
-    pub fn encode_close(
-        &mut self,
-        code: u16,
-        reason: &[u8],
-        dst: &mut [u8],
-    ) -> Result<usize, EncodeError> {
+    pub fn encode_close(&mut self, code: u16, reason: &[u8]) -> Result<(), EncodeError> {
         let payload_len = 2 + reason.len();
         if payload_len > 125 {
             return Err(EncodeError::ControlPayloadTooLarge(payload_len));
         }
+        self.write_buf.clear();
+        self.write_buf.append(&code.to_be_bytes());
+        self.write_buf.append(reason);
+        let (hdr, mask_key) = self.build_header(0x88, payload_len);
+        if let Some(mask) = mask_key {
+            super::mask::apply_mask(self.write_buf.data_mut(), mask);
+        }
+        self.write_buf.prepend(hdr.as_bytes());
+        Ok(())
+    }
 
-        let mut close_payload = [0u8; 125];
-        close_payload[..2].copy_from_slice(&code.to_be_bytes());
-        close_payload[2..payload_len].copy_from_slice(reason);
+    /// Encode an empty close frame into the internal buffer.
+    ///
+    /// Used when `CloseCode::NoStatus` is intended — RFC 6455 §7.4.1
+    /// reserves code 1005 from appearing in close frame payloads.
+    pub fn encode_empty_close(&mut self) {
+        self.encode_into(0x88, &[]);
+    }
 
-        Ok(self.encode(0x88, &close_payload[..payload_len], dst))
+    /// Encode a close frame with structured [`CloseCode`](super::CloseCode) and UTF-8 reason.
+    ///
+    /// # Panics
+    /// Panics if `code` is `CloseCode::NoStatus` (RFC 6455 reserves 1005
+    /// from appearing on the wire — use [`encode_empty_close`](Self::encode_empty_close)).
+    /// Panics if 2 + reason.len() exceeds 125 bytes.
+    pub fn encode_close_code(
+        &mut self,
+        code: super::message::CloseCode,
+        reason: &str,
+    ) -> Result<(), EncodeError> {
+        assert!(
+            code != super::message::CloseCode::NoStatus,
+            "CloseCode::NoStatus cannot be sent on the wire — use encode_empty_close()"
+        );
+        self.encode_close(code.as_u16(), reason.as_bytes())
+    }
+
+    /// Encode a text frame, writing the payload via a closure.
+    ///
+    /// The closure writes directly into the internal buffer — no intermediate
+    /// allocation. The WS frame header (including payload length) is
+    /// prepended after the closure returns.
+    ///
+    /// ```ignore
+    /// writer.encode_text_writer(|w| {
+    ///     use std::io::Write;
+    ///     serde_json::to_writer(w, &msg)
+    /// })?;
+    /// ```
+    pub fn encode_text_writer<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut nexus_net::buf::WriteBufWriter<'_>) -> Result<(), E>,
+    {
+        self.encode_writer_into(0x81, f)
+    }
+
+    /// Encode a binary frame, writing the payload via a closure.
+    pub fn encode_binary_writer<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut nexus_net::buf::WriteBufWriter<'_>) -> Result<(), E>,
+    {
+        self.encode_writer_into(0x82, f)
+    }
+
+    /// Encode a text frame with a fixed-size payload via closure.
+    ///
+    /// The closure receives `&mut [u8]` of exactly `len` bytes.
+    pub fn encode_text_fixed(&mut self, len: usize, f: impl FnOnce(&mut [u8])) {
+        self.encode_fixed_into(0x81, len, f);
+    }
+
+    /// Encode a binary frame with a fixed-size payload via closure.
+    pub fn encode_binary_fixed(&mut self, len: usize, f: impl FnOnce(&mut [u8])) {
+        self.encode_fixed_into(0x82, len, f);
     }
 
     /// Maximum encoded size for a given payload length.
@@ -147,31 +232,66 @@ impl FrameWriter {
         header + mask + payload_len
     }
 
-    /// Encode an empty close frame (no status code on the wire).
+    /// Encode a text message frame into a raw byte slice. Returns bytes written.
     ///
-    /// Used when `CloseCode::NoStatus` is intended — RFC 6455 §7.4.1
-    /// reserves code 1005 from appearing in close frame payloads.
-    pub fn encode_empty_close(&mut self, dst: &mut [u8]) -> usize {
-        self.encode(0x88, &[], dst) // FIN + Close, zero payload
-    }
-
-    /// Encode a close frame with structured [`CloseCode`](super::CloseCode) and UTF-8 reason.
+    /// Zero-copy path — no internal buffer used. Use this when you already
+    /// own a pre-allocated slice. Prefer [`encode_text`](Self::encode_text)
+    /// for the common case.
     ///
     /// # Panics
-    /// Panics if `code` is `CloseCode::NoStatus` (RFC 6455 reserves 1005
-    /// from appearing on the wire — use [`encode_empty_close`](Self::encode_empty_close)).
-    /// Panics if 2 + reason.len() exceeds 125 bytes.
-    pub fn encode_close_code(
+    /// Panics if `dst` is too small. Use [`max_encoded_len`](Self::max_encoded_len).
+    pub fn encode_text_raw(&mut self, payload: &[u8], dst: &mut [u8]) -> usize {
+        self.encode_slice(0x81, payload, dst)
+    }
+
+    /// Encode a binary message frame into a raw byte slice. Returns bytes written.
+    pub fn encode_binary_raw(&mut self, payload: &[u8], dst: &mut [u8]) -> usize {
+        self.encode_slice(0x82, payload, dst)
+    }
+
+    /// Encode a ping control frame into a raw byte slice. Returns bytes written.
+    ///
+    /// Returns `Err` if payload exceeds 125 bytes (RFC 6455 §5.5).
+    pub fn encode_ping_raw(
         &mut self,
-        code: super::message::CloseCode,
-        reason: &str,
+        payload: &[u8],
         dst: &mut [u8],
     ) -> Result<usize, EncodeError> {
-        assert!(
-            code != super::message::CloseCode::NoStatus,
-            "CloseCode::NoStatus cannot be sent on the wire — use encode_empty_close()"
-        );
-        self.encode_close(code.as_u16(), reason.as_bytes(), dst)
+        if payload.len() > 125 {
+            return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
+        }
+        Ok(self.encode_slice(0x89, payload, dst))
+    }
+
+    /// Encode a pong control frame into a raw byte slice. Returns bytes written.
+    ///
+    /// Returns `Err` if payload exceeds 125 bytes (RFC 6455 §5.5).
+    pub fn encode_pong_raw(
+        &mut self,
+        payload: &[u8],
+        dst: &mut [u8],
+    ) -> Result<usize, EncodeError> {
+        if payload.len() > 125 {
+            return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
+        }
+        Ok(self.encode_slice(0x8A, payload, dst))
+    }
+
+    /// Encode a close frame into a raw byte slice. Returns bytes written.
+    pub fn encode_close_raw(
+        &mut self,
+        code: u16,
+        reason: &[u8],
+        dst: &mut [u8],
+    ) -> Result<usize, EncodeError> {
+        let payload_len = 2 + reason.len();
+        if payload_len > 125 {
+            return Err(EncodeError::ControlPayloadTooLarge(payload_len));
+        }
+        let mut close_payload = [0u8; 125];
+        close_payload[..2].copy_from_slice(&code.to_be_bytes());
+        close_payload[2..payload_len].copy_from_slice(reason);
+        Ok(self.encode_slice(0x88, &close_payload[..payload_len], dst))
     }
 
     /// Build just the frame header. Returns (header_bytes, length, optional mask_key).
@@ -216,177 +336,48 @@ impl FrameWriter {
         (hdr, mask_key)
     }
 
-    /// Encode a complete frame into a WriteBuf.
-    ///
-    /// Clears the WriteBuf, appends payload, applies mask if client,
-    /// prepends header. Result: contiguous `[header | masked_payload]`.
-    pub fn encode_text_into(&mut self, payload: &[u8], dst: &mut nexus_net::buf::WriteBuf) {
-        self.encode_into(0x81, payload, dst);
-    }
+    // =========================================================================
+    // Internal
+    // =========================================================================
 
-    /// Encode a binary frame into a WriteBuf.
-    pub fn encode_binary_into(&mut self, payload: &[u8], dst: &mut nexus_net::buf::WriteBuf) {
-        self.encode_into(0x82, payload, dst);
-    }
-
-    /// Encode a ping frame into a WriteBuf.
-    pub fn encode_ping_into(
-        &mut self,
-        payload: &[u8],
-        dst: &mut nexus_net::buf::WriteBuf,
-    ) -> Result<(), EncodeError> {
-        if payload.len() > 125 {
-            return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
-        }
-        self.encode_into(0x89, payload, dst);
-        Ok(())
-    }
-
-    /// Encode a pong frame into a WriteBuf.
-    pub fn encode_pong_into(
-        &mut self,
-        payload: &[u8],
-        dst: &mut nexus_net::buf::WriteBuf,
-    ) -> Result<(), EncodeError> {
-        if payload.len() > 125 {
-            return Err(EncodeError::ControlPayloadTooLarge(payload.len()));
-        }
-        self.encode_into(0x8A, payload, dst);
-        Ok(())
-    }
-
-    /// Encode a close frame into a WriteBuf.
-    pub fn encode_close_into(
-        &mut self,
-        code: u16,
-        reason: &[u8],
-        dst: &mut nexus_net::buf::WriteBuf,
-    ) -> Result<(), EncodeError> {
-        let payload_len = 2 + reason.len();
-        if payload_len > 125 {
-            return Err(EncodeError::ControlPayloadTooLarge(payload_len));
-        }
-        dst.clear();
-        dst.append(&code.to_be_bytes());
-        dst.append(reason);
-        let (hdr, mask_key) = self.build_header(0x88, payload_len);
-        if let Some(mask) = mask_key {
-            super::mask::apply_mask(dst.data_mut(), mask);
-        }
-        dst.prepend(hdr.as_bytes());
-        Ok(())
-    }
-
-    /// Encode a text frame, writing the payload via a closure.
-    ///
-    /// The closure writes directly into the WriteBuf — no intermediate
-    /// allocation. The WS frame header (including payload length) is
-    /// prepended after the closure returns.
-    ///
-    /// ```ignore
-    /// writer.encode_text_writer(&mut wbuf, |w| {
-    ///     use std::io::Write;
-    ///     serde_json::to_writer(w, &msg)
-    /// })?;
-    /// ```
-    pub fn encode_text_writer<F, E>(
-        &mut self,
-        dst: &mut nexus_net::buf::WriteBuf,
-        f: F,
-    ) -> Result<(), E>
-    where
-        F: FnOnce(&mut nexus_net::buf::WriteBufWriter<'_>) -> Result<(), E>,
-    {
-        self.encode_writer_into(0x81, dst, f)
-    }
-
-    /// Encode a binary frame, writing the payload via a closure.
-    pub fn encode_binary_writer<F, E>(
-        &mut self,
-        dst: &mut nexus_net::buf::WriteBuf,
-        f: F,
-    ) -> Result<(), E>
-    where
-        F: FnOnce(&mut nexus_net::buf::WriteBufWriter<'_>) -> Result<(), E>,
-    {
-        self.encode_writer_into(0x82, dst, f)
-    }
-
-    /// Encode a text frame with a fixed-size payload via closure.
-    ///
-    /// The closure receives `&mut [u8]` of exactly `len` bytes.
-    pub fn encode_text_fixed(
-        &mut self,
-        dst: &mut nexus_net::buf::WriteBuf,
-        len: usize,
-        f: impl FnOnce(&mut [u8]),
-    ) {
-        self.encode_fixed_into(0x81, dst, len, f);
-    }
-
-    /// Encode a binary frame with a fixed-size payload via closure.
-    pub fn encode_binary_fixed(
-        &mut self,
-        dst: &mut nexus_net::buf::WriteBuf,
-        len: usize,
-        f: impl FnOnce(&mut [u8]),
-    ) {
-        self.encode_fixed_into(0x82, dst, len, f);
-    }
-
-    fn encode_into(&mut self, byte0: u8, payload: &[u8], dst: &mut nexus_net::buf::WriteBuf) {
-        dst.clear();
-        dst.append(payload);
+    fn encode_into(&mut self, byte0: u8, payload: &[u8]) {
+        self.write_buf.clear();
+        self.write_buf.append(payload);
         let (hdr, mask_key) = self.build_header(byte0, payload.len());
         if let Some(mask) = mask_key {
-            super::mask::apply_mask(dst.data_mut(), mask);
+            super::mask::apply_mask(self.write_buf.data_mut(), mask);
         }
-        dst.prepend(hdr.as_bytes());
+        self.write_buf.prepend(hdr.as_bytes());
     }
 
-    fn encode_writer_into<F, E>(
-        &mut self,
-        byte0: u8,
-        dst: &mut nexus_net::buf::WriteBuf,
-        f: F,
-    ) -> Result<(), E>
+    fn encode_writer_into<F, E>(&mut self, byte0: u8, f: F) -> Result<(), E>
     where
         F: FnOnce(&mut nexus_net::buf::WriteBufWriter<'_>) -> Result<(), E>,
     {
-        dst.clear();
+        self.write_buf.clear();
         let payload_len = {
-            let mut bw = nexus_net::buf::WriteBufWriter::new(dst);
+            let mut bw = nexus_net::buf::WriteBufWriter::new(&mut self.write_buf);
             f(&mut bw)?;
             bw.written()
         };
         let (hdr, mask_key) = self.build_header(byte0, payload_len);
         if let Some(mask) = mask_key {
-            super::mask::apply_mask(dst.data_mut(), mask);
+            super::mask::apply_mask(self.write_buf.data_mut(), mask);
         }
-        dst.prepend(hdr.as_bytes());
+        self.write_buf.prepend(hdr.as_bytes());
         Ok(())
     }
 
-    fn encode_fixed_into(
-        &mut self,
-        byte0: u8,
-        dst: &mut nexus_net::buf::WriteBuf,
-        len: usize,
-        f: impl FnOnce(&mut [u8]),
-    ) {
-        dst.clear();
-        dst.extend_zeroed(len);
-        f(dst.data_mut());
+    fn encode_fixed_into(&mut self, byte0: u8, len: usize, f: impl FnOnce(&mut [u8])) {
+        self.write_buf.clear();
+        self.write_buf.extend_zeroed(len);
+        f(self.write_buf.data_mut());
         let (hdr, mask_key) = self.build_header(byte0, len);
         if let Some(mask) = mask_key {
-            super::mask::apply_mask(dst.data_mut(), mask);
+            super::mask::apply_mask(self.write_buf.data_mut(), mask);
         }
-        dst.prepend(hdr.as_bytes());
+        self.write_buf.prepend(hdr.as_bytes());
     }
-
-    // =========================================================================
-    // Internal
-    // =========================================================================
 
     /// Generate a 4-byte mask key from the internal PRNG.
     ///
@@ -404,17 +395,15 @@ impl FrameWriter {
         mask
     }
 
-    fn encode(&mut self, byte0: u8, payload: &[u8], dst: &mut [u8]) -> usize {
+    fn encode_slice(&mut self, byte0: u8, payload: &[u8], dst: &mut [u8]) -> usize {
         let mask_bit: u8 = if self.role == Role::Client { 0x80 } else { 0 };
         let payload_len = payload.len();
 
         let mut offset = 0;
 
-        // Byte 0: FIN + opcode
         dst[offset] = byte0;
         offset += 1;
 
-        // Byte 1: MASK bit + payload length
         if payload_len <= 125 {
             dst[offset] = mask_bit | (payload_len as u8);
             offset += 1;
@@ -430,13 +419,10 @@ impl FrameWriter {
             offset += 8;
         }
 
-        // Mask key (client only)
         if self.role == Role::Client {
             let mask = self.generate_mask();
             dst[offset..offset + 4].copy_from_slice(&mask);
             offset += 4;
-
-            // Copy and mask payload
             dst[offset..offset + payload_len].copy_from_slice(payload);
             super::mask::apply_mask(&mut dst[offset..offset + payload_len], mask);
         } else {
@@ -453,86 +439,83 @@ mod tests {
 
     #[test]
     fn encode_text_server() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(5)];
-        let n = writer.encode_text(b"Hello", &mut dst);
-        assert_eq!(n, 7);
-        assert_eq!(dst[0], 0x81); // FIN + Text
-        assert_eq!(dst[1], 0x05); // no mask, len=5
-        assert_eq!(&dst[2..7], b"Hello");
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_text(b"Hello");
+        let d = writer.data();
+        assert_eq!(d[0], 0x81); // FIN + Text
+        assert_eq!(d[1], 0x05); // no mask, len=5
+        assert_eq!(&d[2..], b"Hello");
     }
 
     #[test]
     fn encode_binary_server() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(4)];
-        let n = writer.encode_binary(&[0xDE, 0xAD, 0xBE, 0xEF], &mut dst);
-        assert_eq!(n, 6);
-        assert_eq!(dst[0], 0x82); // FIN + Binary
-        assert_eq!(&dst[2..6], &[0xDE, 0xAD, 0xBE, 0xEF]);
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_binary(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let d = writer.data();
+        assert_eq!(d[0], 0x82); // FIN + Binary
+        assert_eq!(&d[2..], &[0xDE, 0xAD, 0xBE, 0xEF]);
     }
 
     #[test]
     fn encode_close_server() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(9)];
-        let n = writer.encode_close(1000, b"goodbye", &mut dst).unwrap();
-        assert_eq!(dst[0], 0x88); // FIN + Close
-        assert_eq!(&dst[2..4], &1000u16.to_be_bytes());
-        assert_eq!(&dst[4..n], b"goodbye");
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_close(1000, b"goodbye").unwrap();
+        let d = writer.data();
+        assert_eq!(d[0], 0x88); // FIN + Close
+        assert_eq!(&d[2..4], &1000u16.to_be_bytes());
+        assert_eq!(&d[4..], b"goodbye");
     }
 
     #[test]
     fn encode_ping_server() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(4)];
-        let n = writer.encode_ping(b"ping", &mut dst).unwrap();
-        assert_eq!(dst[0], 0x89); // FIN + Ping
-        assert_eq!(&dst[2..n], b"ping");
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_ping(b"ping").unwrap();
+        let d = writer.data();
+        assert_eq!(d[0], 0x89); // FIN + Ping
+        assert_eq!(&d[2..], b"ping");
     }
 
     #[test]
     fn encode_pong_server() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(4)];
-        let n = writer.encode_pong(b"pong", &mut dst).unwrap();
-        assert_eq!(dst[0], 0x8A); // FIN + Pong
-        assert_eq!(&dst[2..n], b"pong");
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_pong(b"pong").unwrap();
+        let d = writer.data();
+        assert_eq!(d[0], 0x8A); // FIN + Pong
+        assert_eq!(&d[2..], b"pong");
     }
 
     #[test]
     fn encode_client_is_masked() {
-        let mut writer = FrameWriter::new(Role::Client);
-        let mut dst = vec![0u8; writer.max_encoded_len(5)];
-        let n = writer.encode_text(b"Hello", &mut dst);
-        assert_eq!(n, 11); // 2 header + 4 mask + 5 payload
-        assert_eq!(dst[0], 0x81); // FIN + Text
-        assert_eq!(dst[1] & 0x80, 0x80); // mask bit set
-        assert_eq!(dst[1] & 0x7F, 5); // len=5
-        // Payload is masked — shouldn't equal plaintext
-        assert_ne!(&dst[6..11], b"Hello");
+        let mut writer = FrameWriter::new(Role::Client, 65_536);
+        writer.encode_text(b"Hello");
+        let d = writer.data();
+        assert_eq!(d.len(), 11); // 2 header + 4 mask + 5 payload
+        assert_eq!(d[0], 0x81); // FIN + Text
+        assert_eq!(d[1] & 0x80, 0x80); // mask bit set
+        assert_eq!(d[1] & 0x7F, 5); // len=5
+        assert_ne!(&d[6..11], b"Hello"); // masked
     }
 
     #[test]
     fn encode_16bit_length() {
-        let mut writer = FrameWriter::new(Role::Server);
+        let mut writer = FrameWriter::new(Role::Server, 1 << 18);
         let payload = vec![0x42; 256];
-        let mut dst = vec![0u8; writer.max_encoded_len(256)];
-        let n = writer.encode_binary(&payload, &mut dst);
-        assert_eq!(n, 4 + 256); // 2 + 2 (16-bit len) + 256
-        assert_eq!(dst[1] & 0x7F, 126); // extended 16-bit
-        let len = u16::from_be_bytes([dst[2], dst[3]]);
+        writer.encode_binary(&payload);
+        let d = writer.data();
+        assert_eq!(d.len(), 4 + 256); // 2 + 2 (16-bit len) + 256
+        assert_eq!(d[1] & 0x7F, 126); // extended 16-bit
+        let len = u16::from_be_bytes([d[2], d[3]]);
         assert_eq!(len, 256);
     }
 
     #[test]
     fn max_encoded_len_small() {
-        let server = FrameWriter::new(Role::Server);
+        let server = FrameWriter::new(Role::Server, 65_536);
         assert_eq!(server.max_encoded_len(0), 2);
         assert_eq!(server.max_encoded_len(125), 2 + 125);
         assert_eq!(server.max_encoded_len(126), 4 + 126);
 
-        let client = FrameWriter::new(Role::Client);
+        let client = FrameWriter::new(Role::Client, 65_536);
         assert_eq!(client.max_encoded_len(0), 2 + 4);
         assert_eq!(client.max_encoded_len(125), 2 + 4 + 125);
     }
@@ -540,12 +523,11 @@ mod tests {
     #[test]
     fn round_trip_server() {
         use crate::ws::{FrameReader, Message};
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; writer.max_encoded_len(5)];
-        let n = writer.encode_text(b"Hello", &mut dst);
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_text(b"Hello");
 
         let mut reader = FrameReader::builder().role(Role::Client).build();
-        reader.read(&dst[..n]).unwrap();
+        reader.read(writer.data()).unwrap();
         assert!(matches!(
             reader.next().unwrap().unwrap(),
             Message::Text("Hello")
@@ -555,12 +537,11 @@ mod tests {
     #[test]
     fn round_trip_client() {
         use crate::ws::{FrameReader, Message};
-        let mut writer = FrameWriter::new(Role::Client);
-        let mut dst = vec![0u8; writer.max_encoded_len(5)];
-        let n = writer.encode_text(b"Hello", &mut dst);
+        let mut writer = FrameWriter::new(Role::Client, 65_536);
+        writer.encode_text(b"Hello");
 
         let mut reader = FrameReader::builder().role(Role::Server).build();
-        reader.read(&dst[..n]).unwrap();
+        reader.read(writer.data()).unwrap();
         assert!(matches!(
             reader.next().unwrap().unwrap(),
             Message::Text("Hello")
@@ -570,14 +551,11 @@ mod tests {
     #[test]
     fn encode_close_code_round_trip() {
         use crate::ws::{CloseCode, FrameReader, Message};
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; 64];
-        let n = writer
-            .encode_close_code(CloseCode::Normal, "goodbye", &mut dst)
-            .unwrap();
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_close_code(CloseCode::Normal, "goodbye").unwrap();
 
         let mut reader = FrameReader::builder().role(Role::Client).build();
-        reader.read(&dst[..n]).unwrap();
+        reader.read(writer.data()).unwrap();
         match reader.next().unwrap().unwrap() {
             Message::Close(cf) => {
                 assert_eq!(cf.code, CloseCode::Normal);
@@ -589,70 +567,73 @@ mod tests {
 
     #[test]
     fn ping_too_large_returns_err() {
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut dst = vec![0u8; 256];
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
         assert!(matches!(
-            writer.encode_ping(&[0; 126], &mut dst),
+            writer.encode_ping(&[0; 126]),
             Err(super::EncodeError::ControlPayloadTooLarge(126))
         ));
     }
 
     #[test]
-    fn encode_text_writer_matches_into() {
-        use nexus_net::buf::WriteBuf;
-        let mut writer = FrameWriter::new(Role::Server);
-        let payload = b"Hello, world!";
-
-        let mut wbuf1 = WriteBuf::new(128, 14);
-        writer.encode_text_into(payload, &mut wbuf1);
-
-        let mut wbuf2 = WriteBuf::new(128, 14);
-        writer
-            .encode_text_writer(&mut wbuf2, |w| {
-                use std::io::Write;
-                w.write_all(payload)
-            })
-            .unwrap();
-
-        assert_eq!(wbuf1.data(), wbuf2.data());
-    }
-
-    #[test]
-    fn encode_binary_fixed_matches_into() {
-        use nexus_net::buf::WriteBuf;
-        let mut writer = FrameWriter::new(Role::Server);
-        let payload = [0xDE, 0xAD, 0xBE, 0xEF];
-
-        let mut wbuf1 = WriteBuf::new(128, 14);
-        writer.encode_binary_into(&payload, &mut wbuf1);
-
-        let mut wbuf2 = WriteBuf::new(128, 14);
-        writer.encode_binary_fixed(&mut wbuf2, payload.len(), |buf| {
-            buf.copy_from_slice(&payload);
-        });
-
-        assert_eq!(wbuf1.data(), wbuf2.data());
-    }
-
-    #[test]
     fn encode_text_writer_round_trip() {
         use crate::ws::{FrameReader, Message};
-        use nexus_net::buf::WriteBuf;
 
-        let mut writer = FrameWriter::new(Role::Server);
-        let mut wbuf = WriteBuf::new(128, 14);
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
         writer
-            .encode_text_writer(&mut wbuf, |w| {
+            .encode_text_writer(|w| {
                 use std::io::Write;
                 w.write_all(b"test message")
             })
             .unwrap();
 
         let mut reader = FrameReader::builder().role(Role::Client).build();
-        reader.read(wbuf.data()).unwrap();
+        reader.read(writer.data()).unwrap();
         assert!(matches!(
             reader.next().unwrap().unwrap(),
             Message::Text("test message")
         ));
+    }
+
+    #[test]
+    fn encode_text_writer_matches_fixed() {
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        let payload = b"Hello, world!";
+
+        writer
+            .encode_text_writer(|w| {
+                use std::io::Write;
+                w.write_all(payload)
+            })
+            .unwrap();
+        let via_writer = writer.data().to_vec();
+
+        writer.encode_text_fixed(payload.len(), |buf| {
+            buf.copy_from_slice(payload);
+        });
+        let via_fixed = writer.data().to_vec();
+
+        assert_eq!(via_writer, via_fixed);
+    }
+
+    #[test]
+    fn advance_consumes_bytes() {
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        writer.encode_text(b"Hello");
+        let total = writer.data().len();
+        writer.advance(2);
+        assert_eq!(writer.data().len(), total - 2);
+    }
+
+    #[test]
+    fn encode_text_raw_matches_internal() {
+        let mut writer = FrameWriter::new(Role::Server, 65_536);
+        let payload = b"Hi";
+
+        writer.encode_text(payload);
+        let via_internal = writer.data().to_vec();
+
+        let mut dst = vec![0u8; writer.max_encoded_len(payload.len())];
+        let n = writer.encode_text_raw(payload, &mut dst);
+        assert_eq!(&dst[..n], via_internal.as_slice());
     }
 }

--- a/nexus-web/src/ws/stream.rs
+++ b/nexus-web/src/ws/stream.rs
@@ -428,11 +428,7 @@ impl ClientBuilder {
 
     /// Accept an incoming WebSocket connection (server-side).
     pub fn accept<S: Read + Write>(self, stream: S) -> Result<Client<S>, Error> {
-        Client::accept_impl(
-            stream,
-            self.reader_builder,
-            self.write_buf_capacity,
-        )
+        Client::accept_impl(stream, self.reader_builder, self.write_buf_capacity)
     }
 
     fn apply_socket_opts(&self, tcp: &std::net::TcpStream) -> Result<(), Error> {
@@ -519,11 +515,7 @@ impl<S> Client<S> {
     }
 
     /// Internal constructor. Used by Connecting::finish().
-    pub(crate) fn from_parts_internal(
-        stream: S,
-        reader: FrameReader,
-        writer: FrameWriter,
-    ) -> Self {
+    pub(crate) fn from_parts_internal(stream: S, reader: FrameReader, writer: FrameWriter) -> Self {
         Self {
             stream,
             reader,

--- a/nexus-web/src/ws/stream.rs
+++ b/nexus-web/src/ws/stream.rs
@@ -7,7 +7,6 @@ use super::frame::Role;
 use super::frame_reader::{FrameReader, FrameReaderBuilder};
 use super::frame_writer::FrameWriter;
 use super::message::{CloseCode, Message};
-use nexus_net::buf::WriteBuf;
 
 use super::handshake;
 use super::handshake::HandshakeError;
@@ -215,7 +214,6 @@ impl From<TlsError> for Error {
 pub struct ClientBuilder {
     pub(crate) reader_builder: FrameReaderBuilder,
     pub(crate) write_buf_capacity: usize,
-    pub(crate) write_buf_headroom: usize,
     #[cfg(feature = "tls")]
     pub(crate) tls_config: Option<TlsConfig>,
     pub(crate) tcp_nodelay: bool,
@@ -234,7 +232,6 @@ impl ClientBuilder {
         Self {
             reader_builder: FrameReader::builder(),
             write_buf_capacity: 65_536,
-            write_buf_headroom: 14,
             #[cfg(feature = "tls")]
             tls_config: None,
             tcp_nodelay: false,
@@ -374,7 +371,6 @@ impl ClientBuilder {
             parsed.path,
             self.reader_builder,
             self.write_buf_capacity,
-            self.write_buf_headroom,
         )
     }
 
@@ -410,7 +406,6 @@ impl ClientBuilder {
             parsed.path,
             self.reader_builder,
             self.write_buf_capacity,
-            self.write_buf_headroom,
         )
     }
 
@@ -428,7 +423,6 @@ impl ClientBuilder {
             parsed.path,
             self.reader_builder,
             self.write_buf_capacity,
-            self.write_buf_headroom,
         )
     }
 
@@ -438,7 +432,6 @@ impl ClientBuilder {
             stream,
             self.reader_builder,
             self.write_buf_capacity,
-            self.write_buf_headroom,
         )
     }
 
@@ -501,7 +494,6 @@ pub struct Client<S> {
     pub(crate) stream: S,
     pub(crate) reader: FrameReader,
     pub(crate) writer: FrameWriter,
-    pub(crate) write_buf: WriteBuf,
     pub(crate) poisoned: bool,
 }
 
@@ -522,23 +514,20 @@ impl<S> Client<S> {
             stream,
             reader,
             writer,
-            write_buf: WriteBuf::new(65_536, 14),
             poisoned: false,
         }
     }
 
-    /// Internal constructor with all fields. Used by Connecting::finish().
+    /// Internal constructor. Used by Connecting::finish().
     pub(crate) fn from_parts_internal(
         stream: S,
         reader: FrameReader,
         writer: FrameWriter,
-        write_buf: WriteBuf,
     ) -> Self {
         Self {
             stream,
             reader,
             writer,
-            write_buf,
             poisoned: false,
         }
     }
@@ -606,47 +595,38 @@ impl<S: Read + Write> Client<S> {
 
     /// Send a text message.
     pub fn send_text(&mut self, text: &str) -> Result<(), Error> {
-        self.writer
-            .encode_text_into(text.as_bytes(), &mut self.write_buf);
+        self.writer.encode_text(text.as_bytes());
         self.flush_write_buf_or_poison()
     }
 
     /// Send a binary message.
     pub fn send_binary(&mut self, data: &[u8]) -> Result<(), Error> {
-        self.writer.encode_binary_into(data, &mut self.write_buf);
+        self.writer.encode_binary(data);
         self.flush_write_buf_or_poison()
     }
 
     /// Send a ping.
     pub fn send_ping(&mut self, data: &[u8]) -> Result<(), Error> {
-        self.writer
-            .encode_ping_into(data, &mut self.write_buf)
-            .map_err(Error::Encode)?;
+        self.writer.encode_ping(data).map_err(Error::Encode)?;
         self.flush_write_buf_or_poison()
     }
 
     /// Send a pong.
     pub fn send_pong(&mut self, data: &[u8]) -> Result<(), Error> {
-        self.writer
-            .encode_pong_into(data, &mut self.write_buf)
-            .map_err(Error::Encode)?;
+        self.writer.encode_pong(data).map_err(Error::Encode)?;
         self.flush_write_buf_or_poison()
     }
 
     /// Initiate close handshake.
     pub fn close(&mut self, code: CloseCode, reason: &str) -> Result<(), Error> {
         if code == CloseCode::NoStatus {
-            let mut dst = [0u8; 14];
-            let n = self.writer.encode_empty_close(&mut dst);
-            self.write_raw(&dst[..n]).inspect_err(|_| {
-                self.poisoned = true;
-            })
+            self.writer.encode_empty_close();
         } else {
             self.writer
-                .encode_close_into(code.as_u16(), reason.as_bytes(), &mut self.write_buf)
+                .encode_close(code.as_u16(), reason.as_bytes())
                 .map_err(Error::Encode)?;
-            self.flush_write_buf_or_poison()
         }
+        self.flush_write_buf_or_poison()
     }
 
     // =========================================================================
@@ -668,15 +648,8 @@ impl<S: Read + Write> Client<S> {
         })
     }
 
-    /// Flush the write_buf to the socket.
     fn flush_write_buf(&mut self) -> Result<(), Error> {
-        self.stream.write_all(self.write_buf.data())?;
-        Ok(())
-    }
-
-    /// Write raw bytes to the socket.
-    fn write_raw(&mut self, data: &[u8]) -> Result<(), Error> {
-        self.stream.write_all(data)?;
+        self.stream.write_all(self.writer.data())?;
         Ok(())
     }
 
@@ -692,7 +665,6 @@ impl<S: Read + Write> Client<S> {
         path: &str,
         reader_builder: FrameReaderBuilder,
         write_cap: usize,
-        write_headroom: usize,
     ) -> Result<Self, Error> {
         let key = handshake::generate_key();
         let key_str = std::str::from_utf8(&key).expect("base64 output is valid ASCII");
@@ -757,8 +729,7 @@ impl<S: Read + Write> Client<S> {
                     return Ok(Self {
                         stream,
                         reader,
-                        writer: FrameWriter::new(Role::Client),
-                        write_buf: WriteBuf::new(write_cap, write_headroom),
+                        writer: FrameWriter::new(Role::Client, write_cap),
                         poisoned: false,
                     });
                 }
@@ -772,7 +743,6 @@ impl<S: Read + Write> Client<S> {
         mut stream: S,
         reader_builder: FrameReaderBuilder,
         write_cap: usize,
-        write_headroom: usize,
     ) -> Result<Self, Error> {
         let mut req_reader = crate::http::RequestReader::new(4096);
         let mut tmp = [0u8; 4096];
@@ -846,8 +816,7 @@ impl<S: Read + Write> Client<S> {
         Ok(Self {
             stream,
             reader,
-            writer: FrameWriter::new(Role::Server),
-            write_buf: WriteBuf::new(write_cap, write_headroom),
+            writer: FrameWriter::new(Role::Server, write_cap),
             poisoned: false,
         })
     }
@@ -856,16 +825,23 @@ impl<S: Read + Write> Client<S> {
 /// Create a matched FrameReader + FrameWriter pair.
 ///
 /// Prevents mismatched roles between reader and writer.
-pub fn pair(role: Role) -> (FrameReader, FrameWriter) {
+pub fn pair(role: Role, write_capacity: usize) -> (FrameReader, FrameWriter) {
     (
         FrameReader::builder().role(role).build(),
-        FrameWriter::new(role),
+        FrameWriter::new(role, write_capacity),
     )
 }
 
 /// Create a pair with a configured FrameReader.
-pub fn pair_with(role: Role, reader_builder: FrameReaderBuilder) -> (FrameReader, FrameWriter) {
-    (reader_builder.role(role).build(), FrameWriter::new(role))
+pub fn pair_with(
+    role: Role,
+    reader_builder: FrameReaderBuilder,
+    write_capacity: usize,
+) -> (FrameReader, FrameWriter) {
+    (
+        reader_builder.role(role).build(),
+        FrameWriter::new(role, write_capacity),
+    )
 }
 
 fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
@@ -932,7 +908,7 @@ mod tests {
 
         #[test]
         fn pair_creates_matching_roles() {
-            let (mut reader, _writer) = pair(Role::Client);
+            let (mut reader, _writer) = pair(Role::Client, 65_536);
             let frame = make_frame(true, 0x1, b"test");
             reader.read(&frame).unwrap();
             let msg = reader.next().unwrap().unwrap();
@@ -990,7 +966,7 @@ mod tests {
         fn ws_from_bytes(data: Vec<u8>) -> Client<ByteAtATimeStream> {
             let mock = ByteAtATimeStream::new(data);
             let reader = FrameReader::builder().role(Role::Client).build();
-            let writer = FrameWriter::new(Role::Client);
+            let writer = FrameWriter::new(Role::Client, 65_536);
             Client::from_parts(mock, reader, writer)
         }
 
@@ -1081,7 +1057,7 @@ mod tests {
             }
 
             let reader = FrameReader::builder().role(Role::Client).build();
-            let writer = FrameWriter::new(Role::Client);
+            let writer = FrameWriter::new(Role::Client, 65_536);
             let mut ws = Client::from_parts(WouldBlockStream, reader, writer);
             assert!(ws.recv().unwrap().is_none());
         }


### PR DESCRIPTION
Closes #467.

`FrameWriter` now owns its output buffer. Callers no longer manage a separate `WriteBuf`.

- `FrameWriter::new(role, capacity)` — allocates internal `WriteBuf` with 14-byte headroom
- `data() -> &[u8]` — encoded frame bytes, ready to send
- `advance(n)` — partial-write cursor; auto-resets on full drain
- `encode_*` methods write to the internal buffer
- Raw-slice path preserved as `encode_*_raw` for zero-copy use cases

Updated: `nexus-web` stream/connecting, `nexus-async-web` parts/streams/`WsStream` Sink impl, all benchmarks and examples.