### PR TITLE
feat(fix-engine): synchronous TCP transport (#517)

### DIFF
--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -7,6 +7,7 @@
 //! are invariant across all FIX versions.
 
 use nexus_net::buf::{ReadBuf, WriteBuf};
+use nexus_net::wire::ParserSink;
 
 const SOH: u8 = 0x01;
 
@@ -297,6 +298,18 @@ impl FrameReader {
         let len = data.len();
         self.buf.advance(len);
         len
+    }
+}
+
+impl ParserSink for FrameReader {
+    #[inline]
+    fn spare(&mut self) -> &mut [u8] {
+        self.buf.spare()
+    }
+
+    #[inline]
+    fn filled(&mut self, n: usize) {
+        self.buf.filled(n);
     }
 }
 

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -12,6 +12,10 @@ mod framework;
 #[cfg(unix)]
 pub mod persist;
 mod session;
+#[cfg(unix)]
+mod timestamp;
+#[cfg(unix)]
+pub mod transport;
 
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
@@ -19,4 +23,6 @@ pub use frame::{
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem, ResendPlan};
+#[cfg(unix)]
+pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -23,6 +23,6 @@ pub use frame::{
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem, ResendPlan};
+pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
 #[cfg(unix)]
 pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};
-pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -22,7 +22,7 @@ pub use frame::{
 };
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
-pub use persist::{FixJournal, ReplayItem, ResendPlan};
+pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
 #[cfg(unix)]
 pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -18,5 +18,5 @@ pub use frame::{
 };
 pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
 #[cfg(unix)]
