### PR TITLE
feat(conductor): wakeup-free MPSC + adaptive backoff (#499)

### DIFF
--- a/nexus-journal/Cargo.toml
+++ b/nexus-journal/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 nexus-platform = { version = "0.1.0", path = "../nexus-platform" }
+nexus-queue = { version = "1.3.1", path = "../nexus-queue" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/nexus-journal/src/rotating/conductor.rs
+++ b/nexus-journal/src/rotating/conductor.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use nexus_platform::{FileLock, MappedFile, Mapping};
 use nexus_platform::MapHints;
+use nexus_platform::{FileLock, MappedFile, Mapping};
 use nexus_queue::mpsc;
 
 const LOCK_FILE: &str = "conductor.lock";
@@ -275,11 +275,7 @@ struct PendingCreate {
     hints: MapHints,
 }
 
-fn conductor_main(
-    rx: &mpsc::Consumer<CleanRequest>,
-    closing: &AtomicBool,
-    parked: &AtomicBool,
-) {
+fn conductor_main(rx: &mpsc::Consumer<CleanRequest>, closing: &AtomicBool, parked: &AtomicBool) {
     const MAX_SLEEP: Duration = Duration::from_secs(3);
     let mut sleep_dur = Duration::from_millis(1);
     let mut pending: Vec<PendingCreate> = Vec::new();

--- a/nexus-journal/src/rotating/conductor.rs
+++ b/nexus-journal/src/rotating/conductor.rs
@@ -4,13 +4,13 @@ use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 use nexus_platform::{FileLock, MappedFile, Mapping};
-
 use nexus_platform::MapHints;
+use nexus_queue::mpsc;
 
 const LOCK_FILE: &str = "conductor.lock";
 const DEFAULT_CLEAN_QUEUE_DEPTH: usize = 4;
@@ -160,13 +160,22 @@ impl ConductorBuilder {
     pub fn open(self) -> Result<Conductor, super::OpenError> {
         std::fs::create_dir_all(&self.dir)?;
 
-        let (tx, rx) = std::sync::mpsc::sync_channel(self.clean_queue_depth);
-        let thread = std::thread::spawn(move || conductor_main(&rx));
+        let (tx, rx) = mpsc::ring_buffer(self.clean_queue_depth);
+        let closing = Arc::new(AtomicBool::new(false));
+        let parked = Arc::new(AtomicBool::new(false));
+
+        let closing_c = Arc::clone(&closing);
+        let parked_c = Arc::clone(&parked);
+        let thread = std::thread::spawn(move || conductor_main(&rx, &closing_c, &parked_c));
+        let wake_thread = thread.thread().clone();
 
         Ok(Conductor {
             dir: self.dir,
-            tx: Some(tx),
+            tx,
             thread: Some(thread),
+            closing,
+            parked,
+            wake_thread,
             archive: self.archive,
         })
     }
@@ -178,8 +187,11 @@ impl ConductorBuilder {
 /// creates fresh replacements. Drop to shut the thread down gracefully.
 pub struct Conductor {
     dir: PathBuf,
-    tx: Option<std::sync::mpsc::SyncSender<CleanRequest>>,
+    tx: mpsc::Producer<CleanRequest>,
     thread: Option<JoinHandle<()>>,
+    closing: Arc<AtomicBool>,
+    parked: Arc<AtomicBool>,
+    wake_thread: std::thread::Thread,
     archive: bool,
 }
 
@@ -225,8 +237,16 @@ impl Conductor {
         &self.dir
     }
 
-    pub(crate) fn sender(&self) -> std::sync::mpsc::SyncSender<CleanRequest> {
-        self.tx.as_ref().expect("conductor shut down").clone()
+    pub(crate) fn sender(&self) -> mpsc::Producer<CleanRequest> {
+        self.tx.clone()
+    }
+
+    pub(crate) fn parked(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.parked)
+    }
+
+    pub(crate) fn wake_thread(&self) -> std::thread::Thread {
+        self.wake_thread.clone()
     }
 
     pub(crate) fn archive(&self) -> bool {
@@ -236,7 +256,8 @@ impl Conductor {
 
 impl Drop for Conductor {
     fn drop(&mut self) {
-        drop(self.tx.take());
+        self.closing.store(true, Ordering::Release);
+        self.wake_thread.unpark();
         if let Some(t) = self.thread.take() {
             let _ = t.join();
         }
@@ -254,7 +275,13 @@ struct PendingCreate {
     hints: MapHints,
 }
 
-fn conductor_main(rx: &std::sync::mpsc::Receiver<CleanRequest>) {
+fn conductor_main(
+    rx: &mpsc::Consumer<CleanRequest>,
+    closing: &AtomicBool,
+    parked: &AtomicBool,
+) {
+    const MAX_SLEEP: Duration = Duration::from_secs(3);
+    let mut sleep_dur = Duration::from_millis(1);
     let mut pending: Vec<PendingCreate> = Vec::new();
 
     loop {
@@ -275,36 +302,39 @@ fn conductor_main(rx: &std::sync::mpsc::Receiver<CleanRequest>) {
             false
         });
 
-        // Non-blocking drain of new requests.
+        // Drain all available requests.
         let mut drained = false;
-        let mut disconnected = false;
-        loop {
-            match rx.try_recv() {
-                Ok(req) => {
-                    drained = true;
-                    process_request(req, &mut pending);
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    disconnected = true;
-                    break;
-                }
-            }
+        while let Some(req) = rx.pop() {
+            drained = true;
+            process_request(req, &mut pending);
         }
 
-        if disconnected {
+        if closing.load(Ordering::Acquire) {
             break;
         }
 
-        // Block only when idle; sleep briefly if still retrying.
-        if pending.is_empty() {
-            match rx.recv() {
-                Ok(req) => process_request(req, &mut pending),
-                Err(_) => break,
-            }
-        } else if !drained {
-            std::thread::sleep(Duration::from_millis(250));
+        if drained || !pending.is_empty() {
+            // Had activity — reset backoff and loop immediately.
+            sleep_dur = Duration::from_millis(1);
+            continue;
         }
+
+        // No work — prepare to park with adaptive backoff.
+        parked.store(true, Ordering::Release);
+        // Close the race: a producer may have pushed between our drain and the
+        // parked store. If so, process it and skip sleeping.
+        if let Some(req) = rx.pop() {
+            parked.store(false, Ordering::Relaxed);
+            process_request(req, &mut pending);
+            sleep_dur = Duration::from_millis(1);
+            continue;
+        }
+        std::thread::park_timeout(sleep_dur);
+        parked.store(false, Ordering::Relaxed);
+        if closing.load(Ordering::Acquire) {
+            break;
+        }
+        sleep_dur = (sleep_dur * 2).min(MAX_SLEEP);
     }
 }
 

--- a/nexus-journal/src/rotating/conductor.rs
+++ b/nexus-journal/src/rotating/conductor.rs
@@ -162,11 +162,11 @@ impl ConductorBuilder {
 
         let (tx, rx) = mpsc::ring_buffer(self.clean_queue_depth);
         let closing = Arc::new(AtomicBool::new(false));
-        let parked = Arc::new(AtomicBool::new(false));
+        let alive = Arc::new(AtomicBool::new(true));
 
         let closing_c = Arc::clone(&closing);
-        let parked_c = Arc::clone(&parked);
-        let thread = std::thread::spawn(move || conductor_main(&rx, &closing_c, &parked_c));
+        let alive_c = Arc::clone(&alive);
+        let thread = std::thread::spawn(move || conductor_main(&rx, &closing_c, &alive_c));
         let wake_thread = thread.thread().clone();
 
         Ok(Conductor {
@@ -174,7 +174,7 @@ impl ConductorBuilder {
             tx,
             thread: Some(thread),
             closing,
-            parked,
+            alive,
             wake_thread,
             archive: self.archive,
         })
@@ -185,12 +185,14 @@ impl ConductorBuilder {
 ///
 /// Owns the background cleanup thread that archives evicted segments and
 /// creates fresh replacements. Drop to shut the thread down gracefully.
+///
+/// Must outlive any [`RotatingJournal`](super::RotatingJournal) opened through it.
 pub struct Conductor {
     dir: PathBuf,
     tx: mpsc::Producer<CleanRequest>,
     thread: Option<JoinHandle<()>>,
     closing: Arc<AtomicBool>,
-    parked: Arc<AtomicBool>,
+    alive: Arc<AtomicBool>,
     wake_thread: std::thread::Thread,
     archive: bool,
 }
@@ -241,8 +243,8 @@ impl Conductor {
         self.tx.clone()
     }
 
-    pub(crate) fn parked(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.parked)
+    pub(crate) fn alive(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.alive)
     }
 
     pub(crate) fn wake_thread(&self) -> std::thread::Thread {
@@ -275,7 +277,7 @@ struct PendingCreate {
     hints: MapHints,
 }
 
-fn conductor_main(rx: &mpsc::Consumer<CleanRequest>, closing: &AtomicBool, parked: &AtomicBool) {
+fn conductor_main(rx: &mpsc::Consumer<CleanRequest>, closing: &AtomicBool, alive: &AtomicBool) {
     const MAX_SLEEP: Duration = Duration::from_secs(3);
     let mut sleep_dur = Duration::from_millis(1);
     let mut pending: Vec<PendingCreate> = Vec::new();
@@ -309,29 +311,19 @@ fn conductor_main(rx: &mpsc::Consumer<CleanRequest>, closing: &AtomicBool, parke
             break;
         }
 
-        if drained || !pending.is_empty() {
-            // Had activity — reset backoff and loop immediately.
+        if drained {
             sleep_dur = Duration::from_millis(1);
             continue;
         }
 
-        // No work — prepare to park with adaptive backoff.
-        parked.store(true, Ordering::Release);
-        // Close the race: a producer may have pushed between our drain and the
-        // parked store. If so, process it and skip sleeping.
-        if let Some(req) = rx.pop() {
-            parked.store(false, Ordering::Relaxed);
-            process_request(req, &mut pending);
-            sleep_dur = Duration::from_millis(1);
-            continue;
-        }
         std::thread::park_timeout(sleep_dur);
-        parked.store(false, Ordering::Relaxed);
         if closing.load(Ordering::Acquire) {
             break;
         }
         sleep_dur = (sleep_dur * 2).min(MAX_SLEEP);
     }
+
+    alive.store(false, Ordering::Release);
 }
 
 /// Prefault a freshly provisioned or reused segment before publishing it.

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -34,7 +34,7 @@ const EPOCH_MASK: u32 = 0x3FFF_FFFF;
 
 struct SessionResources {
     tx: mpsc::Producer<CleanRequest>,
-    parked: Arc<AtomicBool>,
+    alive: Arc<AtomicBool>,
     wake_thread: std::thread::Thread,
     session_lock: FileLock,
 }
@@ -149,7 +149,7 @@ impl<'a> RotatingJournalBuilder<'a> {
         let name_bytes = self.name.as_deref().unwrap_or("").as_bytes();
         let res = SessionResources {
             tx: self.conductor.sender(),
-            parked: self.conductor.parked(),
+            alive: self.conductor.alive(),
             wake_thread: self.conductor.wake_thread(),
             session_lock,
         };
@@ -241,7 +241,7 @@ pub struct RotatingJournal {
     slots: [Slot; 3],
     manifest: Manifest,
     tx: mpsc::Producer<CleanRequest>,
-    parked: Arc<AtomicBool>,
+    alive: Arc<AtomicBool>,
     wake_thread: std::thread::Thread,
     swap: Arc<SegmentSwap>,
     _session_lock: FileLock,
@@ -474,7 +474,7 @@ impl RotatingJournal {
             slots: [s0, s1, s2],
             manifest,
             tx: res.tx,
-            parked: res.parked,
+            alive: res.alive,
             wake_thread: res.wake_thread,
             swap,
             _session_lock: res.session_lock,
@@ -572,7 +572,7 @@ impl RotatingJournal {
             slots,
             manifest,
             tx: res.tx,
-            parked: res.parked,
+            alive: res.alive,
             wake_thread: res.wake_thread,
             swap,
             _session_lock: res.session_lock,
@@ -651,17 +651,13 @@ impl RotatingJournal {
 
         match self.tx.push(request) {
             Ok(()) => {
-                // Unpark the conductor only if it is actually sleeping.
-                if self.parked.load(Ordering::Acquire) {
-                    self.wake_thread.unpark();
-                }
+                self.wake_thread.unpark();
             }
             Err(full) => {
                 assert!(
-                    !self.tx.is_disconnected(),
+                    self.alive.load(Ordering::Acquire),
                     "conductor cleanup thread has exited unexpectedly"
                 );
-                // Queue full; put the mapping back and retry next append.
                 let mapping = full.into_inner().mapping.expect("just set it");
                 // SAFETY: we set Pending above; inner is uninit; restoring Dirty.
                 unsafe { self.swap.store_dirty(mapping) };

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use nexus_platform::{FileLock, MappedFile, Mapping};
 use nexus_platform::MapHints;
+use nexus_platform::{FileLock, MappedFile, Mapping};
 use nexus_queue::mpsc;
 
 use conductor::{CleanRequest, SWAP_CLEAN, SWAP_DIRTY, SegmentSwap};

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -8,10 +8,11 @@ mod tests;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use nexus_platform::{FileLock, MappedFile, Mapping};
-
 use nexus_platform::MapHints;
+use nexus_queue::mpsc;
 
 use conductor::{CleanRequest, SWAP_CLEAN, SWAP_DIRTY, SegmentSwap};
 use frame::{
@@ -32,7 +33,9 @@ const EPOCH_MASK: u32 = 0x3FFF_FFFF;
 // ---------------------------------------------------------------------------
 
 struct SessionResources {
-    tx: std::sync::mpsc::SyncSender<CleanRequest>,
+    tx: mpsc::Producer<CleanRequest>,
+    parked: Arc<AtomicBool>,
+    wake_thread: std::thread::Thread,
     session_lock: FileLock,
 }
 
@@ -146,6 +149,8 @@ impl<'a> RotatingJournalBuilder<'a> {
         let name_bytes = self.name.as_deref().unwrap_or("").as_bytes();
         let res = SessionResources {
             tx: self.conductor.sender(),
+            parked: self.conductor.parked(),
+            wake_thread: self.conductor.wake_thread(),
             session_lock,
         };
 
@@ -235,7 +240,9 @@ impl<'a> RotatingJournalBuilder<'a> {
 pub struct RotatingJournal {
     slots: [Slot; 3],
     manifest: Manifest,
-    tx: std::sync::mpsc::SyncSender<CleanRequest>,
+    tx: mpsc::Producer<CleanRequest>,
+    parked: Arc<AtomicBool>,
+    wake_thread: std::thread::Thread,
     swap: Arc<SegmentSwap>,
     _session_lock: FileLock,
     segment_size: usize,
@@ -467,6 +474,8 @@ impl RotatingJournal {
             slots: [s0, s1, s2],
             manifest,
             tx: res.tx,
+            parked: res.parked,
+            wake_thread: res.wake_thread,
             swap,
             _session_lock: res.session_lock,
             segment_size: size,
@@ -563,6 +572,8 @@ impl RotatingJournal {
             slots,
             manifest,
             tx: res.tx,
+            parked: res.parked,
+            wake_thread: res.wake_thread,
             swap,
             _session_lock: res.session_lock,
             segment_size: size,
@@ -638,16 +649,22 @@ impl RotatingJournal {
         // Transition Dirty → Pending before send.
         self.swap.mark_pending();
 
-        match self.tx.try_send(request) {
-            Ok(()) => {}
-            Err(std::sync::mpsc::TrySendError::Full(returned)) => {
-                // Channel full; put the mapping back and retry next append.
-                let mapping = returned.mapping.expect("just set it");
+        match self.tx.push(request) {
+            Ok(()) => {
+                // Unpark the conductor only if it is actually sleeping.
+                if self.parked.load(Ordering::Acquire) {
+                    self.wake_thread.unpark();
+                }
+            }
+            Err(full) => {
+                assert!(
+                    !self.tx.is_disconnected(),
+                    "conductor cleanup thread has exited unexpectedly"
+                );
+                // Queue full; put the mapping back and retry next append.
+                let mapping = full.into_inner().mapping.expect("just set it");
                 // SAFETY: we set Pending above; inner is uninit; restoring Dirty.
                 unsafe { self.swap.store_dirty(mapping) };
-            }
-            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
-                panic!("conductor cleanup thread has exited unexpectedly");
             }
         }
     }


### PR DESCRIPTION
Closes #499.

Replaces `std::sync::mpsc::sync_channel` with `nexus_queue::mpsc::ring_buffer` and rewrites the conductor work loop with adaptive backoff + conditional unpark.

## What changed

**`conductor.rs`**
- Channel: `sync_channel` → `mpsc::ring_buffer` (lock-free, no futex on push)
- `Conductor` gains `closing: Arc<AtomicBool>`, `parked: Arc<AtomicBool>`, `wake_thread: Thread`
- `Drop`: sets `closing = true`, unparks thread, joins — immediate shutdown (no sleep expiry wait)
- `conductor_main`: adaptive backoff — drain → if idle: `parked.store(true)` → re-check (race close) → `park_timeout` with exponential backoff (1ms → ... → 3s cap)

**`mod.rs`**
- `SessionResources` / `RotatingJournal`: `SyncSender` → `Producer`, gain `parked` + `wake_thread`
- `try_flush_dirty`: after successful push, conditionally unparks conductor (`parked.load(Acquire)` — single atomic check, syscall only when conductor is actually sleeping)