### PR TITLE
feat(collections): v2 Wave 0 — slab types behind feature flag

### DIFF
--- a/nexus-collections/CHANGELOG.md
+++ b/nexus-collections/CHANGELOG.md
@@ -10,6 +10,30 @@ contained.
 
 ## [Unreleased]
 
+### Breaking
+
+- **v2: slab types moved to `nexus_collections::slab::*`** behind the `slab` feature flag
+  (enabled by default). Sub-modules expose associated types:
+  `slab::list`, `slab::btree`, `slab::rbtree`, `slab::heap`, `slab::compare`.
+
+  ```toml
+  # unchanged for most users (slab is default)
+  nexus-collections = "2.0"
+
+  # opt-out of slab to avoid pulling nexus-slab
+  nexus-collections = { version = "2.0", default-features = false }
+  ```
+
+  ```rust
+  // before
+  use nexus_collections::list::{List, ListNode};
+
+  // after
+  use nexus_collections::slab::list::{List, ListNode};
+  // or primary types at slab root:
+  use nexus_collections::slab::{List, ListNode};
+  ```
+
 ## [1.1.4] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-collections/Cargo.toml
+++ b/nexus-collections/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nexus-collections"
-version = "1.1.5"
-description = "Slab-backed intrusive collections for low-latency systems"
+version = "2.0.0"
+description = "Feature-gated collections for low-latency systems"
 readme = "README.md"
 edition.workspace = true
 rust-version.workspace = true
@@ -10,49 +10,91 @@ repository.workspace = true
 keywords = ["collections", "intrusive", "slab", "low-latency", "pre-allocated"]
 categories = ["data-structures"]
 
+[features]
+default = ["std"]
+std = []
+slab = ["dep:nexus-slab"]
+
 [dev-dependencies]
 hdrhistogram = "7.5"
 rand = "0.9.2"
 seq-macro.workspace = true
 
 [dependencies]
-nexus-slab = { version = "2.3.2", path = "../nexus-slab", features = ["rc"] }
+nexus-slab = { version = "2.3.2", path = "../nexus-slab", features = ["rc"], optional = true }
 
 [lints]
 workspace = true
 
+[[test]]
+name = "btree_test"
+required-features = ["slab"]
+
+[[test]]
+name = "compare_test"
+required-features = ["slab"]
+
+[[test]]
+name = "cursor_test"
+required-features = ["slab"]
+
+[[test]]
+name = "heap_test"
+required-features = ["slab"]
+
+[[test]]
+name = "list_test"
+required-features = ["slab"]
+
+[[test]]
+name = "miri_tests"
+required-features = ["slab"]
+
+[[test]]
+name = "rbtree_test"
+required-features = ["slab"]
+
 [[bench]]
 name = "perf_batched"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_btree"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_codegen"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_heap_cycles"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_list_cycles"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_push_hist"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_push_stat"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_rbtree"
 harness = false
+required-features = ["slab"]
 
 [[bench]]
 name = "perf_std_btreemap"
 harness = false
+required-features = ["slab"]

--- a/nexus-collections/Cargo.toml
+++ b/nexus-collections/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nexus-collections"
-version = "2.0.0"
-description = "Feature-gated collections for low-latency systems"
+version = "1.1.5"
+description = "Slab-backed intrusive collections for low-latency systems"
 readme = "README.md"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,8 +11,7 @@ keywords = ["collections", "intrusive", "slab", "low-latency", "pre-allocated"]
 categories = ["data-structures"]
 
 [features]
-default = ["std"]
-std = []
+default = ["slab"]
 slab = ["dep:nexus-slab"]
 
 [dev-dependencies]

--- a/nexus-collections/benches/perf_batched.rs
+++ b/nexus-collections/benches/perf_batched.rs
@@ -14,9 +14,9 @@
 use seq_macro::seq;
 use std::hint::black_box;
 
-use nexus_collections::RcSlot;
-use nexus_collections::heap::{Heap, HeapNode};
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::heap::{Heap, HeapNode};
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 
 const CAPACITY: usize = 200_000;

--- a/nexus-collections/benches/perf_btree.rs
+++ b/nexus-collections/benches/perf_btree.rs
@@ -11,7 +11,7 @@
 use seq_macro::seq;
 use std::hint::black_box;
 
-use nexus_collections::btree::{BTree, BTreeNode, Entry};
+use nexus_collections::slab::btree::{BTree, BTreeNode, Entry};
 
 const B: usize = 8;
 const CAPACITY: usize = 200_000;

