### PR TITLE
feat(fix-engine): resend walk — gap-fill admin + coalesce (#520)

### DIFF
--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -12,10 +12,6 @@ mod framework;
 #[cfg(unix)]
 pub mod persist;
 mod session;
-#[cfg(unix)]
-mod timestamp;
-#[cfg(unix)]
-pub mod transport;
 
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
@@ -24,5 +20,3 @@ pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
-#[cfg(unix)]
-pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -17,4 +17,6 @@ pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
 };
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
+#[cfg(unix)]
+pub use persist::{FixJournal, ReplayItem, ResendPlan};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -12,11 +12,17 @@ mod framework;
 #[cfg(unix)]
 pub mod persist;
 mod session;
+#[cfg(unix)]
+mod timestamp;
+#[cfg(unix)]
+pub mod transport;
 
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
 };
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
-pub use persist::{FixJournal, ReplayItem, ResendPlan};
+pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
+#[cfg(unix)]
+pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -13,9 +13,7 @@ pub enum ReplayItem<'a> {
     /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
     /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
     GapFill { seq: u32, new_seq: u32 },
-    /// Original stored bytes for the app message; the transport is responsible
-    /// for adding `PossDupFlag(43)`, `OrigSendingTime(122)`, and a fresh
-    /// `SendingTime(52)` before retransmitting.
+    /// Original stored bytes; transport reframes with `PossDupFlag` and fresh timestamps.
     App(&'a [u8]),
 }
 
