### PR TITLE
feat(shm): ShmSlot + ShmRingBuffer cross-process primitives (#393, #392)

### DIFF
--- a/nexus-shm/Cargo.toml
+++ b/nexus-shm/Cargo.toml
@@ -17,6 +17,9 @@ workspace = true
 crossbeam-utils.workspace = true
 nexus-platform = { version = "0.1.0", path = "../nexus-platform" }
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -11,6 +11,8 @@ pub enum ShmError {
     HugePagesUnavailable(std::io::Error),
     OwnerActive,
     Os(std::io::Error),
+    ElemSizeMismatch { written: usize, expected: usize },
+    CorruptHeader,
 }
 
 impl fmt::Display for ShmError {
@@ -28,6 +30,10 @@ impl fmt::Display for ShmError {
             Self::HugePagesUnavailable(e) => write!(f, "huge pages unavailable: {e}"),
             Self::OwnerActive => write!(f, "segment already owned by a live process"),
             Self::Os(e) => write!(f, "{e}"),
+            Self::ElemSizeMismatch { written, expected } => {
+                write!(f, "element size mismatch: segment has {written}, reader expects {expected}")
+            }
+            Self::CorruptHeader => write!(f, "segment header is corrupt"),
         }
     }
 }

--- a/nexus-shm/src/error.rs
+++ b/nexus-shm/src/error.rs
@@ -31,7 +31,10 @@ impl fmt::Display for ShmError {
             Self::OwnerActive => write!(f, "segment already owned by a live process"),
             Self::Os(e) => write!(f, "{e}"),
             Self::ElemSizeMismatch { written, expected } => {
-                write!(f, "element size mismatch: segment has {written}, reader expects {expected}")
+                write!(
+                    f,
+                    "element size mismatch: segment has {written}, reader expects {expected}"
+                )
             }
             Self::CorruptHeader => write!(f, "segment header is corrupt"),
         }

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -3,16 +3,19 @@
 //! Implements the foundation layer: the segment control block, the
 //! mmap-backed [`Segment`], and two-tier liveness (atomic status + OFD lock).
 //! Also provides [`ShmSlotWriter`] / [`ShmSlotReader`] for cross-process
-//! latest-value sharing via seqlock.
+//! latest-value sharing via seqlock, and [`ShmRingWriter`] / [`ShmRingReader`]
+//! for cross-process SPSC messaging.
 
 pub(crate) mod control;
 mod error;
 pub mod pod;
+mod ring;
 mod segment;
 mod slot;
 
 pub use error::ShmError;
 pub use nexus_platform::{Liveness, MapHints, MappedFile};
 pub use pod::Pod;
+pub use ring::{ShmRingReader, ShmRingWriter};
 pub use segment::{Segment, Status};
 pub use slot::{ShmSlotReader, ShmSlotWriter, SlotRead};

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -2,11 +2,17 @@
 //!
 //! Implements the foundation layer: the segment control block, the
 //! mmap-backed [`Segment`], and two-tier liveness (atomic status + OFD lock).
+//! Also provides [`ShmSlotWriter`] / [`ShmSlotReader`] for cross-process
+//! latest-value sharing via seqlock.
 
 pub(crate) mod control;
 mod error;
+pub mod pod;
 mod segment;
+mod slot;
 
 pub use error::ShmError;
 pub use nexus_platform::{Liveness, MapHints, MappedFile};
+pub use pod::Pod;
 pub use segment::{Segment, Status};
+pub use slot::{ShmSlotReader, ShmSlotWriter, SlotRead};

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -1,0 +1,23 @@
+/// Marker trait for types safe to place in shared memory.
+///
+/// # Safety
+/// The type must have no heap pointers, no `Drop`, and a stable
+/// binary representation (`repr(C)` or `repr(transparent)`).
+/// Any bit pattern that fits in `size_of::<Self>()` bytes must be valid.
+pub unsafe trait Pod: Sized + 'static {}
+
+unsafe impl Pod for u8 {}
+unsafe impl Pod for u16 {}
+unsafe impl Pod for u32 {}
+unsafe impl Pod for u64 {}
+unsafe impl Pod for u128 {}
+unsafe impl Pod for i8 {}
+unsafe impl Pod for i16 {}
+unsafe impl Pod for i32 {}
+unsafe impl Pod for i64 {}
+unsafe impl Pod for i128 {}
+unsafe impl Pod for f32 {}
+unsafe impl Pod for f64 {}
+unsafe impl Pod for usize {}
+unsafe impl Pod for isize {}
+unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -18,6 +18,11 @@ unsafe impl Pod for i64 {}
 unsafe impl Pod for i128 {}
 unsafe impl Pod for f32 {}
 unsafe impl Pod for f64 {}
