### PR TITLE
refactor: MappedFileOptions builder replaces MapOptions

### DIFF
--- a/nexus-platform/src/lib.rs
+++ b/nexus-platform/src/lib.rs
@@ -15,4 +15,4 @@ pub mod mapping;
 pub use file_lock::FileLock;
 pub use lease::{Liveness, ProcessLease};
 pub use mapped_file::MappedFile;
-pub use mapping::{Advice, MapError, MapOptions, Mapping, Protection, Sharing};
+pub use mapping::{Advice, MapError, MappedFileOptions, Mapping, Protection, Sharing};

--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use std::os::fd::OwnedFd;
 use std::path::Path;
 
-use crate::mapping::{MapError, MapOptions, Mapping, Protection, Sharing};
+use crate::mapping::{MapError, MappedFileOptions, Mapping, Protection, Sharing};
 
 /// RAII file-backed memory mapping. Unmaps on drop.
 ///
@@ -16,69 +16,63 @@ use crate::mapping::{MapError, MapOptions, Mapping, Protection, Sharing};
 /// All operations on the mapped bytes (`as_slice`, `read_at`, `write_at`,
 /// `as_ptr`) are delegated to the inner [`Mapping`]. See its documentation
 /// for the shared-mapping caveat.
+///
+/// # Usage
+///
+/// ## Convenience constructors (default options)
+///
+/// ```no_run
+/// # use nexus_platform::MappedFile;
+/// # use std::num::NonZeroUsize;
+/// # let path = std::path::Path::new("/tmp/seg");
+/// let mf = MappedFile::create(path, NonZeroUsize::new(4096).unwrap())?;
+/// let mf = MappedFile::open(path)?;
+/// let mf = MappedFile::open_readonly(path)?;
+/// # Ok::<_, nexus_platform::MapError>(())
+/// ```
+///
+/// ## Builder (full control)
+///
+/// ```no_run
+/// # use nexus_platform::MappedFile;
+/// # use std::num::NonZeroUsize;
+/// # let path = std::path::Path::new("/tmp/seg");
+/// let mf = MappedFile::options()
+///     .read_write()
+///     .shared()
+///     .pretouch(true)
+///     .create(path, NonZeroUsize::new(4096).unwrap())?;
+/// # Ok::<_, nexus_platform::MapError>(())
+/// ```
 pub struct MappedFile {
     mapping: Mapping,
 }
 
 impl MappedFile {
+    /// Return a builder for full control over protection, sharing, and hints.
+    pub fn options() -> MappedFileOptions {
+        MappedFileOptions::default()
+    }
+
     /// Create or open a file at `path`, set its length to `len`, and map it
     /// as [`Sharing::Shared`] with [`Protection::ReadWrite`].
     ///
     /// This is the common case for IPC segments. The file is created if it
     /// does not exist. If the file already exists, it is resized to `len`
     /// (extending or truncating as needed).
-    pub fn create(path: &Path, len: NonZeroUsize, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)?;
-        file.set_len(len.get() as u64)?;
-        Self::from_file(file, len, 0, Protection::ReadWrite, Sharing::Shared, opts)
+    pub fn create(path: &Path, len: NonZeroUsize) -> Result<Self, MapError> {
+        MappedFileOptions::default().create(path, len)
     }
 
     /// Open an existing file and map it as [`Sharing::Shared`] with
     /// [`Protection::ReadWrite`] at its current length.
-    pub fn open(path: &Path, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new().read(true).write(true).open(path)?;
-        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
-        Self::from_file(file, len, 0, Protection::ReadWrite, Sharing::Shared, opts)
+    pub fn open(path: &Path) -> Result<Self, MapError> {
+        MappedFileOptions::default().open(path)
     }
 
     /// Open an existing file read-only and map it as [`Sharing::Private`].
-    pub fn open_readonly(path: &Path, opts: MapOptions) -> Result<Self, MapError> {
-        let file = OpenOptions::new().read(true).open(path)?;
-        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
-        Self::from_file(file, len, 0, Protection::ReadOnly, Sharing::Private, opts)
-    }
-
-    /// Map an already-opened file with full control over protection,
-    /// sharing mode, and file offset.
-    ///
-    /// `offset` must be page-aligned (typically 4096 on Linux). The kernel
-    /// will return an error if it is not.
-    ///
-    /// Returns [`MapError::OutOfBounds`] if `offset + len` exceeds the
-    /// file size.
-    pub fn from_file(
-        file: File,
-        len: NonZeroUsize,
-        offset: u64,
-        prot: Protection,
-        sharing: Sharing,
-        opts: MapOptions,
-    ) -> Result<Self, MapError> {
-        let file_len = file.metadata()?.len();
-        let end = offset
-            .checked_add(len.get() as u64)
-            .ok_or(MapError::OutOfBounds)?;
-        if end > file_len {
-            return Err(MapError::OutOfBounds);
-        }
-        let fd = OwnedFd::from(file);
-        let mapping = Mapping::new(fd, len, offset, prot, sharing, opts)?;
-        Ok(Self { mapping })
+    pub fn open_readonly(path: &Path) -> Result<Self, MapError> {
+        MappedFileOptions::default().read_only().private().open(path)
     }
 
     /// Access the underlying [`Mapping`].
@@ -95,6 +89,59 @@ impl std::ops::Deref for MappedFile {
     }
 }
 
+impl MappedFileOptions {
+    /// Create or open a file at `path`, set its length to `len`, and map it.
+    ///
+    /// The file is created if it does not exist. If the file already exists,
+    /// it is resized to `len` (extending or truncating as needed).
+    pub fn create(self, path: &Path, len: NonZeroUsize) -> Result<MappedFile, MapError> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        file.set_len(len.get() as u64)?;
+        let fd = OwnedFd::from(file);
+        let mapping = Mapping::new(fd, len, self)?;
+        Ok(MappedFile { mapping })
+    }
+
+    /// Open an existing file and map it at its current length.
+    ///
+    /// The file is opened with the access mode implied by the protection
+    /// setting. `offset` is ignored; the whole file is mapped from the start.
+    pub fn open(self, path: &Path) -> Result<MappedFile, MapError> {
+        let write = self.prot == Protection::ReadWrite;
+        let file = OpenOptions::new().read(true).write(write).open(path)?;
+        let len =
+            NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
+        let fd = OwnedFd::from(file);
+        let opts = MappedFileOptions { offset: 0, ..self };
+        let mapping = Mapping::new(fd, len, opts)?;
+        Ok(MappedFile { mapping })
+    }
+
+    /// Map an already-opened file with full control over length and offset.
+    ///
+    /// `self.offset` must be page-aligned (typically 4096 on Linux).
+    /// Returns [`MapError::OutOfBounds`] if `offset + len` exceeds the
+    /// file size.
+    pub fn from_file(self, file: File, len: NonZeroUsize) -> Result<MappedFile, MapError> {
+        let file_len = file.metadata()?.len();
+        let end = self
+            .offset
+            .checked_add(len.get() as u64)
+            .ok_or(MapError::OutOfBounds)?;
+        if end > file_len {
+            return Err(MapError::OutOfBounds);
+        }
+        let fd = OwnedFd::from(file);
+        let mapping = Mapping::new(fd, len, self)?;
+        Ok(MappedFile { mapping })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,12 +155,7 @@ mod tests {
         let path = temp_path("rw");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         assert_eq!(m.len(), 4096);
         assert!(m.is_writable());
 
@@ -130,16 +172,11 @@ mod tests {
         let path = temp_path("open");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(256).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(256).unwrap()).unwrap();
         m.write_at(b"hello", 10).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open(&path).unwrap();
         let mut buf = [0u8; 5];
         m2.read_at(&mut buf, 10);
         assert_eq!(&buf, b"hello");
@@ -152,16 +189,11 @@ mod tests {
         let path = temp_path("readonly");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(128).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(128).unwrap()).unwrap();
         m.write_at(b"data", 0).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open_readonly(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open_readonly(&path).unwrap();
         assert!(!m2.is_writable());
         assert_eq!(&m2.as_slice()[..4], b"data");
 
@@ -173,8 +205,7 @@ mod tests {
         let path = temp_path("slice");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(64).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(64).unwrap()).unwrap();
         m.write_at(&[1, 2, 3, 4], 0).unwrap();
         assert_eq!(&m.as_slice()[..4], &[1, 2, 3, 4]);
 
@@ -186,8 +217,7 @@ mod tests {
         let path = temp_path("partial");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let mut buf = [0u8; 16];
         let n = m.read_at(&mut buf, 4);
         assert_eq!(n, 4);
@@ -200,8 +230,7 @@ mod tests {
         let path = temp_path("wpartial");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let n = m.write_at(&[1, 2, 3, 4], 6).unwrap();
         assert_eq!(n, 2);
         assert_eq!(&m.as_slice()[6..8], &[1, 2]);
@@ -214,8 +243,7 @@ mod tests {
         let path = temp_path("beyond");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap(), MapOptions::default())
-            .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(8).unwrap()).unwrap();
         let mut buf = [0u8; 4];
         let n = m.read_at(&mut buf, 100);
         assert_eq!(n, 0);
@@ -227,10 +255,7 @@ mod tests {
     fn open_empty_file_fails() {
         let path = temp_path("empty");
         std::fs::write(&path, b"").unwrap();
-        assert!(matches!(
-            MappedFile::open(&path, MapOptions::default()),
-            Err(MapError::EmptyFile)
-        ));
+        assert!(matches!(MappedFile::open(&path), Err(MapError::EmptyFile)));
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -239,12 +264,7 @@ mod tests {
         let path = temp_path("sync");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         m.write_at(b"durable", 0).unwrap();
         m.sync().unwrap();
 
@@ -256,16 +276,25 @@ mod tests {
         let path = temp_path("advise");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
         m.advise(crate::Advice::Sequential).unwrap();
         m.advise(crate::Advice::Random).unwrap();
         m.advise(crate::Advice::WillNeed).unwrap();
         m.advise(crate::Advice::Normal).unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn builder_pretouch() {
+        let path = temp_path("pretouch");
+        let _ = std::fs::remove_file(&path);
+
+        let m = MappedFile::options()
+            .pretouch(true)
+            .create(&path, NonZeroUsize::new(4096).unwrap())
+            .unwrap();
+        assert!(m.is_writable());
 
         std::fs::remove_file(&path).unwrap();
     }
@@ -284,15 +313,9 @@ mod tests {
             .unwrap();
         file.set_len(8192).unwrap();
 
-        let full = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(8192).unwrap(),
-            0,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        )
-        .unwrap();
+        let full = MappedFile::options()
+            .from_file(file, NonZeroUsize::new(8192).unwrap())
+            .unwrap();
         full.write_at(b"offset-test", 4096).unwrap();
         drop(full);
 
@@ -301,15 +324,10 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let window = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(4096).unwrap(),
-            4096,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        )
-        .unwrap();
+        let window = MappedFile::options()
+            .offset(4096)
+            .from_file(file, NonZeroUsize::new(4096).unwrap())
+            .unwrap();
         assert_eq!(&window.as_slice()[..11], b"offset-test");
 
         std::fs::remove_file(&path).unwrap();
@@ -320,16 +338,11 @@ mod tests {
         let path = temp_path("write-ro");
         let _ = std::fs::remove_file(&path);
 
-        let m = MappedFile::create(
-            &path,
-            NonZeroUsize::new(128).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
+        let m = MappedFile::create(&path, NonZeroUsize::new(128).unwrap()).unwrap();
         m.write_at(b"setup", 0).unwrap();
         drop(m);
 
-        let m2 = MappedFile::open_readonly(&path, MapOptions::default()).unwrap();
+        let m2 = MappedFile::open_readonly(&path).unwrap();
         let err = m2.write_at(b"nope", 0).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
 
@@ -350,14 +363,7 @@ mod tests {
             .unwrap();
         file.set_len(4096).unwrap();
 
-        let result = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(8192).unwrap(),
-            0,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        );
+        let result = MappedFile::options().from_file(file, NonZeroUsize::new(8192).unwrap());
         assert!(matches!(result, Err(MapError::OutOfBounds)));
 
         let file = OpenOptions::new()
@@ -365,14 +371,9 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let result = MappedFile::from_file(
-            file,
-            NonZeroUsize::new(4096).unwrap(),
-            4096,
-            Protection::ReadWrite,
-            Sharing::Shared,
-            MapOptions::default(),
-        );
+        let result = MappedFile::options()
+            .offset(4096)
+            .from_file(file, NonZeroUsize::new(4096).unwrap());
         assert!(matches!(result, Err(MapError::OutOfBounds)));
 
         std::fs::remove_file(&path).unwrap();
@@ -383,13 +384,8 @@ mod tests {
         let path = temp_path("shared");
         let _ = std::fs::remove_file(&path);
 
-        let m1 = MappedFile::create(
-            &path,
-            NonZeroUsize::new(4096).unwrap(),
-            MapOptions::default(),
-        )
-        .unwrap();
-        let m2 = MappedFile::open(&path, MapOptions::default()).unwrap();
+        let m1 = MappedFile::create(&path, NonZeroUsize::new(4096).unwrap()).unwrap();
+        let m2 = MappedFile::open(&path).unwrap();
 
         m1.write_at(b"visible", 0).unwrap();
         let mut buf = [0u8; 7];

--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use std::os::fd::OwnedFd;
 use std::path::Path;
 
-use crate::mapping::{MapError, MappedFileOptions, Mapping, Protection, Sharing};
+use crate::mapping::{MapError, MappedFileOptions, Mapping, Protection};
 
 /// RAII file-backed memory mapping. Unmaps on drop.
 ///

--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -72,7 +72,10 @@ impl MappedFile {
 
     /// Open an existing file read-only and map it as [`Sharing::Private`].
     pub fn open_readonly(path: &Path) -> Result<Self, MapError> {
-        MappedFileOptions::default().read_only().private().open(path)
+        MappedFileOptions::default()
+            .read_only()
+            .private()
+            .open(path)
     }
 
     /// Access the underlying [`Mapping`].
@@ -114,8 +117,7 @@ impl MappedFileOptions {
     pub fn open(self, path: &Path) -> Result<MappedFile, MapError> {
         let write = self.prot == Protection::ReadWrite;
         let file = OpenOptions::new().read(true).write(write).open(path)?;
-        let len =
-            NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
+        let len = NonZeroUsize::new(file.metadata()?.len() as usize).ok_or(MapError::EmptyFile)?;
         let fd = OwnedFd::from(file);
         let opts = MappedFileOptions { offset: 0, ..self };
         let mapping = Mapping::new(fd, len, opts)?;

--- a/nexus-platform/src/mapping/mod.rs
+++ b/nexus-platform/src/mapping/mod.rs
@@ -208,9 +208,23 @@ pub struct Mapping {
 impl Mapping {
     /// Create a mapping from a raw fd. The fd must already be open and
     /// sized appropriately.
-    pub(crate) fn new(fd: OwnedFd, len: NonZeroUsize, opts: MappedFileOptions) -> Result<Self, MapError> {
-        let map_opts = MapOptions { pretouch: opts.pretouch, huge_pages: opts.huge_pages };
-        let ptr = imp::map(fd.as_fd(), len, opts.offset, opts.prot, opts.sharing, map_opts)?;
+    pub(crate) fn new(
+        fd: OwnedFd,
+        len: NonZeroUsize,
+        opts: MappedFileOptions,
+    ) -> Result<Self, MapError> {
+        let map_opts = MapOptions {
+            pretouch: opts.pretouch,
+            huge_pages: opts.huge_pages,
+        };
+        let ptr = imp::map(
+            fd.as_fd(),
+            len,
+            opts.offset,
+            opts.prot,
+            opts.sharing,
+            map_opts,
+        )?;
         Ok(Self {
             ptr,
             len,

--- a/nexus-platform/src/mapping/mod.rs
+++ b/nexus-platform/src/mapping/mod.rs
@@ -55,17 +55,90 @@ pub enum Advice {
     NoHugePage,
 }
 
-/// Platform-aware hints for mapping creation. Fields are best-effort:
-/// each platform backend documents what it actually provides.
+/// Platform-aware hints for mapping creation.
 ///
-/// - `pretouch`: pre-fault pages into memory on creation.
-///   Linux: `MAP_POPULATE`. macOS: `madvise(MADV_WILLNEED)`.
-/// - `huge_pages`: request huge-page backing.
-///   Linux: `MAP_HUGETLB`. Others: best-effort or no-op.
+/// Used internally by [`Mapping::new`] and the Linux backend. The public
+/// surface for callers is [`MappedFileOptions`].
 #[derive(Debug, Clone, Copy, Default)]
-pub struct MapOptions {
+pub(crate) struct MapOptions {
+    pub(crate) pretouch: bool,
+    pub(crate) huge_pages: bool,
+}
+
+/// Builder for creating a [`MappedFile`](super::MappedFile).
+///
+/// Obtain via [`MappedFile::options()`](super::MappedFile::options). Chain
+/// configuration methods, then call a terminal (`create`, `open`,
+/// `from_file`) to produce the mapping.
+///
+/// # Defaults
+///
+/// | field       | default                |
+/// |-------------|------------------------|
+/// | protection  | `ReadWrite`            |
+/// | sharing     | `Shared`               |
+/// | pretouch    | `false`                |
+/// | huge_pages  | `false`                |
+/// | offset      | `0`                    |
+#[derive(Debug, Clone, Copy)]
+pub struct MappedFileOptions {
+    pub(crate) prot: Protection,
+    pub(crate) sharing: Sharing,
     pub pretouch: bool,
     pub huge_pages: bool,
+    pub(crate) offset: u64,
+}
+
+impl Default for MappedFileOptions {
+    fn default() -> Self {
+        Self {
+            prot: Protection::ReadWrite,
+            sharing: Sharing::Shared,
+            pretouch: false,
+            huge_pages: false,
+            offset: 0,
+        }
+    }
+}
+
+impl MappedFileOptions {
+    pub fn read_write(mut self) -> Self {
+        self.prot = Protection::ReadWrite;
+        self
+    }
+
+    pub fn read_only(mut self) -> Self {
+        self.prot = Protection::ReadOnly;
+        self
+    }
+
+    pub fn shared(mut self) -> Self {
+        self.sharing = Sharing::Shared;
+        self
+    }
+
+    pub fn private(mut self) -> Self {
+        self.sharing = Sharing::Private;
+        self
+    }
+
+    /// Pre-fault pages into memory on creation (`MAP_POPULATE` on Linux).
+    pub fn pretouch(mut self, enable: bool) -> Self {
+        self.pretouch = enable;
+        self
+    }
+
+    /// Request huge-page backing (`MAP_HUGETLB` on Linux).
+    pub fn huge_pages(mut self, enable: bool) -> Self {
+        self.huge_pages = enable;
+        self
+    }
+
+    /// File offset for the mapping (must be page-aligned).
+    pub fn offset(mut self, off: u64) -> Self {
+        self.offset = off;
+        self
+    }
 }
 
 /// Error from memory-mapping operations.
@@ -135,20 +208,14 @@ pub struct Mapping {
 impl Mapping {
     /// Create a mapping from a raw fd. The fd must already be open and
     /// sized appropriately.
-    pub(crate) fn new(
-        fd: OwnedFd,
-        len: NonZeroUsize,
-        offset: u64,
-        prot: Protection,
-        sharing: Sharing,
-        opts: MapOptions,
-    ) -> Result<Self, MapError> {
-        let ptr = imp::map(fd.as_fd(), len, offset, prot, sharing, opts)?;
+    pub(crate) fn new(fd: OwnedFd, len: NonZeroUsize, opts: MappedFileOptions) -> Result<Self, MapError> {
+        let map_opts = MapOptions { pretouch: opts.pretouch, huge_pages: opts.huge_pages };
+        let ptr = imp::map(fd.as_fd(), len, opts.offset, opts.prot, opts.sharing, map_opts)?;
         Ok(Self {
             ptr,
             len,
             fd,
-            writable: prot == Protection::ReadWrite,
+            writable: opts.prot == Protection::ReadWrite,
         })
     }
 

--- a/nexus-shm/benches/journal.rs
+++ b/nexus-shm/benches/journal.rs
@@ -1,12 +1,12 @@
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use nexus_shm::{FixHeader, Journal, JournalConfig, MapOptions};
+use nexus_shm::{FixHeader, Journal, JournalConfig, MappedFile};
 
 fn cfg(segment_size: usize) -> JournalConfig {
     JournalConfig {
         segment_size,
-        map: MapOptions::default(),
+        map: MappedFile::options(),
     }
 }
 

--- a/nexus-shm/benches/ofd_liveness.rs
+++ b/nexus-shm/benches/ofd_liveness.rs
@@ -10,14 +10,14 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use nexus_shm::{Liveness, MapOptions, Segment};
+use nexus_shm::{Liveness, MappedFile, Segment};
 
 fn bench_peer_liveness(c: &mut Criterion) {
     let path = std::env::temp_dir().join(format!("nexus-shm-bench-{}", std::process::id()));
     let _ = std::fs::remove_file(&path);
 
-    let owner = Segment::create(&path, 4096, MapOptions::default()).unwrap();
-    let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+    let owner = Segment::create(&path, 4096, MappedFile::options()).unwrap();
+    let peer = Segment::attach(&path, MappedFile::options()).unwrap();
     assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
     c.benchmark_group("ofd_liveness")

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
 use crate::segment::Segment;
-use nexus_platform::MapOptions;
+use nexus_platform::{MappedFile, MappedFileOptions};
 
 pub use error::JournalError;
 pub use header::{FixHeader, RecordHeader, SeqHeader};
@@ -26,14 +26,14 @@ const MIN_SEGMENT: usize = 64;
 #[derive(Clone, Copy)]
 pub struct JournalConfig {
     pub segment_size: usize,
-    pub map: MapOptions,
+    pub map: MappedFileOptions,
 }
 
 impl Default for JournalConfig {
     fn default() -> Self {
         Self {
             segment_size: 64 * 1024 * 1024,
-            map: MapOptions::default(),
+            map: MappedFile::options(),
         }
     }
 }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -13,7 +13,7 @@ use super::header::{RecordHeader, SeqHeader};
 pub struct Reader<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
-    pub(super) map: nexus_platform::MapOptions,
+    pub(super) map: nexus_platform::MappedFileOptions,
     pub(super) segments: Vec<Segment>,
     pub(super) seg_idx: usize,
     pub(super) cursor: usize,

--- a/nexus-shm/src/journal/tests.rs
+++ b/nexus-shm/src/journal/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::MapOptions;
+use nexus_platform::MappedFile;
 
 use super::{FixHeader, Journal, JournalConfig, JournalError};
 
@@ -26,7 +26,7 @@ fn fix(seq: u64) -> FixHeader {
 fn cfg(segment_size: usize) -> JournalConfig {
     JournalConfig {
         segment_size,
-        map: MapOptions::default(),
+        map: MappedFile::options(),
     }
 }
 

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -11,7 +11,7 @@ use super::header::RecordHeader;
 pub struct Writer<H: RecordHeader> {
     pub(super) base: std::path::PathBuf,
     pub(super) segment_size: usize,
-    pub(super) map: nexus_platform::MapOptions,
+    pub(super) map: nexus_platform::MappedFileOptions,
     pub(super) active: Segment,
     pub(super) index: u64,
     pub(super) tail: usize,

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -16,7 +16,7 @@ pub use journal::{
     FixHeader, Journal, JournalConfig, JournalError, ReadRange, ReadRecord, Reader, RecordHeader,
     SeqHeader, WriteClaim, Writer,
 };
-pub use nexus_platform::{Liveness, MapOptions};
+pub use nexus_platform::{Liveness, MappedFile, MappedFileOptions};
 pub use pod::Pod;
 pub use seglog::{
     Conductor, ConductorBuilder, Frame, LogError, LogOffset, OpenError, SegmentedLog,

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -249,8 +249,7 @@ fn archive_segment(data: *mut u8, segment_size: usize, path: &Path) {
     let mut cur = 0usize;
     while cur + FRAME_HDR <= segment_size {
         // SAFETY: `cur` is an 8-aligned offset within the mmap'd segment.
-        let stored =
-            unsafe { (*commit_len_ptr(data.add(cur))).load(Ordering::Acquire) };
+        let stored = unsafe { (*commit_len_ptr(data.add(cur))).load(Ordering::Acquire) };
         if stored == 0 {
             break;
         }

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -6,7 +6,7 @@ use std::thread::JoinHandle;
 
 use nexus_platform::FileLock;
 
-use super::frame::commit_len_ptr;
+use super::frame::{FRAME_HDR, commit_len_ptr, footprint};
 
 const LOCK_FILE: &str = "conductor.lock";
 const DEFAULT_CLEAN_QUEUE_DEPTH: usize = 4;
@@ -19,6 +19,8 @@ pub(crate) struct CleanRequest {
     pub(crate) data: *mut u8,
     pub(crate) segment_size: usize,
     pub(crate) ready: Arc<AtomicBool>,
+    /// If set, write committed frames here before zeroing.
+    pub(crate) archive_path: Option<PathBuf>,
 }
 
 // SAFETY: `data` points into a mmap'd segment that remains mapped until the
@@ -43,12 +45,14 @@ unsafe impl Send for CleanRequest {}
 /// # use nexus_shm::ConductorBuilder;
 /// let mut conductor = ConductorBuilder::new("/tmp/journal")
 ///     .clean_queue_depth(16)
+///     .archive(true)
 ///     .open()
 ///     .unwrap();
 /// ```
 pub struct ConductorBuilder {
     dir: PathBuf,
     clean_queue_depth: usize,
+    archive: bool,
 }
 
 impl ConductorBuilder {
@@ -56,6 +60,7 @@ impl ConductorBuilder {
         Self {
             dir: dir.as_ref().to_path_buf(),
             clean_queue_depth: DEFAULT_CLEAN_QUEUE_DEPTH,
+            archive: false,
         }
     }
 
@@ -66,6 +71,19 @@ impl ConductorBuilder {
     /// `append` will block briefly until the conductor thread drains one.
     pub fn clean_queue_depth(mut self, depth: usize) -> Self {
         self.clean_queue_depth = depth;
+        self
+    }
+
+    /// Archive evicted segments to `{session_dir}/archive/seg_{epoch}.dat`
+    /// before zeroing (default: off).
+    ///
+    /// Archive format: committed frames written densely — each frame as
+    /// `[commit_len:u32][session_id:u32][payload...]` with no inter-frame
+    /// padding. Readable with the same `commit_len`-walk as recovery.
+    /// I/O errors during archival are silently ignored; the segment is
+    /// always zeroed and the ready flag always set.
+    pub fn archive(mut self, enable: bool) -> Self {
+        self.archive = enable;
         self
     }
 
@@ -80,6 +98,7 @@ impl ConductorBuilder {
             dir: self.dir,
             tx: Some(tx),
             thread: Some(thread),
+            archive: self.archive,
         })
     }
 }
@@ -106,18 +125,21 @@ impl ConductorBuilder {
 ///     session.lock      <- OFD-locked while open (prevents double-open)
 ///     journal.manifest
 ///     seg0.dat, seg1.dat, seg2.dat
+///     archive/          <- present only when archival is enabled
+///       seg_{epoch}.dat
 /// ```
 pub struct Conductor {
     dir: PathBuf,
     tx: Option<std::sync::mpsc::SyncSender<CleanRequest>>,
     thread: Option<JoinHandle<()>>,
+    archive: bool,
 }
 
 impl Conductor {
     /// Open a conductor rooted at `dir` with default configuration.
     ///
     /// Creates the directory if it does not exist. Use [`ConductorBuilder`]
-    /// for custom configuration (e.g. clean queue depth).
+    /// for custom configuration (e.g. clean queue depth, archival).
     pub fn open(dir: impl AsRef<Path>) -> Result<Self, super::OpenError> {
         ConductorBuilder::new(dir).open()
     }
@@ -166,6 +188,10 @@ impl Conductor {
     pub(crate) fn sender(&self) -> std::sync::mpsc::SyncSender<CleanRequest> {
         self.tx.as_ref().expect("conductor shut down").clone()
     }
+
+    pub(crate) fn archive(&self) -> bool {
+        self.archive
+    }
 }
 
 impl Drop for Conductor {
@@ -193,22 +219,53 @@ impl Drop for Conductor {
 /// `join()`).
 fn conductor_main(rx: std::sync::mpsc::Receiver<CleanRequest>) {
     for req in rx {
-        // TODO: archive the evicted segment to disk before cleaning
-        //       (read segment data via req.data/req.segment_size, write
-        //       to archive dir, then zero). Archival I/O errors must not
-        //       panic — a panic here leaves in-flight `ready` flags false,
-        //       causing SegmentedLog::drop to spin forever. Handle errors
-        //       gracefully (log + skip) and always proceed to the zero +
-        //       ready store below.
+        if let Some(ref path) = req.archive_path {
+            archive_segment(req.data, req.segment_size, path);
+        }
 
         // SAFETY: `req.data` points to the start of a live mmap'd segment.
         // See `CleanRequest` Send impl for lifetime reasoning.
         unsafe { (*commit_len_ptr(req.data)).store(0, Ordering::Release) };
-        // segment_size is unused today but carried for archival (will need
-        // it to know how many bytes to flush before zeroing).
-        let _ = req.segment_size;
         req.ready.store(true, Ordering::Release);
     }
+}
+
+/// Write committed frames from the evicted segment to `path` as a dense blob.
+///
+/// Walks frames using `commit_len` (encoded as `body + 1`) until the first
+/// zero, writing each as `[commit_len:u32][session_id:u32][payload...]`
+/// with no inter-frame padding. I/O errors are silently ignored.
+fn archive_segment(data: *mut u8, segment_size: usize, path: &Path) {
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let file = match std::fs::File::create(path) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    let mut writer = std::io::BufWriter::new(file);
+    let mut cur = 0usize;
+    while cur + FRAME_HDR <= segment_size {
+        // SAFETY: `cur` is an 8-aligned offset within the mmap'd segment.
+        let stored =
+            unsafe { (*commit_len_ptr(data.add(cur))).load(Ordering::Acquire) };
+        if stored == 0 {
+            break;
+        }
+        let body = (stored - 1) as usize;
+        if cur + FRAME_HDR + body > segment_size {
+            break;
+        }
+        // Write the frame header + payload densely (no alignment padding).
+        let frame = unsafe { std::slice::from_raw_parts(data.add(cur), FRAME_HDR + body) };
+        if writer.write_all(frame).is_err() {
+            return;
+        }
+        cur += footprint(body);
+    }
+    let _ = writer.flush();
 }
 
 /// Atomically claim the next session ID using a lock file.

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -236,10 +236,15 @@ fn conductor_main(rx: std::sync::mpsc::Receiver<CleanRequest>) {
 /// zero, writing each as `[commit_len:u32][session_id:u32][payload...]`
 /// with no inter-frame padding. I/O errors are silently ignored.
 fn archive_segment(data: *mut u8, segment_size: usize, path: &Path) {
-    if path.parent().is_some_and(|p| std::fs::create_dir_all(p).is_err()) {
+    if path
+        .parent()
+        .is_some_and(|p| std::fs::create_dir_all(p).is_err())
+    {
         return;
     }
-    let Ok(file) = std::fs::File::create(path) else { return };
+    let Ok(file) = std::fs::File::create(path) else {
+        return;
+    };
     let mut writer = std::io::BufWriter::new(file);
     let mut cur = 0usize;
     while cur + FRAME_HDR <= segment_size {

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -236,15 +236,10 @@ fn conductor_main(rx: std::sync::mpsc::Receiver<CleanRequest>) {
 /// zero, writing each as `[commit_len:u32][session_id:u32][payload...]`
 /// with no inter-frame padding. I/O errors are silently ignored.
 fn archive_segment(data: *mut u8, segment_size: usize, path: &Path) {
-    if let Some(parent) = path.parent() {
-        if std::fs::create_dir_all(parent).is_err() {
-            return;
-        }
+    if path.parent().is_some_and(|p| std::fs::create_dir_all(p).is_err()) {
+        return;
     }
-    let file = match std::fs::File::create(path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
+    let Ok(file) = std::fs::File::create(path) else { return };
     let mut writer = std::io::BufWriter::new(file);
     let mut cur = 0usize;
     while cur + FRAME_HDR <= segment_size {

--- a/nexus-shm/src/seglog/manifest.rs
+++ b/nexus-shm/src/seglog/manifest.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use nexus_platform::{MapOptions, MappedFile};
+use nexus_platform::MappedFile;
 
 use crate::error::ShmError;
 
@@ -80,7 +80,7 @@ impl Manifest {
         name: &[u8],
     ) -> Result<Self, ShmError> {
         let len = NonZeroUsize::new(MANIFEST_FILE_SIZE).unwrap();
-        let mapping = MappedFile::create(path, len, MapOptions::default())?;
+        let mapping = MappedFile::create(path, len)?;
 
         // SAFETY: the mapping covers at least MANIFEST_FILE_SIZE bytes and is
         // page-aligned. We hold exclusive access (just created the file).
@@ -100,7 +100,7 @@ impl Manifest {
     }
 
     pub(crate) fn open(path: &Path) -> Result<Self, ShmError> {
-        let mapping = MappedFile::open(path, MapOptions::default())?;
+        let mapping = MappedFile::open(path)?;
         let hdr = Self::header_of(&mapping);
 
         if hdr.magic != MAGIC {

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::segment::Segment;
-use nexus_platform::{FileLock, MapOptions};
+use nexus_platform::{FileLock, MappedFile, MappedFileOptions};
 
 use conductor::CleanRequest;
 use frame::{ALIGN, FRAME_HDR, align_up, commit_len_ptr, footprint, session_id_ptr};
@@ -155,11 +155,10 @@ impl<'a> SegmentedLogBuilder<'a> {
         }
     }
 
-    fn map_options(&self) -> MapOptions {
-        MapOptions {
-            pretouch: self.pretouch,
-            huge_pages: self.huge_pages,
-        }
+    fn map_options(&self) -> MappedFileOptions {
+        MappedFile::options()
+            .pretouch(self.pretouch)
+            .huge_pages(self.huge_pages)
     }
 }
 
@@ -422,7 +421,7 @@ impl SegmentedLog {
     fn create_fresh(
         dir: &Path,
         size: usize,
-        map: MapOptions,
+        map: MappedFileOptions,
         session_id: u32,
         name: &[u8],
         res: SessionResources,
@@ -474,7 +473,7 @@ impl SegmentedLog {
     fn recover(
         dir: &Path,
         requested_size: usize,
-        map: MapOptions,
+        map: MappedFileOptions,
         strict: bool,
         expected_session_id: u32,
         res: SessionResources,

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -142,11 +142,16 @@ impl<'a> SegmentedLogBuilder<'a> {
             session_lock,
         };
 
+        let archive_dir = self
+            .conductor
+            .archive()
+            .then(|| session_dir.join("archive"));
+
         let mpath = manifest_path(&session_dir);
         if mpath.exists() {
-            SegmentedLog::recover(&session_dir, size, map, strict, id, res)
+            SegmentedLog::recover(&session_dir, size, map, strict, id, res, archive_dir)
         } else {
-            SegmentedLog::create_fresh(&session_dir, size, map, id, name_bytes, res)
+            SegmentedLog::create_fresh(&session_dir, size, map, id, name_bytes, res, archive_dir)
         }
     }
 
@@ -226,6 +231,8 @@ pub struct SegmentedLog {
     cursor: usize,
     epoch: u64,
     slot_gen: [u32; 3],
+    /// Archive directory for evicted segments; `None` if archival is disabled.
+    archive_dir: Option<PathBuf>,
 }
 
 impl SegmentedLog {
@@ -419,6 +426,7 @@ impl SegmentedLog {
         session_id: u32,
         name: &[u8],
         res: SessionResources,
+        archive_dir: Option<PathBuf>,
     ) -> Result<Self, OpenError> {
         let manifest = Manifest::create(&manifest_path(dir), size as u64, session_id, name)?;
 
@@ -459,6 +467,7 @@ impl SegmentedLog {
             // u32::MAX marks inactive slots — no real epoch will match,
             // so reads against prev/standby correctly return None.
             slot_gen: [0, u32::MAX, u32::MAX],
+            archive_dir,
         })
     }
 
@@ -469,6 +478,7 @@ impl SegmentedLog {
         strict: bool,
         expected_session_id: u32,
         res: SessionResources,
+        archive_dir: Option<PathBuf>,
     ) -> Result<Self, OpenError> {
         let manifest = Manifest::open(&manifest_path(dir))?;
         let manifest_size = manifest.segment_size() as usize;
@@ -554,6 +564,7 @@ impl SegmentedLog {
             cursor,
             epoch,
             slot_gen,
+            archive_dir,
         })
     }
 
@@ -563,10 +574,15 @@ impl SegmentedLog {
         }
 
         let old_prev = self.prev;
+        let archive_path = self
+            .archive_dir
+            .as_deref()
+            .map(|dir| dir.join(format!("seg_{}.dat", self.epoch)));
         let request = CleanRequest {
             data: self.slots[old_prev].data,
             segment_size: self.segment_size,
             ready: Arc::clone(&self.ready),
+            archive_path,
         };
 
         self.ready.store(false, Ordering::Release);

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::AtomicU32;
 
-use nexus_platform::{Liveness, MapOptions, MappedFile, ProcessLease};
+use nexus_platform::{Liveness, MappedFile, MappedFileOptions, ProcessLease};
 
 use crate::control::{ControlBlock, status};
 use crate::error::ShmError;
@@ -30,12 +30,12 @@ pub struct Segment {
 }
 
 impl Segment {
-    pub fn create(path: &Path, data_len: usize, opts: MapOptions) -> Result<Self, ShmError> {
+    pub fn create(path: &Path, data_len: usize, opts: MappedFileOptions) -> Result<Self, ShmError> {
         if data_len == 0 {
             return Err(ShmError::EmptySegment);
         }
         let total = HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)?;
-        let mapping = MappedFile::create(path, total, opts)?;
+        let mapping = opts.read_write().shared().create(path, total)?;
 
         if !ProcessLease::claim(mapping.as_fd())? {
             return Err(ShmError::OwnerActive);
@@ -54,8 +54,8 @@ impl Segment {
         })
     }
 
-    pub fn attach(path: &Path, opts: MapOptions) -> Result<Self, ShmError> {
-        let mapping = MappedFile::open(path, opts)?;
+    pub fn attach(path: &Path, opts: MappedFileOptions) -> Result<Self, ShmError> {
+        let mapping = opts.read_write().shared().open(path)?;
         Self::control_of(&mapping).validate()?;
         Ok(Self {
             mapping,
@@ -181,7 +181,7 @@ impl Drop for Segment {
     }
 }
 
-fn flags(opts: MapOptions) -> u16 {
+fn flags(opts: MappedFileOptions) -> u16 {
     u16::from(opts.pretouch) | (u16::from(opts.huge_pages) << 1)
 }
 
@@ -189,7 +189,7 @@ fn flags(opts: MapOptions) -> u16 {
 mod tests {
     use super::{Liveness, Segment, Status};
     use crate::error::ShmError;
-    use nexus_platform::MapOptions;
+    use nexus_platform::MappedFile;
 
     fn temp_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("nexus-shm-{}-{}", std::process::id(), name))
@@ -200,13 +200,13 @@ mod tests {
         let path = temp_path("roundtrip");
         let _ = std::fs::remove_file(&path);
 
-        let mut seg = Segment::create(&path, 4096, MapOptions::default()).unwrap();
+        let mut seg = Segment::create(&path, 4096, MappedFile::options()).unwrap();
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 
         unsafe { seg.slice_mut_at(0, 1)[0] = 0xAB };
 
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let peer = Segment::attach(&path, MappedFile::options()).unwrap();
         assert_eq!(peer.data_len(), 4096);
         assert_eq!(peer.status(), Status::Alive);
         assert_eq!(unsafe { peer.slice_at(0, 1)[0] }, 0xAB);
@@ -219,10 +219,10 @@ mod tests {
         let path = temp_path("dead");
         let _ = std::fs::remove_file(&path);
 
-        let seg = Segment::create(&path, 64, MapOptions::default()).unwrap();
+        let seg = Segment::create(&path, 64, MappedFile::options()).unwrap();
         drop(seg);
 
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let peer = Segment::attach(&path, MappedFile::options()).unwrap();
         assert_eq!(peer.status(), Status::Dead);
 
         std::fs::remove_file(&path).unwrap();
@@ -233,7 +233,7 @@ mod tests {
         let path = temp_path("zero");
         let _ = std::fs::remove_file(&path);
         assert!(matches!(
-            Segment::create(&path, 0, MapOptions::default()),
+            Segment::create(&path, 0, MappedFile::options()),
             Err(ShmError::EmptySegment)
         ));
     }
@@ -243,8 +243,8 @@ mod tests {
         let path = temp_path("liveness");
         let _ = std::fs::remove_file(&path);
 
-        let owner = Segment::create(&path, 64, MapOptions::default()).unwrap();
-        let peer = Segment::attach(&path, MapOptions::default()).unwrap();
+        let owner = Segment::create(&path, 64, MappedFile::options()).unwrap();
+        let peer = Segment::attach(&path, MappedFile::options()).unwrap();
         assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
         drop(owner);
@@ -258,7 +258,7 @@ mod tests {
         let path = temp_path("foreign");
         std::fs::write(&path, vec![0u8; 4096]).unwrap();
 
-        assert!(Segment::attach(&path, MapOptions::default()).is_err());
+        assert!(Segment::attach(&path, MappedFile::options()).is_err());
 
         std::fs::remove_file(&path).unwrap();
     }


### PR DESCRIPTION
Closes #486

Introduces `MappedFileOptions` — an `OpenOptions`-style builder for `MappedFile` — and removes the thin `MapOptions` struct.

**API changes in `nexus-platform`:**
- `MappedFile::options()` → `MappedFileOptions` (new)
- `MappedFile::create(path, len)` — no opts param
- `MappedFile::open(path)` — no opts param
- `MappedFile::open_readonly(path)` — no opts param
- `MappedFile::options().offset(n).from_file(file, len)` replaces the old 6-param `from_file`
- `MapOptions` removed from public API (internal only)

**Builder methods:** `read_write()`, `read_only()`, `shared()`, `private()`, `pretouch(bool)`, `huge_pages(bool)`, `offset(u64)`

**nexus-shm call sites updated:** `Segment`, `JournalConfig`, `SegmentedLogBuilder`, manifests, benches.

Prepares the options surface for `SharedMemory` (#482).