### PR TITLE
fix(codec): FieldReader::next_data_field + codegen error propagation (#429)

### DIFF
--- a/nexus-fix-codec/src/error.rs
+++ b/nexus-fix-codec/src/error.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 /// Error during FIX message decoding.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Message is too short to contain required header fields.
     Truncated,
@@ -15,6 +16,8 @@ pub enum DecodeError {
     MissingBodyLength,
     /// Checksum validation failed.
     Checksum(ChecksumError),
+    /// DATA field declared a zero or inconsistent length.
+    InvalidLength,
 }
 
 impl fmt::Display for DecodeError {
@@ -26,6 +29,7 @@ impl fmt::Display for DecodeError {
             Self::MissingBeginString => f.write_str("missing or misplaced BeginString (tag 8)"),
             Self::MissingBodyLength => f.write_str("missing or misplaced BodyLength (tag 9)"),
             Self::Checksum(e) => write!(f, "checksum: {}", e),
+            Self::InvalidLength => f.write_str("DATA field declared invalid length"),
         }
     }
 }
@@ -187,6 +191,10 @@ mod tests {
         assert_eq!(
             DecodeError::Checksum(ce).to_string(),
             "checksum: expected 178, computed 042"
+        );
+        assert_eq!(
+            DecodeError::InvalidLength.to_string(),
+            "DATA field declared invalid length"
         );
     }
 

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -68,6 +68,29 @@ impl<'a> FieldReader<'a> {
         }
     }
 
+    #[inline]
+    pub fn next_data_field(&mut self, len: usize) -> Result<RawField, crate::DecodeError> {
+        if len == 0 {
+            return Err(crate::DecodeError::Truncated);
+        }
+        let field_start = self.field_start;
+        let (tag, tag_len) = parse_tag(self.buf.get(field_start..).unwrap_or(b""));
+        if tag_len == 0 {
+            return Err(crate::DecodeError::InvalidTag);
+        }
+        if self.buf.get(field_start + tag_len) != Some(&b'=') {
+            return Err(crate::DecodeError::MissingSeparator);
+        }
+        let value_start = field_start + tag_len + 1;
+        let data_end = value_start + len;
+        if self.buf.get(data_end) != Some(&b'\x01') {
+            return Err(crate::DecodeError::Truncated);
+        }
+        let span = FieldSpan::new(value_start as u32, len as u32);
+        self.resync_after_data(data_end + 1);
+        Ok(RawField { tag, value: span })
+    }
+
     /// Resume scanning at `data_end`, having consumed a length-prefixed DATA
     /// field whose value may contain SOH bytes.
     ///
