### PR TITLE
chore(shm/fix-engine): volatile seqlock payload, file-API dedup, loom/miri runners (#514, #515)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,3 +104,11 @@ jobs:
       run: git diff --exit-code nexus-inference/tests/fixtures/lgb_*
     - name: Verify Rust matches LightGBM
       run: cargo test -p nexus-inference --features loader-lightgbm --test lightgbm_integration
+
+  loom:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
+    - name: Loom model checks (all loom_* tests)
+      run: ./tools/loom.sh

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -18,6 +18,13 @@ pub struct FixJournal {
 }
 
 impl FixJournal {
+    /// Open (or recover) the journal for a single session under `dir`.
+    ///
+    /// `window` is the resend horizon in messages (must be a power of two): the
+    /// last `window` sequence numbers are replayable, older ones are gap-filled.
+    ///
+    /// One session per journal: if a session already exists under `dir`, the
+    /// first one is reopened; otherwise a new session is created.
     pub fn open(dir: impl AsRef<Path>, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;
@@ -53,6 +60,13 @@ impl FixJournal {
         }
     }
 
+    /// Archive an outbound message after it has been sent.
+    ///
+    /// `msg` is the already-formatted wire message; `seq` must equal its
+    /// `MsgSeqNum` (tag 34). The send path satisfies this by construction — `seq`
+    /// is passed in only to index the resend ring without re-parsing on the hot
+    /// path; the cold paths ([`resend`](Self::resend), [`recover`](Self::recover))
+    /// read the seqnum back out of the message via tag 34.
     pub fn store(&mut self, seq: u32, msg: &[u8]) -> Result<(), WriteError> {
         let offset = self.journal.append(msg)?;
         self.offsets[seq as usize & (self.window - 1)] = Some(offset);

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use nexus_platform::{MapHints, MappedFile};
+use nexus_platform::MapHints;
 
 use crate::error::ShmError;
 use crate::pod::Pod;
@@ -85,9 +85,7 @@ impl<T: Pod> ShmRingWriter<T> {
             .checked_mul(size_of::<T>())
             .and_then(|s| s.checked_add(DATA_OFFSET))
             .ok_or(ShmError::SizeOverflow)?;
-        let total = Segment::total_size(data_len)?;
-        let mf = MappedFile::create(path.as_ref(), total)?;
-        let segment = Segment::create(mf, data_len, hints)?;
+        let segment = Segment::create_file(path, data_len, hints)?;
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
             std::ptr::write(
@@ -152,8 +150,7 @@ impl<T: Pod> ShmRingReader<T> {
     /// Returns `Err` if the header is corrupt, the element size doesn't match
     /// `size_of::<T>()`, or the mapping is too small for the stored capacity.
     pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
-        let mf = MappedFile::open(path.as_ref())?;
-        let segment = Segment::attach(mf)?;
+        let segment = Segment::attach_file(path)?;
         let capacity = read_capacity(&segment);
         if !capacity.is_power_of_two() || capacity == 0 {
             return Err(ShmError::CorruptHeader);

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -365,6 +365,22 @@ mod tests {
     }
 
     #[test]
+    fn create_file_rejects_live_owner() {
+        let path = temp_path("live-owner");
+        let _ = std::fs::remove_file(&path);
+
+        // First owner stays alive (held in scope), so create_file on the same
+        // path must refuse to clobber it.
+        let _live = Segment::create_file(&path, 64, MapHints::default()).unwrap();
+        assert!(matches!(
+            Segment::create_file(&path, 64, MapHints::default()),
+            Err(ShmError::OwnerActive)
+        ));
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
     fn generation_increments_on_recreate() {
         let path = temp_path("generation");
         let _ = std::fs::remove_file(&path);

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering, fence};
 
-use nexus_platform::{Liveness, MapHints, MappedFile};
+use nexus_platform::{Liveness, MapHints};
 
 use crate::error::ShmError;
 use crate::pod::Pod;
@@ -73,9 +73,7 @@ impl<T: Pod> ShmSlotWriter<T> {
             PAYLOAD_OFFSET,
         );
         let data_len = data_len::<T>();
-        let total = Segment::total_size(data_len)?;
-        let mf = MappedFile::create(path.as_ref(), total)?;
-        let segment = Segment::create(mf, data_len, hints)?;
+        let segment = Segment::create_file(path, data_len, hints)?;
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
             std::ptr::write(elem_size_ptr(&segment), size_of::<T>() as u64);
@@ -91,12 +89,20 @@ impl<T: Pod> ShmSlotWriter<T> {
     /// Uses the seqlock protocol: odd version marks mid-write. A `fence(Release)`
     /// after the odd-mark prevents the payload store from being reordered before it
     /// on weak-memory architectures (ARM/POWER).
+    ///
+    /// The payload store is `write_volatile`: the reader races this write under the
+    /// seqlock (it copies optimistically, then re-checks the version). A plain
+    /// store would be a data race the compiler may assume can't happen; `volatile`
+    /// tells it the memory is modified externally (another process maps the same
+    /// region) and must not be elided, fused, or reordered against the fences.
     pub fn write(&self, value: &T) {
         let ver = unsafe { &*version_ptr(&self.segment) };
         let dst = payload_ptr::<T>(&self.segment);
         ver.fetch_add(1, Ordering::Relaxed);
         fence(Ordering::Release);
-        unsafe { std::ptr::copy_nonoverlapping(value as *const T, dst, 1) };
+        // SAFETY: `dst` is a live, writable `T`-aligned slot the writer owns for
+        // the duration of this store; `value` is read by value (Pod: no Drop).
+        unsafe { dst.write_volatile(std::ptr::read(value)) };
         fence(Ordering::Release);
         ver.fetch_add(1, Ordering::Relaxed);
     }
@@ -118,8 +124,7 @@ impl<T: Pod> ShmSlotReader<T> {
     /// Returns `Err(ShmError::ElemSizeMismatch)` if the slot was created with a
     /// different element size than `size_of::<T>()`.
     pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
-        let mf = MappedFile::open(path.as_ref())?;
-        let segment = Segment::attach(mf)?;
+        let segment = Segment::attach_file(path)?;
         let written = unsafe { std::ptr::read(elem_size_ptr(&segment)) } as usize;
         if written != size_of::<T>() {
             return Err(ShmError::ElemSizeMismatch {
@@ -166,7 +171,9 @@ impl<T: Pod> ShmSlotReader<T> {
                 }
             }
             fence(Ordering::Acquire);
-            unsafe { std::ptr::copy_nonoverlapping(src, self.buf.as_mut_ptr(), 1) };
+            // SAFETY: `src` points at the live payload slot; `read_volatile` (vs a
+            // plain read) keeps the optimistic, racing read defined — see `write`.
+            unsafe { self.buf.as_mut_ptr().write(src.read_volatile()) };
             fence(Ordering::Acquire);
             let v2 = ver.load(Ordering::Relaxed);
             if v1 != v2 {

--- a/tools/loom.sh
+++ b/tools/loom.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run loom model-checking tests (compiled under --cfg loom) for the workspace
+# or specific crates. Loom tests live at <crate>/tests/loom_*.rs and are
+# excluded from normal `cargo test` by the `#![cfg(loom)]` gate.
+#
+# Usage:
+#   ./tools/loom.sh                          # every loom test in the workspace
+#   ./tools/loom.sh nexus-channel nexus-shm  # only these crates
+#
+# Loom explores interleavings exhaustively. For a larger model that takes too
+# long, bound the search by exporting LOOM_MAX_PREEMPTIONS (e.g. =3).
+
+cd "$(dirname "$0")/.."
+
+export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }--cfg loom"
+shopt -s nullglob
+
+declare -a files=()
+if [ $# -eq 0 ]; then
+    files=(*/tests/loom_*.rs)
+else
+    for crate in "$@"; do
+        files+=("$crate"/tests/loom_*.rs)
+    done
+fi
+
+if [ ${#files[@]} -eq 0 ]; then
+    echo "no loom tests found"
+    exit 0
+fi
+
+for f in "${files[@]}"; do
+    crate="${f%%/*}"
+    test="$(basename "$f" .rs)"
+    echo "=== loom: $crate :: $test ==="
+    cargo test -p "$crate" --test "$test" --release
+done

--- a/tools/miri.sh
+++ b/tools/miri.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run miri tests (the tests/miri_tests.rs target) for the workspace or specific
+# crates. Requires the nightly toolchain with the miri component:
+#
+#   rustup toolchain install nightly
+#   rustup +nightly component add miri
+#
+# Usage:
+#   ./tools/miri.sh               # every miri_tests target in the workspace
+#   ./tools/miri.sh nexus-slab    # only this crate
+#
+# -Zmiri-ignore-leaks is required because slab backing memory uses Box::leak
+# for stable addresses; override by exporting MIRIFLAGS.
+
+cd "$(dirname "$0")/.."
+
+export MIRIFLAGS="${MIRIFLAGS:--Zmiri-ignore-leaks}"
+shopt -s nullglob
+
+declare -a files=()
+if [ $# -eq 0 ]; then
+    files=(*/tests/miri_tests.rs)
+else
+    for crate in "$@"; do
+        files+=("$crate"/tests/miri_tests.rs)
+    done
+fi
+
+if [ ${#files[@]} -eq 0 ]; then
+    echo "no miri tests found"
+    exit 0
+fi
+
+for f in "${files[@]}"; do
+    crate="${f%%/*}"
+    echo "=== miri: $crate ==="
+    cargo +nightly miri test -p "$crate" --test miri_tests
+done


### PR DESCRIPTION
Batch cleanup of the deferred follow-ups from the recent fix-engine / shm / channel / pool PRs, plus the loom/miri runner scripts.

## #514 — ShmSlot seqlock payload is now defined, not benign-UB
`slot.rs` `write`/`read` move the payload via `write_volatile`/`read_volatile` instead of raw `ptr::copy`. The fences (which provide ordering) are unchanged; `volatile` is what makes the optimistic, racing seqlock access *defined* — it tells the compiler the region is modified externally (another process maps it) so the access can't be elided, fused, or reordered against the fences. Closes #514.

## #515 — cleanup items (partial)
- **shm**: `slot.rs`/`ring.rs` now use `Segment::create_file`/`attach_file` instead of inline `MappedFile::create` + `Segment::create` (and drop the now-unused `MappedFile` imports).
- **shm**: added `create_file_rejects_live_owner` test — the `OwnerActive` branch of `create_file` that had no coverage.
- **fix-engine**: doc comments on `FixJournal::store` (the `seq == MsgSeqNum` contract) and `open` (single-session, `window` = resend horizon).

Deferred (left open in #515, with reasons):
- pool `BoundedPool` capacity-in-`Debug` — its shrinking-`Vec` design doesn't store total capacity, so this needs a struct field, not a `Debug` tweak.
- fix-engine `recover()` manifest-cached `last_seq` — needs a new `RotatingJournal` accessor; the bounded live-window scan is fine for now.

## Tooling — loom & miri runners
- `tools/loom.sh` — discovers and runs every `tests/loom_*.rs` under `--cfg loom` (whole workspace or named crates).
- `tools/miri.sh` — runs every `tests/miri_tests.rs` via `cargo +nightly miri test` with `-Zmiri-ignore-leaks`.
- CI gains a **`loom` job** (calls `tools/loom.sh`) — previously **no** loom test ran in CI; now all 39 across 6 crates do (~22s).

## Verification
- `cargo test` green on touched crates; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- Full loom suite passes under `--cfg loom` (incl. the channel park/notify and shm SPSC ring models).
