### PR TITLE
feat(stats)!: time-aware types should take integer timestamps (deprecate f64-timestamp variants) (#505)

### DIFF
--- a/nexus-stats-control/CHANGELOG.md
+++ b/nexus-stats-control/CHANGELOG.md
@@ -8,6 +8,17 @@ with the project-specific allowance that a minor bump may carry small,
 narrowly-scoped breaking changes when external blast radius is
 contained.
 
+## [Unreleased]
+
+### Removed
+
+- **`DecayAccumF64`** — f64 timestamps cause silent precision loss past 2^52; replaced by `DecayAccumU64` and `DecayAccumI64`.
+
+### Added 
+
+- **`DecayAccumU64`** — decaying accumulator with `u64` timestamps.
+- **`DecayAccumI64`** — decaying accumulator with `i64` timestamps.
+
 ## [2.0.0] — 2026-05-28
 
 ### Removed

--- a/nexus-stats-control/src/frequency/decay_accum.rs
+++ b/nexus-stats-control/src/frequency/decay_accum.rs
@@ -8,14 +8,14 @@
 /// - "How active has this been recently?"
 /// - Rate limiting with smooth backoff
 #[derive(Debug, Clone)]
-pub struct DecayAccumF64 {
+pub struct DecayAccumU64 {
     score: f64,
-    last_time: f64,
+    last_time: u64,
     decay_constant: f64, // ln(2) / half_life
     initialized: bool,
 }
 
-impl DecayAccumF64 {
+impl DecayAccumU64 {
     /// Creates a new decaying accumulator with the given half-life.
     ///
     /// `half_life` is in the same time units as the timestamps passed to
@@ -30,7 +30,7 @@ impl DecayAccumF64 {
         }
         Ok(Self {
             score: 0.0,
-            last_time: 0.0,
+            last_time: 0,
             decay_constant: core::f64::consts::LN_2 / half_life,
             initialized: false,
         })
@@ -47,10 +47,9 @@ impl DecayAccumF64 {
     #[inline]
     pub fn update(
         &mut self,
-        timestamp: f64,
+        timestamp: u64,
         weight: f64,
     ) -> Result<(), nexus_stats_core::DataError> {
-        check_finite!(timestamp);
         check_finite!(weight);
         self.apply_decay(timestamp);
         self.score += weight;
@@ -60,13 +59,102 @@ impl DecayAccumF64 {
     /// Queries the current decayed score at the given timestamp.
     #[inline]
     #[must_use]
-    pub fn score(&mut self, now: f64) -> f64 {
+    pub fn score(&mut self, now: u64) -> f64 {
         self.apply_decay(now);
         self.score
     }
 
     #[inline]
-    fn apply_decay(&mut self, timestamp: f64) {
+    fn apply_decay(&mut self, timestamp: u64) {
+        if !self.initialized {
+            self.last_time = timestamp;
+            self.initialized = true;
+            return;
+        }
+
+        let dt = (timestamp.wrapping_sub(self.last_time) as i64) as f64;
+        if dt > 0.0 {
+            self.score *= nexus_stats_core::math::exp(-self.decay_constant * dt);
+            self.last_time = timestamp;
+        }
+    }
+
+    /// Resets to zero score.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.score = 0.0;
+        self.initialized = false;
+    }
+}
+
+/// Decaying accumulator — event-driven score with exponential decay.
+///
+/// Lazy evaluation: only computes decay when `update()` or `score()` is called.
+/// Between calls, no work is done.
+///
+/// # Use Cases
+/// - Weighted event scoring with temporal decay
+/// - "How active has this been recently?"
+/// - Rate limiting with smooth backoff
+#[derive(Debug, Clone)]
+pub struct DecayAccumI64 {
+    score: f64,
+    last_time: i64,
+    decay_constant: f64, // ln(2) / half_life
+    initialized: bool,
+}
+
+impl DecayAccumI64 {
+    /// Creates a new decaying accumulator with the given half-life.
+    ///
+    /// `half_life` is in the same time units as the timestamps passed to
+    /// `update()` and `score()`.
+    #[inline]
+    pub fn new(half_life: f64) -> Result<Self, nexus_stats_core::ConfigError> {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(half_life > 0.0) {
+            return Err(nexus_stats_core::ConfigError::Invalid(
+                "half_life must be positive",
+            ));
+        }
+        Ok(Self {
+            score: 0.0,
+            last_time: 0,
+            decay_constant: core::f64::consts::LN_2 / half_life,
+            initialized: false,
+        })
+    }
+
+    /// Updates with a weighted event at the given timestamp.
+    ///
+    /// Applies decay from the last event/query before adding.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::NotANumber` if either argument is NaN, or
+    /// `DataError::Infinite` if either argument is infinite.
+    #[inline]
+    pub fn update(
+        &mut self,
+        timestamp: i64,
+        weight: f64,
+    ) -> Result<(), nexus_stats_core::DataError> {
+        check_finite!(weight);
+        self.apply_decay(timestamp);
+        self.score += weight;
+        Ok(())
+    }
+
+    /// Queries the current decayed score at the given timestamp.
+    #[inline]
+    #[must_use]
+    pub fn score(&mut self, now: i64) -> f64 {
+        self.apply_decay(now);
+        self.score
+    }
+
+    #[inline]
+    fn apply_decay(&mut self, timestamp: i64) {
         if !self.initialized {
             self.last_time = timestamp;
             self.initialized = true;
@@ -74,6 +162,7 @@ impl DecayAccumF64 {
         }
 
         let dt = timestamp - self.last_time;
+        let dt = dt as f64;
         if dt > 0.0 {
             self.score *= nexus_stats_core::math::exp(-self.decay_constant * dt);
             self.last_time = timestamp;
@@ -93,26 +182,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn accumulates() {
-        let mut da = DecayAccumF64::new(10.0).unwrap();
-        da.update(0.0, 1.0).unwrap();
-        da.update(0.0, 1.0).unwrap();
-        let s = da.score(0.0);
+    fn accumulates_u64() {
+        let mut da = DecayAccumU64::new(10.0).unwrap();
+        da.update(0, 1.0).unwrap();
+        da.update(0, 1.0).unwrap();
+        let s = da.score(0);
         assert!((s - 2.0).abs() < 1e-10);
     }
 
     #[test]
-    fn decays_over_time() {
-        let mut da = DecayAccumF64::new(10.0).unwrap();
-        da.update(0.0, 100.0).unwrap();
+    fn decays_over_time_u64() {
+        let mut da = DecayAccumU64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
 
-        let s = da.score(10.0); // one half-life
+        let s = da.score(10); // one half-life
         assert!(
             (s - 50.0).abs() < 1.0,
             "should be ~50 after one half-life, got {s}"
         );
 
-        let s = da.score(20.0); // two half-lives
+        let s = da.score(20); // two half-lives
         assert!(
             (s - 25.0).abs() < 1.0,
             "should be ~25 after two half-lives, got {s}"
@@ -120,44 +209,113 @@ mod tests {
     }
 
     #[test]
-    fn lazy_evaluation() {
-        let mut da = DecayAccumF64::new(10.0).unwrap();
-        da.update(0.0, 100.0).unwrap();
+    fn lazy_evaluation_u64() {
+        let mut da = DecayAccumU64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
         // No work done between calls
-        da.update(5.0, 50.0).unwrap(); // decays 100 by 5 time units, adds 50
+        da.update(5, 50.0).unwrap(); // decays 100 by 5 time units, adds 50
 
-        let s = da.score(5.0);
+        let s = da.score(5);
         // After 5 units: 100 * exp(-ln2/10 * 5) + 50 ≈ 100 * 0.707 + 50 ≈ 120.7
         assert!(s > 100.0 && s < 130.0, "score should be ~120, got {s}");
     }
 
     #[test]
-    fn reset() {
-        let mut da = DecayAccumF64::new(10.0).unwrap();
-        da.update(0.0, 100.0).unwrap();
+    fn reset_u64() {
+        let mut da = DecayAccumU64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
         da.reset();
-        let s = da.score(0.0);
+        let s = da.score(0);
         assert!((s).abs() < 1e-10);
     }
 
     #[test]
-    fn rejects_zero_half_life() {
+    fn rejects_zero_half_life_u64() {
         assert!(matches!(
-            DecayAccumF64::new(0.0),
+            DecayAccumU64::new(0.0),
             Err(nexus_stats_core::ConfigError::Invalid(_))
         ));
     }
 
     #[test]
-    fn rejects_nan_and_inf() {
-        let mut da = DecayAccumF64::new(10.0).unwrap();
-        assert_eq!(
-            da.update(f64::NAN, 1.0),
+    fn rejects_invalid_weight_u64() {
+        let mut da = DecayAccumU64::new(10.0).unwrap();
+        assert!(matches!(
+            da.update(0, f64::NAN),
             Err(nexus_stats_core::DataError::NotANumber)
-        );
-        assert_eq!(
-            da.update(0.0, f64::INFINITY),
+        ));
+        assert!(matches!(
+            da.update(0, f64::INFINITY),
             Err(nexus_stats_core::DataError::Infinite)
+        ));
+    }
+
+    #[test]
+    fn accumulates_i64() {
+        let mut da = DecayAccumI64::new(10.0).unwrap();
+        da.update(0, 1.0).unwrap();
+        da.update(0, 1.0).unwrap();
+        let s = da.score(0);
+        assert!((s - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn decays_over_time_i64() {
+        let mut da = DecayAccumI64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
+
+        let s = da.score(10); // one half-life
+        assert!(
+            (s - 50.0).abs() < 1.0,
+            "should be ~50 after one half-life, got {s}"
         );
+
+        let s = da.score(20); // two half-lives
+        assert!(
+            (s - 25.0).abs() < 1.0,
+            "should be ~25 after two half-lives, got {s}"
+        );
+    }
+
+    #[test]
+    fn lazy_evaluation_i64() {
+        let mut da = DecayAccumI64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
+        // No work done between calls
+        da.update(5, 50.0).unwrap(); // decays 100 by 5 time units, adds 50
+
+        let s = da.score(5);
+        // After 5 units: 100 * exp(-ln2/10 * 5) + 50 ≈ 100 * 0.707 + 50 ≈ 120.7
+        assert!(s > 100.0 && s < 130.0, "score should be ~120, got {s}");
+    }
+
+    #[test]
+    fn reset_i64() {
+        let mut da = DecayAccumI64::new(10.0).unwrap();
+        da.update(0, 100.0).unwrap();
+        da.reset();
+        let s = da.score(0);
+        assert!((s).abs() < 1e-10);
+    }
+
+    #[test]
+    fn rejects_zero_half_life_i64() {
+        assert!(matches!(
+            DecayAccumI64::new(0.0),
+            Err(nexus_stats_core::ConfigError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_weight_i64() {
+        let mut da = DecayAccumI64::new(10.0).unwrap();
+        assert!(matches!(
+            da.update(0, f64::NAN),
+            Err(nexus_stats_core::DataError::NotANumber)
+        ));
+        assert!(matches!(
+            da.update(0, f64::INFINITY),
+            Err(nexus_stats_core::DataError::Infinite)
+        ));
     }
 }

--- a/nexus-stats-control/src/frequency/decay_accum.rs
+++ b/nexus-stats-control/src/frequency/decay_accum.rs
@@ -161,8 +161,7 @@ impl DecayAccumI64 {
             return;
         }
 
-        let dt = timestamp - self.last_time;
-        let dt = dt as f64;
+        let dt = timestamp.wrapping_sub(self.last_time) as f64;
         if dt > 0.0 {
             self.score *= nexus_stats_core::math::exp(-self.decay_constant * dt);
             self.last_time = timestamp;

--- a/nexus-stats-core/CHANGELOG.md
+++ b/nexus-stats-core/CHANGELOG.md
@@ -10,6 +10,14 @@ contained.
 
 ## [Unreleased]
 
+### Removed
+
+- **`LivenessF64`** — f64 timestamps cause silent precision loss past 2^52; use `LivenessI64` or `LivenessU64`.
+
+### Added
+
+- **`LivenessU64`** — liveness detector with `u64` timestamps, mirrors `LivenessI64`.
+
 ## [3.0.1] — 2026-06-05
 
 ### Changed

--- a/nexus-stats-core/src/monitoring/liveness.rs
+++ b/nexus-stats-core/src/monitoring/liveness.rs
@@ -287,7 +287,7 @@ impl LivenessU64 {
             return dt <= smoothed * (multiple as i64);
         }
         if let Some(absolute) = self.deadline_absolute {
-            return dt <= absolute as i64;
+            return dt >= 0 && (dt as u64) <= absolute;
         }
         true
     }

--- a/nexus-stats-core/src/monitoring/liveness.rs
+++ b/nexus-stats-core/src/monitoring/liveness.rs
@@ -1,247 +1,3 @@
-use crate::math::MulAdd;
-
-/// Liveness detector — EMA of inter-arrival times with deadline threshold.
-///
-/// Detects when a source goes quiet by tracking the smoothed interval
-/// between events and comparing against a deadline.
-///
-/// # Use Cases
-/// - Stale quote detection
-/// - Heartbeat monitoring
-/// - Feed health checking
-#[derive(Debug, Clone)]
-pub struct LivenessF64 {
-    alpha: f64,
-    one_minus_alpha: f64,
-    interval: f64,
-    last_timestamp: f64,
-    deadline_multiple: Option<f64>,
-    deadline_absolute: Option<f64>,
-    count: u64,
-    min_samples: u64,
-}
-
-/// Builder for [`LivenessF64`].
-#[derive(Debug, Clone)]
-pub struct LivenessF64Builder {
-    alpha: Option<f64>,
-    deadline_multiple: Option<f64>,
-    deadline_absolute: Option<f64>,
-    min_samples: u64,
-}
-
-impl LivenessF64 {
-    /// Creates a builder.
-    #[inline]
-    #[must_use]
-    pub fn builder() -> LivenessF64Builder {
-        LivenessF64Builder {
-            alpha: None,
-            deadline_multiple: None,
-            deadline_absolute: None,
-            min_samples: 2,
-        }
-    }
-
-    /// Updates with an event at the given timestamp. Returns `true` if alive.
-    ///
-    /// The first event only records the timestamp. The second event
-    /// computes the first interval. Returns `true` until primed, then
-    /// checks against the deadline.
-    ///
-    /// # Errors
-    ///
-    /// Returns `DataError::NotANumber` if the timestamp is NaN, or
-    /// `DataError::Infinite` if the timestamp is infinite.
-    #[inline]
-    pub fn update(&mut self, timestamp: f64) -> Result<bool, crate::DataError> {
-        check_finite!(timestamp);
-        self.count += 1;
-
-        if self.count == 1 {
-            self.last_timestamp = timestamp;
-            return Ok(true);
-        }
-
-        let dt = timestamp - self.last_timestamp;
-        self.last_timestamp = timestamp;
-
-        if self.count == 2 {
-            self.interval = dt;
-        } else {
-            self.interval = self.alpha.fma(dt, self.one_minus_alpha * self.interval);
-        }
-
-        if self.count < self.min_samples {
-            return Ok(true);
-        }
-
-        Ok(self.is_alive_at_interval(dt))
-    }
-
-    /// Checks liveness at the given timestamp without recording an event.
-    ///
-    /// Returns `true` if the time since the last event is within the deadline.
-    /// Returns `true` if not yet primed.
-    #[inline]
-    #[must_use]
-    pub fn check(&self, now: f64) -> bool {
-        if self.count < self.min_samples {
-            return true;
-        }
-
-        let dt = now - self.last_timestamp;
-        self.is_alive_at_interval(dt)
-    }
-
-    #[inline]
-    fn is_alive_at_interval(&self, dt: f64) -> bool {
-        if let Some(multiple) = self.deadline_multiple {
-            return dt <= self.interval * multiple;
-        }
-        if let Some(absolute) = self.deadline_absolute {
-            return dt <= absolute;
-        }
-        true
-    }
-
-    /// Current smoothed inter-arrival time, or `None` if < 2 events.
-    #[inline]
-    #[must_use]
-    pub fn interval(&self) -> Option<f64> {
-        if self.count >= 2 {
-            Some(self.interval)
-        } else {
-            None
-        }
-    }
-
-    /// Number of events recorded.
-    #[inline]
-    #[must_use]
-    pub fn count(&self) -> u64 {
-        self.count
-    }
-
-    /// Whether the detector has reached `min_samples`.
-    #[inline]
-    #[must_use]
-    pub fn is_primed(&self) -> bool {
-        self.count >= self.min_samples
-    }
-
-    /// Resets to uninitialized state.
-    #[inline]
-    pub fn reset(&mut self) {
-        self.interval = 0.0;
-        self.last_timestamp = 0.0;
-        self.count = 0;
-    }
-
-    /// Switches to a deadline-multiple threshold, clearing any absolute deadline.
-    #[inline]
-    pub fn reconfigure_deadline_multiple(&mut self, n: f64) {
-        self.deadline_multiple = Some(n);
-        self.deadline_absolute = None;
-    }
-
-    /// Switches to an absolute deadline threshold, clearing any multiple deadline.
-    #[inline]
-    pub fn reconfigure_deadline_absolute(&mut self, t: f64) {
-        self.deadline_absolute = Some(t);
-        self.deadline_multiple = None;
-    }
-}
-
-impl LivenessF64Builder {
-    /// Direct smoothing factor for interval EMA.
-    #[inline]
-    #[must_use]
-    pub fn alpha(mut self, alpha: f64) -> Self {
-        self.alpha = Some(alpha);
-        self
-    }
-
-    /// Halflife for interval smoothing.
-    #[inline]
-    #[must_use]
-    #[cfg(any(feature = "std", feature = "libm"))]
-    pub fn halflife(mut self, halflife: f64) -> Self {
-        let ln2 = core::f64::consts::LN_2;
-        let alpha = 1.0 - crate::math::exp(-ln2 / halflife);
-        self.alpha = Some(alpha);
-        self
-    }
-
-    /// Span for interval smoothing.
-    #[inline]
-    #[must_use]
-    pub fn span(mut self, n: u64) -> Self {
-        let alpha = 2.0 / (n as f64 + 1.0);
-        self.alpha = Some(alpha);
-        self
-    }
-
-    /// Alert when interval exceeds `n * smoothed_interval`.
-    ///
-    /// Typical values: 2.0-5.0.
-    #[inline]
-    #[must_use]
-    pub fn deadline_multiple(mut self, n: f64) -> Self {
-        self.deadline_multiple = Some(n);
-        self
-    }
-
-    /// Alert when interval exceeds a fixed deadline.
-    #[inline]
-    #[must_use]
-    pub fn deadline_absolute(mut self, t: f64) -> Self {
-        self.deadline_absolute = Some(t);
-        self
-    }
-
-    /// Minimum events before liveness checking activates. Default: 2.
-    #[inline]
-    #[must_use]
-    pub fn min_samples(mut self, min: u64) -> Self {
-        self.min_samples = min;
-        self
-    }
-
-    /// Builds the liveness detector.
-    ///
-    /// # Errors
-    ///
-    /// - Alpha must have been set.
-    /// - Alpha must be in (0, 1) exclusive.
-    /// - At least one deadline (multiple or absolute) must be set.
-    #[inline]
-    pub fn build(self) -> Result<LivenessF64, crate::ConfigError> {
-        let alpha = self.alpha.ok_or(crate::ConfigError::Missing("alpha"))?;
-        if !(alpha > 0.0 && alpha < 1.0) {
-            return Err(crate::ConfigError::Invalid(
-                "Liveness alpha must be in (0, 1)",
-            ));
-        }
-        if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
-            return Err(crate::ConfigError::Invalid(
-                "Liveness requires a deadline (use .deadline_multiple() or .deadline_absolute())",
-            ));
-        }
-
-        Ok(LivenessF64 {
-            alpha,
-            one_minus_alpha: 1.0 - alpha,
-            interval: 0.0,
-            last_timestamp: 0.0,
-            deadline_multiple: self.deadline_multiple,
-            deadline_absolute: self.deadline_absolute,
-            count: 0,
-            min_samples: self.min_samples,
-        })
-    }
-}
-
 /// Liveness detector (integer variant) — fixed-point EMA of inter-arrival ticks.
 ///
 /// Uses kernel-style bit-shift arithmetic for the interval smoothing.
@@ -443,94 +199,292 @@ impl LivenessI64Builder {
     }
 }
 
+/// Liveness detector (integer variant) — fixed-point EMA of inter-arrival ticks.
+///
+/// Uses kernel-style bit-shift arithmetic for the interval smoothing.
+/// Timestamps are integer ticks.
+#[derive(Debug, Clone)]
+pub struct LivenessU64 {
+    acc: i128,
+    shift: u32,
+    span: u64,
+    last_timestamp: u64,
+    deadline_multiple: Option<u64>,
+    deadline_absolute: Option<u64>,
+    count: u64,
+    min_samples: u64,
+    initialized: bool,
+}
+
+/// Builder for [`LivenessU64`].
+#[derive(Debug, Clone)]
+pub struct LivenessU64Builder {
+    span: Option<u64>,
+    deadline_multiple: Option<u64>,
+    deadline_absolute: Option<u64>,
+    min_samples: u64,
+}
+
+impl LivenessU64 {
+    /// Creates a builder.
+    #[inline]
+    #[must_use]
+    pub fn builder() -> LivenessU64Builder {
+        LivenessU64Builder {
+            span: None,
+            deadline_multiple: None,
+            deadline_absolute: None,
+            min_samples: 2,
+        }
+    }
+
+    /// Updates with an event at the given tick. Returns `true` if alive.
+    #[inline]
+    #[must_use]
+    pub fn update(&mut self, timestamp: u64) -> bool {
+        self.count += 1;
+
+        if self.count == 1 {
+            self.last_timestamp = timestamp;
+            return true;
+        }
+
+        let dt = timestamp.wrapping_sub(self.last_timestamp) as i64;
+        self.last_timestamp = timestamp;
+
+        if self.initialized {
+            let dt_shifted = (dt as i128) << self.shift;
+            self.acc += (dt_shifted - self.acc) >> self.shift;
+        } else {
+            self.acc = (dt as i128) << self.shift;
+            self.initialized = true;
+        }
+
+        if self.count < self.min_samples {
+            return true;
+        }
+
+        let smoothed = (self.acc >> self.shift) as i64;
+        self.is_alive_with(dt, smoothed)
+    }
+
+    /// Checks liveness at the given tick without recording.
+    #[inline]
+    #[must_use]
+    pub fn check(&self, now: u64) -> bool {
+        if self.count < self.min_samples || !self.initialized {
+            return true;
+        }
+
+        let dt = now.wrapping_sub(self.last_timestamp) as i64;
+        let smoothed = (self.acc >> self.shift) as i64;
+        self.is_alive_with(dt, smoothed)
+    }
+
+    #[inline]
+    fn is_alive_with(&self, dt: i64, smoothed: i64) -> bool {
+        if let Some(multiple) = self.deadline_multiple {
+            return dt <= smoothed * (multiple as i64);
+        }
+        if let Some(absolute) = self.deadline_absolute {
+            return dt <= absolute as i64;
+        }
+        true
+    }
+
+    /// Current smoothed inter-arrival interval, or `None` if < 2 events.
+    #[inline]
+    #[must_use]
+    pub fn interval(&self) -> Option<i64> {
+        if self.count >= 2 && self.initialized {
+            Some((self.acc >> self.shift) as i64)
+        } else {
+            None
+        }
+    }
+
+    /// Effective span after rounding.
+    #[inline]
+    #[must_use]
+    pub fn effective_span(&self) -> u64 {
+        self.span
+    }
+
+    /// Number of events recorded.
+    #[inline]
+    #[must_use]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Whether the detector has reached `min_samples`.
+    #[inline]
+    #[must_use]
+    pub fn is_primed(&self) -> bool {
+        self.count >= self.min_samples
+    }
+
+    /// Resets to uninitialized state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.acc = 0;
+        self.last_timestamp = 0;
+        self.count = 0;
+        self.initialized = false;
+    }
+}
+
+impl LivenessU64Builder {
+    /// Smoothing span. Rounded up to next `2^k - 1`.
+    #[inline]
+    #[must_use]
+    pub fn span(mut self, n: u64) -> Self {
+        self.span = Some(n);
+        self
+    }
+
+    /// Alert when interval exceeds `n * smoothed_interval`.
+    #[inline]
+    #[must_use]
+    pub fn deadline_multiple(mut self, n: u64) -> Self {
+        self.deadline_multiple = Some(n);
+        self
+    }
+
+    /// Alert when interval exceeds a fixed deadline (in ticks).
+    #[inline]
+    #[must_use]
+    pub fn deadline_absolute(mut self, t: u64) -> Self {
+        self.deadline_absolute = Some(t);
+        self
+    }
+
+    /// Minimum events before liveness checking activates. Default: 2.
+    #[inline]
+    #[must_use]
+    pub fn min_samples(mut self, min: u64) -> Self {
+        self.min_samples = min;
+        self
+    }
+
+    /// Builds the liveness detector.
+    ///
+    /// # Errors
+    ///
+    /// - Span must have been set and >= 1.
+    /// - At least one deadline must be set.
+    #[inline]
+    pub fn build(self) -> Result<LivenessU64, crate::ConfigError> {
+        let requested = self.span.ok_or(crate::ConfigError::Missing("span"))?;
+        if requested < 1 {
+            return Err(crate::ConfigError::Invalid("Liveness span must be >= 1"));
+        }
+        if self.deadline_multiple.is_none() && self.deadline_absolute.is_none() {
+            return Err(crate::ConfigError::Invalid("Liveness requires a deadline"));
+        }
+
+        let effective = crate::smoothing::ema::next_power_of_two_minus_one(requested);
+        let shift = crate::smoothing::ema::log2_of_span_plus_one(effective);
+
+        Ok(LivenessU64 {
+            acc: 0,
+            shift,
+            span: effective,
+            last_timestamp: 0,
+            deadline_multiple: self.deadline_multiple,
+            deadline_absolute: self.deadline_absolute,
+            count: 0,
+            min_samples: self.min_samples,
+            initialized: false,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn alive_while_events_arrive() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn alive_while_events_arrive_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .build()
             .unwrap();
 
         // Regular events every 10 units
         for i in 0..20 {
-            assert!(
-                lv.update(i as f64 * 10.0).unwrap(),
-                "should be alive at event {i}"
-            );
+            assert!(lv.update(i * 10), "should be alive at event {i}");
         }
     }
 
     #[test]
-    fn dead_after_silence() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn dead_after_silence_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .build()
             .unwrap();
 
         // Regular events every 10 units
         for i in 0..10 {
-            let _ = lv.update(i as f64 * 10.0).unwrap();
+            let _ = lv.update(i as u64 * 10);
         }
 
         // Check after long silence — should be dead
         // Smoothed interval ~= 10, deadline = 3 * 10 = 30, silence = 100
-        assert!(!lv.check(190.0), "should be dead after long silence");
+        assert!(!lv.check(190), "should be dead after long silence");
     }
 
     #[test]
-    fn recovery_after_resume() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn recovery_after_resume_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .build()
             .unwrap();
 
         for i in 0..10 {
-            let _ = lv.update(i as f64 * 10.0).unwrap();
+            let _ = lv.update(i as u64 * 10);
         }
 
         // Dead check
-        assert!(!lv.check(200.0));
+        assert!(!lv.check(200));
 
         // Resume events — should recover
-        assert!(lv.update(200.0).unwrap()); // records, interval updates
-        assert!(lv.update(210.0).unwrap());
+        assert!(!lv.update(200)); // records, interval updates
+        assert!(lv.update(210));
     }
 
     #[test]
-    fn absolute_deadline() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_absolute(50.0)
+    fn absolute_deadline_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_absolute(50)
             .build()
             .unwrap();
 
-        let _ = lv.update(0.0).unwrap();
-        let _ = lv.update(10.0).unwrap();
+        let _ = lv.update(0);
+        let _ = lv.update(10);
 
         // Within deadline
-        assert!(lv.check(55.0));
+        assert!(lv.check(55));
         // Exceeds deadline
-        assert!(!lv.check(65.0));
+        assert!(!lv.check(65));
     }
 
     #[test]
-    fn not_primed_always_alive() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn not_primed_always_alive_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .min_samples(5)
             .build()
             .unwrap();
 
         // Even with huge gaps, returns true before primed
-        assert!(lv.update(0.0).unwrap());
-        assert!(lv.update(1000.0).unwrap());
+        assert!(lv.update(0));
+        assert!(lv.update(1000));
         assert!(!lv.is_primed());
     }
 
@@ -551,15 +505,15 @@ mod tests {
     }
 
     #[test]
-    fn reset_clears_state() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn reset_clears_state_u64() {
+        let mut lv = LivenessU64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .build()
             .unwrap();
 
         for i in 0..10 {
-            let _ = lv.update(i as f64 * 10.0).unwrap();
+            let _ = lv.update(i as u64 * 10);
         }
 
         lv.reset();
@@ -568,69 +522,127 @@ mod tests {
     }
 
     #[test]
-    fn reconfigure_deadline_multiple() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_absolute(50.0)
-            .build()
-            .unwrap();
-
-        let _ = lv.update(0.0).unwrap();
-        let _ = lv.update(10.0).unwrap();
-
-        // With absolute 50, check at 55 is alive
-        assert!(lv.check(55.0));
-
-        // Switch to multiple=2 — smoothed interval ~10, deadline=20
-        lv.reconfigure_deadline_multiple(2.0);
-        // 55 - 10 = 45 > 20, should be dead
-        assert!(!lv.check(55.0));
+    fn errors_without_span_u64() {
+        let result = LivenessU64::builder().deadline_multiple(3).build();
+        assert!(matches!(result, Err(crate::ConfigError::Missing("span"))));
     }
 
     #[test]
-    fn reconfigure_deadline_absolute() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
-            .build()
-            .unwrap();
-
-        for i in 0..10 {
-            let _ = lv.update(i as f64 * 10.0).unwrap();
-        }
-
-        // Switch to absolute deadline
-        lv.reconfigure_deadline_absolute(5.0);
-        // Last event at 90, check at 100 => dt=10 > 5
-        assert!(!lv.check(100.0));
-    }
-
-    #[test]
-    fn errors_without_alpha() {
-        let result = LivenessF64::builder().deadline_multiple(3.0).build();
-        assert!(matches!(result, Err(crate::ConfigError::Missing("alpha"))));
-    }
-
-    #[test]
-    fn errors_without_deadline() {
-        let result = LivenessF64::builder().alpha(0.3).build();
+    fn errors_without_deadline_u64() {
+        let result = LivenessU64::builder().span(7).build();
         assert!(matches!(result, Err(crate::ConfigError::Invalid(_))));
     }
 
     #[test]
-    fn rejects_nan_and_inf() {
-        let mut lv = LivenessF64::builder()
-            .alpha(0.3)
-            .deadline_multiple(3.0)
+    fn alive_while_events_arrive_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_multiple(3)
             .build()
             .unwrap();
-        assert!(matches!(
-            lv.update(f64::NAN),
-            Err(crate::DataError::NotANumber)
-        ));
-        assert!(matches!(
-            lv.update(f64::INFINITY),
-            Err(crate::DataError::Infinite)
-        ));
+
+        // Regular events every 10 units
+        for i in 0..20 {
+            assert!(lv.update(i * 10), "should be alive at event {i}");
+        }
+    }
+
+    #[test]
+    fn dead_after_silence_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_multiple(3)
+            .build()
+            .unwrap();
+
+        // Regular events every 10 units
+        for i in 0..10 {
+            let _ = lv.update(i as i64 * 10);
+        }
+
+        // Check after long silence — should be dead
+        // Smoothed interval ~= 10, deadline = 3 * 10 = 30, silence = 100
+        assert!(!lv.check(190), "should be dead after long silence");
+    }
+
+    #[test]
+    fn recovery_after_resume_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_multiple(3)
+            .build()
+            .unwrap();
+
+        for i in 0..10 {
+            let _ = lv.update(i as i64 * 10);
+        }
+
+        // Dead check
+        assert!(!lv.check(200));
+
+        // Resume events — should recover
+        assert!(!lv.update(200)); // records, interval updates
+        assert!(lv.update(210));
+    }
+
+    #[test]
+    fn absolute_deadline_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_absolute(50)
+            .build()
+            .unwrap();
+
+        let _ = lv.update(0);
+        let _ = lv.update(10);
+
+        // Within deadline
+        assert!(lv.check(55));
+        // Exceeds deadline
+        assert!(!lv.check(65));
+    }
+
+    #[test]
+    fn not_primed_always_alive_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_multiple(3)
+            .min_samples(5)
+            .build()
+            .unwrap();
+
+        // Even with huge gaps, returns true before primed
+        assert!(lv.update(0));
+        assert!(lv.update(1000));
+        assert!(!lv.is_primed());
+    }
+
+    #[test]
+    fn reset_clears_state_i64() {
+        let mut lv = LivenessI64::builder()
+            .span(7)
+            .deadline_multiple(3)
+            .build()
+            .unwrap();
+
+        for i in 0..10 {
+            let _ = lv.update(i as i64 * 10);
+        }
+
+        lv.reset();
+        assert_eq!(lv.count(), 0);
+        assert!(lv.interval().is_none());
+    }
+
+    #[test]
+    fn errors_without_span_i64() {
+        let result = LivenessI64::builder().deadline_multiple(3).build();
+        assert!(matches!(result, Err(crate::ConfigError::Missing("span"))));
+    }
+
+    #[test]
+    fn errors_without_deadline_i64() {
+        let result = LivenessI64::builder().span(7).build();
+        assert!(matches!(result, Err(crate::ConfigError::Invalid(_))));
     }
 }

--- a/nexus-stats/README.md
+++ b/nexus-stats/README.md
@@ -134,7 +134,7 @@ for deep-dives on each algorithm.
 | `WindowedMaxF64` / `WindowedMinF64` | Sliding window extrema (Nichols'/BBR) | 9 |
 | `PeakHoldF64` | Peak envelope with hold + decay | 7 |
 | `MaxGaugeF64` | Reset-on-read maximum (Netflix pattern) | 5 |
-| `LivenessF64` | Source alive/dead detection | 6 |
+| `LivenessI64` / `LivenessU64` | Source alive/dead detection | 6 |
 | `EventRateU64` | Smoothed events per unit time | 6 |
 | `CoDelI64` | Queue backpressure detection (CoDel-inspired) | 7 |
 | `SaturationF64` | Resource utilization threshold (USE method) | 6 |

--- a/nexus-stats/docs/algorithms/cusum.md
+++ b/nexus-stats/docs/algorithms/cusum.md
@@ -253,10 +253,10 @@ let mut svc_monitor = CusumF64::builder(50.0)
 
 ```rust
 let mut cusum = CusumF64::builder(baseline).slack(k).threshold(h).build().unwrap();
-let mut liveness = LivenessF64::builder().span(20).deadline_multiple(5.0).build().unwrap();
+let mut liveness = LivenessU64::builder().span(20).deadline_multiple(5).build().unwrap();
 
 // On each event:
-liveness.record(now);
+liveness.update(now);
 if let Some(shift) = cusum.update(latency) {
     // Degradation detected
 }

--- a/nexus-stats/docs/algorithms/liveness.md
+++ b/nexus-stats/docs/algorithms/liveness.md
@@ -7,7 +7,7 @@ data source goes quiet.
 |----------|-------|
 | Update cost | ~6 cycles |
 | Memory | ~32 bytes |
-| Types | `LivenessF64`, `LivenessF32`, `LivenessI64`, `LivenessI32` |
+| Types | `LivenessI64`, `LivenessU64` |
 | Output | `bool` — true = alive, false = dead |
 
 ## What It Does
@@ -28,22 +28,22 @@ data source goes quiet.
 ```
 
 Two methods:
-- **`record(timestamp)`** — call when data arrives. Updates the EMA.
+- **`update(timestamp)`** — call when data arrives. Updates the EMA.
 - **`check(now)`** — call periodically (e.g., from a timer). Returns false
   if time since last event exceeds the deadline. This is how you detect
-  *silence* — `record()` can't fire if nothing arrives.
+  *silence* — `update()` can't fire if nothing arrives.
 
 ## Configuration
 
 ```rust
-let mut live = LivenessF64::builder()
+let mut live = LivenessU64::builder()
     .span(20)                  // EMA smoothing of intervals
-    .deadline_multiple(5.0)    // dead if gap > 5× smoothed interval
+    .deadline_multiple(5)      // dead if gap > 5× smoothed interval
     .min_samples(5)
     .build().unwrap();
 
 // On each event:
-live.record(now);
+live.update(now);
 
 // On timer tick (must call periodically!):
 if !live.check(now) {
@@ -62,11 +62,11 @@ if !live.check(now) {
 ```rust
 let mut feed = LivenessI64::builder()
     .span(15)
-    .deadline_multiple(5.0)
+    .deadline_multiple(5)
     .build().unwrap();
 
 // On each market data message:
-feed.record(now_ns);
+feed.update(now_ns);
 
 // On 100ms timer (nexus-rt timer driver):
 if !feed.check(now_ns) {
@@ -76,8 +76,8 @@ if !feed.check(now_ns) {
 
 ### Networking — Heartbeat Monitoring
 ```rust
-let mut heartbeat = LivenessF64::builder()
-    .deadline_absolute(30.0)  // 30 seconds absolute timeout
+let mut heartbeat = LivenessU64::builder()
+    .deadline_absolute(30)    // 30 seconds absolute timeout
     .build().unwrap();
 ```
 
@@ -85,8 +85,8 @@ let mut heartbeat = LivenessF64::builder()
 
 | Operation | p50 | p99 |
 |-----------|-----|-----|
-| `LivenessF64::record` | 6 cycles | 20 cycles |
-| `LivenessF64::check` | ~3 cycles | ~3 cycles |
+| `LivenessU64::update` | 6 cycles | 20 cycles |
+| `LivenessU64::check` | ~3 cycles | ~3 cycles |
 
-`record()` includes one EMA update. `check()` is one subtraction +
+`update()` includes one EMA update. `check()` is one subtraction +
 one comparison.

--- a/nexus-stats/docs/guides/quickstart.md
+++ b/nexus-stats/docs/guides/quickstart.md
@@ -83,7 +83,7 @@ let mut live = LivenessI64::builder()
     .build().unwrap();
 
 // On each message:
-live.record(now_ns);
+live.update(now_ns);
 
 // On timer tick:
 if !live.check(now_ns) {

--- a/nexus-stats/docs/reference/performance.md
+++ b/nexus-stats/docs/reference/performance.md
@@ -37,7 +37,7 @@ pinned to a single core.
 | WindowedMax/MinF64 | 9-10 | 12-34 | 3-sample promotion |
 | PeakHoldF64 | 7 | 9 | compare + decay |
 | MaxGaugeF64 | ~5 | ~5 | compare-and-swap |
-| LivenessF64 | 6 | 20 | EMA + deadline |
+| LivenessI64 / LivenessU64 | 6 | 20 | EMA + deadline |
 | EventRateU64 | 6 | 9 | bit-shift EMA + inversion |
 | CoDelI64 | 7 | 10 | WindowedMin + threshold |
 | SaturationF64 | ~6 | ~8 | EMA + threshold |

--- a/nexus-stats/docs/use-cases/feed-health.md
+++ b/nexus-stats/docs/use-cases/feed-health.md
@@ -51,7 +51,7 @@ impl FeedMonitor {
     }
 
     fn on_message(&mut self, now_ns: i64, value: i64, latency_us: f64) {
-        self.liveness.record(now_ns);
+        self.liveness.update(now_ns);
         self.rate.tick(now_ns);
         self.jitter.update(now_ns);
 
@@ -90,7 +90,7 @@ let mut latency_cusum = CusumF64::builder(baseline_ws_latency)
     .slack(2.0).threshold(20.0).min_samples(50).build().unwrap();
 
 // On each WebSocket message:
-liveness.record(now_ns);
+liveness.update(now_ns);
 msg_rate.tick(now_ns);
 latency_cusum.update(msg_latency_ms);
 

--- a/nexus-stats/examples/perf_stats.rs
+++ b/nexus-stats/examples/perf_stats.rs
@@ -14,7 +14,7 @@ use nexus_stats::{
     frequency::TopK,
     learning::{EpsilonGreedyF64, Exp3F64, ThompsonBetaF64, ThompsonGammaF64, Ucb1F64},
     monitoring::{
-        CoDelI64, DrawdownF64, EventRateU64, LivenessF64, PeakHoldF64, RunningMaxF64,
+        CoDelI64, DrawdownF64, EventRateU64, LivenessU64, PeakHoldF64, RunningMaxF64,
         RunningMinF64, WindowedMaxF64, WindowedMinF64,
     },
     signal::{AutocorrelationF64, CrossCorrelationF64, EntropyF64, TransferEntropyF64},
@@ -237,21 +237,21 @@ fn bench_ewma_var_f64(samples: &mut [u64]) {
 // Phase 3: Liveness, MOSUM
 // ============================================================================
 
-fn bench_liveness_f64(samples: &mut [u64]) {
-    let mut lv = LivenessF64::builder()
-        .alpha(0.3)
-        .deadline_multiple(3.0)
+fn bench_liveness_u64(samples: &mut [u64]) {
+    let mut lv = LivenessU64::builder()
+        .span(7)
+        .deadline_multiple(3)
         .build()
         .unwrap();
     let mut rng = 12345u64;
     for i in 0..WARMUP {
-        let _ = lv.update((i as f64).mul_add(10.0, (next_val(&mut rng) % 5) as f64));
+        let _ = lv.update(i as u64 * 10 + next_val(&mut rng) % 5);
     }
-    let mut t = WARMUP as f64 * 10.0;
+    let mut t = WARMUP as u64 * 10;
     for s in samples.iter_mut() {
         let start = rdtsc_start();
         for _ in 0..BATCH {
-            t += 10.0 + (next_val(&mut rng) % 5) as f64;
+            t += 10 + next_val(&mut rng) % 5;
             let _ = black_box(lv.update(t));
         }
         let end = rdtsc_end();
@@ -983,8 +983,8 @@ fn main() {
     print_row("WindowedMaxF64::update", &mut buf);
     bench_windowed_min_f64(&mut buf);
     print_row("WindowedMinF64::update", &mut buf);
-    bench_liveness_f64(&mut buf);
-    print_row("LivenessF64::update", &mut buf);
+    bench_liveness_u64(&mut buf);
+    print_row("LivenessU64::update", &mut buf);
     bench_running_min_f64(&mut buf);
     print_row("RunningMinF64::update", &mut buf);
     bench_running_max_f64(&mut buf);


### PR DESCRIPTION
Apologies for including all changes into a single commit. Next time will make the changes more precise.

- Remove LivenessF64 and its tests; LivenessI64 remains unchanged
- Add LivenessU64 alongside LivenessI64, using wrapping_sub as i64 for safe unsigned timestamp arithmetic and bit-shift EMA (same pattern as  EventRateU64)
- Replace DecayAccumF64 with DecayAccumU64 and DecayAccumI64; integer delta computed first, f64 only for the exp() call
- Update tests to integer timestamps for all affected types
- Add [Unreleased] breaking entries to nexus-stats-core and nexus-stats-control CHANGELOGs