### PR TITLE
refactor: MappedFileOptions builder, MapHints for nexus-shm

### DIFF
--- a/nexus-platform/src/lib.rs
+++ b/nexus-platform/src/lib.rs
@@ -14,5 +14,5 @@ pub mod mapping;
 
 pub use file_lock::FileLock;
 pub use lease::{Liveness, ProcessLease};
-pub use mapped_file::MappedFile;
-pub use mapping::{Advice, MapError, MapOptions, Mapping, Protection, Sharing};
+pub use mapped_file::{MappedFile, MappedFileOptions};
+pub use mapping::{Advice, MapError, Mapping, Protection, Sharing};

--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -126,7 +126,9 @@ impl MappedFileOptions {
             .offset
             .checked_add(len.get() as u64)
             .ok_or(MapError::OutOfBounds)?;
-        file.set_len(total)?;
+        if total > file.metadata()?.len() {
+            file.set_len(total)?;
+        }
         self.map_file(file, len)
     }
 
@@ -140,7 +142,11 @@ impl MappedFileOptions {
         } else {
             OpenOptions::new().read(true).open(path)?
         };
-        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
+        let file_len = file.metadata()?.len();
+        let remaining = file_len
+            .checked_sub(self.offset)
+            .ok_or(MapError::OutOfBounds)?;
+        let len = NonZeroUsize::new(remaining as usize).ok_or(MapError::EmptyFile)?;
         self.map_file(file, len)
     }
 

--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -5,6 +5,172 @@ use std::path::Path;
 
 use crate::mapping::{MapError, MapOptions, Mapping, Protection, Sharing};
 
+/// Builder for [`MappedFile`] creation, following the [`std::fs::OpenOptions`]
+/// pattern.
+///
+/// Obtained via [`MappedFile::options()`]. Configure protection, sharing mode,
+/// and mapping hints, then call a terminal method to create the mapping.
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | protection | [`Protection::ReadWrite`] |
+/// | sharing | [`Sharing::Shared`] |
+/// | pretouch | `false` |
+/// | huge_pages | `false` |
+/// | offset | `0` |
+///
+/// # Examples
+///
+/// ```no_run
+/// use nexus_platform::MappedFile;
+/// use std::num::NonZeroUsize;
+/// use std::path::Path;
+///
+/// // Full control via builder
+/// let mf = MappedFile::options()
+///     .pretouch(true)
+///     .create(Path::new("/tmp/segment"), NonZeroUsize::new(4096).unwrap())
+///     .unwrap();
+///
+/// // Read-only private mapping
+/// let mf = MappedFile::options()
+///     .read_only()
+///     .private()
+///     .open(Path::new("/tmp/segment"))
+///     .unwrap();
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct MappedFileOptions {
+    protection: Protection,
+    sharing: Sharing,
+    pretouch: bool,
+    huge_pages: bool,
+    offset: u64,
+}
+
+impl MappedFileOptions {
+    fn new() -> Self {
+        Self {
+            protection: Protection::ReadWrite,
+            sharing: Sharing::Shared,
+            pretouch: false,
+            huge_pages: false,
+            offset: 0,
+        }
+    }
+
+    /// Set the mapping protection to [`Protection::ReadWrite`].
+    pub fn read_write(&mut self) -> &mut Self {
+        self.protection = Protection::ReadWrite;
+        self
+    }
+
+    /// Set the mapping protection to [`Protection::ReadOnly`].
+    pub fn read_only(&mut self) -> &mut Self {
+        self.protection = Protection::ReadOnly;
+        self
+    }
+
+    /// Share writes with the backing store and other mappings
+    /// ([`Sharing::Shared`], `MAP_SHARED`).
+    pub fn shared(&mut self) -> &mut Self {
+        self.sharing = Sharing::Shared;
+        self
+    }
+
+    /// Copy-on-write: writes are private to this mapping
+    /// ([`Sharing::Private`], `MAP_PRIVATE`).
+    pub fn private(&mut self) -> &mut Self {
+        self.sharing = Sharing::Private;
+        self
+    }
+
+    /// Pre-fault pages into memory on creation.
+    ///
+    /// Linux: `MAP_POPULATE`. Other platforms: best-effort.
+    pub fn pretouch(&mut self, pretouch: bool) -> &mut Self {
+        self.pretouch = pretouch;
+        self
+    }
+
+    /// Request huge-page backing.
+    ///
+    /// Linux: `MAP_HUGETLB`. Other platforms: best-effort or no-op.
+    pub fn huge_pages(&mut self, huge_pages: bool) -> &mut Self {
+        self.huge_pages = huge_pages;
+        self
+    }
+
+    /// Set the byte offset into the file where the mapping begins.
+    ///
+    /// Must be page-aligned (typically 4096 on Linux). Default: `0`.
+    pub fn offset(&mut self, offset: u64) -> &mut Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Create or open a file at `path`, set its length, and map it.
+    ///
+    /// The file is created if it does not exist. If it already exists, it
+    /// is resized so the file covers at least `offset + len` bytes.
+    pub fn create(&self, path: &Path, len: NonZeroUsize) -> Result<MappedFile, MapError> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        let total = self
+            .offset
+            .checked_add(len.get() as u64)
+            .ok_or(MapError::OutOfBounds)?;
+        file.set_len(total)?;
+        self.map_file(file, len)
+    }
+
+    /// Open an existing file and map it at its current length.
+    ///
+    /// File permissions are matched to the configured protection: read-write
+    /// opens for writing, read-only opens read-only.
+    pub fn open(&self, path: &Path) -> Result<MappedFile, MapError> {
+        let file = if self.protection == Protection::ReadWrite {
+            OpenOptions::new().read(true).write(true).open(path)?
+        } else {
+            OpenOptions::new().read(true).open(path)?
+        };
+        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
+        self.map_file(file, len)
+    }
+
+    /// Map an already-opened file.
+    ///
+    /// Returns [`MapError::OutOfBounds`] if `offset + len` exceeds the
+    /// file size.
+    pub fn from_file(&self, file: File, len: NonZeroUsize) -> Result<MappedFile, MapError> {
+        self.map_file(file, len)
+    }
+
+    fn map_file(&self, file: File, len: NonZeroUsize) -> Result<MappedFile, MapError> {
+        let file_len = file.metadata()?.len();
+        let end = self
+            .offset
+            .checked_add(len.get() as u64)
+            .ok_or(MapError::OutOfBounds)?;
+        if end > file_len {
+            return Err(MapError::OutOfBounds);
+        }
+        let fd = OwnedFd::from(file);
+        let opts = MapOptions {
+            pretouch: self.pretouch,
+            huge_pages: self.huge_pages,
+        };
+        let mapping = Mapping::new(fd, len, self.offset, self.protection, self.sharing, opts)?;
+        Ok(MappedFile { mapping })
+    }
+}
+
 /// RAII file-backed memory mapping. Unmaps on drop.
 ///
 /// Maps a persistent file on a durable filesystem (ext4, xfs, etc.) into