@@ -106,7 +104,7 @@ impl FixJournal {
     /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
     /// Reject, SequenceReset) are gap-filled; consecutive gap-fills are
     /// coalesced into a single `GapFill { seq, new_seq }`. App messages are
-    /// yielded as borrowed original bytes; the transport owns the reframing.
+    /// yielded as borrowed original bytes.
     pub fn resend_range<'a, F>(&'a self, begin: u32, end: u32, mut emit: F)
     where
         F: FnMut(ReplayItem<'a>),

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -62,7 +62,10 @@ impl<'a> Iterator for ResendIter<'a> {
                         let app = ReplayItem::App(p);
                         if let Some(gs) = self.gap_start.take() {
                             self.deferred = Some(app);
-                            return Some(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                            return Some(ReplayItem::GapFill {
+                                seq: gs,
+                                new_seq: seq,
+                            });
                         }
                         return Some(app);
                     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use nexus_fix_codec::{find_tag, parse_fix_seqnum};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
-pub enum ResendPlan<'a> {
+enum ResendPlan<'a> {
     Replay(Frame<'a>),
     GapFill(u32),
 }
@@ -20,6 +20,59 @@ pub struct FixJournal {
     window: usize,
     next_outbound: u32,
     next_inbound: u32,
+}
+
+struct ResendIter<'a> {
+    journal: &'a FixJournal,
+    seq: u32,
+    high: u32,
+    gap_start: Option<u32>,
+    deferred: Option<ReplayItem<'a>>,
+    done: bool,
+}
+
+impl<'a> Iterator for ResendIter<'a> {
+    type Item = ReplayItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(item) = self.deferred.take() {
+            return Some(item);
+        }
+        loop {
+            if self.done {
+                return None;
+            }
+            if self.seq > self.high {
+                self.done = true;
+                return self.gap_start.take().map(|gs| ReplayItem::GapFill {
+                    seq: gs,
+                    new_seq: self.high.wrapping_add(1),
+                });
+            }
+            let seq = self.seq;
+            self.seq += 1;
+            let is_gap = match self.journal.resend_one(seq) {
+                ResendPlan::GapFill(_) => true,
+                ResendPlan::Replay(frame) => {
+                    let p = frame.payload();
+                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
+                    if is_admin_type(msg_type) {
+                        true
+                    } else {
+                        let app = ReplayItem::App(p);
+                        if let Some(gs) = self.gap_start.take() {
+                            self.deferred = Some(app);
+                            return Some(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                        }
+                        return Some(app);
+                    }
+                }
+            };
+            if is_gap && self.gap_start.is_none() {
+                self.gap_start = Some(seq);
+            }
+        }
+    }
 }
 
 impl FixJournal {
@@ -79,7 +132,7 @@ impl FixJournal {
         Ok(())
     }
 
-    pub fn resend(&self, seq: u32) -> ResendPlan<'_> {
+    fn resend_one(&self, seq: u32) -> ResendPlan<'_> {
         let slot = seq as usize & (self.window - 1);
         if let Some(off) = self.offsets[slot]
             && let Some(frame) = self.journal.read(off)
@@ -94,51 +147,19 @@ impl FixJournal {
         ResendPlan::GapFill(seq)
     }
 
-    pub fn resend_range<'a, F>(&'a self, begin: u32, end: u32, mut emit: F)
-    where
-        F: FnMut(ReplayItem<'a>),
-    {
+    pub fn resend(&'_ self, begin: u32, end: u32) -> impl Iterator<Item = ReplayItem<'_>> + '_ {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
         } else {
             end
         };
-        if begin > high {
-            return;
-        }
-
-        let mut gap_start: Option<u32> = None;
-
-        for seq in begin..=high {
-            let is_gap = match self.resend(seq) {
-                ResendPlan::GapFill(_) => true,
-                ResendPlan::Replay(frame) => {
-                    let p = frame.payload();
-                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
-                    if is_admin_type(msg_type) {
-                        true
-                    } else {
-                        if let Some(gs) = gap_start.take() {
-                            emit(ReplayItem::GapFill {
-                                seq: gs,
-                                new_seq: seq,
-                            });
-                        }
-                        emit(ReplayItem::App(p));
-                        false
-                    }
-                }
-            };
-            if is_gap && gap_start.is_none() {
-                gap_start = Some(seq);
-            }
-        }
-
-        if let Some(gs) = gap_start {
-            emit(ReplayItem::GapFill {
-                seq: gs,
-                new_seq: high.wrapping_add(1),
-            });
+        ResendIter {
+            journal: self,
+            seq: begin,
+            high,
+            gap_start: None,
+            deferred: None,
+            done: begin > high,
         }
     }
 
@@ -189,9 +210,7 @@ mod tests {
     }
 
     fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'_>> {
-        let mut items = Vec::new();
-        j.resend_range(begin, end, |item| items.push(item));
-        items
+        j.resend(begin, end).collect()
     }
 
     #[test]
@@ -204,7 +223,7 @@ mod tests {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        match j.resend(3) {
+        match j.resend_one(3) {
             ResendPlan::Replay(frame) => {
                 assert_eq!(frame.payload(), fix_msg(3).as_slice());
             }
@@ -242,7 +261,7 @@ mod tests {
         let mut j = FixJournal::open(&dir, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
 
-        match j.resend(2) {
+        match j.resend_one(2) {
             ResendPlan::GapFill(2) => {}
             _ => panic!("expected GapFill(2)"),
         }
@@ -261,7 +280,7 @@ mod tests {
         }
 
         let results: Vec<bool> = (1u32..=5)
-            .map(|seq| matches!(j.resend(seq), ResendPlan::Replay(_)))
+            .map(|seq| matches!(j.resend_one(seq), ResendPlan::Replay(_)))
             .collect();
         assert_eq!(results, vec![true, false, true, false, true]);
 

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -266,7 +266,7 @@ mod tests {
 
         match j.resend_one(2) {
             ResendPlan::GapFill => {}
-            _ => panic!("expected GapFill(2)"),
+            ResendPlan::Replay(_) => panic!("expected GapFill"),
         }
 
         cleanup(&dir);

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -134,7 +134,10 @@ impl FixJournal {
                         true
                     } else {
                         if let Some(gs) = gap_start.take() {
-                            emit(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                            emit(ReplayItem::GapFill {
+                                seq: gs,
+                                new_seq: seq,
+                            });
                         }
                         emit(ReplayItem::App(reframe(p)));
                         false
@@ -218,9 +221,7 @@ fn reframe(msg: &[u8]) -> Vec<u8> {
     let mut bl_buf = [0u8; 10];
     let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
 
-    let mut out = Vec::with_capacity(
-        2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7,
-    );
+    let mut out = Vec::with_capacity(2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7);
     out.extend_from_slice(b"8=");
     out.extend_from_slice(begin_string);
     out.push(0x01);
@@ -371,7 +372,10 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 4 }
+        ));
 
         cleanup(&dir);
     }
@@ -389,9 +393,15 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 5);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 3 }));
+        assert!(matches!(
+            items[1],
+            ReplayItem::GapFill { seq: 2, new_seq: 3 }
+        ));
         assert!(matches!(items[2], ReplayItem::App(_)));
-        assert!(matches!(items[3], ReplayItem::GapFill { seq: 4, new_seq: 5 }));
+        assert!(matches!(
+            items[3],
+            ReplayItem::GapFill { seq: 4, new_seq: 5 }
+        ));
         assert!(matches!(items[4], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -411,7 +421,10 @@ mod tests {
         // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
         let items = collect_range(&j, 1, 8);
         assert_eq!(items.len(), 5);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 5 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 5 }
+        ));
         assert!(matches!(items[1], ReplayItem::App(_)));
         assert!(matches!(items[2], ReplayItem::App(_)));
         assert!(matches!(items[3], ReplayItem::App(_)));
@@ -426,7 +439,8 @@ mod tests {
         cleanup(&dir);
 
         let mut j = FixJournal::open(&dir, 64).unwrap();
-        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00")).unwrap();
+        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00"))
+            .unwrap();
 
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
@@ -454,7 +468,10 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 3);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 5 }));
+        assert!(matches!(
+            items[1],
+            ReplayItem::GapFill { seq: 2, new_seq: 5 }
+        ));
         assert!(matches!(items[2], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -472,7 +489,10 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 4 }
+        ));
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,11 +1,23 @@
 use std::path::Path;
 
-use nexus_fix_codec::{find_tag, parse_fix_seqnum};
+use nexus_fix_codec::{
+    FieldReader, checksum, encode_fix_uint, find_tag, format_checksum, parse_fix_seqnum,
+};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
 pub enum ResendPlan<'a> {
     Replay(Frame<'a>),
     GapFill(u32),
+}
+
+/// Output of a single [`FixJournal::resend_range`] step.
+pub enum ReplayItem {
+    /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
+    /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
+    GapFill { seq: u32, new_seq: u32 },
+    /// Re-framed app message with `PossDupFlag(43)=Y` and
+    /// `OrigSendingTime(122)` from the original `SendingTime(52)`.
+    App(Vec<u8>),
 }
 
 pub struct FixJournal {
@@ -89,6 +101,59 @@ impl FixJournal {
         ResendPlan::GapFill(seq)
     }
 
+    /// Walk `begin..=end` and emit [`ReplayItem`]s via `emit`.
+    ///
+    /// `end == 0` means all messages up to `next_outbound - 1`. Holes and
+    /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
+    /// SequenceReset) are gap-filled; consecutive gap-fills are coalesced into
+    /// a single `GapFill { seq, new_seq }`. App messages are re-framed with
+    /// `PossDupFlag(43)=Y` and `OrigSendingTime(122)` from the stored
+    /// `SendingTime(52)`.
+    pub fn resend_range<F>(&self, begin: u32, end: u32, mut emit: F)
+    where
+        F: FnMut(ReplayItem),
+    {
+        let high = if end == 0 {
+            self.next_outbound.saturating_sub(1)
+        } else {
+            end
+        };
+        if begin > high {
+            return;
+        }
+
+        let mut gap_start: Option<u32> = None;
+
+        for seq in begin..=high {
+            let is_gap = match self.resend(seq) {
+                ResendPlan::GapFill(_) => true,
+                ResendPlan::Replay(frame) => {
+                    let p = frame.payload();
+                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
+                    if is_admin_type(msg_type) {
+                        true
+                    } else {
+                        if let Some(gs) = gap_start.take() {
+                            emit(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                        }
+                        emit(ReplayItem::App(reframe(p)));
+                        false
+                    }
+                }
+            };
+            if is_gap && gap_start.is_none() {
+                gap_start = Some(seq);
+            }
+        }
+
+        if let Some(gs) = gap_start {
+            emit(ReplayItem::GapFill {
+                seq: gs,
+                new_seq: high.wrapping_add(1),
+            });
+        }
+    }
+
     pub fn next_outbound(&self) -> u32 {
         self.next_outbound
     }
@@ -107,9 +172,75 @@ impl FixJournal {
     }
 }
 
+fn is_admin_type(msg_type: &[u8]) -> bool {
+    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"4")
+}
+
+fn push_field(buf: &mut Vec<u8>, tag: u32, value: &[u8]) {
+    let mut tmp = [0u8; 10];
+    let n = encode_fix_uint(tag, &mut tmp);
+    buf.extend_from_slice(&tmp[..n]);
+    buf.push(b'=');
+    buf.extend_from_slice(value);
+    buf.push(0x01);
+}
+
+fn reframe(msg: &[u8]) -> Vec<u8> {
+    let begin_string = find_tag(msg, 0, 8).map_or(b"FIX.4.2" as &[u8], |s| s.slice(msg));
+    let orig_time = find_tag(msg, 0, 52).map(|s| s.slice(msg));
+
+    let mut body: Vec<u8> = Vec::with_capacity(msg.len() + 32);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(msg, 0) {
+        match field.tag {
+            8 | 9 | 10 | 43 | 122 => {}
+            52 => {
+                push_field(&mut body, 52, field.value.slice(msg));
+                push_field(&mut body, 43, b"Y");
+                if let Some(t) = orig_time {
+                    push_field(&mut body, 122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => push_field(&mut body, field.tag, field.value.slice(msg)),
+        }
+    }
+
+    if !poss_dup_done {
+        push_field(&mut body, 43, b"Y");
+        if let Some(t) = orig_time {
+            push_field(&mut body, 122, t);
+        }
+    }
+
+    let body_len = body.len();
+    let mut bl_buf = [0u8; 10];
+    let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
+
+    let mut out = Vec::with_capacity(
+        2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7,
+    );
+    out.extend_from_slice(b"8=");
+    out.extend_from_slice(begin_string);
+    out.push(0x01);
+    out.extend_from_slice(b"9=");
+    out.extend_from_slice(&bl_buf[..bl_n]);
+    out.push(0x01);
+    out.extend_from_slice(&body);
+
+    let sum = checksum(&out);
+    out.extend_from_slice(b"10=");
+    out.extend_from_slice(&format_checksum(sum));
+    out.push(0x01);
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nexus_fix_codec::validate_checksum;
     use std::path::PathBuf;
 
     fn tmp_dir(name: &str) -> PathBuf {
@@ -122,6 +253,20 @@ mod tests {
 
     fn fix_msg(seq: u32) -> Vec<u8> {
         format!("8=FIX.4.2\x0134={seq}\x0135=D\x0110=000\x01").into_bytes()
+    }
+
+    fn fix_admin(seq: u32, msg_type: &str) -> Vec<u8> {
+        format!("8=FIX.4.2\x0134={seq}\x0135={msg_type}\x0110=000\x01").into_bytes()
+    }
+
+    fn fix_msg_with_time(seq: u32, time: &str) -> Vec<u8> {
+        format!("8=FIX.4.2\x0134={seq}\x0135=D\x0152={time}\x0110=000\x01").into_bytes()
+    }
+
+    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem> {
+        let mut items = Vec::new();
+        j.resend_range(begin, end, |item| items.push(item));
+        items
     }
 
     #[test]
@@ -210,6 +355,141 @@ mod tests {
         assert_eq!(j.next_inbound(), 3);
         j.set_next_inbound(10);
         assert_eq!(j.next_inbound(), 10);
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_admin_skip() {
+        let dir = tmp_dir("rr-admin-skip");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        j.store(1, &fix_admin(1, "A")).unwrap();
+        j.store(2, &fix_admin(2, "0")).unwrap();
+        j.store(3, &fix_admin(3, "5")).unwrap();
+
+        let items = collect_range(&j, 1, 3);
+        assert_eq!(items.len(), 1);
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_interior_holes() {
+        let dir = tmp_dir("rr-holes");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        for seq in [1u32, 3, 5] {
+            j.store(seq, &fix_msg(seq)).unwrap();
+        }
+
+        let items = collect_range(&j, 1, 5);
+        assert_eq!(items.len(), 5);
+        assert!(matches!(items[0], ReplayItem::App(_)));
+        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 3 }));
+        assert!(matches!(items[2], ReplayItem::App(_)));
+        assert!(matches!(items[3], ReplayItem::GapFill { seq: 4, new_seq: 5 }));
+        assert!(matches!(items[4], ReplayItem::App(_)));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_straddle_window() {
+        let dir = tmp_dir("rr-straddle");
+        cleanup(&dir);
+
+        // Window=4: seqs 1..4 are overwritten when 5..8 are stored.
+        let mut j = FixJournal::open(&dir, 4).unwrap();
+        for seq in 1..=8u32 {
+            j.store(seq, &fix_msg(seq)).unwrap();
+        }
+
+        // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
+        let items = collect_range(&j, 1, 8);
+        assert_eq!(items.len(), 5);
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 5 }));
+        assert!(matches!(items[1], ReplayItem::App(_)));
+        assert!(matches!(items[2], ReplayItem::App(_)));
+        assert!(matches!(items[3], ReplayItem::App(_)));
+        assert!(matches!(items[4], ReplayItem::App(_)));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_poss_dup_reframe() {
+        let dir = tmp_dir("rr-reframe");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00")).unwrap();
+
+        let items = collect_range(&j, 1, 1);
+        assert_eq!(items.len(), 1);
+        let ReplayItem::App(ref reframed) = items[0] else {
+            panic!("expected App");
+        };
+        let pd = find_tag(reframed, 0, 43).expect("tag 43 missing");
+        assert_eq!(pd.slice(reframed), b"Y");
+        let osd = find_tag(reframed, 0, 122).expect("tag 122 missing");
+        assert_eq!(osd.slice(reframed), b"20240101-12:00:00");
+        validate_checksum(reframed).expect("checksum invalid");
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_coalesced_gapfill() {
+        let dir = tmp_dir("rr-coalesced");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        j.store(1, &fix_msg(1)).unwrap();
+        j.store(5, &fix_msg(5)).unwrap();
+
+        let items = collect_range(&j, 1, 5);
+        assert_eq!(items.len(), 3);
+        assert!(matches!(items[0], ReplayItem::App(_)));
+        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 5 }));
+        assert!(matches!(items[2], ReplayItem::App(_)));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_all_gapfill() {
+        let dir = tmp_dir("rr-allgap");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        j.store(1, &fix_admin(1, "A")).unwrap();
+        j.store(2, &fix_admin(2, "1")).unwrap();
+        j.store(3, &fix_admin(3, "2")).unwrap();
+
+        let items = collect_range(&j, 1, 3);
+        assert_eq!(items.len(), 1);
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_range_end_zero_means_all() {
+        let dir = tmp_dir("rr-endzero");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        for seq in 1..=3u32 {
+            j.store(seq, &fix_msg(seq)).unwrap();
+        }
+
+        let items = collect_range(&j, 1, 0);
+        assert_eq!(items.len(), 3);
+        assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 
-use nexus_fix_codec::{
-    FieldReader, checksum, encode_fix_uint, find_tag, format_checksum, parse_fix_seqnum,
-};
+use nexus_fix_codec::{find_tag, parse_fix_seqnum};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
 pub enum ResendPlan<'a> {
@@ -11,13 +9,14 @@ pub enum ResendPlan<'a> {
 }
 
 /// Output of a single [`FixJournal::resend_range`] step.
-pub enum ReplayItem {
+pub enum ReplayItem<'a> {
     /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
     /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
     GapFill { seq: u32, new_seq: u32 },
-    /// Re-framed app message with `PossDupFlag(43)=Y` and
-    /// `OrigSendingTime(122)` from the original `SendingTime(52)`.
-    App(Vec<u8>),
+    /// Original stored bytes for the app message; the transport is responsible
+    /// for adding `PossDupFlag(43)`, `OrigSendingTime(122)`, and a fresh
+    /// `SendingTime(52)` before retransmitting.
+    App(&'a [u8]),
 }
 
 pub struct FixJournal {
@@ -105,13 +104,12 @@ impl FixJournal {
     ///
     /// `end == 0` means all messages up to `next_outbound - 1`. Holes and
     /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
-    /// SequenceReset) are gap-filled; consecutive gap-fills are coalesced into
-    /// a single `GapFill { seq, new_seq }`. App messages are re-framed with
-    /// `PossDupFlag(43)=Y` and `OrigSendingTime(122)` from the stored
-    /// `SendingTime(52)`.
-    pub fn resend_range<F>(&self, begin: u32, end: u32, mut emit: F)
+    /// Reject, SequenceReset) are gap-filled; consecutive gap-fills are
+    /// coalesced into a single `GapFill { seq, new_seq }`. App messages are
+    /// yielded as borrowed original bytes; the transport owns the reframing.
+    pub fn resend_range<'a, F>(&'a self, begin: u32, end: u32, mut emit: F)
     where
-        F: FnMut(ReplayItem),
+        F: FnMut(ReplayItem<'a>),
     {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
@@ -139,7 +137,7 @@ impl FixJournal {
                                 new_seq: seq,
                             });
                         }
-                        emit(ReplayItem::App(reframe(p)));
+                        emit(ReplayItem::App(p));
                         false
                     }
                 }
@@ -176,72 +174,12 @@ impl FixJournal {
 }
 
 fn is_admin_type(msg_type: &[u8]) -> bool {
-    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"4")
-}
-
-fn push_field(buf: &mut Vec<u8>, tag: u32, value: &[u8]) {
-    let mut tmp = [0u8; 10];
-    let n = encode_fix_uint(tag, &mut tmp);
-    buf.extend_from_slice(&tmp[..n]);
-    buf.push(b'=');
-    buf.extend_from_slice(value);
-    buf.push(0x01);
-}
-
-fn reframe(msg: &[u8]) -> Vec<u8> {
-    let begin_string = find_tag(msg, 0, 8).map_or(b"FIX.4.2" as &[u8], |s| s.slice(msg));
-    let orig_time = find_tag(msg, 0, 52).map(|s| s.slice(msg));
-
-    let mut body: Vec<u8> = Vec::with_capacity(msg.len() + 32);
-    let mut poss_dup_done = false;
-
-    for field in FieldReader::new(msg, 0) {
-        match field.tag {
-            8 | 9 | 10 | 43 | 122 => {}
-            52 => {
-                push_field(&mut body, 52, field.value.slice(msg));
-                push_field(&mut body, 43, b"Y");
-                if let Some(t) = orig_time {
-                    push_field(&mut body, 122, t);
-                }
-                poss_dup_done = true;
-            }
-            _ => push_field(&mut body, field.tag, field.value.slice(msg)),
-        }
-    }
-
-    if !poss_dup_done {
-        push_field(&mut body, 43, b"Y");
-        if let Some(t) = orig_time {
-            push_field(&mut body, 122, t);
-        }
-    }
-
-    let body_len = body.len();
-    let mut bl_buf = [0u8; 10];
-    let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
-
-    let mut out = Vec::with_capacity(2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7);
-    out.extend_from_slice(b"8=");
-    out.extend_from_slice(begin_string);
-    out.push(0x01);
-    out.extend_from_slice(b"9=");
-    out.extend_from_slice(&bl_buf[..bl_n]);
-    out.push(0x01);
-    out.extend_from_slice(&body);
-
-    let sum = checksum(&out);
-    out.extend_from_slice(b"10=");
-    out.extend_from_slice(&format_checksum(sum));
-    out.push(0x01);
-
-    out
+    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"3" | b"4")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nexus_fix_codec::validate_checksum;
     use std::path::PathBuf;
 
     fn tmp_dir(name: &str) -> PathBuf {
@@ -264,7 +202,7 @@ mod tests {
         format!("8=FIX.4.2\x0134={seq}\x0135=D\x0152={time}\x0110=000\x01").into_bytes()
     }
 
-    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem> {
+    fn collect_range<'a>(j: &'a FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'a>> {
         let mut items = Vec::new();
         j.resend_range(begin, end, |item| items.push(item));
         items
@@ -434,24 +372,20 @@ mod tests {
     }
 
     #[test]
-    fn resend_range_poss_dup_reframe() {
-        let dir = tmp_dir("rr-reframe");
+    fn resend_range_yields_original_bytes() {
+        let dir = tmp_dir("rr-original");
         cleanup(&dir);
 
         let mut j = FixJournal::open(&dir, 64).unwrap();
-        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00"))
-            .unwrap();
+        let msg = fix_msg_with_time(1, "20240101-12:00:00");
+        j.store(1, &msg).unwrap();
 
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
-        let ReplayItem::App(ref reframed) = items[0] else {
+        let ReplayItem::App(bytes) = items[0] else {
             panic!("expected App");
         };
-        let pd = find_tag(reframed, 0, 43).expect("tag 43 missing");
-        assert_eq!(pd.slice(reframed), b"Y");
-        let osd = find_tag(reframed, 0, 122).expect("tag 122 missing");
-        assert_eq!(osd.slice(reframed), b"20240101-12:00:00");
-        validate_checksum(reframed).expect("checksum invalid");
+        assert_eq!(bytes, msg.as_slice());
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -202,7 +202,7 @@ mod tests {
         format!("8=FIX.4.2\x0134={seq}\x0135=D\x0152={time}\x0110=000\x01").into_bytes()
     }
 
-    fn collect_range<'a>(j: &'a FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'a>> {
+    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'_>> {
         let mut items = Vec::new();
         j.resend_range(begin, end, |item| items.push(item));
         items

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -8,12 +8,8 @@ pub enum ResendPlan<'a> {
     GapFill(u32),
 }
 
-/// Output of a single [`FixJournal::resend_range`] step.
 pub enum ReplayItem<'a> {
-    /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
-    /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
     GapFill { seq: u32, new_seq: u32 },
-    /// Original stored bytes; transport reframes with `PossDupFlag` and fresh timestamps.
     App(&'a [u8]),
 }
 
@@ -98,13 +94,6 @@ impl FixJournal {
         ResendPlan::GapFill(seq)
     }
 
-    /// Walk `begin..=end` and emit [`ReplayItem`]s via `emit`.
-    ///
-    /// `end == 0` means all messages up to `next_outbound - 1`. Holes and
-    /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
-    /// Reject, SequenceReset) are gap-filled; consecutive gap-fills are
-    /// coalesced into a single `GapFill { seq, new_seq }`. App messages are
-    /// yielded as borrowed original bytes.
     pub fn resend_range<'a, F>(&'a self, begin: u32, end: u32, mut emit: F)
     where
         F: FnMut(ReplayItem<'a>),
@@ -165,7 +154,6 @@ impl FixJournal {
         self.next_inbound = self.next_inbound.wrapping_add(1);
     }
 
-    /// Caller restores from Logon's `NextExpectedMsgSeqNum` field.
     pub fn set_next_inbound(&mut self, seq: u32) {
         self.next_inbound = seq;
     }
@@ -348,13 +336,11 @@ mod tests {
         let dir = tmp_dir("rr-straddle");
         cleanup(&dir);
 
-        // Window=4: seqs 1..4 are overwritten when 5..8 are stored.
         let mut j = FixJournal::open(&dir, 4).unwrap();
         for seq in 1..=8u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
         let items = collect_range(&j, 1, 8);
         assert_eq!(items.len(), 5);
         assert!(matches!(

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -5,7 +5,7 @@ use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, Wri
 
 enum ResendPlan<'a> {
     Replay(Frame<'a>),
-    GapFill(u32),
+    GapFill,
 }
 
 pub enum ReplayItem<'a> {
@@ -52,7 +52,7 @@ impl<'a> Iterator for ResendIter<'a> {
             let seq = self.seq;
             self.seq += 1;
             let is_gap = match self.journal.resend_one(seq) {
-                ResendPlan::GapFill(_) => true,
+                ResendPlan::GapFill => true,
                 ResendPlan::Replay(frame) => {
                     let p = frame.payload();
                     let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
@@ -147,7 +147,7 @@ impl FixJournal {
                 return ResendPlan::Replay(frame);
             }
         }
-        ResendPlan::GapFill(seq)
+        ResendPlan::GapFill
     }
 
     pub fn resend(&'_ self, begin: u32, end: u32) -> impl Iterator<Item = ReplayItem<'_>> + '_ {
@@ -230,7 +230,7 @@ mod tests {
             ResendPlan::Replay(frame) => {
                 assert_eq!(frame.payload(), fix_msg(3).as_slice());
             }
-            ResendPlan::GapFill(_) => panic!("expected Replay"),
+            ResendPlan::GapFill => panic!("expected Replay"),
         }
 
         cleanup(&dir);
@@ -265,7 +265,7 @@ mod tests {
         j.store(1, &fix_msg(1)).unwrap();
 
         match j.resend_one(2) {
-            ResendPlan::GapFill(2) => {}
+            ResendPlan::GapFill => {}
             _ => panic!("expected GapFill(2)"),
         }
 

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -396,8 +396,8 @@ impl SessionState {
         out
     }
 
-    /// Handles a received ResendRequest. Emits a gap-fill SequenceReset covering
-    /// the requested range and surfaces `Event::ResendRange` for the persistence layer.
+    /// Handles a received ResendRequest. Surfaces `Event::ResendRange` so the
+    /// persistence layer can drive the replay walk via [`FixJournal::resend_range`].
     pub fn on_resend_request(
         &mut self,
         seq: u32,
@@ -416,11 +416,6 @@ impl SessionState {
         self.test_request_sent = None;
         let mut out = Out::EMPTY;
         if self.validate_seq(seq, poss_dup, now, &mut out) {
-            self.last_sent = Some(now);
-            out.push_admin(AdminMsg::SequenceReset {
-                seq: begin,
-                new_seq: self.next_outbound,
-            });
             out.push_event(Event::ResendRange { begin, end });
             self.check_resend_done();
         }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -396,8 +396,6 @@ impl SessionState {
         out
     }
 
-    /// Handles a received ResendRequest. Surfaces `Event::ResendRange` so the
-    /// persistence layer can drive the replay walk via [`FixJournal::resend_range`].
     pub fn on_resend_request(
         &mut self,
         seq: u32,

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -231,7 +231,7 @@ fn sequence_reset_reset_mode_ignores_seq() {
 }
 
 #[test]
-fn resend_request_is_gap_filled() {
+fn resend_request_surfaces_event() {
     let mut s = new_session();
     let now = Instant::now();
     establish(&mut s, now);
@@ -240,12 +240,9 @@ fn resend_request_is_gap_filled() {
 
     let out = s.on_resend_request(2, false, 2, 3, now);
     assert_eq!(out.event(), Some(Event::ResendRange { begin: 2, end: 3 }));
-    let admins = admin_msgs(out);
-    assert_eq!(admins.len(), 1);
-    assert!(matches!(
-        admins[0],
-        AdminMsg::SequenceReset { seq: 2, new_seq: 4 }
-    ));
+    // The replay walk (gap-fills + PossDup re-frames) is driven by the
+    // persistence layer via FixJournal::resend_range — no admin emitted here.
+    assert_eq!(admin_msgs(out).len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #520.

## What

`FixJournal::resend_range(begin, end, emit)` — the replay walk the session layer was missing.

Walks `begin..=end` (0 = unbounded, up to `next_outbound - 1`), and for each seqnum:
- **Hole / rotated-out** (`GapFill`) → gap-fill
- **Admin message** (Logon A, Logout 5, Heartbeat 0, TestRequest 1, ResendRequest 2, SequenceReset 4) → gap-fill
- **App message** → re-frame with `PossDupFlag(43)=Y` + `OrigSendingTime(122)` from stored `SendingTime(52)`; recomputed `BodyLength`/`CheckSum`
- Consecutive gap-fills coalesce into a single `ReplayItem::GapFill { seq, new_seq }`

`SessionState::on_resend_request` no longer emits a placeholder `SequenceReset`; it surfaces `Event::ResendRange` so the caller drives the walk via `resend_range`.

## Tests

- `resend_range_admin_skip` — all-admin range → single coalesced gap-fill
- `resend_range_interior_holes` — stored 1,3,5; range 1..5 → Replay/GapFill alternating, each gap is per-seqnum
- `resend_range_straddle_window` — window=4, stored 1..8; seqs 1..4 rotated out → one coalesced GapFill + 4 App
- `resend_range_poss_dup_reframe` — checks tag 43=Y, tag 122=original SendingTime, valid checksum
- `resend_range_coalesced_gapfill` — stored 1 and 5; range 1..5 → App, GapFill{2..5}, App
- `resend_range_all_gapfill` — all admin → single GapFill
- `resend_range_end_zero_means_all` — end=0 walks up to next_outbound-1