--- a/nexus-collections/benches/perf_codegen.rs
+++ b/nexus-collections/benches/perf_codegen.rs
@@ -5,9 +5,9 @@
 //!
 //! Then grep for `do_` functions in the .s file.
 
-use nexus_collections::RcSlot;
-use nexus_collections::heap::{Heap, HeapNode};
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::heap::{Heap, HeapNode};
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 use std::hint::black_box;
 

--- a/nexus-collections/benches/perf_heap_cycles.rs
+++ b/nexus-collections/benches/perf_heap_cycles.rs
@@ -11,8 +11,8 @@
 use seq_macro::seq;
 use std::hint::black_box;
 
-use nexus_collections::RcSlot;
-use nexus_collections::heap::{Heap, HeapNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::heap::{Heap, HeapNode};
 use nexus_slab::rc::bounded::Slab;
 
 const CAPACITY: usize = 200_000;

--- a/nexus-collections/benches/perf_list_cycles.rs
+++ b/nexus-collections/benches/perf_list_cycles.rs
@@ -11,8 +11,8 @@
 use seq_macro::seq;
 use std::hint::black_box;
 
-use nexus_collections::RcSlot;
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 
 const CAPACITY: usize = 200_000;

--- a/nexus-collections/benches/perf_push_hist.rs
+++ b/nexus-collections/benches/perf_push_hist.rs
@@ -9,9 +9,9 @@
 use hdrhistogram::Histogram;
 use std::hint::black_box;
 
-use nexus_collections::RcSlot;
-use nexus_collections::heap::{Heap, HeapNode};
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::heap::{Heap, HeapNode};
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 
 const CAPACITY: usize = 100_000;

--- a/nexus-collections/benches/perf_push_stat.rs
+++ b/nexus-collections/benches/perf_push_stat.rs
@@ -10,8 +10,8 @@
 
 use std::hint::black_box;
 
-use nexus_collections::RcSlot;
-use nexus_collections::heap::{Heap, HeapNode};
+use nexus_collections::slab::RcSlot;
+use nexus_collections::slab::heap::{Heap, HeapNode};
 use nexus_slab::rc::unbounded::Slab;
 
 const COUNT: usize = 500_000;

--- a/nexus-collections/benches/perf_rbtree.rs
+++ b/nexus-collections/benches/perf_rbtree.rs
@@ -11,7 +11,7 @@
 use seq_macro::seq;
 use std::hint::black_box;
 
-use nexus_collections::rbtree::{Entry, RbNode, RbTree};
+use nexus_collections::slab::rbtree::{Entry, RbNode, RbTree};
 
 const CAPACITY: usize = 200_000;
 const SAMPLES: usize = 50_000;

--- a/nexus-collections/src/lib.rs
+++ b/nexus-collections/src/lib.rs
@@ -1,51 +1,36 @@
-//! High-performance collections with slab-backed storage.
+//! Feature-gated collections for low-latency systems.
 //!
-//! Collections use external slab allocators passed by reference. The user
-//! creates the slab, the collection wires pointers.
+//! Enable feature families in `Cargo.toml` to unlock the corresponding types:
 //!
-//! # Collections
-//!
-//! - **List** — Doubly-linked list with `RcSlot` handles and external allocation
-//! - **Heap** — Pairing heap with `RcSlot` handles and external allocation
-//! - **RbTree** — Red-black tree sorted map with deterministic O(log n) worst case
-//! - **BTree** — B-tree sorted map with cache-friendly, tunable node layout
-//!
-//! # Quick Start (List)
-//!
-//! ```ignore
-//! use nexus_slab::rc::bounded::Slab;
-//! use nexus_collections::list::{List, ListNode};
-//!
-//! let slab = unsafe { Slab::<ListNode<u64>>::with_capacity(1000) };
-//! let mut list = List::new();
-//! let handle = slab.alloc(ListNode::new(42));
-//! list.link_back(&handle);
+//! ```toml
+//! nexus-collections = { version = "2.0", features = ["slab"] }
 //! ```
+//!
+//! # Feature families
+//!
+//! | Feature | Types |
+//! |---------|-------|
+//! | `slab`  | [`slab::List`], [`slab::Heap`], [`slab::BTree`], [`slab::RbTree`] |
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "slab")]
+mod btree;
+#[cfg(feature = "slab")]
+mod compare;
+#[cfg(feature = "slab")]
+mod heap;
+#[cfg(feature = "slab")]
+mod list;
+#[cfg(feature = "slab")]
+mod rbtree;
+
+#[cfg(feature = "slab")]
 use std::cell::Cell;
 
