### PR TITLE
Segment: encapsulate raw pointer access

### DIFF
--- a/nexus-shm/src/journal/frame.rs
+++ b/nexus-shm/src/journal/frame.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::AtomicU32;
-
 pub(crate) const FRAME_HEADER: usize = 8;
 pub(crate) const ALIGN: usize = 8;
 
@@ -12,25 +10,4 @@ pub(crate) const fn align_up(n: usize) -> usize {
 
 pub(crate) const fn footprint(body: usize) -> usize {
     FRAME_HEADER + align_up(body)
-}
-
-pub(crate) unsafe fn commit_len<'a>(ptr: *mut u8) -> &'a AtomicU32 {
-    // SAFETY: caller guarantees ptr is 8-byte-aligned, initialized, and live for
-    // 'a; AtomicU32 shares u32's layout.
-    unsafe { AtomicU32::from_ptr(ptr.cast()) }
-}
-
-pub(crate) unsafe fn write_kind(ptr: *mut u8, frame_type: u16) {
-    // SAFETY: caller guarantees the 8-byte frame header at ptr is within a live
-    // mapping reserved for this record.
-    unsafe {
-        std::ptr::write_unaligned(ptr.add(4).cast::<u16>(), frame_type);
-        std::ptr::write_unaligned(ptr.add(6).cast::<u16>(), 0);
-    }
-}
-
-pub(crate) unsafe fn read_kind(ptr: *mut u8) -> u16 {
-    // SAFETY: caller guarantees the frame header is published (read after an
-    // Acquire load of commit_len) and within a live mapping.
-    unsafe { std::ptr::read_unaligned(ptr.add(4).cast::<u16>()) }
 }

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -18,7 +18,7 @@ pub use header::{FixHeader, RecordHeader, SeqHeader};
 pub use reader::{ReadRange, ReadRecord, Reader};
 pub use writer::{WriteClaim, Writer};
 
-use frame::{FRAME_HEADER, TYPE_PAD, align_up, commit_len, footprint, read_kind};
+use frame::{FRAME_HEADER, TYPE_PAD, align_up, footprint};
 
 const MIN_SEGMENT: usize = 64;
 
@@ -87,17 +87,16 @@ impl<H: RecordHeader> Journal<H> {
 }
 
 fn recover_tail<H: RecordHeader>(seg: &Segment, segment_size: usize) -> usize {
-    let data = seg.data();
     let hsize = size_of::<H>();
     let mut cur = 0;
     while cur + FRAME_HEADER <= segment_size {
         // SAFETY: `cur` is an 8-aligned offset within the mapped data region.
-        let cl = unsafe { commit_len(data.add(cur)) }.load(Ordering::Acquire);
+        let cl = unsafe { seg.commit_len_at(cur) }.load(Ordering::Acquire);
         if cl == 0 {
             break;
         }
         // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
-        if unsafe { read_kind(data.add(cur)) } == TYPE_PAD {
+        if unsafe { seg.frame_kind_at(cur) } == TYPE_PAD {
             cur += align_up(cl as usize);
             continue;
         }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -57,8 +57,9 @@ impl<H: RecordHeader> Reader<H> {
             // SAFETY: the committed frame is within the mapping which outlives `&mut self`.
             let data = self.segments[self.seg_idx].data();
             let header = unsafe { self.segments[self.seg_idx].read_at::<H>(off + FRAME_HEADER) };
-            let payload =
-                unsafe { std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize) };
+            let payload = unsafe {
+                std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize)
+            };
             self.cursor = off + footprint(body);
             return Ok(Some(ReadRecord { header, payload }));
         }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -6,7 +6,7 @@ use crate::error::ShmError;
 use crate::segment::Segment;
 
 use super::error::JournalError;
-use super::frame::{FRAME_HEADER, TYPE_PAD, align_up, commit_len, footprint, read_kind};
+use super::frame::{FRAME_HEADER, TYPE_PAD, align_up, footprint};
 use super::header::{RecordHeader, SeqHeader};
 
 /// Read half of a journal: walks committed records across segments in order.
@@ -32,14 +32,14 @@ impl<H: RecordHeader> Reader<H> {
                 }
                 return Ok(None);
             }
-            let data = self.segments[self.seg_idx].data();
+            let seg = &self.segments[self.seg_idx];
             // SAFETY: cursor is an 8-aligned offset within the mapped data.
-            let cl = unsafe { commit_len(data.add(self.cursor)) }.load(Ordering::Acquire);
+            let cl = unsafe { seg.commit_len_at(self.cursor) }.load(Ordering::Acquire);
             if cl == 0 {
                 return Ok(None);
             }
             // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
-            if unsafe { read_kind(data.add(self.cursor)) } == TYPE_PAD {
+            if unsafe { seg.frame_kind_at(self.cursor) } == TYPE_PAD {
                 self.cursor += align_up(cl as usize);
                 if self.cursor + FRAME_HEADER > self.segment_size && !self.advance_segment()? {
                     return Ok(None);
@@ -54,13 +54,10 @@ impl<H: RecordHeader> Reader<H> {
             let off = self.cursor;
             // SAFETY: the committed frame holds `H` at `off + FRAME_HEADER`;
             // `H: Pod`, so an unaligned read is valid.
-            let header =
-                unsafe { std::ptr::read_unaligned(data.add(off + FRAME_HEADER).cast::<H>()) };
+            let header = unsafe { seg.read_at::<H>(off + FRAME_HEADER) };
             // SAFETY: the payload lies within the committed frame and the mapping
             // outlives the borrow held through `&mut self`.
-            let payload = unsafe {
-                std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize)
-            };
+            let payload = unsafe { seg.slice_at(off + FRAME_HEADER + hsize, body - hsize) };
             self.cursor = off + footprint(body);
             return Ok(Some(ReadRecord { header, payload }));
         }
@@ -157,14 +154,14 @@ impl<'a, H: SeqHeader> Iterator for ReadRange<'a, H> {
                 self.cursor = 0;
                 continue;
             }
-            let data = self.segments[self.seg_idx].data();
+            let seg = &self.segments[self.seg_idx];
             // SAFETY: cursor is an 8-aligned offset within the mapped data.
-            let cl = unsafe { commit_len(data.add(self.cursor)) }.load(Ordering::Acquire);
+            let cl = unsafe { seg.commit_len_at(self.cursor) }.load(Ordering::Acquire);
             if cl == 0 {
                 return None;
             }
             // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
-            if unsafe { read_kind(data.add(self.cursor)) } == TYPE_PAD {
+            if unsafe { seg.frame_kind_at(self.cursor) } == TYPE_PAD {
                 self.cursor += align_up(cl as usize);
                 continue;
             }
@@ -176,16 +173,13 @@ impl<'a, H: SeqHeader> Iterator for ReadRange<'a, H> {
             let off = self.cursor;
             self.cursor = off + footprint(body);
             // SAFETY: the committed frame holds `H` at `off + FRAME_HEADER`; `H: Pod`.
-            let header =
-                unsafe { std::ptr::read_unaligned(data.add(off + FRAME_HEADER).cast::<H>()) };
+            let header = unsafe { seg.read_at::<H>(off + FRAME_HEADER) };
             if header.seq() < self.lo || header.seq() > self.hi {
                 continue;
             }
             // SAFETY: the payload lies within the committed frame and `segments`
             // outlives `'a`.
-            let payload = unsafe {
-                std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize)
-            };
+            let payload = unsafe { seg.slice_at(off + FRAME_HEADER + hsize, body - hsize) };
             return Some(ReadRecord { header, payload });
         }
     }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -32,14 +32,14 @@ impl<H: RecordHeader> Reader<H> {
                 }
                 return Ok(None);
             }
-            let seg = &self.segments[self.seg_idx];
             // SAFETY: cursor is an 8-aligned offset within the mapped data.
-            let cl = unsafe { seg.commit_len_at(self.cursor) }.load(Ordering::Acquire);
+            let cl = unsafe { self.segments[self.seg_idx].commit_len_at(self.cursor) }
+                .load(Ordering::Acquire);
             if cl == 0 {
                 return Ok(None);
             }
             // SAFETY: cl > 0 was Acquire-loaded, so the frame header is published.
-            if unsafe { seg.frame_kind_at(self.cursor) } == TYPE_PAD {
+            if unsafe { self.segments[self.seg_idx].frame_kind_at(self.cursor) } == TYPE_PAD {
                 self.cursor += align_up(cl as usize);
                 if self.cursor + FRAME_HEADER > self.segment_size && !self.advance_segment()? {
                     return Ok(None);
@@ -52,12 +52,13 @@ impl<H: RecordHeader> Reader<H> {
                 return Ok(None);
             }
             let off = self.cursor;
-            // SAFETY: the committed frame holds `H` at `off + FRAME_HEADER`;
-            // `H: Pod`, so an unaligned read is valid.
-            let header = unsafe { seg.read_at::<H>(off + FRAME_HEADER) };
-            // SAFETY: the payload lies within the committed frame and the mapping
-            // outlives the borrow held through `&mut self`.
-            let payload = unsafe { seg.slice_at(off + FRAME_HEADER + hsize, body - hsize) };
+            // Raw pointer avoids holding an immutable borrow of `self.segments`
+            // across the mutable `self.cursor` update and potential `advance_segment`.
+            // SAFETY: the committed frame is within the mapping which outlives `&mut self`.
+            let data = self.segments[self.seg_idx].data();
+            let header = unsafe { self.segments[self.seg_idx].read_at::<H>(off + FRAME_HEADER) };
+            let payload =
+                unsafe { std::slice::from_raw_parts(data.add(off + FRAME_HEADER + hsize), body - hsize) };
             self.cursor = off + footprint(body);
             return Ok(Some(ReadRecord { header, payload }));
         }

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 use crate::segment::Segment;
 
 use super::error::JournalError;
-use super::frame::{FRAME_HEADER, TYPE_DATA, TYPE_PAD, commit_len, footprint, write_kind};
+use super::frame::{FRAME_HEADER, TYPE_DATA, TYPE_PAD, footprint};
 use super::header::RecordHeader;
 
 /// Append half of a journal: claims and commits records to the active segment.
@@ -53,11 +53,12 @@ impl<H: RecordHeader> Writer<H> {
     fn roll(&mut self) -> Result<(), JournalError> {
         let remaining = self.segment_size - self.tail;
         if remaining >= FRAME_HEADER {
-            let data = self.active.data();
             // SAFETY: tail is an 8-aligned offset within the mapped data region.
             unsafe {
-                write_kind(data.add(self.tail), TYPE_PAD);
-                commit_len(data.add(self.tail)).store(remaining as u32, Ordering::Release);
+                self.active.write_frame_kind_at(self.tail, TYPE_PAD);
+                self.active
+                    .commit_len_at(self.tail)
+                    .store(remaining as u32, Ordering::Release);
             }
         }
         self.index += 1;
@@ -84,31 +85,41 @@ impl<H: RecordHeader> WriteClaim<'_, H> {
     /// The payload region to fill before committing.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         let start = self.off + FRAME_HEADER + size_of::<H>();
-        let data = self.writer.active.data();
         // SAFETY: the region is reserved for this claim, lies within the mapped
         // data, and is exclusively borrowed through `&mut self`.
-        unsafe { std::slice::from_raw_parts_mut(data.add(start), self.payload_len) }
+        unsafe { self.writer.active.slice_mut_at(start, self.payload_len) }
     }
 
     /// Publish the record: write the header and frame kind, then release the
     /// commit length so readers observe a fully-written record.
     pub fn commit(self) {
-        let data = self.writer.active.data();
         // SAFETY: the header slot is reserved for this claim and within the
         // mapped data; `H: Pod`, so an unaligned byte write is valid.
         unsafe {
-            std::ptr::write_unaligned(data.add(self.off + FRAME_HEADER).cast::<H>(), self.header);
-            write_kind(data.add(self.off), TYPE_DATA);
+            self.writer
+                .active
+                .write_at(self.off + FRAME_HEADER, self.header);
+            self.writer.active.write_frame_kind_at(self.off, TYPE_DATA);
         }
 
         let next = self.off + self.foot;
         if next + FRAME_HEADER <= self.writer.segment_size {
             // SAFETY: `next` is an 8-aligned offset within the mapped data.
-            unsafe { commit_len(data.add(next)).store(0, Ordering::Relaxed) }
+            unsafe {
+                self.writer
+                    .active
+                    .commit_len_at(next)
+                    .store(0, Ordering::Relaxed);
+            }
         }
 
         // SAFETY: the commit-length slot is 8-aligned and within the mapped data.
-        unsafe { commit_len(data.add(self.off)).store(self.body as u32, Ordering::Release) }
+        unsafe {
+            self.writer
+                .active
+                .commit_len_at(self.off)
+                .store(self.body as u32, Ordering::Release);
+        }
         self.writer.tail = next;
     }
 }

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -153,7 +153,7 @@ impl Segment {
     /// The range must be within `data_len()`, exclusively reserved for this
     /// write, and the segment must outlive the slice.
     #[inline]
-    pub(crate) unsafe fn slice_mut_at(&self, offset: usize, len: usize) -> &mut [u8] {
+    pub(crate) unsafe fn slice_mut_at(&mut self, offset: usize, len: usize) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.data().add(offset), len) }
     }
 
@@ -200,7 +200,7 @@ mod tests {
         let path = temp_path("roundtrip");
         let _ = std::fs::remove_file(&path);
 
-        let seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
+        let mut seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 use std::path::Path;
+use std::sync::atomic::AtomicU32;
 
 use nexus_platform::{Liveness, MapOptions, MappedFile, ProcessLease};
 
@@ -79,16 +80,81 @@ impl Segment {
         ProcessLease::probe(self.mapping.as_fd())
     }
 
-    /// Pointer to the payload region, valid for [`Segment::data_len`] bytes for
-    /// as long as this `Segment` lives.
-    ///
-    /// Reads and writes through it must be synchronized by the caller — the
-    /// foundation provides no ordering for the payload (the control block's
-    /// atomics cover only liveness). The primitives built on top supply their
-    /// own sequencing.
-    pub fn data(&self) -> *mut u8 {
+    pub(crate) fn data(&self) -> *mut u8 {
         // SAFETY: the mapping is HEADER + data_len bytes, so HEADER is in bounds.
         unsafe { self.mapping.as_ptr().add(HEADER.get()) }
+    }
+
+    /// `AtomicU32` at `offset` within the payload (commit-length field).
+    ///
+    /// # Safety
+    /// `offset` must be 4-byte-aligned and within `data_len()`.
+    #[inline]
+    pub(crate) unsafe fn commit_len_at(&self, offset: usize) -> &AtomicU32 {
+        unsafe { AtomicU32::from_ptr(self.data().add(offset).cast()) }
+    }
+
+    /// Frame discriminant (bytes 4-5 of the frame header) at `offset`.
+    ///
+    /// # Safety
+    /// The frame header at `offset` must be published (read after an Acquire
+    /// load of `commit_len_at`) and within `data_len()`.
+    #[inline]
+    pub(crate) unsafe fn frame_kind_at(&self, offset: usize) -> u16 {
+        unsafe { std::ptr::read_unaligned(self.data().add(offset + 4).cast()) }
+    }
+
+    /// Write the frame discriminant at `offset` (bytes 4-5) and zero bytes 6-7.
+    ///
+    /// # Safety
+    /// The 8-byte frame header at `offset` must be within `data_len()` and
+    /// reserved for this record.
+    #[inline]
+    pub(crate) unsafe fn write_frame_kind_at(&self, offset: usize, kind: u16) {
+        unsafe {
+            std::ptr::write_unaligned(self.data().add(offset + 4).cast::<u16>(), kind);
+            std::ptr::write_unaligned(self.data().add(offset + 6).cast::<u16>(), 0);
+        }
+    }
+
+    /// Write `val` at `offset` (unaligned).
+    ///
+    /// # Safety
+    /// `[offset, offset + size_of::<T>())` must be within `data_len()` and
+    /// reserved for this write.
+    #[inline]
+    pub(crate) unsafe fn write_at<T: Copy>(&self, offset: usize, val: T) {
+        unsafe { std::ptr::write_unaligned(self.data().add(offset).cast(), val) }
+    }
+
+    /// Read a `T` at `offset` (unaligned).
+    ///
+    /// # Safety
+    /// `[offset, offset + size_of::<T>())` must be within `data_len()` and
+    /// the data must be published before this call.
+    #[inline]
+    pub(crate) unsafe fn read_at<T: Copy>(&self, offset: usize) -> T {
+        unsafe { std::ptr::read_unaligned(self.data().add(offset).cast()) }
+    }
+
+    /// Immutable byte slice `[offset, offset + len)`.
+    ///
+    /// # Safety
+    /// The range must be within `data_len()` and the bytes must be published.
+    /// The returned slice borrows `self` so the segment must outlive the slice.
+    #[inline]
+    pub(crate) unsafe fn slice_at(&self, offset: usize, len: usize) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data().add(offset), len) }
+    }
+
+    /// Mutable byte slice `[offset, offset + len)`.
+    ///
+    /// # Safety
+    /// The range must be within `data_len()`, exclusively reserved for this
+    /// write, and the segment must outlive the slice.
+    #[inline]
+    pub(crate) unsafe fn slice_mut_at(&self, offset: usize, len: usize) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.data().add(offset), len) }
     }
 
     pub fn data_len(&self) -> usize {
@@ -138,12 +204,12 @@ mod tests {
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 
-        unsafe { seg.data().write(0xAB) };
+        unsafe { seg.slice_mut_at(0, 1)[0] = 0xAB };
 
         let peer = Segment::attach(&path, MapOptions::default()).unwrap();
         assert_eq!(peer.data_len(), 4096);
         assert_eq!(peer.status(), Status::Alive);
-        assert_eq!(unsafe { peer.data().read() }, 0xAB);
+        assert_eq!(unsafe { peer.slice_at(0, 1)[0] }, 0xAB);
 
         std::fs::remove_file(&path).unwrap();
     }


### PR DESCRIPTION
Closes #484

`data() -> *mut u8` is now `pub(crate)`. All journal code goes through typed helpers on `Segment`:

- `commit_len_at(offset)` — `&AtomicU32`
- `frame_kind_at(offset)` — `u16` (bytes 4-5 of frame header)
- `write_frame_kind_at(offset, kind)` — writes discriminant + zero reserved bytes
- `write_at<T>(offset, val)` — unaligned write
- `read_at<T>(offset)` — unaligned read
- `slice_at(offset, len)` — `&[u8]`
- `slice_mut_at(offset, len)` — `&mut [u8]`

Frame-level free functions `commit_len`/`write_kind`/`read_kind` removed from `frame.rs`; their logic lives in `Segment` where the pointer lives.