### PR TITLE
feat(seglog): segment archival with SegmentSwap 3-state machine (#479)

### DIFF
--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -1,10 +1,17 @@
+use std::cell::UnsafeCell;
 use std::io::{Read as _, Seek, SeekFrom, Write as _};
+use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
-use nexus_platform::FileLock;
+use nexus_platform::{FileLock, MappedFile};
+
+use crate::MapHints;
+use crate::segment::Segment;
 
 use super::frame::commit_len_ptr;
 
@@ -12,43 +19,114 @@ const LOCK_FILE: &str = "conductor.lock";
 const DEFAULT_CLEAN_QUEUE_DEPTH: usize = 4;
 
 // ---------------------------------------------------------------------------
-// Internal types
+// SegmentSwap — three-state handoff between SegmentedLog and conductor
+// ---------------------------------------------------------------------------
+
+pub(crate) const SWAP_CLEAN: u8 = 0; // conductor wrote a fresh segment; SegmentedLog can rotate
+pub(crate) const SWAP_DIRTY: u8 = 1; // SegmentedLog wrote an evicted segment; conductor must process
+pub(crate) const SWAP_PENDING: u8 = 2; // sent to conductor channel; inner is uninit
+
+/// Lock-free three-state handoff cell.
+///
+/// State machine:
+/// ```text
+/// Clean  ──(rotate takes)──▶ [inner uninit] ──(store_dirty)──▶ Dirty
+/// Dirty  ──(try_flush sends)──▶ Pending
+/// Pending ──(conductor publishes)──▶ Clean
+/// ```
+///
+/// The `state` atomic provides the Acquire/Release barriers:
+/// - `Clean` Acquire: safe to read `inner` (conductor wrote it)
+/// - `Dirty` Acquire: safe to read `inner` (SegmentedLog wrote it)
+/// - `Pending`: `inner` is uninit — nobody touches it
+pub(crate) struct SegmentSwap {
+    state: AtomicU8,
+    inner: UnsafeCell<MaybeUninit<Segment>>,
+}
+
+// SAFETY: access is serialized by `state` — at most one side holds the payload
+// at any point, enforced by the state machine above.
+unsafe impl Sync for SegmentSwap {}
+
+impl SegmentSwap {
+    pub(crate) fn new_clean(segment: Segment) -> Self {
+        Self {
+            state: AtomicU8::new(SWAP_CLEAN),
+            inner: UnsafeCell::new(MaybeUninit::new(segment)),
+        }
+    }
+
+    pub(crate) fn state(&self) -> u8 {
+        self.state.load(Ordering::Acquire)
+    }
+
+    /// Take the segment out, leaving `inner` uninit.
+    ///
+    /// # Safety
+    /// `state` must be `SWAP_CLEAN` or `SWAP_DIRTY` (payload initialized).
+    pub(crate) unsafe fn take(&self) -> Segment {
+        unsafe { (*self.inner.get()).assume_init_read() }
+    }
+
+    /// Write the evicted segment into `inner` and transition to `Dirty`.
+    ///
+    /// # Safety
+    /// `inner` must be uninit (caller just called `take()`).
+    pub(crate) unsafe fn store_dirty(&self, segment: Segment) {
+        unsafe { (*self.inner.get()).write(segment) };
+        self.state.store(SWAP_DIRTY, Ordering::Release);
+    }
+
+    pub(crate) fn mark_pending(&self) {
+        self.state.store(SWAP_PENDING, Ordering::Release);
+    }
+
+    /// Write a fresh replacement segment and transition to `Clean`.
+    ///
+    /// # Safety
+    /// Called only from the conductor thread after `inner` was uninit.
+    pub(crate) unsafe fn publish_clean(&self, segment: Segment) {
+        unsafe { (*self.inner.get()).write(segment) };
+        self.state.store(SWAP_CLEAN, Ordering::Release);
+    }
+}
+
+impl Drop for SegmentSwap {
+    fn drop(&mut self) {
+        let s = *self.state.get_mut();
+        if s == SWAP_CLEAN || s == SWAP_DIRTY {
+            // SAFETY: state guarantees payload is initialized.
+            unsafe { self.inner.get_mut().assume_init_drop() };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CleanRequest
 // ---------------------------------------------------------------------------
 
 pub(crate) struct CleanRequest {
-    pub(crate) data: *mut u8,
+    /// The evicted segment to archive (rename) then drop. `None` for
+    /// retry-only requests where the segment was already dropped.
+    pub(crate) segment: Option<Segment>,
     pub(crate) segment_size: usize,
-    pub(crate) ready: Arc<AtomicBool>,
+    pub(crate) epoch: u64,
+    pub(crate) swap: Arc<SegmentSwap>,
+    /// Path of the slot file to create fresh for the replacement segment.
+    pub(crate) seg_path: PathBuf,
+    pub(crate) hints: MapHints,
+    pub(crate) archive_dir: Option<PathBuf>,
 }
-
-// SAFETY: `data` points into a mmap'd segment that remains mapped until the
-// owning `Slot` drops, which happens only after the SegmentedLog drops. The
-// SegmentedLog holds a sender clone — dropping it before the conductor thread
-// processes the request would unmap the segment. But the segment file itself
-// remains; the conductor only touches the mmap'd data before marking ready,
-// and the SegmentedLog cannot drop until its own Drop runs (which waits for
-// no pending clean via the ready flag in practice).
-unsafe impl Send for CleanRequest {}
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /// Builder for configuring a [`Conductor`].
-///
-/// Use this when the default configuration is not suitable — for example,
-/// to increase the clean queue depth when running many concurrent sessions.
-///
-/// ```no_run
-/// # use nexus_shm::ConductorBuilder;
-/// let mut conductor = ConductorBuilder::new("/tmp/journal")
-///     .clean_queue_depth(16)
-///     .open()
-///     .unwrap();
-/// ```
 pub struct ConductorBuilder {
     dir: PathBuf,
     clean_queue_depth: usize,
+    archive: bool,
 }
 
 impl ConductorBuilder {
@@ -56,78 +134,58 @@ impl ConductorBuilder {
         Self {
             dir: dir.as_ref().to_path_buf(),
             clean_queue_depth: DEFAULT_CLEAN_QUEUE_DEPTH,
+            archive: false,
         }
     }
 
-    /// Maximum number of outstanding segment-clean requests (default: 4).
-    ///
-    /// Each session can have at most one outstanding clean request at a time.
-    /// If multiple sessions rotate simultaneously and the queue is full,
-    /// `append` will block briefly until the conductor thread drains one.
     pub fn clean_queue_depth(mut self, depth: usize) -> Self {
         self.clean_queue_depth = depth;
         self
     }
 
-    /// Open the conductor, creating the root directory if needed.
+    /// Archive evicted segments to `{session_dir}/archive/seg_{epoch}.dat`
+    /// before dropping them (default: off).
+    ///
+    /// When enabled, the segment file is fsynced then renamed (atomic on the
+    /// same filesystem) rather than zeroed. The rename preserves the exact
+    /// on-disk frame format — no copy step, no partial-write risk.
+    pub fn archive(mut self, enable: bool) -> Self {
+        self.archive = enable;
+        self
+    }
+
     pub fn open(self) -> Result<Conductor, super::OpenError> {
         std::fs::create_dir_all(&self.dir)?;
 
         let (tx, rx) = std::sync::mpsc::sync_channel(self.clean_queue_depth);
-        let thread = std::thread::spawn(move || conductor_main(rx));
+        let thread = std::thread::spawn(move || conductor_main(&rx));
 
         Ok(Conductor {
             dir: self.dir,
             tx: Some(tx),
             thread: Some(thread),
+            archive: self.archive,
         })
     }
 }
 
 /// Top-level journal manager.
-///
-/// Owns the background cleanup thread and the root directory. All
-/// [`SegmentedLog`](super::SegmentedLog) instances are opened through
-/// the conductor via [`session()`](Self::session).
-///
-/// # Lifetime
-///
-/// The conductor **must** outlive all [`SegmentedLog`] instances opened
-/// through it. `Conductor::drop` joins the cleanup thread, which blocks
-/// until every session's sender is dropped. Dropping a conductor while
-/// sessions are still alive will block indefinitely.
-///
-/// # Directory layout
-///
-/// ```text
-/// {dir}/
-///   conductor.lock      <- session ID counter (OFD-locked during assignment)
-///   {session_id}/
-///     session.lock      <- OFD-locked while open (prevents double-open)
-///     journal.manifest
-///     seg0.dat, seg1.dat, seg2.dat
-/// ```
 pub struct Conductor {
     dir: PathBuf,
     tx: Option<std::sync::mpsc::SyncSender<CleanRequest>>,
     thread: Option<JoinHandle<()>>,
+    archive: bool,
 }
 
 impl Conductor {
-    /// Open a conductor rooted at `dir` with default configuration.
-    ///
-    /// Creates the directory if it does not exist. Use [`ConductorBuilder`]
-    /// for custom configuration (e.g. clean queue depth).
     pub fn open(dir: impl AsRef<Path>) -> Result<Self, super::OpenError> {
         ConductorBuilder::new(dir).open()
     }
 
-    /// Return a builder for opening or creating a session log.
     pub fn session(&mut self) -> super::SegmentedLogBuilder<'_> {
         super::SegmentedLogBuilder::new(self)
     }
 
-    /// List session IDs that have manifests on disk.
     pub fn sessions_on_disk(&self) -> Result<Vec<u32>, super::OpenError> {
         let mut ids = Vec::new();
         for entry in std::fs::read_dir(&self.dir)? {
@@ -146,15 +204,10 @@ impl Conductor {
         Ok(ids)
     }
 
-    /// Atomically claim the next session ID.
-    ///
-    /// Uses a lock file (`conductor.lock`) to coordinate across processes.
-    /// Multiple conductors on the same directory will never assign the same ID.
     pub(crate) fn next_session_id(&self) -> Result<u32, super::OpenError> {
         claim_next_session_id(&self.dir)
     }
 
-    /// Ensure the lock counter won't collide with an explicitly chosen ID.
     pub(crate) fn register_explicit_id(&self, id: u32) -> Result<(), super::OpenError> {
         ensure_counter_at_least(&self.dir, id)
     }
@@ -166,12 +219,14 @@ impl Conductor {
     pub(crate) fn sender(&self) -> std::sync::mpsc::SyncSender<CleanRequest> {
         self.tx.as_ref().expect("conductor shut down").clone()
     }
+
+    pub(crate) fn archive(&self) -> bool {
+        self.archive
+    }
 }
 
 impl Drop for Conductor {
     fn drop(&mut self) {
-        // Drop our sender first so the channel closes once all SegmentedLog
-        // clones are also dropped.
         drop(self.tx.take());
         if let Some(t) = self.thread.take() {
             let _ = t.join();
@@ -180,43 +235,126 @@ impl Drop for Conductor {
 }
 
 // ---------------------------------------------------------------------------
-// Free functions
+// Conductor work loop
 // ---------------------------------------------------------------------------
 
-/// Background cleanup loop for evicted segments.
-///
-/// Runs on a dedicated thread, processing one `CleanRequest` per segment
-/// rotation. The thread stays alive as long as any `SyncSender` clone
-/// exists — the `Conductor` holds one, and each `SegmentedLog` holds
-/// another. When all senders drop, `rx.recv()` returns `Err`, the
-/// for-loop exits, and the thread returns (unblocking `Conductor::drop`'s
-/// `join()`).
-fn conductor_main(rx: std::sync::mpsc::Receiver<CleanRequest>) {
-    for req in rx {
-        // TODO: archive the evicted segment to disk before cleaning
-        //       (read segment data via req.data/req.segment_size, write
-        //       to archive dir, then zero). Archival I/O errors must not
-        //       panic — a panic here leaves in-flight `ready` flags false,
-        //       causing SegmentedLog::drop to spin forever. Handle errors
-        //       gracefully (log + skip) and always proceed to the zero +
-        //       ready store below.
+struct PendingCreate {
+    swap: Arc<SegmentSwap>,
+    seg_path: PathBuf,
+    segment_size: usize,
+    hints: MapHints,
+}
 
-        // SAFETY: `req.data` points to the start of a live mmap'd segment.
-        // See `CleanRequest` Send impl for lifetime reasoning.
-        unsafe { (*commit_len_ptr(req.data)).store(0, Ordering::Release) };
-        // segment_size is unused today but carried for archival (will need
-        // it to know how many bytes to flush before zeroing).
-        let _ = req.segment_size;
-        req.ready.store(true, Ordering::Release);
+fn conductor_main(rx: &std::sync::mpsc::Receiver<CleanRequest>) {
+    let mut pending: Vec<PendingCreate> = Vec::new();
+
+    loop {
+        // Retry any previously failed segment creates (e.g. ENOSPC).
+        pending.retain(|p| {
+            let Ok(total) = Segment::total_size(p.segment_size) else { return true };
+            file_create(&p.seg_path, total, p.hints)
+                .ok()
+                .and_then(|mf| Segment::create(mf, p.segment_size, p.hints).ok())
+                .is_none_or(|seg| {
+                    // SAFETY: conductor is sole owner; state is Pending (inner uninit).
+                    unsafe {
+                        (*commit_len_ptr(seg.data()))
+                            .store(0, std::sync::atomic::Ordering::Relaxed);
+                        p.swap.publish_clean(seg);
+                    }
+                    false
+                })
+        });
+
+        // Non-blocking drain of new requests.
+        let mut drained = false;
+        while let Ok(req) = rx.try_recv() {
+            drained = true;
+            process_request(req, &mut pending);
+        }
+
+        // Block only when idle; sleep briefly if still retrying.
+        if pending.is_empty() {
+            match rx.recv() {
+                Ok(req) => process_request(req, &mut pending),
+                Err(_) => break,
+            }
+        } else if !drained {
+            std::thread::sleep(Duration::from_millis(250));
+        }
     }
 }
 
-/// Atomically claim the next session ID using a lock file.
-///
-/// Acquires an exclusive lock on `{dir}/conductor.lock`, reads the
-/// current counter, increments it, and writes back. The lock is released
-/// when the `FileLock` drops. The counter file is a plain ASCII integer
-/// for easy inspection.
+fn process_request(req: CleanRequest, pending: &mut Vec<PendingCreate>) {
+    if let Some(segment) = req.segment {
+        // fsync before rename so the archive file is durable. If sync fails,
+        // skip the rename — the data is not guaranteed durable, but we still
+        // proceed to create the replacement segment.
+        // TODO: surface archival I/O failures to callers via a counter/flag.
+        let synced = segment.sync().is_ok();
+
+        if synced
+            && let Some(ref archive_dir) = req.archive_dir
+            && std::fs::create_dir_all(archive_dir).is_ok()
+        {
+            let dst = archive_dir.join(format!("seg_{}.dat", req.epoch));
+            // Rename is atomic on the same filesystem; the mmap follows
+            // the inode so existing readers are unaffected.
+            let _ = std::fs::rename(&req.seg_path, dst);
+        }
+
+        // Drop the Segment (munmap + mark dead + release OFD lock). The file
+        // is either renamed (archive path) or still at seg_path — either way
+        // we're done with the mapping and can create a fresh file at seg_path.
+        drop(segment);
+    }
+
+    let Ok(total) = Segment::total_size(req.segment_size) else {
+        pending.push(PendingCreate {
+            swap: req.swap,
+            seg_path: req.seg_path,
+            segment_size: req.segment_size,
+            hints: req.hints,
+        });
+        return;
+    };
+
+    match file_create(&req.seg_path, total, req.hints)
+        .ok()
+        .and_then(|mf| Segment::create(mf, req.segment_size, req.hints).ok())
+    {
+        Some(seg) => {
+            // SAFETY: state is Pending (inner uninit after SegmentedLog took it).
+            unsafe {
+                (*commit_len_ptr(seg.data())).store(0, std::sync::atomic::Ordering::Relaxed);
+                req.swap.publish_clean(seg);
+            }
+        }
+        None => {
+            pending.push(PendingCreate {
+                swap: req.swap,
+                seg_path: req.seg_path,
+                segment_size: req.segment_size,
+                hints: req.hints,
+            });
+        }
+    }
+}
+
+fn file_create(
+    path: &Path,
+    len: NonZeroUsize,
+    hints: MapHints,
+) -> Result<MappedFile, nexus_platform::MapError> {
+    let mut opts = MappedFile::options();
+    opts.pretouch(hints.pretouch).huge_pages(hints.huge_pages);
+    opts.create(path, len)
+}
+
+// ---------------------------------------------------------------------------
+// Session ID management
+// ---------------------------------------------------------------------------
+
 fn claim_next_session_id(dir: &Path) -> Result<u32, super::OpenError> {
     let mut lock = FileLock::lock(dir.join(LOCK_FILE))?;
     let current = read_counter(lock.file())?;
@@ -225,8 +363,6 @@ fn claim_next_session_id(dir: &Path) -> Result<u32, super::OpenError> {
     Ok(next)
 }
 
-/// Ensure the counter is at least `id` so future auto-assignments won't
-/// collide with explicitly chosen IDs.
 fn ensure_counter_at_least(dir: &Path, id: u32) -> Result<(), super::OpenError> {
     let mut lock = FileLock::lock(dir.join(LOCK_FILE))?;
     let current = read_counter(lock.file())?;

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -251,7 +251,9 @@ fn conductor_main(rx: &std::sync::mpsc::Receiver<CleanRequest>) {
     loop {
         // Retry any previously failed segment creates (e.g. ENOSPC).
         pending.retain(|p| {
-            let Ok(total) = Segment::total_size(p.segment_size) else { return true };
+            let Ok(total) = Segment::total_size(p.segment_size) else {
+                return true;
+            };
             file_create(&p.seg_path, total, p.hints)
                 .ok()
                 .and_then(|mf| Segment::create(mf, p.segment_size, p.hints).ok())

--- a/nexus-shm/src/seglog/conductor.rs
+++ b/nexus-shm/src/seglog/conductor.rs
@@ -123,6 +123,9 @@ pub(crate) struct CleanRequest {
 // ---------------------------------------------------------------------------
 
 /// Builder for configuring a [`Conductor`].
+///
+/// Obtained via [`ConductorBuilder::new`]. Call [`open`](Self::open) to spawn
+/// the background thread and begin accepting sessions.
 pub struct ConductorBuilder {
     dir: PathBuf,
     clean_queue_depth: usize,
@@ -130,6 +133,7 @@ pub struct ConductorBuilder {
 }
 
 impl ConductorBuilder {
+    /// Create a builder rooted at `dir`.
     pub fn new(dir: impl AsRef<Path>) -> Self {
         Self {
             dir: dir.as_ref().to_path_buf(),
@@ -138,6 +142,7 @@ impl ConductorBuilder {
         }
     }
 
+    /// Set the backlog depth of the clean-request channel (default: 4).
     pub fn clean_queue_depth(mut self, depth: usize) -> Self {
         self.clean_queue_depth = depth;
         self
@@ -154,6 +159,7 @@ impl ConductorBuilder {
         self
     }
 
+    /// Spawn the conductor background thread and open the directory.
     pub fn open(self) -> Result<Conductor, super::OpenError> {
         std::fs::create_dir_all(&self.dir)?;
 
@@ -170,6 +176,9 @@ impl ConductorBuilder {
 }
 
 /// Top-level journal manager.
+///
+/// Owns the background cleanup thread that archives evicted segments and
+/// creates fresh replacements. Drop to shut the thread down gracefully.
 pub struct Conductor {
     dir: PathBuf,
     tx: Option<std::sync::mpsc::SyncSender<CleanRequest>>,
@@ -178,14 +187,17 @@ pub struct Conductor {
 }
 
 impl Conductor {
+    /// Shorthand for [`ConductorBuilder::new(dir).open()`](ConductorBuilder::open).
     pub fn open(dir: impl AsRef<Path>) -> Result<Self, super::OpenError> {
         ConductorBuilder::new(dir).open()
     }
 
+    /// Open a new or existing session log under this conductor.
     pub fn session(&mut self) -> super::SegmentedLogBuilder<'_> {
         super::SegmentedLogBuilder::new(self)
     }
 
+    /// List session IDs that have a manifest on disk, sorted ascending.
     pub fn sessions_on_disk(&self) -> Result<Vec<u32>, super::OpenError> {
         let mut ids = Vec::new();
         for entry in std::fs::read_dir(&self.dir)? {
@@ -254,25 +266,39 @@ fn conductor_main(rx: &std::sync::mpsc::Receiver<CleanRequest>) {
             let Ok(total) = Segment::total_size(p.segment_size) else {
                 return true;
             };
-            file_create(&p.seg_path, total, p.hints)
-                .ok()
-                .and_then(|mf| Segment::create(mf, p.segment_size, p.hints).ok())
-                .is_none_or(|seg| {
-                    // SAFETY: conductor is sole owner; state is Pending (inner uninit).
-                    unsafe {
-                        (*commit_len_ptr(seg.data()))
-                            .store(0, std::sync::atomic::Ordering::Relaxed);
-                        p.swap.publish_clean(seg);
-                    }
-                    false
-                })
+            let Some(mf) = file_create(&p.seg_path, total, p.hints).ok() else {
+                return true;
+            };
+            let Some(seg) = Segment::create(mf, p.segment_size, p.hints).ok() else {
+                return true;
+            };
+            // SAFETY: conductor is sole owner; state is Pending (inner uninit).
+            unsafe {
+                (*commit_len_ptr(seg.data())).store(0, std::sync::atomic::Ordering::Relaxed);
+                p.swap.publish_clean(seg);
+            }
+            false
         });
 
         // Non-blocking drain of new requests.
         let mut drained = false;
-        while let Ok(req) = rx.try_recv() {
-            drained = true;
-            process_request(req, &mut pending);
+        let mut disconnected = false;
+        loop {
+            match rx.try_recv() {
+                Ok(req) => {
+                    drained = true;
+                    process_request(req, &mut pending);
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    break;
+                }
+            }
+        }
+
+        if disconnected {
+            break;
         }
 
         // Block only when idle; sleep briefly if still retrying.

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -7,14 +7,14 @@ mod tests;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 
 use crate::segment::Segment;
 use nexus_platform::{FileLock, MappedFile};
 
 use crate::MapHints;
 
-use conductor::CleanRequest;
+use conductor::{CleanRequest, SWAP_CLEAN, SWAP_DIRTY, SegmentSwap};
 use frame::{ALIGN, FRAME_HDR, align_up, commit_len_ptr, footprint, session_id_ptr};
 use manifest::Manifest;
 
@@ -22,7 +22,7 @@ pub use conductor::{Conductor, ConductorBuilder};
 pub use error::{LogError, OpenError};
 pub use frame::{Frame, LogOffset};
 
-const MANIFEST_FILE: &str = "journal.manifest";
+pub(crate) const MANIFEST_FILE: &str = "journal.manifest";
 const SESSION_LOCK_FILE: &str = "session.lock";
 const EPOCH_MASK: u32 = 0x3FFF_FFFF;
 
@@ -32,12 +32,13 @@ const EPOCH_MASK: u32 = 0x3FFF_FFFF;
 
 struct SessionResources {
     tx: std::sync::mpsc::SyncSender<CleanRequest>,
-    ready: Arc<AtomicBool>,
     session_lock: FileLock,
 }
 
 struct Slot {
-    _segment: Segment,
+    // None only for the standby slot (its Segment lives in the swap).
+    segment: Option<Segment>,
+    path: PathBuf,
     data: *mut u8,
 }
 
@@ -140,23 +141,24 @@ impl<'a> SegmentedLogBuilder<'a> {
         let name_bytes = self.name.as_deref().unwrap_or("").as_bytes();
         let res = SessionResources {
             tx: self.conductor.sender(),
-            ready: Arc::new(AtomicBool::new(true)),
             session_lock,
         };
 
+        let archive_dir = self
+            .conductor
+            .archive()
+            .then(|| session_dir.join("archive"));
+
         let mpath = manifest_path(&session_dir);
         if mpath.exists() {
-            SegmentedLog::recover(&session_dir, size, hints, strict, id, res)
+            SegmentedLog::recover(&session_dir, size, hints, strict, id, res, archive_dir)
         } else {
-            SegmentedLog::create_fresh(&session_dir, size, hints, id, name_bytes, res)
+            SegmentedLog::create_fresh(&session_dir, size, hints, id, name_bytes, res, archive_dir)
         }
     }
 
     fn map_hints(&self) -> MapHints {
-        MapHints {
-            pretouch: self.pretouch,
-            huge_pages: self.huge_pages,
-        }
+        MapHints { pretouch: self.pretouch, huge_pages: self.huge_pages }
     }
 }
 
@@ -218,7 +220,7 @@ pub struct SegmentedLog {
     slots: [Slot; 3],
     manifest: Manifest,
     tx: std::sync::mpsc::SyncSender<CleanRequest>,
-    ready: Arc<AtomicBool>,
+    swap: Arc<SegmentSwap>,
     _session_lock: FileLock,
     segment_size: usize,
     session_id: u32,
@@ -228,6 +230,8 @@ pub struct SegmentedLog {
     cursor: usize,
     epoch: u64,
     slot_gen: [u32; 3],
+    hints: MapHints,
+    archive_dir: Option<PathBuf>,
 }
 
 impl SegmentedLog {
@@ -256,6 +260,7 @@ impl SegmentedLog {
     ///
     /// Panics if the conductor cleanup thread has exited (indicates a bug).
     pub fn append(&mut self, payload: &[u8]) -> Result<LogOffset, LogError> {
+        self.try_flush_dirty();
         let body = payload.len();
         let foot = footprint(body);
         if foot > self.segment_size {
@@ -421,37 +426,37 @@ impl SegmentedLog {
         session_id: u32,
         name: &[u8],
         res: SessionResources,
+        archive_dir: Option<PathBuf>,
     ) -> Result<Self, OpenError> {
         let manifest = Manifest::create(&manifest_path(dir), size as u64, session_id, name)?;
+        let total = Segment::total_size(size)?;
 
         let mk = |i: u8| -> Result<Slot, OpenError> {
-            let total = Segment::total_size(size)?;
-            let mf = file_create(&seg_path(dir, i), total, hints)?;
+            let path = seg_path(dir, i);
+            let mf = file_create(&path, total, hints)?;
             let seg = Segment::create(mf, size, hints)?;
             let data = seg.data();
-            Ok(Slot {
-                _segment: seg,
-                data,
-            })
+            // SAFETY: freshly mapped segment, sole owner.
+            unsafe { (*commit_len_ptr(data)).store(0, Ordering::Relaxed) };
+            Ok(Slot { segment: Some(seg), path, data })
         };
 
         let s0 = mk(0)?;
-        let s1 = mk(1)?;
+        // Standby segment lives exclusively in the swap; slots[1] starts empty.
+        let standby_path = seg_path(dir, 1);
+        let standby_mf = file_create(&standby_path, total, hints)?;
+        let standby_seg = Segment::create(standby_mf, size, hints)?;
+        // SAFETY: freshly mapped segment.
+        unsafe { (*commit_len_ptr(standby_seg.data())).store(0, Ordering::Relaxed) };
+        let swap = Arc::new(SegmentSwap::new_clean(standby_seg));
+        let s1 = Slot { segment: None, path: standby_path, data: std::ptr::null_mut() };
         let s2 = mk(2)?;
-
-        // SAFETY: each slot data pointer is the start of a freshly mapped segment
-        // with at least FRAME_HDR bytes and 4-byte alignment from mmap.
-        unsafe {
-            (*commit_len_ptr(s0.data)).store(0, Ordering::Relaxed);
-            (*commit_len_ptr(s1.data)).store(0, Ordering::Relaxed);
-            (*commit_len_ptr(s2.data)).store(0, Ordering::Relaxed);
-        }
 
         Ok(Self {
             slots: [s0, s1, s2],
             manifest,
             tx: res.tx,
-            ready: res.ready,
+            swap,
             _session_lock: res.session_lock,
             segment_size: size,
             session_id,
@@ -460,9 +465,9 @@ impl SegmentedLog {
             standby: 1,
             cursor: 0,
             epoch: 0,
-            // u32::MAX marks inactive slots — no real epoch will match,
-            // so reads against prev/standby correctly return None.
             slot_gen: [0, u32::MAX, u32::MAX],
+            hints,
+            archive_dir,
         })
     }
 
@@ -473,6 +478,7 @@ impl SegmentedLog {
         strict: bool,
         expected_session_id: u32,
         res: SessionResources,
+        archive_dir: Option<PathBuf>,
     ) -> Result<Self, OpenError> {
         let manifest = Manifest::open(&manifest_path(dir))?;
         let manifest_size = manifest.segment_size() as usize;
@@ -503,41 +509,38 @@ impl SegmentedLog {
             _ => {
                 let c = (epoch % 3) as usize;
                 let p = ((epoch - 1) % 3) as usize;
-                // {c, p, s} is always a permutation of {0, 1, 2}
                 let s = 3 - c - p;
                 (c, p, s)
             }
         };
+
+        let total = Segment::total_size(size)?;
 
         let mk = |i: u8| -> Result<Slot, OpenError> {
             let path = seg_path(dir, i);
             let seg = if path.exists() {
                 Segment::attach(file_open(&path, hints)?)?
             } else {
-                let total = Segment::total_size(size)?;
-                Segment::create(file_create(&path, total, hints)?, size, hints)?
+                let mf = file_create(&path, total, hints)?;
+                Segment::create(mf, size, hints)?
             };
             let data = seg.data();
-            Ok(Slot {
-                _segment: seg,
-                data,
-            })
+            Ok(Slot { segment: Some(seg), path, data })
         };
 
-        let s0 = mk(0)?;
-        let s1 = mk(1)?;
-        let s2 = mk(2)?;
-        let slots = [s0, s1, s2];
+        let mut slots = [mk(0)?, mk(1)?, mk(2)?];
 
         let cursor = recover_tail(slots[current].data, size);
 
-        // The standby segment may contain stale committed frames from a
-        // previous epoch. Zero its commit_len so those frames are not
-        // mistaken for valid data when this slot becomes active.
-        // SAFETY: standby is a valid slot index into a live mmap'd segment.
-        unsafe {
-            (*commit_len_ptr(slots[standby].data)).store(0, Ordering::Relaxed);
-        }
+        // Move the standby segment into the swap; its slot becomes empty.
+        // The conductor will archive it and publish a fresh replacement on the
+        // next rotation.
+        let standby_seg = slots[standby].segment.take().expect("just created");
+        // SAFETY: standby segment, sole owner; zeroing commit_len hides any
+        // stale frames that were written in the previous session.
+        unsafe { (*commit_len_ptr(standby_seg.data())).store(0, Ordering::Relaxed) };
+        slots[standby].data = std::ptr::null_mut();
+        let swap = Arc::new(SegmentSwap::new_clean(standby_seg));
 
         let mut slot_gen = [u32::MAX; 3];
         slot_gen[current] = (epoch as u32) & EPOCH_MASK;
@@ -549,7 +552,7 @@ impl SegmentedLog {
             slots,
             manifest,
             tx: res.tx,
-            ready: res.ready,
+            swap,
             _session_lock: res.session_lock,
             segment_size: size,
             session_id,
@@ -559,32 +562,34 @@ impl SegmentedLog {
             cursor,
             epoch,
             slot_gen,
+            hints,
+            archive_dir,
         })
     }
 
     fn rotate(&mut self) -> Result<(), LogError> {
-        if !self.ready.load(Ordering::Acquire) {
+        if self.swap.state() != SWAP_CLEAN {
             return Err(LogError::StandbyNotReady);
         }
 
-        let old_prev = self.prev;
-        let request = CleanRequest {
-            data: self.slots[old_prev].data,
-            segment_size: self.segment_size,
-            ready: Arc::clone(&self.ready),
-        };
+        // Take the replacement segment the conductor prepared.
+        // SAFETY: state == Clean (Acquire) guarantees payload is initialized.
+        let new_seg = unsafe { self.swap.take() };
+        let new_data = new_seg.data();
 
-        self.ready.store(false, Ordering::Release);
-        match self.tx.try_send(request) {
-            Ok(()) => {}
-            Err(std::sync::mpsc::TrySendError::Full(_)) => {
-                self.ready.store(true, Ordering::Release);
-                return Err(LogError::StandbyNotReady);
-            }
-            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
-                panic!("conductor cleanup thread has exited unexpectedly");
-            }
-        }
+        // Install replacement in standby slot (becomes new current).
+        self.slots[self.standby].segment = Some(new_seg);
+        self.slots[self.standby].data = new_data;
+
+        // Evict the prev slot (becomes new standby — empty until conductor replaces it).
+        let old_prev = self.prev;
+        let evicted = self.slots[old_prev].segment.take().expect("prev must have segment");
+        self.slots[old_prev].data = std::ptr::null_mut();
+
+        // Park the evicted segment in the swap so try_flush_dirty can send it.
+        // SAFETY: we just took from swap (inner is uninit), writing before
+        // publishing Dirty (Release).
+        unsafe { self.swap.store_dirty(evicted) };
 
         self.prev = self.current;
         self.current = self.standby;
@@ -594,20 +599,53 @@ impl SegmentedLog {
         self.slot_gen[self.current] = (self.epoch as u32) & EPOCH_MASK;
         self.manifest.set_epoch(self.epoch);
 
+        self.try_flush_dirty();
         Ok(())
+    }
+
+    fn try_flush_dirty(&mut self) {
+        if self.swap.state() != SWAP_DIRTY {
+            return;
+        }
+
+        // SAFETY: state == Dirty (Acquire) guarantees the evicted segment
+        // is in the swap and we own it.
+        let evicted = unsafe { self.swap.take() };
+
+        let request = CleanRequest {
+            segment: Some(evicted),
+            segment_size: self.segment_size,
+            epoch: self.epoch.saturating_sub(1),
+            swap: Arc::clone(&self.swap),
+            seg_path: self.slots[self.standby].path.clone(),
+            hints: self.hints,
+            archive_dir: self.archive_dir.clone(),
+        };
+
+        // Transition Dirty → Pending before send.
+        self.swap.mark_pending();
+
+        match self.tx.try_send(request) {
+            Ok(()) => {}
+            Err(std::sync::mpsc::TrySendError::Full(returned)) => {
+                // Channel full; put the segment back and retry next append.
+                let segment = returned.segment.expect("just set it");
+                // SAFETY: we set Pending above; inner is uninit; restoring Dirty.
+                unsafe { self.swap.store_dirty(segment) };
+            }
+            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                panic!("conductor cleanup thread has exited unexpectedly");
+            }
+        }
     }
 }
 
 impl Drop for SegmentedLog {
     fn drop(&mut self) {
-        // Wait for any in-flight clean request to finish before unmapping
-        // segments. The conductor thread holds a raw pointer into our mmap'd
-        // data — if we unmap first, it would touch freed memory.
-        //
-        // yield_now() is appropriate here because the conductor's work is a
-        // single atomic store — this spin completes in nanoseconds. A sleep
-        // would add milliseconds of unnecessary latency to drop.
-        while !self.ready.load(Ordering::Acquire) {
+        // If a request is in-flight (Pending), wait for the conductor to
+        // publish a replacement (Clean). Once Clean, the conductor is done
+        // with the evicted segment so it's safe to unmap everything.
+        while self.swap.state() == conductor::SWAP_PENDING {
             std::thread::yield_now();
         }
         // _session_lock is dropped here, releasing the OFD lock.

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -158,7 +158,10 @@ impl<'a> SegmentedLogBuilder<'a> {
     }
 
     fn map_hints(&self) -> MapHints {
-        MapHints { pretouch: self.pretouch, huge_pages: self.huge_pages }
+        MapHints {
+            pretouch: self.pretouch,
+            huge_pages: self.huge_pages,
+        }
     }
 }
 
@@ -438,7 +441,11 @@ impl SegmentedLog {
             let data = seg.data();
             // SAFETY: freshly mapped segment, sole owner.
             unsafe { (*commit_len_ptr(data)).store(0, Ordering::Relaxed) };
-            Ok(Slot { segment: Some(seg), path, data })
+            Ok(Slot {
+                segment: Some(seg),
+                path,
+                data,
+            })
         };
 
         let s0 = mk(0)?;
@@ -449,7 +456,11 @@ impl SegmentedLog {
         // SAFETY: freshly mapped segment.
         unsafe { (*commit_len_ptr(standby_seg.data())).store(0, Ordering::Relaxed) };
         let swap = Arc::new(SegmentSwap::new_clean(standby_seg));
-        let s1 = Slot { segment: None, path: standby_path, data: std::ptr::null_mut() };
+        let s1 = Slot {
+            segment: None,
+            path: standby_path,
+            data: std::ptr::null_mut(),
+        };
         let s2 = mk(2)?;
 
         Ok(Self {
@@ -525,7 +536,11 @@ impl SegmentedLog {
                 Segment::create(mf, size, hints)?
             };
             let data = seg.data();
-            Ok(Slot { segment: Some(seg), path, data })
+            Ok(Slot {
+                segment: Some(seg),
+                path,
+                data,
+            })
         };
 
         let mut slots = [mk(0)?, mk(1)?, mk(2)?];
@@ -583,7 +598,10 @@ impl SegmentedLog {
 
         // Evict the prev slot (becomes new standby — empty until conductor replaces it).
         let old_prev = self.prev;
-        let evicted = self.slots[old_prev].segment.take().expect("prev must have segment");
+        let evicted = self.slots[old_prev]
+            .segment
+            .take()
+            .expect("prev must have segment");
         self.slots[old_prev].data = std::ptr::null_mut();
 
         // Park the evicted segment in the swap so try_flush_dirty can send it.

--- a/nexus-shm/src/seglog/mod.rs
+++ b/nexus-shm/src/seglog/mod.rs
@@ -42,9 +42,10 @@ struct Slot {
     data: *mut u8,
 }
 
-// SAFETY: a `Slot` is a mmap'd segment handle plus a cached data pointer into
-// that mapping. The mapping lives in shared memory, not thread-local state.
-// Concurrent access is governed by the frame-level atomics.
+// SAFETY: `Slot` owns an optional mmap'd Segment and a `data` pointer into it
+// (`null_mut()` when the standby slot's segment lives in the swap). The mmap
+// lives in shared memory, not thread-local state. Concurrent access is
+// governed by frame-level atomics and the SegmentSwap state machine.
 unsafe impl Send for Slot {}
 
 // ---------------------------------------------------------------------------
@@ -633,7 +634,7 @@ impl SegmentedLog {
         let request = CleanRequest {
             segment: Some(evicted),
             segment_size: self.segment_size,
-            epoch: self.epoch.saturating_sub(1),
+            epoch: self.epoch.saturating_sub(2),
             swap: Arc::clone(&self.swap),
             seg_path: self.slots[self.standby].path.clone(),
             hints: self.hints,

--- a/nexus-shm/src/seglog/tests.rs
+++ b/nexus-shm/src/seglog/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
 
+use super::conductor::SWAP_CLEAN;
 use super::frame::footprint;
 use super::{Conductor, ConductorBuilder, OpenError, SegmentedLog};
 
@@ -39,7 +39,7 @@ fn open_id(conductor: &mut Conductor, size: usize, id: u32) -> SegmentedLog {
 
 fn wait_conductor(log: &SegmentedLog) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-    while !log.ready.load(Ordering::Acquire) {
+    while log.swap.state() != SWAP_CLEAN {
         assert!(std::time::Instant::now() < deadline, "conductor timed out");
         std::thread::sleep(std::time::Duration::from_millis(1));
     }
@@ -653,7 +653,7 @@ fn conductor_builder_custom_queue_depth() {
     let mut log = open_id(&mut c, 64, 1);
     // Rotate several times — deeper queue should handle it without stalling
     for i in 0u32..40 {
-        if !log.ready.load(Ordering::Acquire) {
+        if log.swap.state() != SWAP_CLEAN {
             wait_conductor(&log);
         }
         log.append(&i.to_le_bytes()).unwrap();
@@ -953,7 +953,7 @@ fn stress_many_rotations_single_session() {
     // 100 rotations worth of data. 4 records per segment × 100 epochs.
     let total_records = 400;
     for i in 0u32..total_records {
-        if !log.ready.load(Ordering::Acquire) {
+        if log.swap.state() != SWAP_CLEAN {
             wait_conductor(&log);
         }
         log.append(&i.to_le_bytes()).unwrap();
@@ -1054,7 +1054,7 @@ fn stress_rotation_then_recovery() {
 
         // Write through many rotations
         for i in 0u32..50 {
-            if !log.ready.load(Ordering::Acquire) {
+            if log.swap.state() != SWAP_CLEAN {
                 wait_conductor(&log);
             }
             log.append(&i.to_le_bytes()).unwrap();
@@ -1089,10 +1089,10 @@ fn stress_interleaved_sessions_with_rotation() {
 
     // Interleave writes, both rotating at different rates
     for i in 0u32..40 {
-        if !log1.ready.load(Ordering::Acquire) {
+        if log1.swap.state() != SWAP_CLEAN {
             wait_conductor(&log1);
         }
-        if !log2.ready.load(Ordering::Acquire) {
+        if log2.swap.state() != SWAP_CLEAN {
             wait_conductor(&log2);
         }
         log1.append(&i.to_le_bytes()).unwrap();
@@ -1175,7 +1175,7 @@ fn stress_large_payloads() {
     let big = vec![0xABu8; 100_000];
 
     for _ in 0..20 {
-        if !log.ready.load(Ordering::Acquire) {
+        if log.swap.state() != SWAP_CLEAN {
             wait_conductor(&log);
         }
         log.append(&big).unwrap();

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -109,6 +109,10 @@ impl Segment {
         ProcessLease::probe(self.mapping.as_fd())
     }
 
+    pub(crate) fn sync(&self) -> std::io::Result<()> {
+        self.mapping.sync()
+    }
+
     pub(crate) fn data(&self) -> *mut u8 {
         // SAFETY: the mapping is HEADER + data_len bytes, so HEADER is in bounds.
         unsafe { self.mapping.as_ptr().add(HEADER.get()) }


### PR DESCRIPTION
Closes #479. Rebased on main after #489/#491/#494.

## What this does

Replaces the `ready:AtomicBool` + inline-zeroing conductor with a `SegmentSwap` 3-state machine (Clean/Dirty/Pending) that carries evicted `Segment` ownership across the conductor boundary.

**State machine:**
```
Clean  ──(rotate takes)──▶ [uninit] ──(store_dirty)──▶ Dirty
Dirty  ──(try_flush sends)──▶ Pending
Pending ──(conductor publishes)──▶ Clean
```

**Key design decisions:**
- Standby slot holds no `Segment` — its segment lives exclusively in the swap until conductor publishes a replacement
- `rotate()`: takes Clean replacement from swap → installs in standby slot; evicts prev → swap as Dirty
- `try_flush_dirty()`: sends Dirty segment to conductor (Pending); retries on next append if channel full
- Conductor fsyncs then renames evicted segment to archive dir before creating replacement (atomic rename, inode follows mmap)
- `Drop`: spins on `SWAP_PENDING` (not a flag) so segments are live until conductor is done

**Adapted to #489/#491/#494:**
- `path` moves off `Segment` into `Slot.path` and `CleanRequest.seg_path`
- `Segment::create(impl Into<Mapping>)` via `file_create() -> MappedFile` pattern
- `MapOptions` → `MapHints`

## Review items addressed

- `set_state(u8)` removed; replaced with typed `mark_pending()`
- `unsafe impl Send for Segment` removed (auto-derives via `Mapping`)
- Archival errors degrade gracefully: sync failure skips rename, still creates replacement; TODO comment flags missing observability counter