### PR TITLE
Segment: accept any backing store via Into<Mapping>

### DIFF
--- a/nexus-platform/src/mapped_file.rs
+++ b/nexus-platform/src/mapped_file.rs
@@ -237,6 +237,12 @@ impl MappedFile {
     }
 }
 
+impl From<MappedFile> for Mapping {
+    fn from(mf: MappedFile) -> Mapping {
+        mf.mapping
+    }
+}
+
 impl std::ops::Deref for MappedFile {
     type Target = Mapping;
 

--- a/nexus-platform/src/shared_memory.rs
+++ b/nexus-platform/src/shared_memory.rs
@@ -248,12 +248,16 @@ impl SharedMemory {
 
 impl From<SharedMemory> for Mapping {
     fn from(shm: SharedMemory) -> Mapping {
-        let shm = std::mem::ManuallyDrop::new(shm);
+        let mut shm = std::mem::ManuallyDrop::new(shm);
         // SAFETY: ManuallyDrop prevents SharedMemory's Drop (which may call
         // shm_unlink). We transfer ownership of the inner Mapping — its own
-        // Drop (munmap) will still run. The CString name is leaked; this is
-        // a small, one-time allocation at segment setup.
-        unsafe { std::ptr::read(&raw const shm.mapping) }
+        // Drop (munmap) will still run. We explicitly drop the CString name
+        // to avoid leaking it.
+        unsafe {
+            let mapping = std::ptr::read(&raw const shm.mapping);
+            std::ptr::drop_in_place(&raw mut shm.name);
+            mapping
+        }
     }
 }
 

--- a/nexus-platform/src/shared_memory.rs
+++ b/nexus-platform/src/shared_memory.rs
@@ -246,6 +246,17 @@ impl SharedMemory {
     }
 }
 
+impl From<SharedMemory> for Mapping {
+    fn from(shm: SharedMemory) -> Mapping {
+        let shm = std::mem::ManuallyDrop::new(shm);
+        // SAFETY: ManuallyDrop prevents SharedMemory's Drop (which may call
+        // shm_unlink). We transfer ownership of the inner Mapping — its own
+        // Drop (munmap) will still run. The CString name is leaked; this is
+        // a small, one-time allocation at segment setup.
+        unsafe { std::ptr::read(&raw const shm.mapping) }
+    }
+}
+
 impl std::ops::Deref for SharedMemory {
     type Target = Mapping;
 

--- a/nexus-shm/benches/ofd_liveness.rs
+++ b/nexus-shm/benches/ofd_liveness.rs
@@ -10,14 +10,21 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use nexus_platform::MappedFile;
 use nexus_shm::{Liveness, MapHints, Segment};
 
 fn bench_peer_liveness(c: &mut Criterion) {
     let path = std::env::temp_dir().join(format!("nexus-shm-bench-{}", std::process::id()));
     let _ = std::fs::remove_file(&path);
 
-    let owner = Segment::create(&path, 4096, MapHints::default()).unwrap();
-    let peer = Segment::attach(&path, MapHints::default()).unwrap();
+    let total = Segment::total_size(4096).unwrap();
+    let owner = Segment::create(
+        MappedFile::create(&path, total).unwrap(),
+        4096,
+        MapHints::default(),
+    )
+    .unwrap();
+    let peer = Segment::attach(MappedFile::open(&path).unwrap()).unwrap();
     assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
     c.benchmark_group("ofd_liveness")

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -7,6 +7,7 @@ pub enum ShmError {
     UnsupportedLayout { found: u16, expected: u16 },
     EmptySegment,
     SizeOverflow,
+    MappingTooSmall { required: usize, actual: usize },
     HugePagesUnavailable(std::io::Error),
     OwnerActive,
     Os(std::io::Error),
@@ -21,6 +22,9 @@ impl fmt::Display for ShmError {
             }
             Self::EmptySegment => write!(f, "segment has zero data length"),
             Self::SizeOverflow => write!(f, "segment size overflows usize"),
+            Self::MappingTooSmall { required, actual } => {
+                write!(f, "mapping too small: need {required} bytes, got {actual}")
+            }
             Self::HugePagesUnavailable(e) => write!(f, "huge pages unavailable: {e}"),
             Self::OwnerActive => write!(f, "segment already owned by a live process"),
             Self::Os(e) => write!(f, "{e}"),

--- a/nexus-shm/src/journal/error.rs
+++ b/nexus-shm/src/journal/error.rs
@@ -48,3 +48,9 @@ impl From<std::io::Error> for JournalError {
         Self::Os(e)
     }
 }
+
+impl From<nexus_platform::MapError> for JournalError {
+    fn from(e: nexus_platform::MapError) -> Self {
+        Self::Shm(ShmError::from(e))
+    }
+}

--- a/nexus-shm/src/journal/mod.rs
+++ b/nexus-shm/src/journal/mod.rs
@@ -7,8 +7,11 @@ mod tests;
 mod writer;
 
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
+
+use nexus_platform::{MapError, MappedFile};
 
 use crate::MapHints;
 use crate::segment::Segment;
@@ -58,7 +61,12 @@ impl<H: RecordHeader> Journal<H> {
         }
 
         let index = last.unwrap_or(0);
-        let active = Segment::create(&segment_path(&base, index), segment_size, cfg.hints)?;
+        let total = Segment::total_size(segment_size)?;
+        let active = Segment::create(
+            file_create(&segment_path(&base, index), total, cfg.hints)?,
+            segment_size,
+            cfg.hints,
+        )?;
         let tail = recover_tail::<H>(&active, segment_size);
 
         let writer = Writer {
@@ -71,7 +79,7 @@ impl<H: RecordHeader> Journal<H> {
             _marker: PhantomData,
         };
 
-        let seg0 = Segment::attach(&segment_path(&base, 0), cfg.hints)?;
+        let seg0 = Segment::attach(file_open(&segment_path(&base, 0), cfg.hints)?)?;
         let reader = Reader {
             base,
             segment_size,
@@ -113,4 +121,20 @@ fn segment_path(base: &Path, index: u64) -> PathBuf {
     let mut p = base.as_os_str().to_owned();
     p.push(format!(".{index}"));
     PathBuf::from(p)
+}
+
+pub(super) fn file_create(
+    path: &Path,
+    len: NonZeroUsize,
+    hints: MapHints,
+) -> Result<MappedFile, MapError> {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts.create(path, len)
+}
+
+pub(super) fn file_open(path: &Path, hints: MapHints) -> Result<MappedFile, MapError> {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts.open(path)
 }

--- a/nexus-shm/src/journal/reader.rs
+++ b/nexus-shm/src/journal/reader.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::sync::atomic::Ordering;
 
-use crate::error::ShmError;
 use crate::segment::Segment;
 
 use super::error::JournalError;
@@ -77,14 +76,16 @@ impl<H: RecordHeader> Reader<H> {
     fn load_next(&mut self) -> Result<bool, JournalError> {
         let next = self.segments.len() as u64;
         let path = super::segment_path(&self.base, next);
-        match Segment::attach(&path, self.hints) {
-            Ok(seg) => {
-                self.segments.push(seg);
-                Ok(true)
+        let mf = match super::file_open(&path, self.hints) {
+            Ok(mf) => mf,
+            Err(nexus_platform::MapError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(false);
             }
-            Err(ShmError::Os(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(e.into()),
-        }
+            Err(e) => return Err(crate::ShmError::from(e).into()),
+        };
+        let seg = Segment::attach(mf)?;
+        self.segments.push(seg);
+        Ok(true)
     }
 
     /// Iterate committed records whose header sequence falls in `range`.

--- a/nexus-shm/src/journal/writer.rs
+++ b/nexus-shm/src/journal/writer.rs
@@ -63,7 +63,12 @@ impl<H: RecordHeader> Writer<H> {
         }
         self.index += 1;
         let path = super::segment_path(&self.base, self.index);
-        self.active = Segment::create(&path, self.segment_size, self.hints)?;
+        let total = Segment::total_size(self.segment_size)?;
+        self.active = Segment::create(
+            super::file_create(&path, total, self.hints)?,
+            self.segment_size,
+            self.hints,
+        )?;
         self.tail = 0;
         Ok(())
     }

--- a/nexus-shm/src/seglog/error.rs
+++ b/nexus-shm/src/seglog/error.rs
@@ -81,6 +81,12 @@ impl From<std::io::Error> for OpenError {
     }
 }
 
+impl From<nexus_platform::MapError> for OpenError {
+    fn from(e: nexus_platform::MapError) -> Self {
+        Self::Shm(ShmError::from(e))
+    }
+}
+
 /// Errors from live [`SegmentedLog`](super::SegmentedLog) operations.
 ///
 /// Returned by [`append`](super::SegmentedLog::append) and internal

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::segment::Segment;
-use nexus_platform::FileLock;
+use nexus_platform::{FileLock, MappedFile};
 
 use crate::MapHints;
 
@@ -425,7 +425,9 @@ impl SegmentedLog {
         let manifest = Manifest::create(&manifest_path(dir), size as u64, session_id, name)?;
 
         let mk = |i: u8| -> Result<Slot, OpenError> {
-            let seg = Segment::create(&seg_path(dir, i), size, hints)?;
+            let total = Segment::total_size(size)?;
+            let mf = file_create(&seg_path(dir, i), total, hints)?;
+            let seg = Segment::create(mf, size, hints)?;
             let data = seg.data();
             Ok(Slot {
                 _segment: seg,
@@ -510,9 +512,10 @@ impl SegmentedLog {
         let mk = |i: u8| -> Result<Slot, OpenError> {
             let path = seg_path(dir, i);
             let seg = if path.exists() {
-                Segment::attach(&path, hints)?
+                Segment::attach(file_open(&path, hints)?)?
             } else {
-                Segment::create(&path, size, hints)?
+                let total = Segment::total_size(size)?;
+                Segment::create(file_create(&path, total, hints)?, size, hints)?
             };
             let data = seg.data();
             Ok(Slot {
@@ -621,6 +624,22 @@ fn seg_path(dir: &Path, i: u8) -> PathBuf {
 
 fn manifest_path(dir: &Path) -> PathBuf {
     dir.join(MANIFEST_FILE)
+}
+
+fn file_create(
+    path: &Path,
+    len: std::num::NonZeroUsize,
+    hints: MapHints,
+) -> Result<MappedFile, nexus_platform::MapError> {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts.create(path, len)
+}
+
+fn file_open(path: &Path, hints: MapHints) -> Result<MappedFile, nexus_platform::MapError> {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts.open(path)
 }
 
 /// Scan from the start of a segment to find the write tail.

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -45,6 +45,13 @@ impl Segment {
             return Err(ShmError::EmptySegment);
         }
         let mapping = mapping.into();
+        let required = HEADER.get() + data_len;
+        if mapping.len() < required {
+            return Err(ShmError::MappingTooSmall {
+                required,
+                actual: mapping.len(),
+            });
+        }
 
         if !ProcessLease::claim(mapping.as_fd())? {
             return Err(ShmError::OwnerActive);
@@ -70,7 +77,15 @@ impl Segment {
 
     pub fn attach(mapping: impl Into<Mapping>) -> Result<Self, ShmError> {
         let mapping = mapping.into();
-        Self::control_of(&mapping).validate()?;
+        let cb = Self::control_of(&mapping);
+        cb.validate()?;
+        let required = HEADER.get() + cb.data_len() as usize;
+        if mapping.len() < required {
+            return Err(ShmError::MappingTooSmall {
+                required,
+                actual: mapping.len(),
+            });
+        }
         Ok(Self {
             mapping,
             creator: false,

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -1,8 +1,7 @@
 use std::num::NonZeroUsize;
-use std::path::Path;
 use std::sync::atomic::AtomicU32;
 
-use nexus_platform::{Liveness, MappedFile, ProcessLease};
+use nexus_platform::{Liveness, Mapping, ProcessLease};
 
 use crate::MapHints;
 
@@ -27,17 +26,25 @@ pub enum Status {
 /// backing file persists after drop so a restarting peer can run crash
 /// recovery; segment owns only the mapping and its liveness signals.
 pub struct Segment {
-    mapping: MappedFile,
+    mapping: Mapping,
     creator: bool,
 }
 
 impl Segment {
-    pub fn create(path: &Path, data_len: usize, hints: MapHints) -> Result<Self, ShmError> {
+    /// The total mapping size needed for a segment with `data_len` payload bytes.
+    pub fn total_size(data_len: usize) -> Result<NonZeroUsize, ShmError> {
+        HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)
+    }
+
+    pub fn create(
+        mapping: impl Into<Mapping>,
+        data_len: usize,
+        hints: MapHints,
+    ) -> Result<Self, ShmError> {
         if data_len == 0 {
             return Err(ShmError::EmptySegment);
         }
-        let total = HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)?;
-        let mapping = file_opts(hints).create(path, total)?;
+        let mapping = mapping.into();
 
         if !ProcessLease::claim(mapping.as_fd())? {
             return Err(ShmError::OwnerActive);
@@ -61,8 +68,8 @@ impl Segment {
         })
     }
 
-    pub fn attach(path: &Path, hints: MapHints) -> Result<Self, ShmError> {
-        let mapping = file_opts(hints).open(path)?;
+    pub fn attach(mapping: impl Into<Mapping>) -> Result<Self, ShmError> {
+        let mapping = mapping.into();
         Self::control_of(&mapping).validate()?;
         Ok(Self {
             mapping,
@@ -172,7 +179,7 @@ impl Segment {
         Self::control_of(&self.mapping)
     }
 
-    fn control_of(mapping: &MappedFile) -> &ControlBlock {
+    fn control_of(mapping: &Mapping) -> &ControlBlock {
         // SAFETY: mmap maps whole pages, so the control block (<= one page) is
         // mapped and page-aligned. All control-block fields are atomic or
         // written once before sharing, so shared `&` access is sound.
@@ -188,12 +195,6 @@ impl Drop for Segment {
     }
 }
 
-fn file_opts(hints: MapHints) -> nexus_platform::MappedFileOptions {
-    let mut opts = MappedFile::options();
-    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
-    opts
-}
-
 fn flags(hints: MapHints) -> u16 {
     u16::from(hints.pretouch) | (u16::from(hints.huge_pages) << 1)
 }
@@ -203,9 +204,19 @@ mod tests {
     use super::{Liveness, Segment, Status};
     use crate::MapHints;
     use crate::error::ShmError;
+    use nexus_platform::MappedFile;
 
     fn temp_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("nexus-shm-{}-{}", std::process::id(), name))
+    }
+
+    fn create_file(path: &std::path::Path, data_len: usize) -> MappedFile {
+        let total = Segment::total_size(data_len).unwrap();
+        MappedFile::create(path, total).unwrap()
+    }
+
+    fn open_file(path: &std::path::Path) -> MappedFile {
+        MappedFile::open(path).unwrap()
     }
 
     #[test]
@@ -213,13 +224,14 @@ mod tests {
         let path = temp_path("roundtrip");
         let _ = std::fs::remove_file(&path);
 
-        let mut seg = Segment::create(&path, 4096, MapHints::default()).unwrap();
+        let mf = create_file(&path, 4096);
+        let mut seg = Segment::create(mf, 4096, MapHints::default()).unwrap();
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 
         unsafe { seg.slice_mut_at(0, 1)[0] = 0xAB };
 
-        let peer = Segment::attach(&path, MapHints::default()).unwrap();
+        let peer = Segment::attach(open_file(&path)).unwrap();
         assert_eq!(peer.data_len(), 4096);
         assert_eq!(peer.status(), Status::Alive);
         assert_eq!(unsafe { peer.slice_at(0, 1)[0] }, 0xAB);
@@ -232,10 +244,10 @@ mod tests {
         let path = temp_path("dead");
         let _ = std::fs::remove_file(&path);
 
-        let seg = Segment::create(&path, 64, MapHints::default()).unwrap();
+        let seg = Segment::create(create_file(&path, 64), 64, MapHints::default()).unwrap();
         drop(seg);
 
-        let peer = Segment::attach(&path, MapHints::default()).unwrap();
+        let peer = Segment::attach(open_file(&path)).unwrap();
         assert_eq!(peer.status(), Status::Dead);
 
         std::fs::remove_file(&path).unwrap();
@@ -245,10 +257,12 @@ mod tests {
     fn rejects_zero_data_len() {
         let path = temp_path("zero");
         let _ = std::fs::remove_file(&path);
+        let mf = create_file(&path, 64);
         assert!(matches!(
-            Segment::create(&path, 0, MapHints::default()),
+            Segment::create(mf, 0, MapHints::default()),
             Err(ShmError::EmptySegment)
         ));
+        std::fs::remove_file(&path).unwrap();
     }
 
     #[test]
@@ -256,8 +270,8 @@ mod tests {
         let path = temp_path("liveness");
         let _ = std::fs::remove_file(&path);
 
-        let owner = Segment::create(&path, 64, MapHints::default()).unwrap();
-        let peer = Segment::attach(&path, MapHints::default()).unwrap();
+        let owner = Segment::create(create_file(&path, 64), 64, MapHints::default()).unwrap();
+        let peer = Segment::attach(open_file(&path)).unwrap();
         assert_eq!(peer.peer_liveness(), Liveness::Alive);
 
         drop(owner);
@@ -271,7 +285,7 @@ mod tests {
         let path = temp_path("foreign");
         std::fs::write(&path, vec![0u8; 4096]).unwrap();
 
-        assert!(Segment::attach(&path, MapHints::default()).is_err());
+        assert!(Segment::attach(open_file(&path)).is_err());
 
         std::fs::remove_file(&path).unwrap();
     }


### PR DESCRIPTION
## Summary

Decouples `Segment` from `MappedFile` so it can accept any backing store — file-backed (`MappedFile`) or POSIX shared memory (`SharedMemory`).

- `Segment` now holds `Mapping` directly instead of `MappedFile`
- `Segment::create` and `Segment::attach` take `impl Into<Mapping>`
- Added `From<MappedFile> for Mapping` and `From<SharedMemory> for Mapping` in nexus-platform
- Added `Segment::total_size(data_len)` helper so callers don't hardcode control block layout
- Journal and seglog create their own `MappedFile` and pass it in (always file-backed)
- Added `From<MapError>` for `JournalError` and `OpenError`

## Motivation

The design calls for two backing stores: file-backed mappings for durable journals (Aeron Archive model) and `/dev/shm` for volatile IPC primitives (`ShmRingBuffer`, `ShmSlot`). Both wrap the same `Mapping` primitive — Segment shouldn't care which one produced it.

Closes #492

## Test plan

- [x] All 77 nexus-shm tests pass (segment, journal, seglog)
- [x] All 32 nexus-platform tests pass
- [x] Clippy clean (`--all-targets --all-features`)
- [x] Formatted