-pub use persist::{FixJournal, ReplayItem};
+pub use persist::{FixJournal, ReplayItem, ResendPlan};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -252,7 +252,7 @@ mod tests {
 
         match j.resend_one(2) {
             ResendPlan::GapFill => {}
-            _ => panic!("expected GapFill(2)"),
+            ResendPlan::Replay(_) => panic!("expected GapFill"),
         }
 
         cleanup(&dir);

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,16 +1,23 @@
 use std::path::Path;
 
-use nexus_fix_codec::{find_tag, parse_fix_seqnum};
+use nexus_fix_codec::{
+    FieldReader, checksum, encode_fix_uint, find_tag, format_checksum, parse_fix_seqnum,
+};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
-enum ResendPlan<'a> {
+pub enum ResendPlan<'a> {
     Replay(Frame<'a>),
-    GapFill,
+    GapFill(u32),
 }
 
-pub enum ReplayItem<'a> {
+/// Output of a single [`FixJournal::resend_range`] step.
+pub enum ReplayItem {
+    /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
+    /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
     GapFill { seq: u32, new_seq: u32 },
-    App(&'a [u8]),
+    /// Re-framed app message with `PossDupFlag(43)=Y` and
+    /// `OrigSendingTime(122)` from the original `SendingTime(52)`.
+    App(Vec<u8>),
 }
 
 pub struct FixJournal {
@@ -22,70 +29,7 @@ pub struct FixJournal {
     next_inbound: u32,
 }
 
-struct ResendIter<'a> {
-    journal: &'a FixJournal,
-    seq: u32,
-    high: u32,
-    gap_start: Option<u32>,
-    deferred: Option<ReplayItem<'a>>,
-    done: bool,
-}
-
-impl<'a> Iterator for ResendIter<'a> {
-    type Item = ReplayItem<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(item) = self.deferred.take() {
-            return Some(item);
-        }
-        loop {
-            if self.done {
-                return None;
-            }
-            if self.seq > self.high {
-                self.done = true;
-                return self.gap_start.take().map(|gs| ReplayItem::GapFill {
-                    seq: gs,
-                    new_seq: self.high.wrapping_add(1),
-                });
-            }
-            let seq = self.seq;
-            self.seq += 1;
-            let is_gap = match self.journal.resend_one(seq) {
-                ResendPlan::GapFill => true,
-                ResendPlan::Replay(frame) => {
-                    let p = frame.payload();
-                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
-                    if is_admin_type(msg_type) {
-                        true
-                    } else {
-                        let app = ReplayItem::App(p);
-                        if let Some(gs) = self.gap_start.take() {
-                            self.deferred = Some(app);
-                            return Some(ReplayItem::GapFill {
-                                seq: gs,
-                                new_seq: seq,
-                            });
-                        }
-                        return Some(app);
-                    }
-                }
-            };
-            if is_gap && self.gap_start.is_none() {
-                self.gap_start = Some(seq);
-            }
-        }
-    }
-}
-
 impl FixJournal {
-    /// Open (or recover) the journal for a single session under `dir`.
-    ///
-    /// `window` is the resend horizon in messages (must be a power of two): the
-    /// last `window` sequence numbers are replayable, older ones are gap-filled.
-    ///
-    /// One session per journal: if a session already exists under `dir`, the
-    /// first one is reopened; otherwise a new session is created.
     pub fn open(dir: impl AsRef<Path>, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;
@@ -121,13 +65,6 @@ impl FixJournal {
         }
     }
 
-    /// Archive an outbound message after it has been sent.
-    ///
-    /// `msg` is the already-formatted wire message; `seq` must equal its
-    /// `MsgSeqNum` (tag 34). The send path satisfies this by construction — `seq`
-    /// is passed in only to index the resend ring without re-parsing on the hot
-    /// path; the cold paths ([`resend`](Self::resend), [`recover`](Self::recover))
-    /// read the seqnum back out of the message via tag 34.
     pub fn store(&mut self, seq: u32, msg: &[u8]) -> Result<(), WriteError> {
         let offset = self.journal.append(msg)?;
         self.offsets[seq as usize & (self.window - 1)] = Some(offset);
@@ -135,7 +72,7 @@ impl FixJournal {
         Ok(())
     }
 
-    fn resend_one(&self, seq: u32) -> ResendPlan<'_> {
+    pub fn resend(&self, seq: u32) -> ResendPlan<'_> {
         let slot = seq as usize & (self.window - 1);
         if let Some(off) = self.offsets[slot]
             && let Some(frame) = self.journal.read(off)
@@ -147,22 +84,59 @@ impl FixJournal {
                 return ResendPlan::Replay(frame);
             }
         }
-        ResendPlan::GapFill
+        ResendPlan::GapFill(seq)
     }
 
-    pub fn resend(&'_ self, begin: u32, end: u32) -> impl Iterator<Item = ReplayItem<'_>> + '_ {
+    /// Walk `begin..=end` and emit [`ReplayItem`]s via `emit`.
+    ///
+    /// `end == 0` means all messages up to `next_outbound - 1`. Holes and
+    /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
+    /// SequenceReset) are gap-filled; consecutive gap-fills are coalesced into
+    /// a single `GapFill { seq, new_seq }`. App messages are re-framed with
+    /// `PossDupFlag(43)=Y` and `OrigSendingTime(122)` from the stored
+    /// `SendingTime(52)`.
+    pub fn resend_range<F>(&self, begin: u32, end: u32, mut emit: F)
+    where
+        F: FnMut(ReplayItem),
+    {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
         } else {
             end
         };
-        ResendIter {
-            journal: self,
-            seq: begin,
-            high,
-            gap_start: None,
-            deferred: None,
-            done: begin > high,
+        if begin > high {
+            return;
+        }
+
+        let mut gap_start: Option<u32> = None;
+
+        for seq in begin..=high {
+            let is_gap = match self.resend(seq) {
+                ResendPlan::GapFill(_) => true,
+                ResendPlan::Replay(frame) => {
+                    let p = frame.payload();
+                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
+                    if is_admin_type(msg_type) {
+                        true
+                    } else {
+                        if let Some(gs) = gap_start.take() {
+                            emit(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                        }
+                        emit(ReplayItem::App(reframe(p)));
+                        false
+                    }
+                }
+            };
+            if is_gap && gap_start.is_none() {
+                gap_start = Some(seq);
+            }
+        }
+
+        if let Some(gs) = gap_start {
+            emit(ReplayItem::GapFill {
+                seq: gs,
+                new_seq: high.wrapping_add(1),
+            });
         }
     }
 
@@ -178,18 +152,81 @@ impl FixJournal {
         self.next_inbound = self.next_inbound.wrapping_add(1);
     }
 
+    /// Caller restores from Logon's `NextExpectedMsgSeqNum` field.
     pub fn set_next_inbound(&mut self, seq: u32) {
         self.next_inbound = seq;
     }
 }
 
 fn is_admin_type(msg_type: &[u8]) -> bool {
-    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"3" | b"4")
+    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"4")
+}
+
+fn push_field(buf: &mut Vec<u8>, tag: u32, value: &[u8]) {
+    let mut tmp = [0u8; 10];
+    let n = encode_fix_uint(tag, &mut tmp);
+    buf.extend_from_slice(&tmp[..n]);
+    buf.push(b'=');
+    buf.extend_from_slice(value);
+    buf.push(0x01);
+}
+
+fn reframe(msg: &[u8]) -> Vec<u8> {
+    let begin_string = find_tag(msg, 0, 8).map_or(b"FIX.4.2" as &[u8], |s| s.slice(msg));
+    let orig_time = find_tag(msg, 0, 52).map(|s| s.slice(msg));
+
+    let mut body: Vec<u8> = Vec::with_capacity(msg.len() + 32);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(msg, 0) {
+        match field.tag {
+            8 | 9 | 10 | 43 | 122 => {}
+            52 => {
+                push_field(&mut body, 52, field.value.slice(msg));
+                push_field(&mut body, 43, b"Y");
+                if let Some(t) = orig_time {
+                    push_field(&mut body, 122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => push_field(&mut body, field.tag, field.value.slice(msg)),
+        }
+    }
+
+    if !poss_dup_done {
+        push_field(&mut body, 43, b"Y");
+        if let Some(t) = orig_time {
+            push_field(&mut body, 122, t);
+        }
+    }
+
+    let body_len = body.len();
+    let mut bl_buf = [0u8; 10];
+    let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
+
+    let mut out = Vec::with_capacity(
+        2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7,
+    );
+    out.extend_from_slice(b"8=");
+    out.extend_from_slice(begin_string);
+    out.push(0x01);
+    out.extend_from_slice(b"9=");
+    out.extend_from_slice(&bl_buf[..bl_n]);
+    out.push(0x01);
+    out.extend_from_slice(&body);
+
+    let sum = checksum(&out);
+    out.extend_from_slice(b"10=");
+    out.extend_from_slice(&format_checksum(sum));
+    out.push(0x01);
+
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nexus_fix_codec::validate_checksum;
     use std::path::PathBuf;
 
     fn tmp_dir(name: &str) -> PathBuf {
@@ -212,8 +249,10 @@ mod tests {
         format!("8=FIX.4.2\x0134={seq}\x0135=D\x0152={time}\x0110=000\x01").into_bytes()
     }
 
-    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'_>> {
-        j.resend(begin, end).collect()
+    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem> {
+        let mut items = Vec::new();
+        j.resend_range(begin, end, |item| items.push(item));
+        items
     }
 
     #[test]
@@ -226,11 +265,11 @@ mod tests {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        match j.resend_one(3) {
+        match j.resend(3) {
             ResendPlan::Replay(frame) => {
                 assert_eq!(frame.payload(), fix_msg(3).as_slice());
             }
-            ResendPlan::GapFill => panic!("expected Replay"),
+            ResendPlan::GapFill(_) => panic!("expected Replay"),
         }
 
         cleanup(&dir);
@@ -264,9 +303,9 @@ mod tests {
         let mut j = FixJournal::open(&dir, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
 
-        match j.resend_one(2) {
-            ResendPlan::GapFill => {}
-            ResendPlan::Replay(_) => panic!("expected GapFill"),
+        match j.resend(2) {
+            ResendPlan::GapFill(2) => {}
+            _ => panic!("expected GapFill(2)"),
         }
 
         cleanup(&dir);
@@ -283,7 +322,7 @@ mod tests {
         }
 
         let results: Vec<bool> = (1u32..=5)
-            .map(|seq| matches!(j.resend_one(seq), ResendPlan::Replay(_)))
+            .map(|seq| matches!(j.resend(seq), ResendPlan::Replay(_)))
             .collect();
         assert_eq!(results, vec![true, false, true, false, true]);
 
@@ -318,10 +357,7 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(
-            items[0],
-            ReplayItem::GapFill { seq: 1, new_seq: 4 }
-        ));
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
 
         cleanup(&dir);
     }
@@ -339,15 +375,9 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 5);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(
-            items[1],
-            ReplayItem::GapFill { seq: 2, new_seq: 3 }
-        ));
+        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 3 }));
         assert!(matches!(items[2], ReplayItem::App(_)));
-        assert!(matches!(
-            items[3],
-            ReplayItem::GapFill { seq: 4, new_seq: 5 }
-        ));
+        assert!(matches!(items[3], ReplayItem::GapFill { seq: 4, new_seq: 5 }));
         assert!(matches!(items[4], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -358,17 +388,16 @@ mod tests {
         let dir = tmp_dir("rr-straddle");
         cleanup(&dir);
 
+        // Window=4: seqs 1..4 are overwritten when 5..8 are stored.
         let mut j = FixJournal::open(&dir, 4).unwrap();
         for seq in 1..=8u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
+        // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
         let items = collect_range(&j, 1, 8);
         assert_eq!(items.len(), 5);
-        assert!(matches!(
-            items[0],
-            ReplayItem::GapFill { seq: 1, new_seq: 5 }
-        ));
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 5 }));
         assert!(matches!(items[1], ReplayItem::App(_)));
         assert!(matches!(items[2], ReplayItem::App(_)));
         assert!(matches!(items[3], ReplayItem::App(_)));
@@ -378,20 +407,23 @@ mod tests {
     }
 
     #[test]
-    fn resend_range_yields_original_bytes() {
-        let dir = tmp_dir("rr-original");
+    fn resend_range_poss_dup_reframe() {
+        let dir = tmp_dir("rr-reframe");
         cleanup(&dir);
 
         let mut j = FixJournal::open(&dir, 64).unwrap();
-        let msg = fix_msg_with_time(1, "20240101-12:00:00");
-        j.store(1, &msg).unwrap();
+        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00")).unwrap();
 
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
-        let ReplayItem::App(bytes) = items[0] else {
+        let ReplayItem::App(ref reframed) = items[0] else {
             panic!("expected App");
         };
-        assert_eq!(bytes, msg.as_slice());
+        let pd = find_tag(reframed, 0, 43).expect("tag 43 missing");
+        assert_eq!(pd.slice(reframed), b"Y");
+        let osd = find_tag(reframed, 0, 122).expect("tag 122 missing");
+        assert_eq!(osd.slice(reframed), b"20240101-12:00:00");
+        validate_checksum(reframed).expect("checksum invalid");
 
         cleanup(&dir);
     }
@@ -408,10 +440,7 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 3);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(
-            items[1],
-            ReplayItem::GapFill { seq: 2, new_seq: 5 }
-        ));
+        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 5 }));
         assert!(matches!(items[2], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -429,10 +458,7 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(
-            items[0],
-            ReplayItem::GapFill { seq: 1, new_seq: 4 }
-        ));
+        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,23 +1,16 @@
 use std::path::Path;
 
-use nexus_fix_codec::{
-    FieldReader, checksum, encode_fix_uint, find_tag, format_checksum, parse_fix_seqnum,
-};
+use nexus_fix_codec::{find_tag, parse_fix_seqnum};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
-pub enum ResendPlan<'a> {
+enum ResendPlan<'a> {
     Replay(Frame<'a>),
     GapFill(u32),
 }
 
-/// Output of a single [`FixJournal::resend_range`] step.
-pub enum ReplayItem {
-    /// Coalesced gap-fill: encode as `SequenceReset(GapFillFlag=Y)` with
-    /// `MsgSeqNum=seq` and `NewSeqNo=new_seq`.
+pub enum ReplayItem<'a> {
     GapFill { seq: u32, new_seq: u32 },
-    /// Re-framed app message with `PossDupFlag(43)=Y` and
-    /// `OrigSendingTime(122)` from the original `SendingTime(52)`.
-    App(Vec<u8>),
+    App(&'a [u8]),
 }
 
 pub struct FixJournal {
@@ -27,6 +20,59 @@ pub struct FixJournal {
     window: usize,
     next_outbound: u32,
     next_inbound: u32,
+}
+
+struct ResendIter<'a> {
+    journal: &'a FixJournal,
+    seq: u32,
+    high: u32,
+    gap_start: Option<u32>,
+    deferred: Option<ReplayItem<'a>>,
+    done: bool,
+}
+
+impl<'a> Iterator for ResendIter<'a> {
+    type Item = ReplayItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(item) = self.deferred.take() {
+            return Some(item);
+        }
+        loop {
+            if self.done {
+                return None;
+            }
+            if self.seq > self.high {
+                self.done = true;
+                return self.gap_start.take().map(|gs| ReplayItem::GapFill {
+                    seq: gs,
+                    new_seq: self.high.wrapping_add(1),
+                });
+            }
+            let seq = self.seq;
+            self.seq += 1;
+            let is_gap = match self.journal.resend_one(seq) {
+                ResendPlan::GapFill(_) => true,
+                ResendPlan::Replay(frame) => {
+                    let p = frame.payload();
+                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
+                    if is_admin_type(msg_type) {
+                        true
+                    } else {
+                        let app = ReplayItem::App(p);
+                        if let Some(gs) = self.gap_start.take() {
+                            self.deferred = Some(app);
+                            return Some(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                        }
+                        return Some(app);
+                    }
+                }
+            };
+            if is_gap && self.gap_start.is_none() {
+                self.gap_start = Some(seq);
+            }
+        }
+    }
 }
 
 impl FixJournal {
@@ -72,7 +118,7 @@ impl FixJournal {
         Ok(())
     }
 
-    pub fn resend(&self, seq: u32) -> ResendPlan<'_> {
+    fn resend_one(&self, seq: u32) -> ResendPlan<'_> {
         let slot = seq as usize & (self.window - 1);
         if let Some(off) = self.offsets[slot]
             && let Some(frame) = self.journal.read(off)
@@ -87,59 +133,19 @@ impl FixJournal {
         ResendPlan::GapFill(seq)
     }
 
-    /// Walk `begin..=end` and emit [`ReplayItem`]s via `emit`.
-    ///
-    /// `end == 0` means all messages up to `next_outbound - 1`. Holes and
-    /// admin messages (Logon, Logout, Heartbeat, TestRequest, ResendRequest,
-    /// SequenceReset) are gap-filled; consecutive gap-fills are coalesced into
-    /// a single `GapFill { seq, new_seq }`. App messages are re-framed with
-    /// `PossDupFlag(43)=Y` and `OrigSendingTime(122)` from the stored
-    /// `SendingTime(52)`.
-    pub fn resend_range<F>(&self, begin: u32, end: u32, mut emit: F)
-    where
-        F: FnMut(ReplayItem),
-    {
+    pub fn resend(&'_ self, begin: u32, end: u32) -> impl Iterator<Item = ReplayItem<'_>> + '_ {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
         } else {
             end
         };
-        if begin > high {
-            return;
-        }
-
-        let mut gap_start: Option<u32> = None;
-
-        for seq in begin..=high {
-            let is_gap = match self.resend(seq) {
-                ResendPlan::GapFill(_) => true,
-                ResendPlan::Replay(frame) => {
-                    let p = frame.payload();
-                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
-                    if is_admin_type(msg_type) {
-                        true
-                    } else {
-                        if let Some(gs) = gap_start.take() {
-                            emit(ReplayItem::GapFill {
-                                seq: gs,
-                                new_seq: seq,
-                            });
-                        }
-                        emit(ReplayItem::App(reframe(p)));
-                        false
-                    }
-                }
-            };
-            if is_gap && gap_start.is_none() {
-                gap_start = Some(seq);
-            }
-        }
-
-        if let Some(gs) = gap_start {
-            emit(ReplayItem::GapFill {
-                seq: gs,
-                new_seq: high.wrapping_add(1),
-            });
+        ResendIter {
+            journal: self,
+            seq: begin,
+            high,
+            gap_start: None,
+            deferred: None,
+            done: begin > high,
         }
     }
 
@@ -155,79 +161,18 @@ impl FixJournal {
         self.next_inbound = self.next_inbound.wrapping_add(1);
     }
 
-    /// Caller restores from Logon's `NextExpectedMsgSeqNum` field.
     pub fn set_next_inbound(&mut self, seq: u32) {
         self.next_inbound = seq;
     }
 }
 
 fn is_admin_type(msg_type: &[u8]) -> bool {
-    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"4")
-}
-
-fn push_field(buf: &mut Vec<u8>, tag: u32, value: &[u8]) {
-    let mut tmp = [0u8; 10];
-    let n = encode_fix_uint(tag, &mut tmp);
-    buf.extend_from_slice(&tmp[..n]);
-    buf.push(b'=');
-    buf.extend_from_slice(value);
-    buf.push(0x01);
-}
-
-fn reframe(msg: &[u8]) -> Vec<u8> {
-    let begin_string = find_tag(msg, 0, 8).map_or(b"FIX.4.2" as &[u8], |s| s.slice(msg));
-    let orig_time = find_tag(msg, 0, 52).map(|s| s.slice(msg));
-
-    let mut body: Vec<u8> = Vec::with_capacity(msg.len() + 32);
-    let mut poss_dup_done = false;
-
-    for field in FieldReader::new(msg, 0) {
-        match field.tag {
-            8 | 9 | 10 | 43 | 122 => {}
-            52 => {
-                push_field(&mut body, 52, field.value.slice(msg));
-                push_field(&mut body, 43, b"Y");
-                if let Some(t) = orig_time {
-                    push_field(&mut body, 122, t);
-                }
-                poss_dup_done = true;
-            }
-            _ => push_field(&mut body, field.tag, field.value.slice(msg)),
-        }
-    }
-
-    if !poss_dup_done {
-        push_field(&mut body, 43, b"Y");
-        if let Some(t) = orig_time {
-            push_field(&mut body, 122, t);
-        }
-    }
-
-    let body_len = body.len();
-    let mut bl_buf = [0u8; 10];
-    let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
-
-    let mut out = Vec::with_capacity(2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7);
-    out.extend_from_slice(b"8=");
-    out.extend_from_slice(begin_string);
-    out.push(0x01);
-    out.extend_from_slice(b"9=");
-    out.extend_from_slice(&bl_buf[..bl_n]);
-    out.push(0x01);
-    out.extend_from_slice(&body);
-
-    let sum = checksum(&out);
-    out.extend_from_slice(b"10=");
-    out.extend_from_slice(&format_checksum(sum));
-    out.push(0x01);
-
-    out
+    matches!(msg_type, b"A" | b"5" | b"0" | b"1" | b"2" | b"3" | b"4")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nexus_fix_codec::validate_checksum;
     use std::path::PathBuf;
 
     fn tmp_dir(name: &str) -> PathBuf {
@@ -250,10 +195,8 @@ mod tests {
         format!("8=FIX.4.2\x0134={seq}\x0135=D\x0152={time}\x0110=000\x01").into_bytes()
     }
 
-    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem> {
-        let mut items = Vec::new();
-        j.resend_range(begin, end, |item| items.push(item));
-        items
+    fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'_>> {
+        j.resend(begin, end).collect()
     }
 
     #[test]
@@ -266,7 +209,7 @@ mod tests {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        match j.resend(3) {
+        match j.resend_one(3) {
             ResendPlan::Replay(frame) => {
                 assert_eq!(frame.payload(), fix_msg(3).as_slice());
             }
@@ -304,7 +247,7 @@ mod tests {
         let mut j = FixJournal::open(&dir, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
 
-        match j.resend(2) {
+        match j.resend_one(2) {
             ResendPlan::GapFill(2) => {}
             _ => panic!("expected GapFill(2)"),
         }
@@ -323,7 +266,7 @@ mod tests {
         }
 
         let results: Vec<bool> = (1u32..=5)
-            .map(|seq| matches!(j.resend(seq), ResendPlan::Replay(_)))
+            .map(|seq| matches!(j.resend_one(seq), ResendPlan::Replay(_)))
             .collect();
         assert_eq!(results, vec![true, false, true, false, true]);
 
@@ -398,13 +341,11 @@ mod tests {
         let dir = tmp_dir("rr-straddle");
         cleanup(&dir);
 
-        // Window=4: seqs 1..4 are overwritten when 5..8 are stored.
         let mut j = FixJournal::open(&dir, 4).unwrap();
         for seq in 1..=8u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
         let items = collect_range(&j, 1, 8);
         assert_eq!(items.len(), 5);
         assert!(matches!(
@@ -420,24 +361,20 @@ mod tests {
     }
 
     #[test]
-    fn resend_range_poss_dup_reframe() {
-        let dir = tmp_dir("rr-reframe");
+    fn resend_range_yields_original_bytes() {
+        let dir = tmp_dir("rr-original");
         cleanup(&dir);
 
         let mut j = FixJournal::open(&dir, 64).unwrap();
-        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00"))
-            .unwrap();
+        let msg = fix_msg_with_time(1, "20240101-12:00:00");
+        j.store(1, &msg).unwrap();
 
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
-        let ReplayItem::App(ref reframed) = items[0] else {
+        let ReplayItem::App(bytes) = items[0] else {
             panic!("expected App");
         };
-        let pd = find_tag(reframed, 0, 43).expect("tag 43 missing");
-        assert_eq!(pd.slice(reframed), b"Y");
-        let osd = find_tag(reframed, 0, 122).expect("tag 122 missing");
-        assert_eq!(osd.slice(reframed), b"20240101-12:00:00");
-        validate_checksum(reframed).expect("checksum invalid");
+        assert_eq!(bytes, msg.as_slice());
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -62,7 +62,10 @@ impl<'a> Iterator for ResendIter<'a> {
                         let app = ReplayItem::App(p);
                         if let Some(gs) = self.gap_start.take() {
                             self.deferred = Some(app);
-                            return Some(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                            return Some(ReplayItem::GapFill {
+                                seq: gs,
+                                new_seq: seq,
+                            });
                         }
                         return Some(app);
                     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -5,7 +5,7 @@ use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, Wri
 
 enum ResendPlan<'a> {
     Replay(Frame<'a>),
-    GapFill(u32),
+    GapFill,
 }
 
 pub enum ReplayItem<'a> {
@@ -52,7 +52,7 @@ impl<'a> Iterator for ResendIter<'a> {
             let seq = self.seq;
             self.seq += 1;
             let is_gap = match self.journal.resend_one(seq) {
-                ResendPlan::GapFill(_) => true,
+                ResendPlan::GapFill => true,
                 ResendPlan::Replay(frame) => {
                     let p = frame.payload();
                     let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
@@ -133,7 +133,7 @@ impl FixJournal {
                 return ResendPlan::Replay(frame);
             }
         }
-        ResendPlan::GapFill(seq)
+        ResendPlan::GapFill
     }
 
     pub fn resend(&'_ self, begin: u32, end: u32) -> impl Iterator<Item = ReplayItem<'_>> + '_ {
@@ -216,7 +216,7 @@ mod tests {
             ResendPlan::Replay(frame) => {
                 assert_eq!(frame.payload(), fix_msg(3).as_slice());
             }
-            ResendPlan::GapFill(_) => panic!("expected Replay"),
+            ResendPlan::GapFill => panic!("expected Replay"),
         }
 
         cleanup(&dir);
@@ -251,7 +251,7 @@ mod tests {
         j.store(1, &fix_msg(1)).unwrap();
 
         match j.resend_one(2) {
-            ResendPlan::GapFill(2) => {}
+            ResendPlan::GapFill => {}
             _ => panic!("expected GapFill(2)"),
         }
 

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -120,7 +120,10 @@ impl FixJournal {
                         true
                     } else {
                         if let Some(gs) = gap_start.take() {
-                            emit(ReplayItem::GapFill { seq: gs, new_seq: seq });
+                            emit(ReplayItem::GapFill {
+                                seq: gs,
+                                new_seq: seq,
+                            });
                         }
                         emit(ReplayItem::App(reframe(p)));
                         false
@@ -204,9 +207,7 @@ fn reframe(msg: &[u8]) -> Vec<u8> {
     let mut bl_buf = [0u8; 10];
     let bl_n = encode_fix_uint(body_len as u32, &mut bl_buf);
 
-    let mut out = Vec::with_capacity(
-        2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7,
-    );
+    let mut out = Vec::with_capacity(2 + begin_string.len() + 1 + 2 + bl_n + 1 + body_len + 7);
     out.extend_from_slice(b"8=");
     out.extend_from_slice(begin_string);
     out.push(0x01);
@@ -357,7 +358,10 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 4 }
+        ));
 
         cleanup(&dir);
     }
@@ -375,9 +379,15 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 5);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 3 }));
+        assert!(matches!(
+            items[1],
+            ReplayItem::GapFill { seq: 2, new_seq: 3 }
+        ));
         assert!(matches!(items[2], ReplayItem::App(_)));
-        assert!(matches!(items[3], ReplayItem::GapFill { seq: 4, new_seq: 5 }));
+        assert!(matches!(
+            items[3],
+            ReplayItem::GapFill { seq: 4, new_seq: 5 }
+        ));
         assert!(matches!(items[4], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -397,7 +407,10 @@ mod tests {
         // Seqs 1..4 rotated out → one coalesced GapFill; seqs 5..8 in-window → 4 App items.
         let items = collect_range(&j, 1, 8);
         assert_eq!(items.len(), 5);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 5 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 5 }
+        ));
         assert!(matches!(items[1], ReplayItem::App(_)));
         assert!(matches!(items[2], ReplayItem::App(_)));
         assert!(matches!(items[3], ReplayItem::App(_)));
@@ -412,7 +425,8 @@ mod tests {
         cleanup(&dir);
 
         let mut j = FixJournal::open(&dir, 64).unwrap();
-        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00")).unwrap();
+        j.store(1, &fix_msg_with_time(1, "20240101-12:00:00"))
+            .unwrap();
 
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
@@ -440,7 +454,10 @@ mod tests {
         let items = collect_range(&j, 1, 5);
         assert_eq!(items.len(), 3);
         assert!(matches!(items[0], ReplayItem::App(_)));
-        assert!(matches!(items[1], ReplayItem::GapFill { seq: 2, new_seq: 5 }));
+        assert!(matches!(
+            items[1],
+            ReplayItem::GapFill { seq: 2, new_seq: 5 }
+        ));
         assert!(matches!(items[2], ReplayItem::App(_)));
 
         cleanup(&dir);
@@ -458,7 +475,10 @@ mod tests {
 
         let items = collect_range(&j, 1, 3);
         assert_eq!(items.len(), 1);
-        assert!(matches!(items[0], ReplayItem::GapFill { seq: 1, new_seq: 4 }));
+        assert!(matches!(
+            items[0],
+            ReplayItem::GapFill { seq: 1, new_seq: 4 }
+        ));
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -79,6 +79,13 @@ impl<'a> Iterator for ResendIter<'a> {
 }
 
 impl FixJournal {
+    /// Open (or recover) the journal for a single session under `dir`.
+    ///
+    /// `window` is the resend horizon in messages (must be a power of two): the
+    /// last `window` sequence numbers are replayable, older ones are gap-filled.
+    ///
+    /// One session per journal: if a session already exists under `dir`, the
+    /// first one is reopened; otherwise a new session is created.
     pub fn open(dir: impl AsRef<Path>, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;
@@ -114,6 +121,13 @@ impl FixJournal {
         }
     }
 
+    /// Archive an outbound message after it has been sent.
+    ///
+    /// `msg` is the already-formatted wire message; `seq` must equal its
+    /// `MsgSeqNum` (tag 34). The send path satisfies this by construction — `seq`
+    /// is passed in only to index the resend ring without re-parsing on the hot
+    /// path; the cold paths ([`resend`](Self::resend), [`recover`](Self::recover))
+    /// read the seqnum back out of the message via tag 34.
     pub fn store(&mut self, seq: u32, msg: &[u8]) -> Result<(), WriteError> {
         let offset = self.journal.append(msg)?;
         self.offsets[seq as usize & (self.window - 1)] = Some(offset);

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -396,6 +396,8 @@ impl SessionState {
         out
     }
 
+    /// Handles a received ResendRequest. Surfaces `Event::ResendRange` so the
+    /// persistence layer can drive the replay walk via [`FixJournal::resend_range`].
     pub fn on_resend_request(
         &mut self,
         seq: u32,

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -466,7 +466,7 @@ impl<S: Read + Write> FixConnection<S> {
                     }
                     ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
                 };
-                retry.map_err(|_| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
+                retry.map_err(|()| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
             }
         }
         flush_to(stream, writer)

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -1,0 +1,544 @@
+use std::io::{self, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use nexus_fix_codec::{
+    FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
+};
+
+use crate::frame::{FrameReader, FrameWriter};
+use crate::framework::SessionConfig;
+use crate::persist::{FixJournal, ReplayItem};
+use crate::session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
+use crate::timestamp::{UTC_TIMESTAMP_LEN, format_utc_timestamp};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Error from [`FixConnection`] operations.
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Synchronous TCP driver for a sans-IO FIX session.
+///
+/// Owns a socket, a [`FrameReader`]/[`FrameWriter`] pair, a [`SessionState`],
+/// and a [`FixJournal`]. The read loop fires [`SessionState`] handlers,
+/// encodes outbound admin messages, drives gap-fill replay from the journal
+/// on `Event::ResendRange`, and delivers in-sequence application frames to
+/// the caller via the `on_app` callback in [`run`](Self::run).
+///
+/// Mirrors the pattern used by `nexus-web`'s `Client<S>`.
+pub struct FixConnection<S> {
+    stream: S,
+    reader: FrameReader,
+    writer: FrameWriter,
+    state: SessionState,
+    journal: FixJournal,
+    config: SessionConfig,
+    begin_string: &'static [u8],
+    initiator: bool,
+}
+
+/// Builder for [`FixConnection`].
+pub struct FixConnectionBuilder {
+    reader_cap: usize,
+    writer_cap: usize,
+    nodelay: bool,
+    connect_timeout: Option<Duration>,
+}
+
+impl FixConnectionBuilder {
+    pub fn reader_capacity(mut self, n: usize) -> Self {
+        self.reader_cap = n;
+        self
+    }
+
+    pub fn writer_capacity(mut self, n: usize) -> Self {
+        self.writer_cap = n;
+        self
+    }
+
+    pub fn nodelay(mut self, v: bool) -> Self {
+        self.nodelay = v;
+        self
+    }
+
+    pub fn connect_timeout(mut self, d: Duration) -> Self {
+        self.connect_timeout = Some(d);
+        self
+    }
+
+    /// Connect to `addr` and return an initiator-mode [`FixConnection`].
+    ///
+    /// Sets `TCP_NODELAY` and a 100 ms read timeout for timer polling.
+    pub fn connect<A: ToSocketAddrs>(
+        self,
+        addr: A,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> io::Result<FixConnection<TcpStream>> {
+        let stream = match self.connect_timeout {
+            Some(t) => {
+                let addrs: Vec<_> = addr.to_socket_addrs()?.collect();
+                let first = addrs
+                    .first()
+                    .ok_or_else(|| io::Error::other("DNS resolved to zero addresses"))?;
+                TcpStream::connect_timeout(first, t)?
+            }
+            None => TcpStream::connect(addr)?,
+        };
+        stream.set_nodelay(self.nodelay)?;
+        stream.set_read_timeout(Some(POLL_INTERVAL))?;
+        Ok(FixConnection {
+            stream,
+            reader: FrameReader::builder()
+                .buffer_capacity(self.reader_cap)
+                .build(),
+            writer: FrameWriter::builder()
+                .buffer_capacity(self.writer_cap)
+                .build(),
+            state,
+            journal,
+            config,
+            begin_string,
+            initiator: true,
+        })
+    }
+
+    /// Wrap an already-connected stream as an acceptor-mode [`FixConnection`].
+    ///
+    /// The caller is responsible for applying socket options (nodelay, read
+    /// timeout) before calling this.
+    pub fn accept<S: Read + Write>(
+        self,
+        stream: S,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> FixConnection<S> {
+        FixConnection {
+            stream,
+            reader: FrameReader::builder()
+                .buffer_capacity(self.reader_cap)
+                .build(),
+            writer: FrameWriter::builder()
+                .buffer_capacity(self.writer_cap)
+                .build(),
+            state,
+            journal,
+            config,
+            begin_string,
+            initiator: false,
+        }
+    }
+}
+
+impl FixConnection<TcpStream> {
+    pub fn builder() -> FixConnectionBuilder {
+        FixConnectionBuilder {
+            reader_cap: 64 * 1024,
+            writer_cap: 64 * 1024,
+            nodelay: true,
+            connect_timeout: None,
+        }
+    }
+}
+
+impl<S: Read + Write> FixConnection<S> {
+    /// Construct from pre-built parts (useful for testing).
+    pub fn from_parts(
+        stream: S,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+        initiator: bool,
+    ) -> Self {
+        Self {
+            stream,
+            reader: FrameReader::builder().build(),
+            writer: FrameWriter::builder().build(),
+            state,
+            journal,
+            config,
+            begin_string,
+            initiator,
+        }
+    }
+
+    pub fn state(&self) -> &SessionState {
+        &self.state
+    }
+
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        &mut self.state
+    }
+
+    /// Allocate the next outbound sequence number for an app message.
+    pub fn allocate_seq(&mut self) -> u32 {
+        self.state.allocate_seq(Instant::now())
+    }
+
+    /// Store `frame` in the journal under `seq` and write it to the stream.
+    ///
+    /// The caller must have pre-encoded the complete FIX frame (including
+    /// `MsgSeqNum(34)=seq`) and must have obtained `seq` via
+    /// [`allocate_seq`](Self::allocate_seq).
+    pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        self.journal
+            .store(seq, frame)
+            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        write_all(&mut self.stream, frame)?;
+        Ok(())
+    }
+
+    /// Initiate a clean logout and flush the Logout message.
+    pub fn logout(&mut self) -> Result<(), Error> {
+        let now = Instant::now();
+        let out = self.state.logout(now);
+        self.flush_out(out, now)
+    }
+
+    /// Drive the session loop until the session disconnects.
+    ///
+    /// If `initiator`, sends a Logon before entering the read loop.
+    /// Calls `on_app` for each in-sequence application message frame.
+    /// Admin messages and timers are handled internally.
+    ///
+    /// Returns the disconnect reason on a clean or protocol-level disconnect.
+    /// Returns `Err` on unrecoverable I/O failure.
+    pub fn run<H>(&mut self, mut on_app: H) -> Result<DisconnectReason, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        if self.initiator {
+            let now = Instant::now();
+            let out = self.state.connect(now);
+            self.flush_out(out, now)?;
+        }
+
+        loop {
+            // Read bytes into the frame reader's spare region.
+            let spare = self.reader.spare();
+            let n = match self.stream.read(spare) {
+                Ok(0) => return Ok(DisconnectReason::Logout),
+                Ok(n) => n,
+                Err(e) if is_timeout(&e) => {
+                    let now = Instant::now();
+                    let out = self.state.on_timeout(now);
+                    if let Some(Event::Disconnected { reason }) = out.event() {
+                        self.flush_out(out, now)?;
+                        return Ok(reason);
+                    }
+                    self.flush_out(out, now)?;
+                    continue;
+                }
+                Err(e) => return Err(Error::Io(e)),
+            };
+            self.reader.filled(n);
+
+            // Drain complete FIX messages from the buffer.
+            loop {
+                match self.reader.next() {
+                    Ok(Some(frame)) => {
+                        let frame = frame.to_vec();
+                        let now = Instant::now();
+                        if let Some(reason) = self.dispatch(&frame, now, &mut on_app)? {
+                            return Ok(reason);
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(_) => {}
+                }
+            }
+            if self.reader.should_compact() {
+                self.reader.compact();
+            }
+        }
+    }
+
+    fn dispatch<H>(
+        &mut self,
+        frame: &[u8],
+        now: Instant,
+        on_app: &mut H,
+    ) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let sender_ok = find_tag(frame, 0, 49)
+            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok = find_tag(frame, 0, 56)
+            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        if !sender_ok || !target_ok {
+            let out = self.state.on_comp_id_mismatch(now);
+            self.flush_out(out, now)?;
+            return Ok(Some(DisconnectReason::CompIdMismatch));
+        }
+
+        let seq = match find_tag(frame, 0, 34)
+            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+        {
+            Some(s) => s as u32,
+            None => return Ok(None),
+        };
+
+        let poss_dup = find_tag(frame, 0, 43)
+            .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+            .unwrap_or(false);
+
+        let msg_type = match find_tag(frame, 0, 35) {
+            Some(s) => s.slice(frame),
+            None => return Ok(None),
+        };
+
+        let (out, is_app) = match msg_type {
+            b"A" => {
+                let hbi = find_tag(frame, 0, 108)
+                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
+                    .unwrap_or(30);
+                let reset = find_tag(frame, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                (self.state.on_logon(seq, hbi, reset, !was_logon_sent, now), false)
+            }
+            b"5" => (self.state.on_logout(seq, poss_dup, now), false),
+            b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
+            b"1" => {
+                let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
+                (self.state.on_test_request(seq, poss_dup, id, now), false)
+            }
+            b"2" => {
+                let begin = find_tag(frame, 0, 7)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let end = find_tag(frame, 0, 16)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (
+                    self.state
+                        .on_resend_request(seq, poss_dup, begin, end, now),
+                    false,
+                )
+            }
+            b"3" => {
+                let ref_seq = find_tag(frame, 0, 45)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (self.state.on_reject(seq, poss_dup, ref_seq, now), false)
+            }
+            b"4" => {
+                let new_seq = find_tag(frame, 0, 36)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let gap_fill = find_tag(frame, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                (
+                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
+                    false,
+                )
+            }
+            _ => (self.state.on_app(seq, poss_dup, now), true),
+        };
+
+        self.flush_out(out, now)?;
+
+        match out.event() {
+            Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
+            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end, now)?,
+            Some(Event::App { .. }) if is_app => on_app(frame),
+            _ => {}
+        }
+
+        Ok(None)
+    }
+
+    fn flush_out(&mut self, out: Out, now: Instant) -> Result<(), Error> {
+        for admin in out.admin_messages() {
+            self.encode_admin(admin, now);
+        }
+        if !self.writer.is_empty() {
+            self.flush_writer()?;
+        }
+        Ok(())
+    }
+
+    fn encode_admin(&mut self, admin: AdminMsg, _now: Instant) {
+        let unix_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i128;
+        let mut ts = [0u8; UTC_TIMESTAMP_LEN];
+        format_utc_timestamp(unix_nanos, &mut ts);
+
+        let msg_type: &[u8] = match admin {
+            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logout { .. } => b"5",
+            AdminMsg::Heartbeat { .. } => b"0",
+            AdminMsg::TestRequest { .. } => b"1",
+            AdminMsg::ResendRequest { .. } => b"2",
+            AdminMsg::SequenceReset { .. } => b"4",
+        };
+
+        let seq = match admin {
+            AdminMsg::Logon { seq, .. }
+            | AdminMsg::Logout { seq }
+            | AdminMsg::Heartbeat { seq, .. }
+            | AdminMsg::TestRequest { seq, .. }
+            | AdminMsg::ResendRequest { seq, .. }
+            | AdminMsg::SequenceReset { seq, .. } => seq,
+        };
+
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
+
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+
+        let (start, len) = {
+            let spare = self.writer.spare();
+            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+            fmt.field(34, &seq_buf[..seq_n]);
+            fmt.field(49, sender.as_bytes());
+            fmt.field(56, target.as_bytes());
+            fmt.field(52, &ts);
+
+            match admin {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                }
+                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
+                AdminMsg::Heartbeat {
+                    echo: Some((id, id_len)),
+                    ..
+                } => {
+                    fmt.field(112, &id[..id_len as usize]);
+                }
+                AdminMsg::TestRequest { id, .. } => {
+                    let mut buf = [0u8; 20];
+                    let n = encode_u64(id, &mut buf);
+                    fmt.field(112, &buf[..n]);
+                }
+                AdminMsg::ResendRequest { begin, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(begin, &mut buf);
+                    fmt.field(7, &buf[..n]);
+                    fmt.field(16, b"0");
+                }
+                AdminMsg::SequenceReset { new_seq, .. } => {
+                    fmt.field(43, b"Y");
+                    fmt.field(123, b"Y");
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(new_seq, &mut buf);
+                    fmt.field(36, &buf[..n]);
+                }
+            }
+
+            match fmt.finish() {
+                Ok(sl) => sl,
+                Err(_) => return,
+            }
+        };
+
+        self.writer.commit(start, len);
+    }
+
+    fn flush_writer(&mut self) -> Result<(), Error> {
+        while !self.writer.is_empty() {
+            let n = self.stream.write(self.writer.data())?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
+            }
+            self.writer.advance(n);
+        }
+        self.stream.flush()?;
+        Ok(())
+    }
+
+    fn do_resend(&mut self, begin: u32, end: u32, now: Instant) -> Result<(), Error> {
+        let mut items: Vec<ReplayItem> = Vec::new();
+        self.journal.resend_range(begin, end, |item| items.push(item));
+
+        for item in items {
+            match item {
+                ReplayItem::GapFill { seq, new_seq } => {
+                    self.encode_admin(AdminMsg::SequenceReset { seq, new_seq }, now);
+                }
+                ReplayItem::App(frame) => {
+                    if !self.writer.is_empty() {
+                        self.flush_writer()?;
+                    }
+                    write_all(&mut self.stream, &frame)?;
+                }
+            }
+        }
+
+        if !self.writer.is_empty() {
+            self.flush_writer()?;
+        }
+        Ok(())
+    }
+}
+
+fn is_timeout(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+    )
+}
+
+fn write_all<S: Write>(stream: &mut S, data: &[u8]) -> Result<(), Error> {
+    let mut offset = 0;
+    while offset < data.len() {
+        let n = stream.write(&data[offset..]).map_err(Error::Io)?;
+        if n == 0 {
+            return Err(Error::Io(io::Error::other("write returned 0")));
+        }
+        offset += n;
+    }
+    stream.flush().map_err(Error::Io)
+}
+
+fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
+    if v == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    let mut tmp = [0u8; 20];
+    let mut n = 0;
+    let mut x = v;
+    while x > 0 {
+        tmp[n] = b'0' + (x % 10) as u8;
+        x /= 10;
+        n += 1;
+    }
+    for i in 0..n {
+        out[i] = tmp[n - 1 - i];
+    }
+    n
+}

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -456,16 +456,18 @@ impl<S: Read + Write> FixConnection<S> {
         let target = self.config.target;
 
         {
-            let journal = &self.journal;
+            let iter = self.journal.resend(begin, end);
             let writer = &mut self.writer;
-            journal.resend_range(begin, end, |item| match item {
-                ReplayItem::GapFill { seq, new_seq } => {
-                    encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq);
+            for item in iter {
+                match item {
+                    ReplayItem::GapFill { seq, new_seq } => {
+                        encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq);
+                    }
+                    ReplayItem::App(orig) => {
+                        reframe_app(writer, orig, &ts, begin_string);
+                    }
                 }
-                ReplayItem::App(orig) => {
-                    reframe_app(writer, &orig, &ts, begin_string);
-                }
-            });
+            }
         }
 
         self.flush_writer()

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -243,7 +243,13 @@ impl<S: Read + Write> FixConnection<S> {
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
-        write_all(&mut self.stream, frame)
+        if self.writer.remaining() < frame.len() {
+            self.flush_writer()?;
+        }
+        let spare = self.writer.spare();
+        spare[..frame.len()].copy_from_slice(frame);
+        self.writer.commit(0, frame.len());
+        self.flush_writer()
     }
 
     pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
@@ -438,15 +444,7 @@ impl<S: Read + Write> FixConnection<S> {
     }
 
     fn flush_writer(&mut self) -> Result<(), Error> {
-        while !self.writer.is_empty() {
-            let n = self.stream.write(self.writer.data())?;
-            if n == 0 {
-                return Err(Error::Io(io::Error::other("write returned 0")));
-            }
-            self.writer.advance(n);
-        }
-        self.stream.flush()?;
-        Ok(())
+        flush_to(&mut self.stream, &mut self.writer)
     }
 
     fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
@@ -455,22 +453,31 @@ impl<S: Read + Write> FixConnection<S> {
         let sender = self.config.sender;
         let target = self.config.target;
 
-        {
-            let iter = self.journal.resend(begin, end);
-            let writer = &mut self.writer;
-            for item in iter {
+        let iter = self.journal.resend(begin, end);
+        let writer = &mut self.writer;
+        let stream = &mut self.stream;
+
+        for item in iter {
+            let ok = match &item {
+                ReplayItem::GapFill { seq, new_seq } => {
+                    encode_gap_fill(writer, begin_string, sender, target, &ts, *seq, *new_seq)
+                }
+                ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
+            };
+            if ok.is_err() {
+                flush_to(stream, writer)?;
                 match item {
                     ReplayItem::GapFill { seq, new_seq } => {
-                        encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq);
+                        encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq)
+                            .ok();
                     }
                     ReplayItem::App(orig) => {
-                        reframe_app(writer, orig, &ts, begin_string);
+                        reframe_app(writer, orig, &ts, begin_string).ok();
                     }
                 }
             }
         }
-
-        self.flush_writer()
+        flush_to(stream, writer)
     }
 }
 
@@ -484,6 +491,18 @@ fn make_ts() -> [u8; UTC_TIMESTAMP_LEN] {
     ts
 }
 
+fn flush_to<S: Write>(stream: &mut S, writer: &mut FrameWriter) -> Result<(), Error> {
+    while !writer.is_empty() {
+        let n = stream.write(writer.data())?;
+        if n == 0 {
+            return Err(Error::Io(io::Error::other("write returned 0")));
+        }
+        writer.advance(n);
+    }
+    stream.flush()?;
+    Ok(())
+}
+
 fn encode_gap_fill(
     writer: &mut FrameWriter,
     begin_string: &'static [u8],
@@ -492,7 +511,7 @@ fn encode_gap_fill(
     ts: &[u8],
     seq: u32,
     new_seq: u32,
-) {
+) -> Result<(), ()> {
     let spare = writer.spare();
     let mut seq_buf = [0u8; 10];
     let seq_n = encode_fix_uint(seq, &mut seq_buf);
@@ -506,12 +525,17 @@ fn encode_gap_fill(
     let mut nsq_buf = [0u8; 10];
     let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
     fmt.field(36, &nsq_buf[..nsq_n]);
-    if let Ok((start, len)) = fmt.finish() {
-        writer.commit(start, len);
-    }
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
 }
 
-fn reframe_app(writer: &mut FrameWriter, orig: &[u8], ts: &[u8], begin_string: &'static [u8]) {
+fn reframe_app(
+    writer: &mut FrameWriter,
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Result<(), ()> {
     let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
     let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
 
@@ -541,9 +565,9 @@ fn reframe_app(writer: &mut FrameWriter, orig: &[u8], ts: &[u8], begin_string: &
         }
     }
 
-    if let Ok((start, len)) = fmt.finish() {
-        writer.commit(start, len);
-    }
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
 }
 
 fn is_timeout(e: &io::Error) -> bool {
@@ -551,18 +575,6 @@ fn is_timeout(e: &io::Error) -> bool {
         e.kind(),
         io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
-}
-
-fn write_all<S: Write>(stream: &mut S, data: &[u8]) -> Result<(), Error> {
-    let mut offset = 0;
-    while offset < data.len() {
-        let n = stream.write(&data[offset..]).map_err(Error::Io)?;
-        if n == 0 {
-            return Err(Error::Io(io::Error::other("write returned 0")));
-        }
-        offset += n;
-    }
-    stream.flush().map_err(Error::Io)
 }
 
 fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -286,19 +286,17 @@ impl<S: Read + Write> FixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let sender_ok = find_tag(frame, 0, 49)
-            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
-        let target_ok = find_tag(frame, 0, 56)
-            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        let sender_ok =
+            find_tag(frame, 0, 49).is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok =
+            find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
         if !sender_ok || !target_ok {
             let out = self.state.on_comp_id_mismatch(now);
             self.flush_out(out, now)?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
         }
 
-        let seq = match find_tag(frame, 0, 34)
-            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-        {
+        let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
             Some(s) => s as u32,
             None => return Ok(None),
         };
@@ -321,7 +319,10 @@ impl<S: Read + Write> FixConnection<S> {
                     .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
                     .unwrap_or(false);
                 let was_logon_sent = self.state.state() == State::LogonSent;
-                (self.state.on_logon(seq, hbi, reset, !was_logon_sent, now), false)
+                (
+                    self.state.on_logon(seq, hbi, reset, !was_logon_sent, now),
+                    false,
+                )
             }
             b"5" => (self.state.on_logout(seq, poss_dup, now), false),
             b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
@@ -337,8 +338,7 @@ impl<S: Read + Write> FixConnection<S> {
                     .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
                     .unwrap_or(0) as u32;
                 (
-                    self.state
-                        .on_resend_request(seq, poss_dup, begin, end, now),
+                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
                     false,
                 )
             }
@@ -482,7 +482,8 @@ impl<S: Read + Write> FixConnection<S> {
 
     fn do_resend(&mut self, begin: u32, end: u32, now: Instant) -> Result<(), Error> {
         let mut items: Vec<ReplayItem> = Vec::new();
-        self.journal.resend_range(begin, end, |item| items.push(item));
+        self.journal
+            .resend_range(begin, end, |item| items.push(item));
 
         for item in items {
             match item {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -227,6 +227,10 @@ impl<S: Read + Write> FixConnection<S> {
         Ok(None)
     }
 
+    pub fn wants_read(&self) -> bool {
+        self.state.state() != State::Disconnected
+    }
+
     pub fn wants_write(&self) -> bool {
         !self.writer.is_empty()
     }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -466,9 +466,7 @@ impl<S: Read + Write> FixConnection<S> {
                     }
                     ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
                 };
-                retry.map_err(|_| {
-                    Error::FrameTooLarge(writer.remaining().saturating_add(1))
-                })?;
+                retry.map_err(|_| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
             }
         }
         flush_to(stream, writer)

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -3,27 +3,27 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use nexus_fix_codec::{
-    FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
+    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
+    parse_fix_uint,
 };
 
-use crate::frame::{FrameReader, FrameWriter};
-use crate::framework::SessionConfig;
+use crate::frame::{FrameError, FrameReader, FrameWriter};
+use crate::framework::{CompId, SessionConfig};
 use crate::persist::{FixJournal, ReplayItem};
 use crate::session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
 use crate::timestamp::{UTC_TIMESTAMP_LEN, format_utc_timestamp};
 
-const POLL_INTERVAL: Duration = Duration::from_millis(100);
-
-/// Error from [`FixConnection`] operations.
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
+    FrameTooLarge(usize),
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(e) => write!(f, "I/O: {e}"),
+            Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
         }
     }
 }
@@ -36,15 +36,6 @@ impl From<io::Error> for Error {
     }
 }
 
-/// Synchronous TCP driver for a sans-IO FIX session.
-///
-/// Owns a socket, a [`FrameReader`]/[`FrameWriter`] pair, a [`SessionState`],
-/// and a [`FixJournal`]. The read loop fires [`SessionState`] handlers,
-/// encodes outbound admin messages, drives gap-fill replay from the journal
-/// on `Event::ResendRange`, and delivers in-sequence application frames to
-/// the caller via the `on_app` callback in [`run`](Self::run).
-///
-/// Mirrors the pattern used by `nexus-web`'s `Client<S>`.
 pub struct FixConnection<S> {
     stream: S,
     reader: FrameReader,
@@ -53,10 +44,8 @@ pub struct FixConnection<S> {
     journal: FixJournal,
     config: SessionConfig,
     begin_string: &'static [u8],
-    initiator: bool,
 }
 
-/// Builder for [`FixConnection`].
 pub struct FixConnectionBuilder {
     reader_cap: usize,
     writer_cap: usize,
@@ -85,9 +74,6 @@ impl FixConnectionBuilder {
         self
     }
 
-    /// Connect to `addr` and return an initiator-mode [`FixConnection`].
-    ///
-    /// Sets `TCP_NODELAY` and a 100 ms read timeout for timer polling.
     pub fn connect<A: ToSocketAddrs>(
         self,
         addr: A,
@@ -107,7 +93,6 @@ impl FixConnectionBuilder {
             None => TcpStream::connect(addr)?,
         };
         stream.set_nodelay(self.nodelay)?;
-        stream.set_read_timeout(Some(POLL_INTERVAL))?;
         Ok(FixConnection {
             stream,
             reader: FrameReader::builder()
@@ -120,14 +105,9 @@ impl FixConnectionBuilder {
             journal,
             config,
             begin_string,
-            initiator: true,
         })
     }
 
-    /// Wrap an already-connected stream as an acceptor-mode [`FixConnection`].
-    ///
-    /// The caller is responsible for applying socket options (nodelay, read
-    /// timeout) before calling this.
     pub fn accept<S: Read + Write>(
         self,
         stream: S,
@@ -148,7 +128,6 @@ impl FixConnectionBuilder {
             journal,
             config,
             begin_string,
-            initiator: false,
         }
     }
 }
@@ -165,14 +144,12 @@ impl FixConnection<TcpStream> {
 }
 
 impl<S: Read + Write> FixConnection<S> {
-    /// Construct from pre-built parts (useful for testing).
     pub fn from_parts(
         stream: S,
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
         begin_string: &'static [u8],
-        initiator: bool,
     ) -> Self {
         Self {
             stream,
@@ -182,7 +159,6 @@ impl<S: Read + Write> FixConnection<S> {
             journal,
             config,
             begin_string,
-            initiator,
         }
     }
 
@@ -194,87 +170,81 @@ impl<S: Read + Write> FixConnection<S> {
         &mut self.state
     }
 
-    /// Allocate the next outbound sequence number for an app message.
     pub fn allocate_seq(&mut self) -> u32 {
         self.state.allocate_seq(Instant::now())
     }
 
-    /// Store `frame` in the journal under `seq` and write it to the stream.
-    ///
-    /// The caller must have pre-encoded the complete FIX frame (including
-    /// `MsgSeqNum(34)=seq`) and must have obtained `seq` via
-    /// [`allocate_seq`](Self::allocate_seq).
+    pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.connect(now);
+        self.flush_out(out)
+    }
+
+    pub fn recv<H>(
+        &mut self,
+        now: Instant,
+        on_app: &mut H,
+    ) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let spare = self.reader.spare();
+        let n = match self.stream.read(spare) {
+            Ok(0) => return Ok(Some(DisconnectReason::Logout)),
+            Ok(n) => n,
+            Err(e) if is_timeout(&e) => {
+                let out = self.state.on_timeout(now);
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    self.flush_out(out)?;
+                    return Ok(Some(reason));
+                }
+                self.flush_out(out)?;
+                return Ok(None);
+            }
+            Err(e) => return Err(Error::Io(e)),
+        };
+        self.reader.filled(n);
+
+        loop {
+            match self.reader.next() {
+                Ok(Some(frame)) => {
+                    let frame = frame.to_vec();
+                    if let Some(reason) = self.dispatch(&frame, now, on_app)? {
+                        return Ok(Some(reason));
+                    }
+                }
+                Ok(None) => break,
+                Err(FrameError::MessageTooLarge { size }) => {
+                    return Err(Error::FrameTooLarge(size));
+                }
+                Err(FrameError::Garbage { .. }) => {}
+            }
+        }
+
+        if self.reader.should_compact() {
+            self.reader.compact();
+        }
+
+        Ok(None)
+    }
+
+    pub fn wants_write(&self) -> bool {
+        !self.writer.is_empty()
+    }
+
+    pub fn flush(&mut self) -> Result<(), Error> {
+        self.flush_writer()
+    }
+
     pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
-        write_all(&mut self.stream, frame)?;
-        Ok(())
+        write_all(&mut self.stream, frame)
     }
 
-    /// Initiate a clean logout and flush the Logout message.
-    pub fn logout(&mut self) -> Result<(), Error> {
-        let now = Instant::now();
+    pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
         let out = self.state.logout(now);
-        self.flush_out(out, now)
-    }
-
-    /// Drive the session loop until the session disconnects.
-    ///
-    /// If `initiator`, sends a Logon before entering the read loop.
-    /// Calls `on_app` for each in-sequence application message frame.
-    /// Admin messages and timers are handled internally.
-    ///
-    /// Returns the disconnect reason on a clean or protocol-level disconnect.
-    /// Returns `Err` on unrecoverable I/O failure.
-    pub fn run<H>(&mut self, mut on_app: H) -> Result<DisconnectReason, Error>
-    where
-        H: FnMut(&[u8]),
-    {
-        if self.initiator {
-            let now = Instant::now();
-            let out = self.state.connect(now);
-            self.flush_out(out, now)?;
-        }
-
-        loop {
-            // Read bytes into the frame reader's spare region.
-            let spare = self.reader.spare();
-            let n = match self.stream.read(spare) {
-                Ok(0) => return Ok(DisconnectReason::Logout),
-                Ok(n) => n,
-                Err(e) if is_timeout(&e) => {
-                    let now = Instant::now();
-                    let out = self.state.on_timeout(now);
-                    if let Some(Event::Disconnected { reason }) = out.event() {
-                        self.flush_out(out, now)?;
-                        return Ok(reason);
-                    }
-                    self.flush_out(out, now)?;
-                    continue;
-                }
-                Err(e) => return Err(Error::Io(e)),
-            };
-            self.reader.filled(n);
-
-            // Drain complete FIX messages from the buffer.
-            loop {
-                match self.reader.next() {
-                    Ok(Some(frame)) => {
-                        let frame = frame.to_vec();
-                        let now = Instant::now();
-                        if let Some(reason) = self.dispatch(&frame, now, &mut on_app)? {
-                            return Ok(reason);
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(_) => {}
-                }
-            }
-            if self.reader.should_compact() {
-                self.reader.compact();
-            }
-        }
+        self.flush_out(out)
     }
 
     fn dispatch<H>(
@@ -292,7 +262,7 @@ impl<S: Read + Write> FixConnection<S> {
             find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
         if !sender_ok || !target_ok {
             let out = self.state.on_comp_id_mismatch(now);
-            self.flush_out(out, now)?;
+            self.flush_out(out)?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
         }
 
@@ -363,11 +333,11 @@ impl<S: Read + Write> FixConnection<S> {
             _ => (self.state.on_app(seq, poss_dup, now), true),
         };
 
-        self.flush_out(out, now)?;
+        self.flush_out(out)?;
 
         match out.event() {
             Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
-            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end, now)?,
+            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end)?,
             Some(Event::App { .. }) if is_app => on_app(frame),
             _ => {}
         }
@@ -375,9 +345,9 @@ impl<S: Read + Write> FixConnection<S> {
         Ok(None)
     }
 
-    fn flush_out(&mut self, out: Out, now: Instant) -> Result<(), Error> {
+    fn flush_out(&mut self, out: Out) -> Result<(), Error> {
         for admin in out.admin_messages() {
-            self.encode_admin(admin, now);
+            self.encode_admin(admin);
         }
         if !self.writer.is_empty() {
             self.flush_writer()?;
@@ -385,13 +355,8 @@ impl<S: Read + Write> FixConnection<S> {
         Ok(())
     }
 
-    fn encode_admin(&mut self, admin: AdminMsg, _now: Instant) {
-        let unix_nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as i128;
-        let mut ts = [0u8; UTC_TIMESTAMP_LEN];
-        format_utc_timestamp(unix_nanos, &mut ts);
+    fn encode_admin(&mut self, admin: AdminMsg) {
+        let ts = make_ts();
 
         let msg_type: &[u8] = match admin {
             AdminMsg::Logon { .. } => b"A",
@@ -480,29 +445,98 @@ impl<S: Read + Write> FixConnection<S> {
         Ok(())
     }
 
-    fn do_resend(&mut self, begin: u32, end: u32, now: Instant) -> Result<(), Error> {
-        let mut items: Vec<ReplayItem> = Vec::new();
-        self.journal
-            .resend_range(begin, end, |item| items.push(item));
+    fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
+        let ts = make_ts();
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
 
-        for item in items {
-            match item {
+        {
+            let journal = &self.journal;
+            let writer = &mut self.writer;
+            journal.resend_range(begin, end, |item| match item {
                 ReplayItem::GapFill { seq, new_seq } => {
-                    self.encode_admin(AdminMsg::SequenceReset { seq, new_seq }, now);
+                    encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq);
                 }
-                ReplayItem::App(frame) => {
-                    if !self.writer.is_empty() {
-                        self.flush_writer()?;
-                    }
-                    write_all(&mut self.stream, &frame)?;
+                ReplayItem::App(orig) => {
+                    reframe_app(writer, &orig, &ts, begin_string);
                 }
-            }
+            });
         }
 
-        if !self.writer.is_empty() {
-            self.flush_writer()?;
+        self.flush_writer()
+    }
+}
+
+fn make_ts() -> [u8; UTC_TIMESTAMP_LEN] {
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i128;
+    let mut ts = [0u8; UTC_TIMESTAMP_LEN];
+    format_utc_timestamp(unix_nanos, &mut ts);
+    ts
+}
+
+fn encode_gap_fill(
+    writer: &mut FrameWriter,
+    begin_string: &'static [u8],
+    sender: CompId,
+    target: CompId,
+    ts: &[u8],
+    seq: u32,
+    new_seq: u32,
+) {
+    let spare = writer.spare();
+    let mut seq_buf = [0u8; 10];
+    let seq_n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
+    fmt.field(34, &seq_buf[..seq_n]);
+    fmt.field(49, sender.as_bytes());
+    fmt.field(56, target.as_bytes());
+    fmt.field(52, ts);
+    fmt.field(43, b"Y");
+    fmt.field(123, b"Y");
+    let mut nsq_buf = [0u8; 10];
+    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
+    fmt.field(36, &nsq_buf[..nsq_n]);
+    if let Ok((start, len)) = fmt.finish() {
+        writer.commit(start, len);
+    }
+}
+
+fn reframe_app(writer: &mut FrameWriter, orig: &[u8], ts: &[u8], begin_string: &'static [u8]) {
+    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
+    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
+
+    let spare = writer.spare();
+    let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(orig, 0) {
+        match field.tag {
+            8 | 9 | 10 | 35 | 43 | 122 => {}
+            52 => {
+                fmt.field(52, ts);
+                fmt.field(43, b"Y");
+                if let Some(t) = orig_time {
+                    fmt.field(122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => fmt.field(field.tag, field.value.slice(orig)),
         }
-        Ok(())
+    }
+
+    if !poss_dup_done {
+        fmt.field(43, b"Y");
+        if let Some(t) = orig_time {
+            fmt.field(122, t);
+        }
+    }
+
+    if let Ok((start, len)) = fmt.finish() {
+        writer.commit(start, len);
     }
 }
 

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -243,13 +243,7 @@ impl<S: Read + Write> FixConnection<S> {
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
-        if self.writer.remaining() < frame.len() {
-            self.flush_writer()?;
-        }
-        let spare = self.writer.spare();
-        spare[..frame.len()].copy_from_slice(frame);
-        self.writer.commit(0, frame.len());
-        self.flush_writer()
+        write_through(&mut self.stream, &mut self.writer, frame)
     }
 
     pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
@@ -466,15 +460,15 @@ impl<S: Read + Write> FixConnection<S> {
             };
             if ok.is_err() {
                 flush_to(stream, writer)?;
-                match item {
+                let retry = match item {
                     ReplayItem::GapFill { seq, new_seq } => {
                         encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq)
-                            .ok();
                     }
-                    ReplayItem::App(orig) => {
-                        reframe_app(writer, orig, &ts, begin_string).ok();
-                    }
-                }
+                    ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
+                };
+                retry.map_err(|_| {
+                    Error::FrameTooLarge(writer.remaining().saturating_add(1))
+                })?;
             }
         }
         flush_to(stream, writer)
@@ -501,6 +495,34 @@ fn flush_to<S: Write>(stream: &mut S, writer: &mut FrameWriter) -> Result<(), Er
     }
     stream.flush()?;
     Ok(())
+}
+
+fn write_through<S: Write>(
+    stream: &mut S,
+    writer: &mut FrameWriter,
+    frame: &[u8],
+) -> Result<(), Error> {
+    if writer.remaining() < frame.len() {
+        flush_to(stream, writer)?;
+    }
+    if writer.remaining() >= frame.len() {
+        let spare = writer.spare();
+        spare[..frame.len()].copy_from_slice(frame);
+        writer.commit(0, frame.len());
+    } else {
+        // frame exceeds writer capacity — write directly (writer is empty after flush)
+        let mut off = 0;
+        while off < frame.len() {
+            let n = stream.write(&frame[off..]).map_err(Error::Io)?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
+            }
+            off += n;
+        }
+        stream.flush().map_err(Error::Io)?;
+        return Ok(());
+    }
+    flush_to(stream, writer)
 }
 
 fn encode_gap_fill(

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -37,7 +37,11 @@ fn loopback_pair() -> (TcpStream, TcpStream) {
 
 fn tmp_dir(suffix: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
-    p.push(format!("nexus_fix_transport_{}_{}", std::process::id(), suffix));
+    p.push(format!(
+        "nexus_fix_transport_{}_{}",
+        std::process::id(),
+        suffix
+    ));
     std::fs::create_dir_all(&p).unwrap();
     p
 }
@@ -52,7 +56,9 @@ struct Peer {
 
 impl Peer {
     fn new(stream: TcpStream, sender: CompId, target: CompId) -> Self {
-        stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
         Self {
             stream,
             sender,

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -1,0 +1,263 @@
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, FixConnection, FixJournal, SessionConfig, SessionState,
+};
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn sender() -> CompId {
+    CompId::new(b"INITIATOR").unwrap()
+}
+fn target() -> CompId {
+    CompId::new(b"ACCEPTOR").unwrap()
+}
+
+fn session_cfg(sender: CompId, target: CompId) -> SessionConfig {
+    SessionConfig { sender, target }
+}
+
+fn journal(dir: &PathBuf) -> FixJournal {
+    FixJournal::open(dir, 256).unwrap()
+}
+
+fn loopback_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = TcpStream::connect(addr).unwrap();
+    let (server, _) = listener.accept().unwrap();
+    (client, server)
+}
+
+fn tmp_dir(suffix: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("nexus_fix_transport_{}_{}", std::process::id(), suffix));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Minimal FIX peer that can send/receive raw frames.
+struct Peer {
+    stream: TcpStream,
+    sender: CompId,
+    target: CompId,
+    next_out: u32,
+}
+
+impl Peer {
+    fn new(stream: TcpStream, sender: CompId, target: CompId) -> Self {
+        stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        Self {
+            stream,
+            sender,
+            target,
+            next_out: 1,
+        }
+    }
+
+    fn send_logon(&mut self, hbi: u32) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 512];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut hbi_buf = [0u8; 10];
+        let hbi_n = encode_fix_uint(hbi, &mut hbi_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"A");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(108, &hbi_buf[..hbi_n]);
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn send_logout(&mut self) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 256];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"5");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn send_app(&mut self, extra_tag: u32, extra_val: &[u8]) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 512];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(extra_tag, extra_val);
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn recv_msg(&mut self, buf: &mut [u8]) -> usize {
+        self.stream.read(buf).unwrap()
+    }
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn initiator_logon_and_logout() {
+    let dir = tmp_dir("logon_logout");
+    let (client_sock, server_sock) = loopback_pair();
+    client_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let t_sender = sender();
+    let t_target = target();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(server_sock, target(), sender());
+        let mut buf = [0u8; 512];
+        // read logon from initiator
+        let n = peer.recv_msg(&mut buf);
+        assert!(n > 0);
+        // reply with logon then immediately logout (no HB wait needed)
+        peer.send_logon(30);
+        peer.send_logout();
+        // absorb the initiator's logout reply
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut conn = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(t_sender, t_target),
+        journal(&dir),
+        b"FIX.4.4",
+        true, // initiator
+    );
+
+    let reason = conn.run(|_| {}).unwrap();
+    assert_eq!(reason, DisconnectReason::Logout);
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn acceptor_receives_app_message() {
+    let dir = tmp_dir("acceptor_app");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        // initiate the session from the peer side
+        peer.send_logon(30);
+        // absorb the acceptor's logon reply
+        let mut buf = [0u8; 512];
+        let _ = peer.recv_msg(&mut buf);
+        // send an app message
+        peer.send_app(11, b"ORD-1");
+        // send logout
+        peer.send_logout();
+        // absorb logout reply
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut received: Vec<Vec<u8>> = Vec::new();
+    let dir2 = tmp_dir("acceptor_app_srv");
+    let mut conn = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir2),
+        b"FIX.4.4",
+        false, // acceptor
+    );
+
+    let reason = conn.run(|frame| received.push(frame.to_vec())).unwrap();
+    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(received.len(), 1);
+    assert!(received[0].starts_with(b"8=FIX.4.4"));
+
+    handle.join().unwrap();
+    let _ = dir;
+}
+
+#[test]
+fn resend_request_triggers_gap_fill() {
+    let dir_srv = tmp_dir("resend_srv");
+    let dir_cli = tmp_dir("resend_cli");
+    let (client_sock, server_sock) = loopback_pair();
+    client_sock
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+
+    // The server side will pre-store app messages 2..=3 in its journal,
+    // then send a ResendRequest to the client, and verify it gets replayed.
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(server_sock, target(), sender());
+        let mut buf = [0u8; 4096];
+
+        // read logon
+        let _ = peer.recv_msg(&mut buf);
+        // reply logon
+        peer.send_logon(30);
+
+        // send resend request for seqs 2..=3
+        let mut rbuf = [0u8; 256];
+        let mut fmt = FrameFormatter::new(&mut rbuf, b"FIX.4.4", b"2");
+        fmt.field(34, b"2");
+        fmt.field(49, b"ACCEPTOR");
+        fmt.field(56, b"INITIATOR");
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(7, b"2");
+        fmt.field(16, b"3");
+        let (start, len) = fmt.finish().unwrap();
+        peer.stream.write_all(&rbuf[start..start + len]).unwrap();
+        peer.stream.flush().unwrap();
+        peer.next_out = 3; // ResendRequest consumed seq 2
+
+        // read the gap-fill SequenceReset reply
+        let n = peer.recv_msg(&mut buf);
+        assert!(n > 0);
+
+        peer.send_logout();
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut conn = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(sender(), target()),
+        journal(&dir_cli),
+        b"FIX.4.4",
+        true,
+    );
+
+    // initiator sends logon (seq 1), so next_out is 2 after logon
+    // seqs 2 and 3 were never stored → gap-fill expected
+    let reason = conn.run(|_| {}).unwrap();
+    assert_eq!(reason, DisconnectReason::Logout);
+
+    handle.join().unwrap();
+    let _ = dir_srv;
+}

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -3,11 +3,12 @@
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
 use nexus_fix_engine::{
     CompId, DisconnectReason, FixConnection, FixJournal, SessionConfig, SessionState,
+    TransportError,
 };
 
 // ── helpers ─────────────────────────────────────────────────────────────────
@@ -44,6 +45,21 @@ fn tmp_dir(suffix: &str) -> PathBuf {
     ));
     std::fs::create_dir_all(&p).unwrap();
     p
+}
+
+/// Drive a `FixConnection` to completion, calling `on_app` for each app frame.
+fn drive<H>(
+    conn: &mut FixConnection<TcpStream>,
+    mut on_app: H,
+) -> Result<DisconnectReason, TransportError>
+where
+    H: FnMut(&[u8]),
+{
+    loop {
+        if let Some(reason) = conn.recv(Instant::now(), &mut on_app)? {
+            return Ok(reason);
+        }
+    }
 }
 
 /// Minimal FIX peer that can send/receive raw frames.
@@ -143,7 +159,7 @@ fn initiator_logon_and_logout() {
         // read logon from initiator
         let n = peer.recv_msg(&mut buf);
         assert!(n > 0);
-        // reply with logon then immediately logout (no HB wait needed)
+        // reply with logon then immediately logout
         peer.send_logon(30);
         peer.send_logout();
         // absorb the initiator's logout reply
@@ -156,10 +172,10 @@ fn initiator_logon_and_logout() {
         session_cfg(t_sender, t_target),
         journal(&dir),
         b"FIX.4.4",
-        true, // initiator
     );
+    conn.connect(Instant::now()).unwrap();
 
-    let reason = conn.run(|_| {}).unwrap();
+    let reason = drive(&mut conn, |_| {}).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
 
     handle.join().unwrap();
@@ -175,14 +191,11 @@ fn acceptor_receives_app_message() {
 
     let handle = std::thread::spawn(move || {
         let mut peer = Peer::new(client_sock, sender(), target());
-        // initiate the session from the peer side
         peer.send_logon(30);
-        // absorb the acceptor's logon reply
         let mut buf = [0u8; 512];
+        // absorb the acceptor's logon reply
         let _ = peer.recv_msg(&mut buf);
-        // send an app message
         peer.send_app(11, b"ORD-1");
-        // send logout
         peer.send_logout();
         // absorb logout reply
         let _ = peer.recv_msg(&mut buf);
@@ -196,10 +209,9 @@ fn acceptor_receives_app_message() {
         session_cfg(target(), sender()),
         journal(&dir2),
         b"FIX.4.4",
-        false, // acceptor
     );
 
-    let reason = conn.run(|frame| received.push(frame.to_vec())).unwrap();
+    let reason = drive(&mut conn, |frame| received.push(frame.to_vec())).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
     assert_eq!(received.len(), 1);
     assert!(received[0].starts_with(b"8=FIX.4.4"));
@@ -217,8 +229,6 @@ fn resend_request_triggers_gap_fill() {
         .set_read_timeout(Some(Duration::from_millis(500)))
         .unwrap();
 
-    // The server side will pre-store app messages 2..=3 in its journal,
-    // then send a ResendRequest to the client, and verify it gets replayed.
     let handle = std::thread::spawn(move || {
         let mut peer = Peer::new(server_sock, target(), sender());
         let mut buf = [0u8; 4096];
@@ -240,7 +250,7 @@ fn resend_request_triggers_gap_fill() {
         let (start, len) = fmt.finish().unwrap();
         peer.stream.write_all(&rbuf[start..start + len]).unwrap();
         peer.stream.flush().unwrap();
-        peer.next_out = 3; // ResendRequest consumed seq 2
+        peer.next_out = 3;
 
         // read the gap-fill SequenceReset reply
         let n = peer.recv_msg(&mut buf);
@@ -256,12 +266,11 @@ fn resend_request_triggers_gap_fill() {
         session_cfg(sender(), target()),
         journal(&dir_cli),
         b"FIX.4.4",
-        true,
     );
+    conn.connect(Instant::now()).unwrap();
 
-    // initiator sends logon (seq 1), so next_out is 2 after logon
     // seqs 2 and 3 were never stored → gap-fill expected
-    let reason = conn.run(|_| {}).unwrap();
+    let reason = drive(&mut conn, |_| {}).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
 
     handle.join().unwrap();

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -11,8 +11,6 @@ use nexus_fix_engine::{
     TransportError,
 };
 
-// ── helpers ─────────────────────────────────────────────────────────────────
-
 fn sender() -> CompId {
     CompId::new(b"INITIATOR").unwrap()
 }
@@ -47,7 +45,6 @@ fn tmp_dir(suffix: &str) -> PathBuf {
     p
 }
 
-/// Drive a `FixConnection` to completion, calling `on_app` for each app frame.
 fn drive<H>(
     conn: &mut FixConnection<TcpStream>,
     mut on_app: H,
@@ -62,7 +59,6 @@ where
     }
 }
 
-/// Minimal FIX peer that can send/receive raw frames.
 struct Peer {
     stream: TcpStream,
     sender: CompId,
@@ -140,8 +136,6 @@ impl Peer {
     }
 }
 
-// ── tests ────────────────────────────────────────────────────────────────────
-
 #[test]
 fn initiator_logon_and_logout() {
     let dir = tmp_dir("logon_logout");
@@ -156,13 +150,10 @@ fn initiator_logon_and_logout() {
     let handle = std::thread::spawn(move || {
         let mut peer = Peer::new(server_sock, target(), sender());
         let mut buf = [0u8; 512];
-        // read logon from initiator
         let n = peer.recv_msg(&mut buf);
         assert!(n > 0);
-        // reply with logon then immediately logout
         peer.send_logon(30);
         peer.send_logout();
-        // absorb the initiator's logout reply
         let _ = peer.recv_msg(&mut buf);
     });
 
@@ -193,11 +184,9 @@ fn acceptor_receives_app_message() {
         let mut peer = Peer::new(client_sock, sender(), target());
         peer.send_logon(30);
         let mut buf = [0u8; 512];
-        // absorb the acceptor's logon reply
         let _ = peer.recv_msg(&mut buf);
         peer.send_app(11, b"ORD-1");
         peer.send_logout();
-        // absorb logout reply
         let _ = peer.recv_msg(&mut buf);
     });
 
@@ -233,12 +222,9 @@ fn resend_request_triggers_gap_fill() {
         let mut peer = Peer::new(server_sock, target(), sender());
         let mut buf = [0u8; 4096];
 
-        // read logon
         let _ = peer.recv_msg(&mut buf);
-        // reply logon
         peer.send_logon(30);
 
-        // send resend request for seqs 2..=3
         let mut rbuf = [0u8; 256];
         let mut fmt = FrameFormatter::new(&mut rbuf, b"FIX.4.4", b"2");
         fmt.field(34, b"2");
@@ -252,7 +238,6 @@ fn resend_request_triggers_gap_fill() {
         peer.stream.flush().unwrap();
         peer.next_out = 3;
 
-        // read the gap-fill SequenceReset reply
         let n = peer.recv_msg(&mut buf);
         assert!(n > 0);
 
@@ -269,7 +254,6 @@ fn resend_request_triggers_gap_fill() {
     );
     conn.connect(Instant::now()).unwrap();
 
-    // seqs 2 and 3 were never stored → gap-fill expected
     let reason = drive(&mut conn, |_| {}).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
 


### PR DESCRIPTION
## Summary

- Add `transport.rs`: `FixConnection<S>` drives the sans-IO `SessionState` over any `Read + Write` stream
- Encode all admin messages (`Logon`, `Logout`, `Heartbeat`, `TestRequest`, `ResendRequest`, `SequenceReset`) via `FrameFormatter`
- Timer polling via 100 ms read timeout; `on_timeout()` fires heartbeats and test-request probes
- ResendRange events drive `FixJournal::resend_range`; gap-fills encoded as `SequenceReset(GapFillFlag=Y)`, app replays written raw
- `FixConnectionBuilder` provides `connect(addr, …)` (initiator) and `accept(stream, …)` (acceptor) constructors
- `send_app(seq, frame)` stores in journal and flushes to socket
- Wire up `mod timestamp` (previously orphan file)
- 3 integration tests covering initiator logon+logout, acceptor app-message delivery, and resend-request gap-fill

## Test plan

- [ ] `cargo test -p nexus-fix-engine` — all 79 tests pass (43 unit + 9 framework + 24 session + 3 transport)
- [ ] `cargo clippy -p nexus-fix-engine --tests` — clean
- [ ] CI lint/build/test