@@ -822,6 +845,114 @@ mod tests {
         assert_eq!(parse_checksum_bytes(b"XYZ"), None); // non-digit
         assert_eq!(parse_checksum_bytes(b"12"), None); // too short
         assert_eq!(parse_checksum_bytes(b"1234"), None); // too long
+    }
+
+    #[test]
+    fn next_data_field_embedded_soh() {
+        let msg = b"95=5\x0196=AB\x01CD\x0155=X\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        let f = r.next_data_field(5).unwrap();
+        assert_eq!(f.tag, 96);
+        assert_eq!(f.value.slice(msg), b"AB\x01CD");
+        let next = r.next_field().unwrap();
+        assert_eq!(next.tag, 55);
+        assert_eq!(next.value.slice(msg), b"X");
+        assert!(r.next_field().is_none());
+    }
+
+    #[test]
+    fn next_data_field_embedded_equals() {
+        let msg = b"95=3\x0196=a=b\x0155=Y\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        let f = r.next_data_field(3).unwrap();
+        assert_eq!(f.tag, 96);
+        assert_eq!(f.value.slice(msg), b"a=b");
+        assert_eq!(r.next_field().unwrap().tag, 55);
+    }
+
+    #[test]
+    fn next_data_field_last_before_checksum() {
+        let body = b"95=3\x0196=ABC\x01";
+        let sum = checksum(body);
+        let mut msg = body.to_vec();
+        msg.extend_from_slice(format!("10={sum:03}\x01").as_bytes());
+        let mut r = FieldReader::new(&msg, 0);
+        r.next_field();
+        let f = r.next_data_field(3).unwrap();
+        assert_eq!(f.value.slice(&msg), b"ABC");
+        let tag10 = r.next_field().unwrap();
+        assert_eq!(tag10.tag, 10);
+    }
+
+    #[test]
+    fn next_data_field_multiple_pairs() {
+        let msg = b"95=2\x0196=AB\x01212=3\x01213=CDE\x0155=Z\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        let f1 = r.next_data_field(2).unwrap();
+        assert_eq!(f1.tag, 96);
+        assert_eq!(f1.value.slice(msg), b"AB");
+        r.next_field();
+        let f2 = r.next_data_field(3).unwrap();
+        assert_eq!(f2.tag, 213);
+        assert_eq!(f2.value.slice(msg), b"CDE");
+        assert_eq!(r.next_field().unwrap().tag, 55);
+    }
+
+    #[test]
+    fn next_data_field_inside_group() {
+        let msg = b"268=1\x0196=AB\x01CD\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field(); // 268=1
+        let f = r.next_data_field(5).unwrap();
+        assert_eq!(f.tag, 96);
+        assert_eq!(f.value.slice(msg), b"AB\x01CD");
+        assert!(r.next_field().is_none());
+    }
+
+    #[test]
+    fn next_data_field_checksum_covers_embedded_soh() {
+        let body = b"95=5\x0196=AB\x01CD\x01";
+        let sum = checksum(body);
+        let mut msg = body.to_vec();
+        msg.extend_from_slice(format!("10={sum:03}\x01").as_bytes());
+        let prefix = &msg[..msg.len() - b"10=000\x01".len()];
+        assert_eq!(checksum(prefix), sum);
+    }
+
+    #[test]
+    fn next_data_field_zero_len_errors() {
+        let msg = b"95=0\x0196=\x0155=X\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        assert!(matches!(
+            r.next_data_field(0),
+            Err(crate::DecodeError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn next_data_field_n_exceeds_remaining() {
+        let msg = b"95=100\x0196=ABC\x01";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        assert!(matches!(
+            r.next_data_field(100),
+            Err(crate::DecodeError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn next_data_field_missing_terminator() {
+        let msg = b"95=3\x0196=ABC";
+        let mut r = FieldReader::new(msg, 0);
+        r.next_field();
+        assert!(matches!(
+            r.next_data_field(3),
+            Err(crate::DecodeError::Truncated)
+        ));
     }
 
     #[test]

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -68,10 +68,15 @@ impl<'a> FieldReader<'a> {
         }
     }
 
+    /// Consume a length-prefixed DATA field.
+    ///
+    /// `len` is the value byte count, excluding the terminating SOH. Returns
+    /// `InvalidLength` if `len == 0`, `Truncated` if the SOH is absent or the
+    /// buffer is too short.
     #[inline]
     pub fn next_data_field(&mut self, len: usize) -> Result<RawField, crate::DecodeError> {
         if len == 0 {
-            return Err(crate::DecodeError::Truncated);
+            return Err(crate::DecodeError::InvalidLength);
         }
         let field_start = self.field_start;
         let (tag, tag_len) = parse_tag(self.buf.get(field_start..).unwrap_or(b""));
@@ -82,6 +87,10 @@ impl<'a> FieldReader<'a> {
             return Err(crate::DecodeError::MissingSeparator);
         }
         let value_start = field_start + tag_len + 1;
+        let remaining = self.buf.len().saturating_sub(value_start);
+        if len > remaining {
+            return Err(crate::DecodeError::Truncated);
+        }
         let data_end = value_start + len;
         if self.buf.get(data_end) != Some(&b'\x01') {
             return Err(crate::DecodeError::Truncated);
@@ -929,7 +938,7 @@ mod tests {
         r.next_field();
         assert!(matches!(
             r.next_data_field(0),
-            Err(crate::DecodeError::Truncated)
+            Err(crate::DecodeError::InvalidLength)
         ));
     }
 

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -67,12 +67,12 @@ fn alpha_decodes_data_field_with_embedded_soh() {
 }
 
 #[test]
-fn alpha_truncated_data_does_not_panic() {
+fn alpha_truncated_data_errors() {
     let msg = b"11=A\x0195=100\x0196=ab\x01";
-    let m = venue_alpha::messages::NewOrderSingle::decode(msg).unwrap();
-    assert_eq!(m.raw_data_length().unwrap().get(), 100);
-    let data = m.raw_data().unwrap().as_bytes();
-    assert!(data.len() <= msg.len());
+    assert!(matches!(
+        venue_alpha::messages::NewOrderSingle::decode(msg),
+        Err(nexus_fix_codec::DecodeError::Truncated)
+    ));
 }
 
 #[test]

--- a/nexus-fix-codegen/src/emit/messages.rs
+++ b/nexus-fix-codegen/src/emit/messages.rs
@@ -216,9 +216,7 @@ fn data_body(len: &RField, data: &RField) -> String {
     let mut b = String::new();
     let _ = writeln!(b, "                m.{} = f.value;", snake(&len.name));
     b.push_str("                let (n, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n");
-    b.push_str(
-        "                let data_f = m.header.reader.next_data_field(n as usize)?;\n",
-    );
+    b.push_str("                let data_f = m.header.reader.next_data_field(n as usize)?;\n");
     let _ = writeln!(b, "                m.{} = data_f.value;", snake(&data.name));
     b
 }

--- a/nexus-fix-codegen/src/emit/messages.rs
+++ b/nexus-fix-codegen/src/emit/messages.rs
@@ -216,20 +216,10 @@ fn data_body(len: &RField, data: &RField) -> String {
     let mut b = String::new();
     let _ = writeln!(b, "                m.{} = f.value;", snake(&len.name));
     b.push_str("                let (n, _) = nexus_fix_codec::parse_tag(f.value.slice(buf));\n");
-    b.push_str("                let dstart = m.header.reader.pos();\n");
-    b.push_str("                let (_, dtl) = nexus_fix_codec::parse_tag(&buf[dstart..]);\n");
-    b.push_str("                let vstart = dstart + dtl + 1;\n");
-    b.push_str("                let dlen = (n as usize).min(buf.len().saturating_sub(vstart));\n");
-    let _ = writeln!(
-        b,
-        "                m.{} = nexus_fix_codec::FieldSpan::new(vstart as u32, dlen as u32);",
-        snake(&data.name)
+    b.push_str(
+        "                let data_f = m.header.reader.next_data_field(n as usize)?;\n",
     );
-    // Skip past the DATA value (which may contain SOH bytes) by repositioning
-    // the reader. The checksum is a separate pass, so there is no accumulator to
-    // keep in sync — `resync_after_data` is a pure jump.
-    b.push_str("                let dend = (vstart + dlen + 1).min(buf.len());\n");
-    b.push_str("                m.header.reader.resync_after_data(dend);\n");
+    let _ = writeln!(b, "                m.{} = data_f.value;", snake(&data.name));
     b
 }
 


### PR DESCRIPTION
Closes #429.

**What**

- `FieldReader::next_data_field(len)` — consumes the next field as exactly `len` raw bytes without SOH-scanning; returns `DecodeError::Truncated` for `len == 0`, `len > remaining`, or missing terminating SOH
- Codegen `data_body` now calls `next_data_field` via `?` instead of silently clamping with `.min(buf.len().saturating_sub(vstart))`

**Tests** — 9 new cases in `reader::tests`: embedded SOH, embedded `=`, last field before `10=`, multiple pairs, inside repeating group, checksum coverage, zero len, N > remaining, missing terminator