@@ -12,6 +178,11 @@ use crate::mapping::{MapError, MapOptions, Mapping, Protection, Sharing};
 /// drop — file lifecycle (unlink, rotate, archive) is the caller's
 /// responsibility. The file persists so that peers or restarting processes
 /// can access it.
+///
+/// For full control over protection, sharing, and mapping hints, use
+/// [`MappedFile::options()`]. The convenience methods [`create`](Self::create),
+/// [`open`](Self::open), and [`open_readonly`](Self::open_readonly) cover
+/// the common cases with sensible defaults.
 ///
 /// All operations on the mapped bytes (`as_slice`, `read_at`, `write_at`,
 /// `as_ptr`) are delegated to the inner [`Mapping`]. See its documentation
@@ -21,64 +192,37 @@ pub struct MappedFile {
 }
 
 impl MappedFile {
+    /// Returns an options builder for configuring and creating a mapping.
+    ///
+    /// See [`MappedFileOptions`] for available settings and examples.
+    pub fn options() -> MappedFileOptions {
+        MappedFileOptions::new()
+    }
+
     /// Create or open a file at `path`, set its length to `len`, and map it
     /// as [`Sharing::Shared`] with [`Protection::ReadWrite`].
     ///
-    /// This is the common case for IPC segments. The file is created if it
-    /// does not exist. If the file already exists, it is resized to `len`
-    /// (extending or truncating as needed).
-    pub fn create(path: &Path, len: NonZeroUsize, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)?;
-        file.set_len(len.get() as u64)?;
-        Self::from_file(file, len, 0, Protection::ReadWrite, Sharing::Shared, opts)
+    /// Convenience for `MappedFile::options().create(path, len)` with
+    /// default settings. The file is created if it does not exist.
+    pub fn create(path: &Path, len: NonZeroUsize) -> Result<Self, MapError> {
+        Self::options().create(path, len)
     }
 
     /// Open an existing file and map it as [`Sharing::Shared`] with
     /// [`Protection::ReadWrite`] at its current length.
-    pub fn open(path: &Path, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new().read(true).write(true).open(path)?;
-        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
-        Self::from_file(file, len, 0, Protection::ReadWrite, Sharing::Shared, opts)
+    ///
+    /// Convenience for `MappedFile::options().open(path)` with default
+    /// settings.
+    pub fn open(path: &Path) -> Result<Self, MapError> {
+        Self::options().open(path)
     }
 
     /// Open an existing file read-only and map it as [`Sharing::Private`].
-    pub fn open_readonly(path: &Path, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new().read(true).open(path)?;
-        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
-        Self::from_file(file, len, 0, Protection::ReadOnly, Sharing::Private, opts)
-    }
-
-    /// Map an already-opened file with full control over protection,
-    /// sharing mode, and file offset.
     ///
-    /// `offset` must be page-aligned (typically 4096 on Linux). The kernel
-    /// will return an error if it is not.
-    ///
-    /// Returns [`MapError::OutOfBounds`] if `offset + len` exceeds the
-    /// file size.
-    pub fn from_file(
-        file: File,
-        len: NonZeroUsize,
-        offset: u64,
-        prot: Protection,
-        sharing: Sharing,
-        opts: MapOptions,
-    ) -> Result<Self, MapError> {
-        let file_len = file.metadata()?.len();
-        let end = offset
-            .checked_add(len.get() as u64)
-            .ok_or(MapError::OutOfBounds)?;
-        if end > file_len {
-            return Err(MapError::OutOfBounds);
-        }
-        let fd = OwnedFd::from(file);
-        let mapping = Mapping::new(fd, len, offset, prot, sharing, opts)?;
-        Ok(Self { mapping })
+    /// Convenience for
+    /// `MappedFile::options().read_only().private().open(path)`.
+    pub fn open_readonly(path: &Path) -> Result<Self, MapError> {
+        Self::options().read_only().private().open(path)
     }
 
     /// Access the underlying [`Mapping`].
@@ -108,12 +252,7 @@ mod tests {
         let path = temp_path("rw");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         assert_eq!(m.len(), 4096);
         assert!(m.is_writable());
 
@@ -130,16 +269,11 @@ mod tests {
         let path = temp_path("open");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(256).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(256).unwrap()).unwrap();
         m.write_at(b"hello", 10).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open(&path).unwrap();
         let mut buf = [0u8; 5];
         m2.read_at(&mut buf, 10);
         assert_eq!(&buf, b"hello");
@@ -152,16 +286,11 @@ mod tests {
         let path = temp_path("readonly");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(128).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(128).unwrap()).unwrap();
         m.write_at(b"data", 0).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open_readonly(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open_readonly(&path).unwrap();
         assert!(!m2.is_writable());
         assert_eq!(&m2.as_slice()[..4], b"data");
 
@@ -173,8 +302,7 @@ mod tests {
         let path = temp_path("slice");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(64).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(64).unwrap()).unwrap();
         m.write_at(&[1, 2, 3, 4], 0).unwrap();
         assert_eq!(&m.as_slice()[..4], &[1, 2, 3, 4]);
 
@@ -186,8 +314,7 @@ mod tests {
         let path = temp_path("partial");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let mut buf = [0u8; 16];
         let n = m.read_at(&mut buf, 4);
         assert_eq!(n, 4);
@@ -200,8 +327,7 @@ mod tests {
         let path = temp_path("wpartial");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let n = m.write_at(&[1, 2, 3, 4], 6).unwrap();
         assert_eq!(n, 2);
         assert_eq!(&m.as_slice()[6..8], &[1, 2]);
@@ -214,8 +340,7 @@ mod tests {
         let path = temp_path("beyond");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let mut buf = [0u8; 4];
         let n = m.read_at(&mut buf, 100);
         assert_eq!(n, 0);
@@ -227,10 +352,7 @@ mod tests {
     fn open_empty_file_fails() {
         let path = temp_path("empty");
         std::fs::write(&path, b"").unwrap();
-        assert!(matches!(
-            MappedFile::open(&path, MapOptions::default()),
-            Err(MapError::EmptyFile)
-        ));
+        assert!(matches!(MappedFile::open(&path), Err(MapError::EmptyFile)));
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -239,12 +361,7 @@ mod tests {
         let path = temp_path("sync");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         m.write_at(b"durable", 0).unwrap();
         m.sync().unwrap();
 
@@ -256,12 +373,7 @@ mod tests {
         let path = temp_path("advise");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         m.advise(crate::Advice::Sequential).unwrap();
         m.advise(crate::Advice::Random).unwrap();
         m.advise(crate::Advice::WillNeed).unwrap();
@@ -284,15 +396,9 @@ mod tests {
             .unwrap();
         file.set_len(8192).unwrap();
 
-        let full = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(8192).unwrap(),
-            0,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        )
-        .unwrap();
+        let full = MappedFile::options()
+            .from_file(file, NonZeroUsize::new(8192).unwrap())
+            .unwrap();
         full.write_at(b"offset-test", 4096).unwrap();
         drop(full);
 
@@ -301,15 +407,10 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let window = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(4096).unwrap(),
-            4096,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        )
-        .unwrap();
+        let window = MappedFile::options()
+            .offset(4096)
+            .from_file(file, NonZeroUsize::new(4096).unwrap())
+            .unwrap();
         assert_eq!(&window.as_slice()[..11], b"offset-test");
 
         std::fs::remove_file(&path).unwrap();
@@ -320,16 +421,11 @@ mod tests {
         let path = temp_path("write-ro");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(128).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(128).unwrap()).unwrap();
         m.write_at(b"setup", 0).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open_readonly(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open_readonly(&path).unwrap();
         let err = m2.write_at(b"nope", 0).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
 
@@ -350,14 +446,7 @@ mod tests {
             .unwrap();
         file.set_len(4096).unwrap();
 
-        let result = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(8192).unwrap(),
-            0,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        );
+        let result = MappedFile::options().from_file(file, NonZeroUsize::new(8192).unwrap());
         assert!(matches!(result, Err(MapError::OutOfBounds)));
 
         let file = OpenOptions::new()
@@ -365,14 +454,9 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let result = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(4096).unwrap(),
-            4096,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        );
+        let result = MappedFile::options()
+            .offset(4096)
+            .from_file(file, NonZeroUsize::new(4096).unwrap());
         assert!(matches!(result, Err(MapError::OutOfBounds)));
 
         std::fs::remove_file(&path).unwrap();
@@ -383,18 +467,63 @@ mod tests {
         let path = temp_path("shared");
         let _ = std::fs::remove_file(&path);
 
-        let m1 = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
-        let m2 = MappedFile::open(&path, MapOptions::default()).unwrap();
+        let m1 = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
+        let m2 = MappedFile::open(&path).unwrap();
 
         m1.write_at(b"visible", 0).unwrap();
         let mut buf = [0u8; 7];
         m2.read_at(&mut buf, 0);
         assert_eq!(&buf, b"visible");
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn options_builder_pretouch() {
+        let path = temp_path("opts-pretouch");
+        let _ = std::fs::remove_file(&path);
+
+        let m = MappedFile::options()
+            .pretouch(true)
+            .create(&path, NonZeroUsize::new(4096).unwrap())
+            .unwrap();
+        assert_eq!(m.len(), 4096);
+        assert!(m.is_writable());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn options_builder_readonly_private() {
+        let path = temp_path("opts-ro");
+        let _ = std::fs::remove_file(&path);
+
+        MappedFile::create(&path, NonZeroUsize::new(256).unwrap()).unwrap();
+
+        let m = MappedFile::options()
+            .read_only()
+            .private()
+            .open(&path)
+            .unwrap();
+        assert!(!m.is_writable());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn options_builder_create_with_offset() {
+        let path = temp_path("opts-offset");
+        let _ = std::fs::remove_file(&path);
+
+        let m = MappedFile::options()
+            .offset(4096)
+            .create(&path, NonZeroUsize::new(4096).unwrap())
+            .unwrap();
+        assert_eq!(m.len(), 4096);
+        m.write_at(b"hello", 0).unwrap();
+
+        let file_len = std::fs::metadata(&path).unwrap().len();
+        assert_eq!(file_len, 8192);
 
         std::fs::remove_file(&path).unwrap();
     }

--- a/nexus-platform/src/mapping/mod.rs
+++ b/nexus-platform/src/mapping/mod.rs
@@ -55,17 +55,10 @@ pub enum Advice {
     NoHugePage,
 }
 
-/// Platform-aware hints for mapping creation. Fields are best-effort:
-/// each platform backend documents what it actually provides.
-///
-/// - `pretouch`: pre-fault pages into memory on creation.
-///   Linux: `MAP_POPULATE`. macOS: `madvise(MADV_WILLNEED)`.
-/// - `huge_pages`: request huge-page backing.
-///   Linux: `MAP_HUGETLB`. Others: best-effort or no-op.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct MapOptions {
-    pub pretouch: bool,
-    pub huge_pages: bool,
+pub(crate) struct MapOptions {
+    pub(crate) pretouch: bool,
+    pub(crate) huge_pages: bool,
 }
 
 /// Error from memory-mapping operations.

--- a/nexus-shm/benches/journal.rs
+++ b/nexus-shm/benches/journal.rs
@@ -1,12 +1,12 @@
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use nexus_shm::{FixHeader, Journal, JournalConfig, MapOptions};
+use nexus_shm::{FixHeader, Journal, JournalConfig, MapHints};
 
 fn cfg(segment_size: usize) -> JournalConfig {
     JournalConfig {
         segment_size,
-        map: MapOptions::default(),
+        hints: MapHints::default(),
     }
 }
 

--- a/nexus-shm/benches/ofd_liveness.rs
+++ b/nexus-shm/benches/ofd_liveness.rs
@@ -10,14 +10,14 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use nexus_shm::{Liveness, MapOptions, Segment};
+use nexus_shm::{Liveness, MapHints, Segment};
 
 fn bench_peer_liveness(c: &mut Criterion) {
     let path = std::env::temp_dir().join(format!("nexus-shm-bench-{}", std::process::id()));
     let _ = std::fs::remove_file(&path);
 
-    let owner = Segment::create(&path, 4096, MapOptions::default()).unwrap();
-    let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+    let owner = Segment::create(&path, 4096, MapHints::default()).unwrap();
+    let peer = Segment::attach(&path, MapHints::default()).unwrap();
     assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
     c.benchmark_group("ofd_liveness")

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -10,8 +10,8 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
+use crate::MapHints;
 use crate::segment::Segment;
-use nexus_platform::MapOptions;
 
 pub use error::JournalError;
 pub use header::{FixHeader, RecordHeader, SeqHeader};
@@ -26,14 +26,14 @@ const MIN_SEGMENT: usize = 64;
 #[derive(Clone, Copy)]
 pub struct JournalConfig {
     pub segment_size: usize,
-    pub map: MapOptions,
+    pub hints: MapHints,
 }
 
 impl Default for JournalConfig {
     fn default() -> Self {
         Self {
             segment_size: 64 * 1024 * 1024,
-            map: MapOptions::default(),
+            hints: MapHints::default(),
         }
     }
 }
@@ -58,24 +58,24 @@ impl<H: RecordHeader> Journal<H> {
         }
 
         let index = last.unwrap_or(0);
-        let active = Segment::create(&segment_path(&base, index), segment_size, cfg.map)?;
+        let active = Segment::create(&segment_path(&base, index), segment_size, cfg.hints)?;
         let tail = recover_tail::<H>(&active, segment_size);
 
         let writer = Writer {
             base: base.clone(),
             segment_size,
-            map: cfg.map,
+            hints: cfg.hints,
             active,
             index,
             tail,
             _marker: PhantomData,
         };
 
-        let seg0 = Segment::attach(&segment_path(&base, 0), cfg.map)?;
+        let seg0 = Segment::attach(&segment_path(&base, 0), cfg.hints)?;
         let reader = Reader {
             base,
             segment_size,
-            map: cfg.map,
+            hints: cfg.hints,
             segments: vec![seg0],
             seg_idx: 0,
             cursor: 0,

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -13,7 +13,7 @@ use super::header::{RecordHeader, SeqHeader};
 pub struct Reader<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
-    pub(super) map: nexus_platform::MapOptions,
+    pub(super) hints: crate::MapHints,
     pub(super) segments: Vec<Segment>,
     pub(super) seg_idx: usize,
     pub(super) cursor: usize,
@@ -77,7 +77,7 @@ impl<H: RecordHeader> Reader<H> {
     fn load_next(&mut self) -> Result<bool, JournalError> {
         let next = self.segments.len() as u64;
         let path = super::segment_path(&self.base, next);
-        match Segment::attach(&path, self.map) {
+        match Segment::attach(&path, self.hints) {
             Ok(seg) => {
                 self.segments.push(seg);
                 Ok(true)

--- a/nexus-shm/src/journal/tests.rs
+++ b/nexus-shm/src/journal/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::MapOptions;
+use crate::MapHints;
 
 use super::{FixHeader, Journal, JournalConfig, JournalError};
 
@@ -26,7 +26,7 @@ fn fix(seq: u64) -> FixHeader {
 fn cfg(segment_size: usize) -> JournalConfig {
     JournalConfig {
         segment_size,
-        map: MapOptions::default(),
+        hints: MapHints::default(),
     }
 }
 

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -11,7 +11,7 @@ use super::header::RecordHeader;
 pub struct Writer<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
-    pub(super) map: nexus_platform::MapOptions,
+    pub(super) hints: crate::MapHints,
     pub(super) active: Segment,
     pub(super) index: u64,
     pub(super) tail: usize,
@@ -63,7 +63,7 @@ impl<H: RecordHeader> Writer<H> {
         }
         self.index += 1;
         let path = super::segment_path(&self.base, self.index);
-        self.active = Segment::create(&path, self.segment_size, self.map)?;
+        self.active = Segment::create(&path, self.segment_size, self.hints)?;
         self.tail = 0;
         Ok(())
     }

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -18,13 +18,13 @@ pub use journal::{
 };
 pub use nexus_platform::Liveness;
 
-/// Mapping hints for segment creation.
+/// Mapping hints for segment creation and attachment.
 ///
 /// These are best-effort: the platform backend documents what it
 /// actually provides. Both default to `false`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MapHints {
-    /// Pre-fault pages into memory on creation (`MAP_POPULATE`).
+    /// Pre-fault pages into memory (`MAP_POPULATE`).
     pub pretouch: bool,
     /// Request huge-page backing (`MAP_HUGETLB`).
     pub huge_pages: bool,

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -16,7 +16,19 @@ pub use journal::{
     FixHeader, Journal, JournalConfig, JournalError, ReadRange, ReadRecord, Reader, RecordHeader,
     SeqHeader, WriteClaim, Writer,
 };
-pub use nexus_platform::{Liveness, MapOptions};
+pub use nexus_platform::Liveness;
+
+/// Mapping hints for segment creation.
+///
+/// These are best-effort: the platform backend documents what it
+/// actually provides. Both default to `false`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MapHints {
+    /// Pre-fault pages into memory on creation (`MAP_POPULATE`).
+    pub pretouch: bool,
+    /// Request huge-page backing (`MAP_HUGETLB`).
+    pub huge_pages: bool,
+}
 pub use pod::Pod;
 pub use seglog::{
     Conductor, ConductorBuilder, Frame, LogError, LogOffset, OpenError, SegmentedLog,

--- a/nexus-shm/src/seglog/manifest.rs
+++ b/nexus-shm/src/seglog/manifest.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use nexus_platform::{MapOptions, MappedFile};
+use nexus_platform::MappedFile;
 
 use crate::error::ShmError;
 
@@ -80,7 +80,7 @@ impl Manifest {
         name: &[u8],
     ) -> Result<Self, ShmError> {
         let len = NonZeroUsize::new(MANIFEST_FILE_SIZE).unwrap();
-        let mapping = MappedFile::create(path, len, MapOptions::default())?;
+        let mapping = MappedFile::create(path, len)?;
 
         // SAFETY: the mapping covers at least MANIFEST_FILE_SIZE bytes and is
         // page-aligned. We hold exclusive access (just created the file).
@@ -100,7 +100,7 @@ impl Manifest {
     }
 
     pub(crate) fn open(path: &Path) -> Result<Self, ShmError> {
-        let mapping = MappedFile::open(path, MapOptions::default())?;
+        let mapping = MappedFile::open(path)?;
         let hdr = Self::header_of(&mapping);
 
         if hdr.magic != MAGIC {

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::segment::Segment;
-use nexus_platform::{FileLock, MapOptions};
+use nexus_platform::FileLock;
+
+use crate::MapHints;
 
 use conductor::CleanRequest;
 use frame::{ALIGN, FRAME_HDR, align_up, commit_len_ptr, footprint, session_id_ptr};
@@ -130,7 +132,7 @@ impl<'a> SegmentedLogBuilder<'a> {
         let session_lock = FileLock::try_lock(session_dir.join(SESSION_LOCK_FILE))?
             .ok_or(OpenError::SessionInUse { session_id: id })?;
 
-        let map = self.map_options();
+        let hints = self.map_hints();
         let size = align_up(self.segment_size.max(FRAME_HDR * 8));
         if size > u32::MAX as usize {
             return Err(OpenError::SegmentTooLarge { size });
@@ -144,14 +146,14 @@ impl<'a> SegmentedLogBuilder<'a> {
 
         let mpath = manifest_path(&session_dir);
         if mpath.exists() {
-            SegmentedLog::recover(&session_dir, size, map, strict, id, res)
+            SegmentedLog::recover(&session_dir, size, hints, strict, id, res)
         } else {
-            SegmentedLog::create_fresh(&session_dir, size, map, id, name_bytes, res)
+            SegmentedLog::create_fresh(&session_dir, size, hints, id, name_bytes, res)
         }
     }
 
-    fn map_options(&self) -> MapOptions {
-        MapOptions {
+    fn map_hints(&self) -> MapHints {
+        MapHints {
             pretouch: self.pretouch,
             huge_pages: self.huge_pages,
         }
@@ -415,7 +417,7 @@ impl SegmentedLog {
     fn create_fresh(
         dir: &Path,
         size: usize,
-        map: MapOptions,
+        hints: MapHints,
         session_id: u32,
         name: &[u8],
         res: SessionResources,
@@ -423,7 +425,7 @@ impl SegmentedLog {
         let manifest = Manifest::create(&manifest_path(dir), size as u64, session_id, name)?;
 
         let mk = |i: u8| -> Result<Slot, OpenError> {
-            let seg = Segment::create(&seg_path(dir, i), size, map)?;
+            let seg = Segment::create(&seg_path(dir, i), size, hints)?;
             let data = seg.data();
             Ok(Slot {
                 _segment: seg,
@@ -465,7 +467,7 @@ impl SegmentedLog {
     fn recover(
         dir: &Path,
         requested_size: usize,
-        map: MapOptions,
+        hints: MapHints,
         strict: bool,
         expected_session_id: u32,
         res: SessionResources,
@@ -508,9 +510,9 @@ impl SegmentedLog {
         let mk = |i: u8| -> Result<Slot, OpenError> {
             let path = seg_path(dir, i);
             let seg = if path.exists() {
-                Segment::attach(&path, map)?
+                Segment::attach(&path, hints)?
             } else {
-                Segment::create(&path, size, map)?
+                Segment::create(&path, size, hints)?
             };
             let data = seg.data();
             Ok(Slot {

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -2,7 +2,9 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::AtomicU32;
 
-use nexus_platform::{Liveness, MapOptions, MappedFile, ProcessLease};
+use nexus_platform::{Liveness, MappedFile, ProcessLease};
+
+use crate::MapHints;
 
 use crate::control::{ControlBlock, status};
 use crate::error::ShmError;
@@ -30,12 +32,12 @@ pub struct Segment {
 }
 
 impl Segment {
-    pub fn create(path: &Path, data_len: usize, opts: MapOptions) -> Result<Self, ShmError> {
+    pub fn create(path: &Path, data_len: usize, hints: MapHints) -> Result<Self, ShmError> {
         if data_len == 0 {
             return Err(ShmError::EmptySegment);
         }
         let total = HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)?;
-        let mapping = MappedFile::create(path, total, opts)?;
+        let mapping = file_opts(hints).create(path, total)?;
 
         if !ProcessLease::claim(mapping.as_fd())? {
             return Err(ShmError::OwnerActive);
@@ -46,7 +48,12 @@ impl Segment {
         // ControlBlock-aligned) covering at least the header.
         let cb = unsafe { &mut *mapping.as_ptr().cast::<ControlBlock>() };
         let generation = cb.generation().wrapping_add(1);
-        cb.write_header(flags(opts), generation, std::process::id(), data_len as u64);
+        cb.write_header(
+            flags(hints),
+            generation,
+            std::process::id(),
+            data_len as u64,
+        );
 
         Ok(Self {
             mapping,
@@ -54,8 +61,8 @@ impl Segment {
         })
     }
 
-    pub fn attach(path: &Path, opts: MapOptions) -> Result<Self, ShmError> {
-        let mapping = MappedFile::open(path, opts)?;
+    pub fn attach(path: &Path, hints: MapHints) -> Result<Self, ShmError> {
+        let mapping = file_opts(hints).open(path)?;
         Self::control_of(&mapping).validate()?;
         Ok(Self {
             mapping,
@@ -181,15 +188,21 @@ impl Drop for Segment {
     }
 }
 
-fn flags(opts: MapOptions) -> u16 {
-    u16::from(opts.pretouch) | (u16::from(opts.huge_pages) << 1)
+fn file_opts(hints: MapHints) -> nexus_platform::MappedFileOptions {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts
+}
+
+fn flags(hints: MapHints) -> u16 {
+    u16::from(hints.pretouch) | (u16::from(hints.huge_pages) << 1)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{Liveness, Segment, Status};
+    use crate::MapHints;
     use crate::error::ShmError;
-    use nexus_platform::MapOptions;
 
     fn temp_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("nexus-shm-{}-{}", std::process::id(), name))
@@ -200,13 +213,13 @@ mod tests {
         let path = temp_path("roundtrip");
         let _ = std::fs::remove_file(&path);
 
-        let mut seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
+        let mut seg = Segment::create(&path, 4096, MapHints::default()).unwrap();
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 
         unsafe { seg.slice_mut_at(0, 1)[0] = 0xAB };
 
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let peer = Segment::attach(&path, MapHints::default()).unwrap();
         assert_eq!(peer.data_len(), 4096);
         assert_eq!(peer.status(), Status::Alive);
         assert_eq!(unsafe { peer.slice_at(0, 1)[0] }, 0xAB);
@@ -219,10 +232,10 @@ mod tests {
         let path = temp_path("dead");
         let _ = std::fs::remove_file(&path);
 
-        let seg = Segment::create(&path, 64, MapOptions::default()).unwrap();
+        let seg = Segment::create(&path, 64, MapHints::default()).unwrap();
         drop(seg);
 
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let peer = Segment::attach(&path, MapHints::default()).unwrap();
         assert_eq!(peer.status(), Status::Dead);
 
         std::fs::remove_file(&path).unwrap();
@@ -233,7 +246,7 @@ mod tests {
         let path = temp_path("zero");
         let _ = std::fs::remove_file(&path);
         assert!(matches!(
-            Segment::create(&path, 0, MapOptions::default()),
+            Segment::create(&path, 0, MapHints::default()),
             Err(ShmError::EmptySegment)
         ));
     }
@@ -243,8 +256,8 @@ mod tests {
         let path = temp_path("liveness");
         let _ = std::fs::remove_file(&path);
 
-        let owner = Segment::create(&path, 64, MapOptions::default()).unwrap();
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let owner = Segment::create(&path, 64, MapHints::default()).unwrap();
+        let peer = Segment::attach(&path, MapHints::default()).unwrap();
         assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
         drop(owner);
@@ -258,7 +271,7 @@ mod tests {
         let path = temp_path("foreign");
         std::fs::write(&path, vec![0u8; 4096]).unwrap();
 
-        assert!(Segment::attach(&path, MapOptions::default()).is_err());
+        assert!(Segment::attach(&path, MapHints::default()).is_err());
 
         std::fs::remove_file(&path).unwrap();
     }


### PR DESCRIPTION
Closes #486

## Summary

- Introduces `MappedFileOptions` builder following `std::fs::OpenOptions` convention (`&mut self` setters, `&self` terminals) for full control over mapped file creation
- Simplifies `MappedFile::create/open/open_readonly` to parameterless convenience methods that delegate to the builder with defaults
- Makes `MapOptions` internal (`pub(crate)`) — no longer part of the public API
- Adds `MapHints` to `nexus-shm` as the crate-owned type for pretouch/huge_pages, replacing the leaked `MapOptions` re-export
- Renames `JournalConfig.map` → `JournalConfig.hints` throughout

## Test plan

- [x] `cargo test --workspace` — all passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests: `options_builder_pretouch`, `options_builder_readonly_private`, `options_builder_create_with_offset`
- [x] Existing tests updated to parameterless convenience methods
- [x] Copilot review feedback addressed: `open()` with offset fix, `create()` no-truncate fix, `MapHints` doc fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)