### PR TITLE
feat(shm): public Segment file API, generation, owner_pid (#474)

### DIFF
--- a/nexus-shm/src/control.rs
+++ b/nexus-shm/src/control.rs
@@ -84,6 +84,10 @@ impl ControlBlockInner {
         self.generation.load(Ordering::Acquire)
     }
 
+    pub(crate) fn owner_pid(&self) -> u32 {
+        self.owner_pid.load(Ordering::Acquire)
+    }
+
     pub(crate) const fn data_len(&self) -> u64 {
         self.data_len
     }

--- a/nexus-shm/src/lib.rs
+++ b/nexus-shm/src/lib.rs
@@ -8,5 +8,5 @@ mod error;
 mod segment;
 
 pub use error::ShmError;
-pub use nexus_platform::{Liveness, MapHints};
+pub use nexus_platform::{Liveness, MapHints, MappedFile};
 pub use segment::{Segment, Status};

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::sync::atomic::AtomicU32;
 
-use nexus_platform::{Liveness, Mapping, ProcessLease};
+use nexus_platform::{Liveness, MappedFile, Mapping, ProcessLease};
 
 use crate::MapHints;
 
@@ -34,6 +35,21 @@ impl Segment {
     /// The total mapping size needed for a segment with `data_len` payload bytes.
     pub fn total_size(data_len: usize) -> Result<NonZeroUsize, ShmError> {
         HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)
+    }
+
+    pub fn create_file(
+        path: impl AsRef<Path>,
+        data_len: usize,
+        hints: MapHints,
+    ) -> Result<Self, ShmError> {
+        let total = Self::total_size(data_len)?;
+        let mf = MappedFile::create(path.as_ref(), total)?;
+        Self::create(mf, data_len, hints)
+    }
+
+    pub fn attach_file(path: impl AsRef<Path>) -> Result<Self, ShmError> {
+        let mf = MappedFile::open(path.as_ref())?;
+        Self::attach(mf)
     }
 
     pub fn create(
@@ -194,6 +210,14 @@ impl Segment {
         self.control().data_len() as usize
     }
 
+    pub fn generation(&self) -> u64 {
+        self.control().generation()
+    }
+
+    pub fn owner_pid(&self) -> u32 {
+        self.control().owner_pid()
+    }
+
     fn control(&self) -> &ControlBlock {
         Self::control_of(&self.mapping)
     }
@@ -305,6 +329,47 @@ mod tests {
         std::fs::write(&path, vec![0u8; 4096]).unwrap();
 
         assert!(Segment::attach(open_file(&path)).is_err());
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn create_file_attach_file_roundtrip() {
+        let path = temp_path("file-api");
+        let _ = std::fs::remove_file(&path);
+
+        let seg = Segment::create_file(&path, 512, MapHints::default()).unwrap();
+        assert_eq!(seg.status(), Status::Alive);
+
+        let peer = Segment::attach_file(&path).unwrap();
+        assert_eq!(peer.data_len(), 512);
+        assert_eq!(peer.status(), Status::Alive);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn generation_increments_on_recreate() {
+        let path = temp_path("generation");
+        let _ = std::fs::remove_file(&path);
+
+        let seg = Segment::create_file(&path, 64, MapHints::default()).unwrap();
+        let gen1 = seg.generation();
+        drop(seg);
+
+        let seg2 = Segment::create_file(&path, 64, MapHints::default()).unwrap();
+        assert_eq!(seg2.generation(), gen1 + 1);
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn owner_pid_is_current_process() {
+        let path = temp_path("owner-pid");
+        let _ = std::fs::remove_file(&path);
+
+        let seg = Segment::create_file(&path, 64, MapHints::default()).unwrap();
+        assert_eq!(seg.owner_pid(), std::process::id());
 
         std::fs::remove_file(&path).unwrap();
     }

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -37,6 +37,11 @@ impl Segment {
         HEADER.checked_add(data_len).ok_or(ShmError::SizeOverflow)
     }
 
+    /// Create a new segment backed by the file at `path`, creating or truncating it.
+    ///
+    /// If the file already exists and its owner is still alive (`peer_liveness()` returns
+    /// `Alive`), returns `ShmError::OwnerActive`. If the owner is dead the segment is
+    /// re-incarnated in place and `generation()` is incremented.
     pub fn create_file(
         path: impl AsRef<Path>,
         data_len: usize,
@@ -47,6 +52,9 @@ impl Segment {
         Self::create(mf, data_len, hints)
     }
 
+    /// Attach to an existing segment backed by the file at `path`.
+    ///
+    /// Equivalent to `MappedFile::open` + `Segment::attach`.
     pub fn attach_file(path: impl AsRef<Path>) -> Result<Self, ShmError> {
         let mf = MappedFile::open(path.as_ref())?;
         Self::attach(mf)
@@ -210,10 +218,18 @@ impl Segment {
         self.control().data_len() as usize
     }
 
+    /// Incarnation counter — incremented each time the segment is re-created over the same file.
+    ///
+    /// Use this to detect that a peer has restarted and re-initialized the region since you
+    /// attached. Not suitable as a per-access validity check.
     pub fn generation(&self) -> u64 {
         self.control().generation()
     }
 
+    /// PID of the process that last called `create` or `create_file` on this segment.
+    ///
+    /// Diagnostic/observability only. PIDs are reused by the OS after a process exits, so
+    /// this is not a liveness check. Use `peer_liveness()` to determine if the owner is alive.
     pub fn owner_pid(&self) -> u32 {
         self.control().owner_pid()
     }


### PR DESCRIPTION
Closes #474.

## What

- `Segment::create_file(path, data_len, hints)` — create without manually constructing `MappedFile`
- `Segment::attach_file(path)` — attach without manually constructing `MappedFile`
- `Segment::generation() -> u64` — control block generation counter
- `Segment::owner_pid() -> u32` — PID of the segment owner
- Re-export `MappedFile` from `nexus_shm` crate root for callers that still need the low-level handle

Three new tests: file-API roundtrip, generation increment on recreate, owner PID.