### PR TITLE
nexus-pool: Debug impls for pool and guard types

### DIFF
--- a/nexus-pool/src/local.rs
+++ b/nexus-pool/src/local.rs
@@ -7,6 +7,7 @@
 //! Both use LIFO ordering for cache locality.
 
 use std::cell::UnsafeCell;
+use std::fmt;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
@@ -405,6 +406,28 @@ impl<T> Drop for Pooled<T> {
         // self.inner Rc drops here: one strong-count--. If we were the
         // last guard, Inner's `data: UnsafeCell<Vec<T>>` drops, which
         // drops every value still in the pool.
+    }
+}
+
+impl<T> fmt::Debug for BoundedPool<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundedPool")
+            .field("available", &self.available())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for Pool<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pool")
+            .field("available", &self.available())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for Pooled<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pooled").finish_non_exhaustive()
     }
 }
 

--- a/nexus-pool/src/sync.rs
+++ b/nexus-pool/src/sync.rs
@@ -5,6 +5,7 @@
 //!
 //! Uses LIFO ordering for cache locality.
 
+use std::fmt;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 
@@ -320,6 +321,21 @@ impl<T> Drop for Pooled<T> {
         // all readers" pattern — sufficient for the refcount alone;
         // the value transfer is independently ordered by the Release
         // CAS in `Inner::push`.
+    }
+}
+
+impl<T> fmt::Debug for Pool<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pool")
+            .field("capacity", &self.inner.slots.len())
+            .field("available", &self.available())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Debug for Pooled<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pooled").finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
Closes #507

Adds manual `Debug` impls with no `T: Debug` bound to `local::BoundedPool`, `local::Pool`, `sync::Pool`, and both `Pooled` variants. Pool types report `available` (and `capacity` for `sync::Pool`); `Pooled` uses `finish_non_exhaustive`.