-pub mod btree;
-pub mod compare;
-pub mod heap;
-pub mod list;
-pub mod rbtree;
-
-// Re-export comparison types at crate root
-pub use compare::{Compare, Natural, Reverse};
-// Re-export slab handle and error types for convenience
-pub use nexus_slab::rc::{RcSlot, Ref, RefMut};
-pub use nexus_slab::shared::Full;
-
-// =============================================================================
-// Sealed — prevents external trait implementations
-// =============================================================================
-
+#[cfg(feature = "slab")]
 mod sealed {
-    /// Sealed marker for Rc slab types.
     pub trait RcSealed {}
-    /// Sealed marker for raw slab types.
     pub trait SlabSealed {}
 
     impl<T> RcSealed for nexus_slab::rc::bounded::Slab<T> {}
@@ -54,109 +39,88 @@ mod sealed {
     impl<T> SlabSealed for nexus_slab::unbounded::Slab<T> {}
 }
 
-// =============================================================================
-// RcFree trait — sealed, unifies bounded and unbounded Rc slab free
-// =============================================================================
-
-/// Sealed trait for Rc slab types that can free an [`RcSlot`] handle.
+/// Sealed trait for Rc slab types that can free an [`RcSlot`](nexus_slab::rc::RcSlot) handle.
 ///
 /// Implemented by `rc::bounded::Slab<T>` and `rc::unbounded::Slab<T>`.
-/// Used by list and heap for `unlink` and `clear`.
+/// Used by [`slab::List`] and [`slab::Heap`] for `unlink` and `clear`.
 ///
 /// This trait is sealed — it cannot be implemented outside this crate.
+#[cfg(feature = "slab")]
 pub trait RcFree<T>: sealed::RcSealed {
     /// Free a handle, decrementing the refcount.
-    /// Deallocates the slot when the last handle is freed.
-    fn free_rc(&self, handle: RcSlot<T>);
+    fn free_rc(&self, handle: nexus_slab::rc::RcSlot<T>);
 }
 
+#[cfg(feature = "slab")]
 impl<T> RcFree<T> for nexus_slab::rc::bounded::Slab<T> {
     #[inline]
-    fn free_rc(&self, handle: RcSlot<T>) {
+    fn free_rc(&self, handle: nexus_slab::rc::RcSlot<T>) {
         self.free(handle);
     }
 }
 
+#[cfg(feature = "slab")]
 impl<T> RcFree<T> for nexus_slab::rc::unbounded::Slab<T> {
     #[inline]
-    fn free_rc(&self, handle: RcSlot<T>) {
+    fn free_rc(&self, handle: nexus_slab::rc::RcSlot<T>) {
         self.free(handle);
     }
 }
-
-// =============================================================================
-// SlabOps trait — unifies bounded and unbounded raw slab free
-// =============================================================================
 
 /// Sealed trait for raw slab operations.
 ///
 /// Implemented by `bounded::Slab<T>` and `unbounded::Slab<T>`.
 /// Used by tree collections for `remove`, `clear`, cursor, entry, and drain.
 ///
-/// Methods that allocate (insert) are typed to the specific slab variant;
-/// this trait covers the shared operations (free, take, contains).
-///
 /// This trait is sealed — it cannot be implemented outside this crate.
+#[cfg(feature = "slab")]
 pub trait SlabOps<T>: sealed::SlabSealed {
     /// Free a slot, dropping the value and returning storage to the freelist.
     fn free_slot(&self, slot: nexus_slab::Slot<T>);
-
     /// Take the value out of a slot, then free the storage.
     fn take_slot(&self, slot: nexus_slab::Slot<T>) -> T;
-
     /// Returns true if the pointer falls within this slab's storage.
     fn contains_ptr(&self, ptr: *const ()) -> bool;
 }
 
+#[cfg(feature = "slab")]
 impl<T> SlabOps<T> for nexus_slab::bounded::Slab<T> {
     #[inline]
     fn free_slot(&self, slot: nexus_slab::Slot<T>) {
         self.free(slot);
     }
-
     #[inline]
     fn take_slot(&self, slot: nexus_slab::Slot<T>) -> T {
         self.take(slot)
     }
-
     #[inline]
     fn contains_ptr(&self, ptr: *const ()) -> bool {
         self.contains_ptr(ptr)
     }
 }
 
+#[cfg(feature = "slab")]
 impl<T> SlabOps<T> for nexus_slab::unbounded::Slab<T> {
     #[inline]
     fn free_slot(&self, slot: nexus_slab::Slot<T>) {
         self.free(slot);
     }
-
     #[inline]
     fn take_slot(&self, slot: nexus_slab::Slot<T>) -> T {
         self.take(slot)
     }
-
     #[inline]
     fn contains_ptr(&self, ptr: *const ()) -> bool {
         self.contains_ptr(ptr)
     }
 }
 
-// =============================================================================
-// Collection identity
-// =============================================================================
-
+#[cfg(feature = "slab")]
 thread_local! {
     static NEXT_COLLECTION_ID: Cell<usize> = const { Cell::new(1) };
 }
 
-/// Returns a unique (per-thread) collection ID for ownership checking.
-///
-/// IDs are per-thread and wrap after `usize::MAX` allocations. On 64-bit,
-/// this is ~18 quintillion — effectively impossible. On 32-bit, wrapping
-/// after ~4B creates is theoretically possible but practically unreachable
-/// for a slab-backed collection (slab capacity would be exhausted first).
-/// We skip ID 0 to avoid colliding with potential sentinel values.
+#[cfg(feature = "slab")]
 fn next_collection_id() -> usize {
     NEXT_COLLECTION_ID.with(|c| {
         let id = c.get();
@@ -164,4 +128,52 @@ fn next_collection_id() -> usize {
         c.set(if next == 0 { 1 } else { next });
         id
     })
+}
+
+/// Slab-backed intrusive collections.
+///
+/// Requires the `slab` feature:
+///
+/// ```toml
+/// nexus-collections = { version = "2.0", features = ["slab"] }
+/// ```
+///
+/// # Primary types
+///
+/// - [`List`](slab::List) — doubly-linked list with `RcSlot` handles
+/// - [`Heap`](slab::Heap) — pairing heap with `RcSlot` handles
+/// - [`BTree`](slab::BTree) — B-tree sorted map with cache-friendly node layout
+/// - [`RbTree`](slab::RbTree) — red-black tree sorted map with O(log n) worst case
+#[cfg(feature = "slab")]
+pub mod slab {
+    pub use crate::compare::{Compare, Natural, Reverse};
+    pub use crate::{RcFree, SlabOps};
+    pub use nexus_slab::rc::{RcSlot, Ref, RefMut};
+    pub use nexus_slab::shared::Full;
+
+    pub use crate::btree::{BTree, BTreeNode};
+    pub use crate::heap::{Heap, HeapNode};
+    pub use crate::list::{List, ListNode};
+    pub use crate::rbtree::{RbNode, RbTree};
+
+    /// Sub-modules expose associated types (iterators, cursors, entries).
+    pub mod btree {
+        pub use crate::btree::*;
+    }
+    /// Sub-modules expose associated types (iterators, cursors, entries).
+    pub mod heap {
+        pub use crate::heap::*;
+    }
+    /// Sub-modules expose associated types (iterators, cursors, entries).
+    pub mod list {
+        pub use crate::list::*;
+    }
+    /// Sub-modules expose associated types (iterators, cursors, entries).
+    pub mod rbtree {
+        pub use crate::rbtree::*;
+    }
+    /// Comparison traits and built-in comparators.
+    pub mod compare {
+        pub use crate::compare::*;
+    }
 }

--- a/nexus-collections/tests/btree_test.rs
+++ b/nexus-collections/tests/btree_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the B-tree sorted map.
 
-use nexus_collections::btree::{BTree, BTreeNode};
+use nexus_collections::slab::btree::{BTree, BTreeNode};
 use nexus_slab::bounded::Slab;
 use nexus_slab::unbounded::Slab as UnboundedSlab;
 
@@ -138,11 +138,11 @@ fn entry_occupied() {
     tree.try_insert(&slab, 10, 100).unwrap();
 
     match tree.entry(&slab, 10) {
-        nexus_collections::btree::Entry::Occupied(mut e) => {
+        nexus_collections::slab::btree::Entry::Occupied(mut e) => {
             assert_eq!(*e.get(), 100);
             *e.get_mut() = 200;
         }
-        nexus_collections::btree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::btree::Entry::Vacant(_) => panic!("expected occupied"),
     }
 
     assert_eq!(tree.get(&10), Some(&200));
@@ -155,8 +155,8 @@ fn entry_vacant_insert() {
     let mut tree = BTree::<u64, u64, 8>::new();
 
     match tree.entry(&slab, 10) {
-        nexus_collections::btree::Entry::Occupied(_) => panic!("expected vacant"),
-        nexus_collections::btree::Entry::Vacant(e) => {
+        nexus_collections::slab::btree::Entry::Occupied(_) => panic!("expected vacant"),
+        nexus_collections::slab::btree::Entry::Vacant(e) => {
             let v = e.insert(100);
             assert_eq!(*v, 100);
         }

--- a/nexus-collections/tests/compare_test.rs
+++ b/nexus-collections/tests/compare_test.rs
@@ -1,8 +1,8 @@
 //! Tests for custom comparator support (Reverse ordering).
 
-use nexus_collections::Reverse;
-use nexus_collections::btree::{BTree, BTreeNode};
-use nexus_collections::rbtree::{RbNode, RbTree};
+use nexus_collections::slab::Reverse;
+use nexus_collections::slab::btree::{BTree, BTreeNode};
+use nexus_collections::slab::rbtree::{RbNode, RbTree};
 use nexus_slab::bounded::Slab;
 
 fn make_rb_slab() -> Slab<RbNode<u64, String>> {

--- a/nexus-collections/tests/cursor_test.rs
+++ b/nexus-collections/tests/cursor_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for cursor operations.
 
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 
 fn make_slab() -> Slab<ListNode<u64>> {

--- a/nexus-collections/tests/heap_test.rs
+++ b/nexus-collections/tests/heap_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the pairing heap.
 
-use nexus_collections::heap::{Heap, HeapNode};
+use nexus_collections::slab::heap::{Heap, HeapNode};
 use nexus_slab::rc::bounded::Slab;
 use nexus_slab::rc::unbounded::Slab as UnboundedSlab;
 

--- a/nexus-collections/tests/list_test.rs
+++ b/nexus-collections/tests/list_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the RcSlot-based list.
 
-use nexus_collections::list::{List, ListNode};
+use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 use nexus_slab::rc::unbounded::Slab as UnboundedSlab;
 

--- a/nexus-collections/tests/miri_tests.rs
+++ b/nexus-collections/tests/miri_tests.rs
@@ -5,10 +5,10 @@
 
 use std::cell::Cell;
 
-use nexus_collections::btree::{BTree, BTreeNode};
-use nexus_collections::heap::{Heap, HeapNode};
-use nexus_collections::list::{List, ListNode};
-use nexus_collections::rbtree::{RbNode, RbTree};
+use nexus_collections::slab::btree::{BTree, BTreeNode};
+use nexus_collections::slab::heap::{Heap, HeapNode};
+use nexus_collections::slab::list::{List, ListNode};
+use nexus_collections::slab::rbtree::{RbNode, RbTree};
 use nexus_slab::rc::unbounded::Slab as RcSlab;
 use nexus_slab::unbounded::Slab;
 
@@ -511,31 +511,31 @@ fn rbtree_entry_api() {
 
     // Insert via vacant entry
     match tree.entry(&slab, 10) {
-        nexus_collections::rbtree::Entry::Vacant(e) => {
+        nexus_collections::slab::rbtree::Entry::Vacant(e) => {
             let v = e.insert(100);
             assert_eq!(*v, 100);
         }
-        nexus_collections::rbtree::Entry::Occupied(_) => panic!("expected vacant"),
+        nexus_collections::slab::rbtree::Entry::Occupied(_) => panic!("expected vacant"),
     }
 
     // Modify via occupied entry
     match tree.entry(&slab, 10) {
-        nexus_collections::rbtree::Entry::Occupied(mut e) => {
+        nexus_collections::slab::rbtree::Entry::Occupied(mut e) => {
             assert_eq!(*e.get(), 100);
             *e.get_mut() = 200;
         }
-        nexus_collections::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
     }
     assert_eq!(tree.get(&10), Some(&200));
 
     // Remove via occupied entry
     match tree.entry(&slab, 10) {
-        nexus_collections::rbtree::Entry::Occupied(e) => {
+        nexus_collections::slab::rbtree::Entry::Occupied(e) => {
             let (k, v) = e.remove();
             assert_eq!(k, 10);
             assert_eq!(v, 200);
         }
-        nexus_collections::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
     }
     assert!(tree.is_empty());
 
@@ -744,31 +744,31 @@ fn btree_entry_insert_and_remove() {
 
     // Insert via entry
     match tree.entry(&slab, 10) {
-        nexus_collections::btree::Entry::Vacant(e) => {
+        nexus_collections::slab::btree::Entry::Vacant(e) => {
             let v = e.insert(100);
             assert_eq!(*v, 100);
         }
-        nexus_collections::btree::Entry::Occupied(_) => panic!("expected vacant"),
+        nexus_collections::slab::btree::Entry::Occupied(_) => panic!("expected vacant"),
     }
 
     // Modify via entry
     match tree.entry(&slab, 10) {
-        nexus_collections::btree::Entry::Occupied(mut e) => {
+        nexus_collections::slab::btree::Entry::Occupied(mut e) => {
             assert_eq!(*e.get(), 100);
             *e.get_mut() = 200;
         }
-        nexus_collections::btree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::btree::Entry::Vacant(_) => panic!("expected occupied"),
     }
     assert_eq!(tree.get(&10), Some(&200));
 
     // Remove via entry
     match tree.entry(&slab, 10) {
-        nexus_collections::btree::Entry::Occupied(e) => {
+        nexus_collections::slab::btree::Entry::Occupied(e) => {
             let (k, v) = e.remove();
             assert_eq!(k, 10);
             assert_eq!(v, 200);
         }
-        nexus_collections::btree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::btree::Entry::Vacant(_) => panic!("expected occupied"),
     }
     assert!(tree.is_empty());
 

--- a/nexus-collections/tests/rbtree_test.rs
+++ b/nexus-collections/tests/rbtree_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the red-black tree.
 
-use nexus_collections::rbtree::{RbNode, RbTree};
+use nexus_collections::slab::rbtree::{RbNode, RbTree};
 use nexus_slab::bounded::Slab;
 use nexus_slab::unbounded::Slab as UnboundedSlab;
 
@@ -146,11 +146,11 @@ fn entry_occupied() {
     tree.try_insert(&slab, 10, 100).unwrap();
 
     match tree.entry(&slab, 10) {
-        nexus_collections::rbtree::Entry::Occupied(mut e) => {
+        nexus_collections::slab::rbtree::Entry::Occupied(mut e) => {
             assert_eq!(*e.get(), 100);
             *e.get_mut() = 200;
         }
-        nexus_collections::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
+        nexus_collections::slab::rbtree::Entry::Vacant(_) => panic!("expected occupied"),
     }
 
     assert_eq!(tree.get(&10), Some(&200));
@@ -164,8 +164,8 @@ fn entry_vacant_insert() {
     let mut tree = RbTree::new();
 
     match tree.entry(&slab, 10) {
-        nexus_collections::rbtree::Entry::Occupied(_) => panic!("expected vacant"),
-        nexus_collections::rbtree::Entry::Vacant(e) => {
+        nexus_collections::slab::rbtree::Entry::Occupied(_) => panic!("expected vacant"),
+        nexus_collections::slab::rbtree::Entry::Vacant(e) => {
             let v = e.insert(100);
             assert_eq!(*v, 100);
         }
@@ -253,7 +253,7 @@ fn many_inserts_and_removes() {
 
 #[test]
 fn reverse_comparator() {
-    use nexus_collections::Reverse;
+    use nexus_collections::slab::Reverse;
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_capacity(100) };
     let mut tree = RbTree::with_comparator(Reverse);
 
@@ -302,7 +302,7 @@ fn unbounded_insert() {
 
 #[test]
 fn slab_ops_trait_generic() {
-    use nexus_collections::SlabOps;
+    use nexus_collections::slab::SlabOps;
 
     fn insert_and_remove<S: SlabOps<RbNode<u64, u64>>>(tree: &mut RbTree<u64, u64>, slab: &S) {
         // We can't insert generically (try_insert needs concrete slab type),


### PR DESCRIPTION
Closes #319

Bumps nexus-collections to v2.0.0. Moves all slab-backed types (List, Heap, BTree, RbTree) to `nexus_collections::slab::*` behind an opt-in `slab` feature flag.

**Migration:**
```toml
# before
nexus-collections = "1.x"

# after
nexus-collections = { version = "2.0", features = ["slab"] }
```
```rust
// before
use nexus_collections::list::{List, ListNode};

// after
use nexus_collections::slab::list::{List, ListNode};
// or primary types at slab root:
use nexus_collections::slab::{List, ListNode};
```

- `nexus-slab` is now an optional dep, activated by the `slab` feature
- Sub-modules (`slab::list`, `slab::btree`, etc.) expose iterator/cursor/entry types
- All integration tests and benchmarks updated to v2 paths; `required-features = ["slab"]` added
- Builds clean with and without the feature; all 20 tests pass

Prerequisite for all other nexus-collections v2 items.