+/// # Cross-process caveat
+///
+/// `usize` and `isize` are pointer-width integers. Both ends of an IPC channel
+/// must run the same architecture (same pointer width); mixing a 32-bit writer
+/// with a 64-bit reader produces wrong values.
 unsafe impl Pod for usize {}
 unsafe impl Pod for isize {}
 unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -90,7 +90,10 @@ impl<T: Pod> ShmRingWriter<T> {
         let segment = Segment::create(mf, data_len, hints)?;
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
-            std::ptr::write(segment.data().add(CAP_OFFSET).cast::<u64>(), capacity as u64);
+            std::ptr::write(
+                segment.data().add(CAP_OFFSET).cast::<u64>(),
+                capacity as u64,
+            );
             std::ptr::write(
                 segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>(),
                 size_of::<T>() as u64,
@@ -157,7 +160,10 @@ impl<T: Pod> ShmRingReader<T> {
         }
         let elem_size = read_elem_size(&segment) as usize;
         if elem_size != size_of::<T>() {
-            return Err(ShmError::ElemSizeMismatch { written: elem_size, expected: size_of::<T>() });
+            return Err(ShmError::ElemSizeMismatch {
+                written: elem_size,
+                expected: size_of::<T>(),
+            });
         }
         Ok(Self {
             segment,

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -11,6 +11,7 @@ use crate::segment::{Segment, Status};
 const TAIL_OFFSET: usize = 0;
 const HEAD_OFFSET: usize = 64;
 const CAP_OFFSET: usize = 128;
+const ELEM_SIZE_OFFSET: usize = 136;
 const DATA_OFFSET: usize = 192;
 
 fn ring_tail(segment: &Segment) -> &AtomicU64 {
@@ -23,6 +24,10 @@ fn ring_head(segment: &Segment) -> &AtomicU64 {
 
 fn read_capacity(segment: &Segment) -> u64 {
     unsafe { std::ptr::read(segment.data().add(CAP_OFFSET).cast::<u64>()) }
+}
+
+fn read_elem_size(segment: &Segment) -> u64 {
+    unsafe { std::ptr::read(segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>()) }
 }
 
 fn slot_ptr<T>(segment: &Segment, slot_idx: u64) -> *mut T {
@@ -76,15 +81,19 @@ impl<T: Pod> ShmRingWriter<T> {
             "align_of::<T>() = {} exceeds DATA_OFFSET = {DATA_OFFSET}",
             align_of::<T>(),
         );
-        let data_len = DATA_OFFSET + capacity * size_of::<T>();
+        let data_len = capacity
+            .checked_mul(size_of::<T>())
+            .and_then(|s| s.checked_add(DATA_OFFSET))
+            .ok_or(ShmError::SizeOverflow)?;
         let total = Segment::total_size(data_len)?;
         let mf = MappedFile::create(path.as_ref(), total)?;
         let segment = Segment::create(mf, data_len, hints)?;
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
+            std::ptr::write(segment.data().add(CAP_OFFSET).cast::<u64>(), capacity as u64);
             std::ptr::write(
-                segment.data().add(CAP_OFFSET).cast::<u64>(),
-                capacity as u64,
+                segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>(),
+                size_of::<T>() as u64,
             );
         }
         Ok(Self {
@@ -136,14 +145,20 @@ unsafe impl<T: Pod + Send> Send for ShmRingWriter<T> {}
 
 impl<T: Pod> ShmRingReader<T> {
     /// Attach to an existing ring buffer at `path`.
+    ///
+    /// Returns `Err` if the header is corrupt, the element size doesn't match
+    /// `size_of::<T>()`, or the mapping is too small for the stored capacity.
     pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
         let mf = MappedFile::open(path.as_ref())?;
         let segment = Segment::attach(mf)?;
         let capacity = read_capacity(&segment);
-        assert!(
-            capacity.is_power_of_two() && capacity > 0,
-            "corrupt ring buffer: capacity {capacity} is not a power of two"
-        );
+        if !capacity.is_power_of_two() || capacity == 0 {
+            return Err(ShmError::CorruptHeader);
+        }
+        let elem_size = read_elem_size(&segment) as usize;
+        if elem_size != size_of::<T>() {
+            return Err(ShmError::ElemSizeMismatch { written: elem_size, expected: size_of::<T>() });
+        }
         Ok(Self {
             segment,
             local_head: 0,

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -356,4 +356,39 @@ mod tests {
 
         std::fs::remove_file(&path).unwrap();
     }
+
+    #[test]
+    fn threaded_spsc_torture() {
+        const COUNT: u64 = 100_000;
+        let path = temp_path("threaded");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u64>::create(&path, 256, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        let wt = std::thread::spawn(move || {
+            for i in 0..COUNT {
+                while !writer.try_push(&i) {
+                    std::hint::spin_loop();
+                }
+            }
+        });
+
+        let rt = std::thread::spawn(move || {
+            let mut expected = 0u64;
+            while expected < COUNT {
+                match reader.try_pop() {
+                    Some(v) => {
+                        assert_eq!(v, expected, "SPSC ordering violation");
+                        expected += 1;
+                    }
+                    None => std::hint::spin_loop(),
+                }
+            }
+        });
+
+        wt.join().unwrap();
+        rt.join().unwrap();
+        std::fs::remove_file(&path).unwrap();
+    }
 }

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -1,0 +1,338 @@
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use nexus_platform::{MapHints, MappedFile};
+
+use crate::error::ShmError;
+use crate::pod::Pod;
+use crate::segment::{Segment, Status};
+
+const TAIL_OFFSET: usize = 0;
+const HEAD_OFFSET: usize = 64;
+const CAP_OFFSET: usize = 128;
+const DATA_OFFSET: usize = 192;
+
+fn ring_tail(segment: &Segment) -> &AtomicU64 {
+    unsafe { &*segment.data().add(TAIL_OFFSET).cast::<AtomicU64>() }
+}
+
+fn ring_head(segment: &Segment) -> &AtomicU64 {
+    unsafe { &*segment.data().add(HEAD_OFFSET).cast::<AtomicU64>() }
+}
+
+fn read_capacity(segment: &Segment) -> u64 {
+    unsafe { std::ptr::read(segment.data().add(CAP_OFFSET).cast::<u64>()) }
+}
+
+fn slot_ptr<T>(segment: &Segment, slot_idx: u64) -> *mut T {
+    unsafe {
+        segment
+            .data()
+            .add(DATA_OFFSET + slot_idx as usize * size_of::<T>())
+            .cast::<T>()
+    }
+}
+
+/// SPSC ring buffer writer backed by a shared-memory segment.
+///
+/// Creates the backing file. Only one writer per file; the process that drops
+/// the writer marks the segment dead, signaling all readers.
+pub struct ShmRingWriter<T: Pod> {
+    segment: Segment,
+    local_tail: u64,
+    cached_head: u64,
+    capacity: u64,
+    mask: u64,
+    _marker: PhantomData<T>,
+}
+
+/// SPSC ring buffer reader backed by a shared-memory segment.
+pub struct ShmRingReader<T: Pod> {
+    segment: Segment,
+    local_head: u64,
+    cached_tail: u64,
+    capacity: u64,
+    mask: u64,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Pod> ShmRingWriter<T> {
+    /// Create a new ring buffer at `path` with `capacity` slots.
+    ///
+    /// `capacity` must be a non-zero power of two.
+    /// Fails if another live writer owns the file.
+    pub fn create(
+        path: impl AsRef<Path>,
+        capacity: usize,
+        hints: MapHints,
+    ) -> Result<Self, ShmError> {
+        assert!(
+            capacity.is_power_of_two(),
+            "capacity must be a non-zero power of two, got {capacity}"
+        );
+        assert!(
+            align_of::<T>() <= DATA_OFFSET,
+            "align_of::<T>() = {} exceeds DATA_OFFSET = {DATA_OFFSET}",
+            align_of::<T>(),
+        );
+        let data_len = DATA_OFFSET + capacity * size_of::<T>();
+        let total = Segment::total_size(data_len)?;
+        let mf = MappedFile::create(path.as_ref(), total)?;
+        let segment = Segment::create(mf, data_len, hints)?;
+        unsafe {
+            std::ptr::write_bytes(segment.data(), 0, data_len);
+            std::ptr::write(
+                segment.data().add(CAP_OFFSET).cast::<u64>(),
+                capacity as u64,
+            );
+        }
+        Ok(Self {
+            segment,
+            local_tail: 0,
+            cached_head: 0,
+            capacity: capacity as u64,
+            mask: capacity as u64 - 1,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Push `value` into the ring buffer.
+    ///
+    /// Returns `false` without writing if the buffer is full.
+    pub fn try_push(&mut self, value: &T) -> bool {
+        let tail = self.local_tail;
+        if tail.wrapping_sub(self.cached_head) >= self.capacity {
+            self.cached_head = ring_head(&self.segment).load(Ordering::Acquire);
+            if tail.wrapping_sub(self.cached_head) >= self.capacity {
+                return false;
+            }
+        }
+        let dst = slot_ptr::<T>(&self.segment, tail & self.mask);
+        unsafe { std::ptr::copy_nonoverlapping(value as *const T, dst, 1) };
+        self.local_tail = tail.wrapping_add(1);
+        ring_tail(&self.segment).store(self.local_tail, Ordering::Release);
+        true
+    }
+
+    /// Number of slots currently occupied.
+    pub fn len(&self) -> usize {
+        let head = ring_head(&self.segment).load(Ordering::Acquire);
+        self.local_tail.wrapping_sub(head) as usize
+    }
+
+    /// `true` if no items are queued.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Maximum number of items the buffer can hold.
+    pub fn capacity(&self) -> usize {
+        self.capacity as usize
+    }
+}
+
+unsafe impl<T: Pod + Send> Send for ShmRingWriter<T> {}
+
+impl<T: Pod> ShmRingReader<T> {
+    /// Attach to an existing ring buffer at `path`.
+    pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
+        let mf = MappedFile::open(path.as_ref())?;
+        let segment = Segment::attach(mf)?;
+        let capacity = read_capacity(&segment);
+        assert!(
+            capacity.is_power_of_two() && capacity > 0,
+            "corrupt ring buffer: capacity {capacity} is not a power of two"
+        );
+        Ok(Self {
+            segment,
+            local_head: 0,
+            cached_tail: 0,
+            capacity,
+            mask: capacity - 1,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Pop the next value from the ring buffer.
+    ///
+    /// Returns `None` if the buffer is empty.
+    pub fn try_pop(&mut self) -> Option<T> {
+        let head = self.local_head;
+        if head == self.cached_tail {
+            self.cached_tail = ring_tail(&self.segment).load(Ordering::Acquire);
+            if head == self.cached_tail {
+                return None;
+            }
+        }
+        let src = slot_ptr::<T>(&self.segment, head & self.mask).cast_const();
+        let value = unsafe { std::ptr::read(src) };
+        self.local_head = head.wrapping_add(1);
+        ring_head(&self.segment).store(self.local_head, Ordering::Release);
+        Some(value)
+    }
+
+    /// Tier-1 liveness of the writer (atomic status field).
+    ///
+    /// `Dead` is authoritative. `Alive` may be stale under `panic=abort` or
+    /// SIGKILL; use `Segment::peer_liveness` for kernel-level confirmation.
+    pub fn writer_status(&self) -> Status {
+        self.segment.status()
+    }
+
+    /// Maximum number of items the buffer can hold.
+    pub fn capacity(&self) -> usize {
+        self.capacity as usize
+    }
+}
+
+unsafe impl<T: Pod + Send> Send for ShmRingReader<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nexus_platform::MapHints;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("nexus-shm-ring-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn empty_on_create() {
+        let path = temp_path("empty");
+        let _ = std::fs::remove_file(&path);
+
+        let writer = ShmRingWriter::<u64>::create(&path, 4, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        assert!(writer.is_empty());
+        assert!(reader.try_pop().is_none());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn push_pop_roundtrip() {
+        let path = temp_path("roundtrip");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u64>::create(&path, 4, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        assert!(writer.try_push(&42));
+        assert_eq!(reader.try_pop(), Some(42));
+        assert!(reader.try_pop().is_none());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn fifo_ordering() {
+        let path = temp_path("fifo");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u32>::create(&path, 8, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u32>::attach(&path).unwrap();
+
+        for i in 0..8u32 {
+            assert!(writer.try_push(&i));
+        }
+        for i in 0..8u32 {
+            assert_eq!(reader.try_pop(), Some(i));
+        }
+        assert!(reader.try_pop().is_none());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn full_returns_false() {
+        let path = temp_path("full");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u64>::create(&path, 2, MapHints::default()).unwrap();
+        let _reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        assert!(writer.try_push(&1));
+        assert!(writer.try_push(&2));
+        assert!(!writer.try_push(&3)); // full
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn wrap_around() {
+        let path = temp_path("wrap");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u64>::create(&path, 4, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        for round in 0..8u64 {
+            for i in 0..4u64 {
+                let val = round * 4 + i;
+                assert!(writer.try_push(&val), "push failed at val={val}");
+            }
+            for i in 0..4u64 {
+                let expected = round * 4 + i;
+                assert_eq!(reader.try_pop(), Some(expected));
+            }
+        }
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn writer_drop_reader_drains_then_empty() {
+        let path = temp_path("drain");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<u64>::create(&path, 4, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<u64>::attach(&path).unwrap();
+
+        writer.try_push(&10);
+        writer.try_push(&20);
+        drop(writer);
+
+        assert_eq!(reader.try_pop(), Some(10));
+        assert_eq!(reader.try_pop(), Some(20));
+        assert!(reader.try_pop().is_none());
+        assert_eq!(reader.writer_status(), Status::Dead);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct Order {
+        price: u64,
+        qty: u32,
+        side: u8,
+        _pad: [u8; 3],
+    }
+    unsafe impl Pod for Order {}
+
+    #[test]
+    fn struct_pod_roundtrip() {
+        let path = temp_path("struct");
+        let _ = std::fs::remove_file(&path);
+
+        let mut writer = ShmRingWriter::<Order>::create(&path, 8, MapHints::default()).unwrap();
+        let mut reader = ShmRingReader::<Order>::attach(&path).unwrap();
+
+        let order = Order {
+            price: 10050,
+            qty: 100,
+            side: 1,
+            _pad: [0; 3],
+        };
+        assert!(writer.try_push(&order));
+
+        let got = reader.try_pop().unwrap();
+        assert_eq!(got.price, 10050);
+        assert_eq!(got.qty, 100);
+        assert_eq!(got.side, 1);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+}

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -1,0 +1,282 @@
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use nexus_platform::{MapHints, MappedFile};
+
+use crate::error::ShmError;
+use crate::pod::Pod;
+use crate::segment::{Segment, Status};
+
+// Version and payload are on separate cache lines to prevent false sharing.
+const PAYLOAD_OFFSET: usize = 64;
+
+fn data_len<T>() -> usize {
+    PAYLOAD_OFFSET + size_of::<T>()
+}
+
+fn version_ptr(segment: &Segment) -> *mut AtomicU64 {
+    segment.data().cast::<AtomicU64>()
+}
+
+fn payload_ptr<T>(segment: &Segment) -> *mut T {
+    unsafe { segment.data().add(PAYLOAD_OFFSET).cast::<T>() }
+}
+
+/// Writes into a shared-memory seqlock slot.
+///
+/// Creates the backing file. Multiple threads may share a writer via `Arc`.
+/// Dropped when the creating process exits; marks the segment dead on drop.
+pub struct ShmSlotWriter<T: Pod> {
+    segment: Segment,
+    _marker: PhantomData<T>,
+}
+
+/// Reads from a shared-memory seqlock slot.
+///
+/// Attaches to a file created by [`ShmSlotWriter`].
+/// Maintains a shadow copy of the last consistent read for stale-read fallback.
+pub struct ShmSlotReader<T: Pod> {
+    segment: Segment,
+    buf: Box<MaybeUninit<T>>,
+    shadow: Box<MaybeUninit<T>>,
+    shadow_valid: bool,
+    _marker: PhantomData<T>,
+}
+
+/// Result of [`ShmSlotReader::read`].
+pub enum SlotRead<'a, T> {
+    /// Consistent value from the current write epoch.
+    Fresh(&'a T),
+    /// Writer is dead mid-write; last successfully read value returned.
+    Stale(&'a T),
+    /// No write has occurred since the slot was created.
+    Empty,
+}
+
+impl<T: Pod> ShmSlotWriter<T> {
+    /// Create a new slot backed by `path`.
+    ///
+    /// Fails if another live writer owns the file.
+    pub fn create(path: impl AsRef<Path>, hints: MapHints) -> Result<Self, ShmError> {
+        assert!(
+            align_of::<T>() <= PAYLOAD_OFFSET,
+            "align_of::<T>() = {} exceeds PAYLOAD_OFFSET = {}; use a repr(C) type with smaller alignment",
+            align_of::<T>(),
+            PAYLOAD_OFFSET,
+        );
+        let data_len = data_len::<T>();
+        let total = Segment::total_size(data_len)?;
+        let mf = MappedFile::create(path.as_ref(), total)?;
+        let segment = Segment::create(mf, data_len, hints)?;
+        // Zero the data region: version = 0 means "never written".
+        unsafe { std::ptr::write_bytes(segment.data(), 0, data_len) };
+        Ok(Self {
+            segment,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Publish `value` to all readers.
+    ///
+    /// Odd version marks mid-write; readers retry or fall back to shadow.
+    pub fn write(&self, value: &T) {
+        let ver = unsafe { &*version_ptr(&self.segment) };
+        let dst = payload_ptr::<T>(&self.segment);
+        ver.fetch_add(1, Ordering::Release);
+        unsafe { std::ptr::copy_nonoverlapping(value as *const T, dst, 1) };
+        ver.fetch_add(1, Ordering::Release);
+    }
+}
+
+// SAFETY: `Segment` wraps a shared mmap; `write` uses the seqlock protocol
+// for synchronization. Multiple concurrent `write` callers would corrupt the
+// seqlock invariant — callers must serialize writes externally if needed.
+// Sharing via `Arc` is safe when writes are externally serialized.
+unsafe impl<T: Pod + Send> Send for ShmSlotWriter<T> {}
+unsafe impl<T: Pod + Sync> Sync for ShmSlotWriter<T> {}
+
+impl<T: Pod> ShmSlotReader<T> {
+    /// Attach to an existing slot at `path`.
+    pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
+        let mf = MappedFile::open(path.as_ref())?;
+        let segment = Segment::attach(mf)?;
+        Ok(Self {
+            segment,
+            buf: Box::new(MaybeUninit::uninit()),
+            shadow: Box::new(MaybeUninit::uninit()),
+            shadow_valid: false,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Read the latest value.
+    ///
+    /// Retries on version mismatch (writer mid-write). Returns `Stale` with
+    /// the last good shadow if the writer died mid-write. Returns `Empty` if
+    /// no write has occurred and no shadow exists.
+    pub fn read(&mut self) -> SlotRead<'_, T> {
+        let ver = unsafe { &*version_ptr(&self.segment) };
+        let src = payload_ptr::<T>(&self.segment).cast_const();
+        loop {
+            let v1 = ver.load(Ordering::Acquire);
+            if v1 == 0 {
+                return SlotRead::Empty;
+            }
+            if v1 & 1 == 1 {
+                match self.segment.status() {
+                    Status::Alive => {
+                        std::hint::spin_loop();
+                        continue;
+                    }
+                    _ => {
+                        return if self.shadow_valid {
+                            SlotRead::Stale(unsafe { self.shadow.assume_init_ref() })
+                        } else {
+                            SlotRead::Empty
+                        };
+                    }
+                }
+            }
+            unsafe { std::ptr::copy_nonoverlapping(src, self.buf.as_mut_ptr(), 1) };
+            let v2 = ver.load(Ordering::Acquire);
+            if v1 != v2 {
+                std::hint::spin_loop();
+                continue;
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(self.buf.as_ptr(), self.shadow.as_mut_ptr(), 1);
+            }
+            self.shadow_valid = true;
+            return SlotRead::Fresh(unsafe { self.shadow.assume_init_ref() });
+        }
+    }
+}
+
+unsafe impl<T: Pod + Send> Send for ShmSlotReader<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nexus_platform::MapHints;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("nexus-shm-slot-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn empty_before_first_write() {
+        let path = temp_path("empty");
+        let _ = std::fs::remove_file(&path);
+
+        let _writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
+
+        assert!(matches!(reader.read(), SlotRead::Empty));
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn write_read_roundtrip() {
+        let path = temp_path("roundtrip");
+        let _ = std::fs::remove_file(&path);
+
+        let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
+
+        writer.write(&42u64);
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 42),
+            _ => panic!("expected Fresh"),
+        }
+
+        writer.write(&99u64);
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 99),
+            _ => panic!("expected Fresh after second write"),
+        }
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn reader_sees_latest_after_multiple_writes() {
+        let path = temp_path("multi");
+        let _ = std::fs::remove_file(&path);
+
+        let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
+
+        for i in 0u64..1000 {
+            writer.write(&i);
+        }
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 999),
+            _ => panic!("expected Fresh"),
+        }
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct Price {
+        bid: f64,
+        ask: f64,
+        seq: u64,
+    }
+    unsafe impl Pod for Price {}
+
+    #[test]
+    fn struct_pod_roundtrip() {
+        let path = temp_path("struct");
+        let _ = std::fs::remove_file(&path);
+
+        let writer = ShmSlotWriter::<Price>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<Price>::attach(&path).unwrap();
+
+        writer.write(&Price {
+            bid: 100.5,
+            ask: 100.6,
+            seq: 7,
+        });
+        match reader.read() {
+            SlotRead::Fresh(p) => {
+                assert_eq!(p.bid, 100.5);
+                assert_eq!(p.ask, 100.6);
+                assert_eq!(p.seq, 7);
+            }
+            _ => panic!("expected Fresh"),
+        }
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn writer_drop_marks_dead_reader_still_reads() {
+        let path = temp_path("dead");
+        let _ = std::fs::remove_file(&path);
+
+        let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
+
+        writer.write(&55u64);
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 55),
+            _ => panic!("expected Fresh"),
+        }
+
+        drop(writer); // marks segment Dead, version left at even value
+
+        // Even version + Dead segment → reader still sees a consistent value.
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 55),
+            SlotRead::Stale(v) => assert_eq!(*v, 55),
+            SlotRead::Empty => panic!("unexpected Empty after write"),
+        }
+
+        std::fs::remove_file(&path).unwrap();
+    }
+}

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -1,15 +1,17 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering, fence};
 
-use nexus_platform::{MapHints, MappedFile};
+use nexus_platform::{Liveness, MapHints, MappedFile};
 
 use crate::error::ShmError;
 use crate::pod::Pod;
-use crate::segment::{Segment, Status};
+use crate::segment::Segment;
 
-// Version and payload are on separate cache lines to prevent false sharing.
+// First cache line: version at offset 0, elem_size at offset 8.
+// Payload on its own cache line at offset 64 to prevent false sharing.
+const ELEM_SIZE_OFFSET: usize = 8;
 const PAYLOAD_OFFSET: usize = 64;
 
 fn data_len<T>() -> usize {
@@ -18,6 +20,10 @@ fn data_len<T>() -> usize {
 
 fn version_ptr(segment: &Segment) -> *mut AtomicU64 {
     segment.data().cast::<AtomicU64>()
+}
+
+fn elem_size_ptr(segment: &Segment) -> *mut u64 {
+    unsafe { segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>() }
 }
 
 fn payload_ptr<T>(segment: &Segment) -> *mut T {
@@ -49,7 +55,7 @@ pub struct ShmSlotReader<T: Pod> {
 pub enum SlotRead<'a, T> {
     /// Consistent value from the current write epoch.
     Fresh(&'a T),
-    /// Writer is dead mid-write; last successfully read value returned.
+    /// Writer died mid-write; last successfully read value returned.
     Stale(&'a T),
     /// No write has occurred since the slot was created.
     Empty,
@@ -62,7 +68,7 @@ impl<T: Pod> ShmSlotWriter<T> {
     pub fn create(path: impl AsRef<Path>, hints: MapHints) -> Result<Self, ShmError> {
         assert!(
             align_of::<T>() <= PAYLOAD_OFFSET,
-            "align_of::<T>() = {} exceeds PAYLOAD_OFFSET = {}; use a repr(C) type with smaller alignment",
+            "align_of::<T>() = {} exceeds PAYLOAD_OFFSET = {}",
             align_of::<T>(),
             PAYLOAD_OFFSET,
         );
@@ -70,38 +76,51 @@ impl<T: Pod> ShmSlotWriter<T> {
         let total = Segment::total_size(data_len)?;
         let mf = MappedFile::create(path.as_ref(), total)?;
         let segment = Segment::create(mf, data_len, hints)?;
-        // Zero the data region: version = 0 means "never written".
-        unsafe { std::ptr::write_bytes(segment.data(), 0, data_len) };
-        Ok(Self {
-            segment,
-            _marker: PhantomData,
-        })
+        unsafe {
+            std::ptr::write_bytes(segment.data(), 0, data_len);
+            std::ptr::write(elem_size_ptr(&segment), size_of::<T>() as u64);
+        }
+        Ok(Self { segment, _marker: PhantomData })
     }
 
     /// Publish `value` to all readers.
     ///
-    /// Odd version marks mid-write; readers retry or fall back to shadow.
+    /// Uses the seqlock protocol: odd version marks mid-write. A `fence(Release)`
+    /// after the odd-mark prevents the payload store from being reordered before it
+    /// on weak-memory architectures (ARM/POWER).
     pub fn write(&self, value: &T) {
         let ver = unsafe { &*version_ptr(&self.segment) };
         let dst = payload_ptr::<T>(&self.segment);
-        ver.fetch_add(1, Ordering::Release);
+        ver.fetch_add(1, Ordering::Relaxed);
+        fence(Ordering::Release);
         unsafe { std::ptr::copy_nonoverlapping(value as *const T, dst, 1) };
-        ver.fetch_add(1, Ordering::Release);
+        fence(Ordering::Release);
+        ver.fetch_add(1, Ordering::Relaxed);
     }
 }
 
-// SAFETY: `Segment` wraps a shared mmap; `write` uses the seqlock protocol
-// for synchronization. Multiple concurrent `write` callers would corrupt the
-// seqlock invariant — callers must serialize writes externally if needed.
-// Sharing via `Arc` is safe when writes are externally serialized.
+// SAFETY: `Segment` wraps a shared mmap; `write` uses the seqlock protocol for
+// synchronization. Multiple concurrent `write` callers would corrupt the seqlock
+// invariant — callers must serialize writes externally. Sharing via `Arc` is
+// safe when writes are externally serialized.
+//
+// `Sync` is intentionally NOT implemented: `&self` write + `Sync` would allow
+// concurrent writes from multiple threads without external serialization, silently
+// corrupting the seqlock.
 unsafe impl<T: Pod + Send> Send for ShmSlotWriter<T> {}
-unsafe impl<T: Pod + Sync> Sync for ShmSlotWriter<T> {}
 
 impl<T: Pod> ShmSlotReader<T> {
     /// Attach to an existing slot at `path`.
+    ///
+    /// Returns `Err(ShmError::ElemSizeMismatch)` if the slot was created with a
+    /// different element size than `size_of::<T>()`.
     pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
         let mf = MappedFile::open(path.as_ref())?;
         let segment = Segment::attach(mf)?;
+        let written = unsafe { std::ptr::read(elem_size_ptr(&segment)) } as usize;
+        if written != size_of::<T>() {
+            return Err(ShmError::ElemSizeMismatch { written, expected: size_of::<T>() });
+        }
         Ok(Self {
             segment,
             buf: Box::new(MaybeUninit::uninit()),
@@ -113,20 +132,21 @@ impl<T: Pod> ShmSlotReader<T> {
 
     /// Read the latest value.
     ///
-    /// Retries on version mismatch (writer mid-write). Returns `Stale` with
-    /// the last good shadow if the writer died mid-write. Returns `Empty` if
-    /// no write has occurred and no shadow exists.
+    /// Returns `Empty` if no write has occurred. Spins if the writer is mid-write
+    /// and alive. Falls back to `Stale` if the writer has crashed mid-write,
+    /// detected via the OFD lock (`peer_liveness`) rather than the atomic status
+    /// field, which can be stale after an abnormal process exit.
     pub fn read(&mut self) -> SlotRead<'_, T> {
         let ver = unsafe { &*version_ptr(&self.segment) };
         let src = payload_ptr::<T>(&self.segment).cast_const();
         loop {
-            let v1 = ver.load(Ordering::Acquire);
+            let v1 = ver.load(Ordering::Relaxed);
             if v1 == 0 {
                 return SlotRead::Empty;
             }
             if v1 & 1 == 1 {
-                match self.segment.status() {
-                    Status::Alive => {
+                match self.segment.peer_liveness() {
+                    Liveness::Alive => {
                         std::hint::spin_loop();
                         continue;
                     }
@@ -139,8 +159,10 @@ impl<T: Pod> ShmSlotReader<T> {
                     }
                 }
             }
+            fence(Ordering::Acquire);
             unsafe { std::ptr::copy_nonoverlapping(src, self.buf.as_mut_ptr(), 1) };
-            let v2 = ver.load(Ordering::Acquire);
+            fence(Ordering::Acquire);
+            let v2 = ver.load(Ordering::Relaxed);
             if v1 != v2 {
                 std::hint::spin_loop();
                 continue;
@@ -158,6 +180,8 @@ unsafe impl<T: Pod + Send> Send for ShmSlotReader<T> {}
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use super::*;
     use nexus_platform::MapHints;
 
@@ -169,12 +193,9 @@ mod tests {
     fn empty_before_first_write() {
         let path = temp_path("empty");
         let _ = std::fs::remove_file(&path);
-
         let _writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
-
         assert!(matches!(reader.read(), SlotRead::Empty));
-
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -182,22 +203,18 @@ mod tests {
     fn write_read_roundtrip() {
         let path = temp_path("roundtrip");
         let _ = std::fs::remove_file(&path);
-
         let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
-
         writer.write(&42u64);
         match reader.read() {
             SlotRead::Fresh(v) => assert_eq!(*v, 42),
             _ => panic!("expected Fresh"),
         }
-
         writer.write(&99u64);
         match reader.read() {
             SlotRead::Fresh(v) => assert_eq!(*v, 99),
             _ => panic!("expected Fresh after second write"),
         }
-
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -205,10 +222,8 @@ mod tests {
     fn reader_sees_latest_after_multiple_writes() {
         let path = temp_path("multi");
         let _ = std::fs::remove_file(&path);
-
         let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
-
         for i in 0u64..1000 {
             writer.write(&i);
         }
@@ -216,7 +231,6 @@ mod tests {
             SlotRead::Fresh(v) => assert_eq!(*v, 999),
             _ => panic!("expected Fresh"),
         }
-
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -233,15 +247,9 @@ mod tests {
     fn struct_pod_roundtrip() {
         let path = temp_path("struct");
         let _ = std::fs::remove_file(&path);
-
         let writer = ShmSlotWriter::<Price>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<Price>::attach(&path).unwrap();
-
-        writer.write(&Price {
-            bid: 100.5,
-            ask: 100.6,
-            seq: 7,
-        });
+        writer.write(&Price { bid: 100.5, ask: 100.6, seq: 7 });
         match reader.read() {
             SlotRead::Fresh(p) => {
                 assert_eq!(p.bid, 100.5);
@@ -250,7 +258,6 @@ mod tests {
             }
             _ => panic!("expected Fresh"),
         }
-
         std::fs::remove_file(&path).unwrap();
     }
 
@@ -258,24 +265,103 @@ mod tests {
     fn writer_drop_marks_dead_reader_still_reads() {
         let path = temp_path("dead");
         let _ = std::fs::remove_file(&path);
-
         let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
-
         writer.write(&55u64);
         match reader.read() {
             SlotRead::Fresh(v) => assert_eq!(*v, 55),
             _ => panic!("expected Fresh"),
         }
-
-        drop(writer); // marks segment Dead, version left at even value
-
-        // Even version + Dead segment → reader still sees a consistent value.
+        drop(writer);
         match reader.read() {
             SlotRead::Fresh(v) | SlotRead::Stale(v) => assert_eq!(*v, 55),
             SlotRead::Empty => panic!("unexpected Empty after write"),
         }
+        std::fs::remove_file(&path).unwrap();
+    }
 
+    #[test]
+    fn elem_size_mismatch_rejected() {
+        let path = temp_path("mismatch");
+        let _ = std::fs::remove_file(&path);
+        let _writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        match ShmSlotReader::<u32>::attach(&path) {
+            Err(ShmError::ElemSizeMismatch { written: 8, expected: 4 }) => {}
+            other => panic!("expected ElemSizeMismatch{{8,4}}, got {other:?}", other = other.err()),
+        }
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn threaded_writer_reader() {
+        let path = temp_path("threaded");
+        let _ = std::fs::remove_file(&path);
+        let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let path2 = path.clone();
+
+        let wt = std::thread::spawn(move || {
+            for i in 0u64..50_000 {
+                writer.write(&i);
+            }
+        });
+
+        let mut reader = ShmSlotReader::<u64>::attach(&path2).unwrap();
+        let rt = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut last = u64::MAX;
+            loop {
+                match reader.read() {
+                    SlotRead::Fresh(v) => {
+                        if last != u64::MAX {
+                            assert!(*v >= last, "value went backwards: {v} < {last}");
+                        }
+                        last = *v;
+                        if last == 49_999 {
+                            break;
+                        }
+                    }
+                    SlotRead::Empty | SlotRead::Stale(_) => {}
+                }
+                assert!(Instant::now() < deadline, "timeout waiting for final value");
+            }
+        });
+
+        wt.join().unwrap();
+        rt.join().unwrap();
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    /// Simulate a mid-write crash: set version to odd (as if killed between the
+    /// two fetch_adds), then drop the writer so the OFD lock is released.
+    /// Reader must return `Stale` via peer_liveness detection, not spin forever.
+    #[test]
+    fn stale_on_mid_write_crash() {
+        let path = temp_path("crash");
+        let _ = std::fs::remove_file(&path);
+        let writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
+        let mut reader = ShmSlotReader::<u64>::attach(&path).unwrap();
+
+        writer.write(&42u64);
+        match reader.read() {
+            SlotRead::Fresh(v) => assert_eq!(*v, 42),
+            _ => panic!("expected Fresh before crash simulation"),
+        }
+
+        // Bump version to odd — simulates being killed between the two increments.
+        let ver = unsafe { &*version_ptr(&writer.segment) };
+        ver.fetch_add(1, Ordering::Relaxed);
+
+        // Drop writer: OFD lock released → peer_liveness() returns Dead.
+        drop(writer);
+
+        match reader.read() {
+            SlotRead::Stale(v) => assert_eq!(*v, 42),
+            other => panic!("expected Stale, got {}", match other {
+                SlotRead::Fresh(_) => "Fresh",
+                SlotRead::Empty => "Empty",
+                SlotRead::Stale(_) => unreachable!(),
+            }),
+        }
         std::fs::remove_file(&path).unwrap();
     }
 }

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -272,8 +272,7 @@ mod tests {
 
         // Even version + Dead segment → reader still sees a consistent value.
         match reader.read() {
-            SlotRead::Fresh(v) => assert_eq!(*v, 55),
-            SlotRead::Stale(v) => assert_eq!(*v, 55),
+            SlotRead::Fresh(v) | SlotRead::Stale(v) => assert_eq!(*v, 55),
             SlotRead::Empty => panic!("unexpected Empty after write"),
         }
 

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering, fence};
+use std::sync::atomic::{fence, AtomicU64, Ordering};
 
 use nexus_platform::{Liveness, MapHints, MappedFile};
 
@@ -80,7 +80,10 @@ impl<T: Pod> ShmSlotWriter<T> {
             std::ptr::write_bytes(segment.data(), 0, data_len);
             std::ptr::write(elem_size_ptr(&segment), size_of::<T>() as u64);
         }
-        Ok(Self { segment, _marker: PhantomData })
+        Ok(Self {
+            segment,
+            _marker: PhantomData,
+        })
     }
 
     /// Publish `value` to all readers.
@@ -119,7 +122,10 @@ impl<T: Pod> ShmSlotReader<T> {
         let segment = Segment::attach(mf)?;
         let written = unsafe { std::ptr::read(elem_size_ptr(&segment)) } as usize;
         if written != size_of::<T>() {
-            return Err(ShmError::ElemSizeMismatch { written, expected: size_of::<T>() });
+            return Err(ShmError::ElemSizeMismatch {
+                written,
+                expected: size_of::<T>(),
+            });
         }
         Ok(Self {
             segment,
@@ -249,7 +255,11 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let writer = ShmSlotWriter::<Price>::create(&path, MapHints::default()).unwrap();
         let mut reader = ShmSlotReader::<Price>::attach(&path).unwrap();
-        writer.write(&Price { bid: 100.5, ask: 100.6, seq: 7 });
+        writer.write(&Price {
+            bid: 100.5,
+            ask: 100.6,
+            seq: 7,
+        });
         match reader.read() {
             SlotRead::Fresh(p) => {
                 assert_eq!(p.bid, 100.5);
@@ -286,8 +296,14 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let _writer = ShmSlotWriter::<u64>::create(&path, MapHints::default()).unwrap();
         match ShmSlotReader::<u32>::attach(&path) {
-            Err(ShmError::ElemSizeMismatch { written: 8, expected: 4 }) => {}
-            other => panic!("expected ElemSizeMismatch{{8,4}}, got {other:?}", other = other.err()),
+            Err(ShmError::ElemSizeMismatch {
+                written: 8,
+                expected: 4,
+            }) => {}
+            other => panic!(
+                "expected ElemSizeMismatch{{8,4}}, got {other:?}",
+                other = other.err()
+            ),
         }
         std::fs::remove_file(&path).unwrap();
     }
@@ -356,11 +372,14 @@ mod tests {
 
         match reader.read() {
             SlotRead::Stale(v) => assert_eq!(*v, 42),
-            other => panic!("expected Stale, got {}", match other {
-                SlotRead::Fresh(_) => "Fresh",
-                SlotRead::Empty => "Empty",
-                SlotRead::Stale(_) => unreachable!(),
-            }),
+            other => panic!(
+                "expected Stale, got {}",
+                match other {
+                    SlotRead::Fresh(_) => "Fresh",
+                    SlotRead::Empty => "Empty",
+                    SlotRead::Stale(_) => unreachable!(),
+                }
+            ),
         }
         std::fs::remove_file(&path).unwrap();
     }

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::Path;
-use std::sync::atomic::{fence, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering, fence};
 
 use nexus_platform::{Liveness, MapHints, MappedFile};
 

--- a/nexus-shm/tests/loom_ring.rs
+++ b/nexus-shm/tests/loom_ring.rs
@@ -1,0 +1,69 @@
+#![cfg(loom)]
+
+use loom::sync::Arc;
+use loom::sync::atomic::{AtomicU64, Ordering};
+use loom::thread;
+
+/// Models the SPSC ring's tail Release/Acquire handshake with a single item slot.
+///
+/// Producer: write item (Relaxed), then publish tail (Release).
+/// Consumer: load tail (Acquire), then read item (Relaxed).
+/// Loom exhaustively verifies that whenever the consumer sees tail > 0,
+/// it observes the item written before the Release store.
+#[test]
+fn spsc_tail_acquire_sees_item() {
+    loom::model(|| {
+        let tail = Arc::new(AtomicU64::new(0));
+        let item = Arc::new(AtomicU64::new(0));
+
+        let tail_w = tail.clone();
+        let item_w = item.clone();
+
+        let producer = thread::spawn(move || {
+            item_w.store(42, Ordering::Relaxed);
+            tail_w.store(1, Ordering::Release);
+        });
+
+        let consumer = thread::spawn(move || {
+            let t = tail.load(Ordering::Acquire);
+            if t > 0 {
+                let v = item.load(Ordering::Relaxed);
+                assert_eq!(v, 42, "stale item after Acquire load of tail");
+            }
+        });
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+    });
+}
+
+/// Models the head Release/Acquire handshake for flow-control:
+/// consumer advances head (Release) to signal a slot is free;
+/// producer loads head (Acquire) before reusing the slot.
+#[test]
+fn spsc_head_acquire_sees_slot_free() {
+    loom::model(|| {
+        let head = Arc::new(AtomicU64::new(0));
+        let slot_reused = Arc::new(AtomicU64::new(0));
+
+        let head_r = head.clone();
+        let slot_r = slot_reused.clone();
+
+        let consumer = thread::spawn(move || {
+            head_r.store(1, Ordering::Release);
+        });
+
+        let producer = thread::spawn(move || {
+            let h = head.load(Ordering::Acquire);
+            if h > 0 {
+                slot_reused.store(1, Ordering::Relaxed);
+            }
+        });
+
+        consumer.join().unwrap();
+        producer.join().unwrap();
+        // If head was observed, slot_reused is set. No assertion needed —
+        // loom verifies no data race on slot_reused.
+        let _ = slot_r.load(Ordering::Relaxed);
+    });
+}


### PR DESCRIPTION
Closes #393, closes #392.

## What

Two cross-process shared-memory primitives over nexus-shm Segment.

### Pod trait (nexus-shm::pod)
Marker trait for types safe in shared memory: flat repr, no heap, no Drop.

### ShmSlot (closes #393)
Cross-process seqlock slot for latest-value sharing.
- ShmSlotWriter::create / ShmSlotReader::attach
- Version counter and payload on separate cache lines (offset 64)
- Writer: odd version = mid-write, even = committed
- SlotRead: Fresh / Stale / Empty — Stale returned when writer dies mid-write
- write takes &self — safe behind Arc when writes are externally serialized

### ShmRingBuffer (closes #392)
Cross-process SPSC ring buffer.
- ShmRingWriter::create / ShmRingReader::attach
- head/tail each on own cache line; data at offset 192
- capacity stored in mmap at offset 128 (read on attach, must be power of two)
- try_push returns false when full; try_pop returns None when empty
- Both sides cache the other end's counter to reduce atomic loads (same as nexus-queue SPSC)
- Crash recovery: tail advances only after full write, so a mid-write crash leaves the slot invisible to the consumer

21 tests total, clippy clean.
