### PR TITLE
fix(fix-engine): transport follow-ups (#537)

### DIFF
--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -1,0 +1,129 @@
+#![cfg(unix)]
+
+//! Blocking session recipe: one initiator connects to one acceptor on localhost,
+//! sends a NewOrder, then logs out.
+//!
+//! Run with: cargo run --example blocking_session
+
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{
+    CompId, FixConnection, FixJournal, SessionConfig, SessionState, State,
+};
+
+const BEGIN: &[u8] = b"FIX.4.4";
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let acceptor_dir = tmp_dir("acceptor");
+    let acceptor = std::thread::spawn(move || run_acceptor(listener, acceptor_dir));
+
+    let initiator_dir = tmp_dir("initiator");
+    run_initiator(addr, initiator_dir);
+
+    acceptor.join().unwrap();
+}
+
+fn run_acceptor(listener: TcpListener, dir: PathBuf) {
+    let (stream, _) = listener.accept().unwrap();
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let mut conn = FixConnection::builder().accept(
+        stream,
+        SessionState::new(Duration::from_secs(30)),
+        SessionConfig {
+            sender: CompId::new(b"ACCEPTOR").unwrap(),
+            target: CompId::new(b"INITIATOR").unwrap(),
+        },
+        FixJournal::open(&dir, 256).unwrap(),
+        BEGIN,
+    );
+
+    let mut n = 0usize;
+    loop {
+        match conn.recv(Instant::now(), &mut |_: &[u8]| n += 1) {
+            Ok(Some(reason)) => {
+                println!("acceptor: {reason:?}, {n} app message(s) received");
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("acceptor error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+fn run_initiator(addr: std::net::SocketAddr, dir: PathBuf) {
+    let mut conn = FixConnection::builder()
+        .connect(
+            addr,
+            SessionState::new(Duration::from_secs(30)),
+            SessionConfig {
+                sender: CompId::new(b"INITIATOR").unwrap(),
+                target: CompId::new(b"ACCEPTOR").unwrap(),
+            },
+            FixJournal::open(&dir, 256).unwrap(),
+            BEGIN,
+        )
+        .unwrap();
+
+    conn.connect(Instant::now()).unwrap();
+
+    // recv until session is active
+    loop {
+        match conn.recv(Instant::now(), &mut |_| {}) {
+            Ok(Some(r)) => {
+                eprintln!("initiator: disconnected before active ({r:?})");
+                return;
+            }
+            Err(e) => {
+                eprintln!("initiator error: {e}");
+                return;
+            }
+            Ok(None) if conn.state().state() == State::Active => break,
+            Ok(None) => {}
+        }
+    }
+
+    // send one NewOrder
+    let seq = conn.allocate_seq();
+    let msg = new_order(seq);
+    conn.send_app(seq, &msg).unwrap();
+
+    // logout
+    conn.logout(Instant::now()).unwrap();
+    loop {
+        match conn.recv(Instant::now(), &mut |_| {}) {
+            Ok(Some(_)) | Err(_) => break,
+            Ok(None) => {}
+        }
+    }
+}
+
+fn new_order(seq: u32) -> Vec<u8> {
+    let mut buf = [0u8; 512];
+    let mut seq_buf = [0u8; 10];
+    let n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    fmt.field(34, &seq_buf[..n]);
+    fmt.field(49, b"INITIATOR");
+    fmt.field(56, b"ACCEPTOR");
+    fmt.field(52, b"20260101-00:00:00.000");
+    fmt.field(11, b"ORD-1");
+    let (start, len) = fmt.finish().unwrap();
+    buf[start..start + len].to_vec()
+}
+
+fn tmp_dir(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("nexus_blocking_{name}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -10,9 +10,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
-use nexus_fix_engine::{
-    CompId, FixConnection, FixJournal, SessionConfig, SessionState, State,
-};
+use nexus_fix_engine::{CompId, FixConnection, FixJournal, SessionConfig, SessionState, State};
 
 const BEGIN: &[u8] = b"FIX.4.4";
 
@@ -31,7 +29,9 @@ fn main() {
 
 fn run_acceptor(listener: TcpListener, dir: PathBuf) {
     let (stream, _) = listener.accept().unwrap();
-    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
 
     let mut conn = FixConnection::builder().accept(
         stream,

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -19,7 +19,7 @@ fn main() {
     let addr = listener.local_addr().unwrap();
 
     let acceptor_dir = tmp_dir("acceptor");
-    let acceptor = std::thread::spawn(move || run_acceptor(listener, &acceptor_dir));
+    let acceptor = std::thread::spawn(move || run_acceptor(&listener, &acceptor_dir));
 
     let initiator_dir = tmp_dir("initiator");
     run_initiator(addr, &initiator_dir);
@@ -27,7 +27,7 @@ fn main() {
     acceptor.join().unwrap();
 }
 
-fn run_acceptor(listener: TcpListener, dir: &Path) {
+fn run_acceptor(listener: &TcpListener, dir: &Path) {
     let (stream, _) = listener.accept().unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
@@ -40,7 +40,7 @@ fn run_acceptor(listener: TcpListener, dir: &Path) {
             sender: CompId::new(b"ACCEPTOR").unwrap(),
             target: CompId::new(b"INITIATOR").unwrap(),
         },
-        FixJournal::open(&dir, 256).unwrap(),
+        FixJournal::open(dir, 256).unwrap(),
         BEGIN,
     );
 
@@ -69,7 +69,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
                 sender: CompId::new(b"INITIATOR").unwrap(),
                 target: CompId::new(b"ACCEPTOR").unwrap(),
             },
-            FixJournal::open(&dir, 256).unwrap(),
+            FixJournal::open(dir, 256).unwrap(),
             BEGIN,
         )
         .unwrap();

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -6,7 +6,7 @@
 //! Run with: cargo run --example blocking_session
 
 use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
@@ -19,15 +19,15 @@ fn main() {
     let addr = listener.local_addr().unwrap();
 
     let acceptor_dir = tmp_dir("acceptor");
-    let acceptor = std::thread::spawn(move || run_acceptor(listener, acceptor_dir));
+    let acceptor = std::thread::spawn(move || run_acceptor(listener, &acceptor_dir));
 
     let initiator_dir = tmp_dir("initiator");
-    run_initiator(addr, initiator_dir);
+    run_initiator(addr, &initiator_dir);
 
     acceptor.join().unwrap();
 }
 
-fn run_acceptor(listener: TcpListener, dir: PathBuf) {
+fn run_acceptor(listener: TcpListener, dir: &Path) {
     let (stream, _) = listener.accept().unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
@@ -60,7 +60,7 @@ fn run_acceptor(listener: TcpListener, dir: PathBuf) {
     }
 }
 
-fn run_initiator(addr: std::net::SocketAddr, dir: PathBuf) {
+fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
     let mut conn = FixConnection::builder()
         .connect(
             addr,

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -437,7 +437,7 @@ impl<S: Read + Write> FixConnection<S> {
                             let mut tmp = vec![0u8; orig.len() + 512];
                             let (start, len) =
                                 reframe_app_into(&mut tmp, orig, &ts, begin_string)
-                                    .ok_or_else(|| Error::FrameTooLarge(orig.len()))?;
+                                    .ok_or(Error::FrameTooLarge(orig.len()))?;
                             tmp.copy_within(start..start + len, 0);
                             tmp.truncate(len);
                             write_through(stream, writer, &tmp)?;

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -429,15 +429,16 @@ impl<S: Read + Write> FixConnection<S> {
                 match item {
                     ReplayItem::GapFill { seq, new_seq } => {
                         encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq)
-                            .map_err(|()| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
+                            .map_err(|()| {
+                                Error::FrameTooLarge(writer.remaining().saturating_add(1))
+                            })?;
                     }
                     ReplayItem::App(orig) => {
                         if reframe_app(writer, orig, &ts, begin_string).is_err() {
                             // frame exceeds writer capacity; reframe into a heap buffer and write through
                             let mut tmp = vec![0u8; orig.len() + 512];
-                            let (start, len) =
-                                reframe_app_into(&mut tmp, orig, &ts, begin_string)
-                                    .ok_or(Error::FrameTooLarge(orig.len()))?;
+                            let (start, len) = reframe_app_into(&mut tmp, orig, &ts, begin_string)
+                                .ok_or(Error::FrameTooLarge(orig.len()))?;
                             tmp.copy_within(start..start + len, 0);
                             tmp.truncate(len);
                             write_through(stream, writer, &tmp)?;
@@ -610,7 +611,11 @@ fn parse_frame_header(frame: &[u8]) -> Option<FrameHeader<'_>> {
     for field in FieldReader::new(frame, 0) {
         match field.tag {
             35 => msg_type = Some(field.value.slice(frame)),
-            34 => seq = parse_fix_seqnum(field.value.slice(frame)).ok().map(|s| s as u32),
+            34 => {
+                seq = parse_fix_seqnum(field.value.slice(frame))
+                    .ok()
+                    .map(|s| s as u32)
+            }
             49 => sender = field.value.slice(frame),
             56 => target = field.value.slice(frame),
             43 => poss_dup = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -260,81 +260,47 @@ impl<S: Read + Write> FixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let sender_ok =
-            find_tag(frame, 0, 49).is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
-        let target_ok =
-            find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
-        if !sender_ok || !target_ok {
+        let Some(h) = parse_frame_header(frame) else {
+            return Ok(None);
+        };
+
+        if h.sender != self.config.target.as_bytes() || h.target != self.config.sender.as_bytes() {
             let out = self.state.on_comp_id_mismatch(now);
             self.flush_out(out)?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
         }
 
-        let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
-            Some(s) => s as u32,
-            None => return Ok(None),
-        };
-
-        let poss_dup = find_tag(frame, 0, 43)
-            .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-            .unwrap_or(false);
-
-        let msg_type = match find_tag(frame, 0, 35) {
-            Some(s) => s.slice(frame),
-            None => return Ok(None),
-        };
-
-        let (out, is_app) = match msg_type {
+        let (out, is_app) = match h.msg_type {
             b"A" => {
-                let hbi = find_tag(frame, 0, 108)
-                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
-                    .unwrap_or(30);
-                let reset = find_tag(frame, 0, 141)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
                 let was_logon_sent = self.state.state() == State::LogonSent;
                 (
-                    self.state.on_logon(seq, hbi, reset, !was_logon_sent, now),
+                    self.state
+                        .on_logon(h.seq, h.heart_bt_int, h.reset, !was_logon_sent, now),
                     false,
                 )
             }
-            b"5" => (self.state.on_logout(seq, poss_dup, now), false),
-            b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
-            b"1" => {
-                let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
-                (self.state.on_test_request(seq, poss_dup, id, now), false)
-            }
-            b"2" => {
-                let begin = find_tag(frame, 0, 7)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                let end = find_tag(frame, 0, 16)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                (
-                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
-                    false,
-                )
-            }
-            b"3" => {
-                let ref_seq = find_tag(frame, 0, 45)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                (self.state.on_reject(seq, poss_dup, ref_seq, now), false)
-            }
-            b"4" => {
-                let new_seq = find_tag(frame, 0, 36)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                let gap_fill = find_tag(frame, 0, 123)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
-                (
-                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
-                    false,
-                )
-            }
-            _ => (self.state.on_app(seq, poss_dup, now), true),
+            b"5" => (self.state.on_logout(h.seq, h.poss_dup, now), false),
+            b"0" => (self.state.on_heartbeat(h.seq, h.poss_dup, now), false),
+            b"1" => (
+                self.state
+                    .on_test_request(h.seq, h.poss_dup, h.test_req_id, now),
+                false,
+            ),
+            b"2" => (
+                self.state
+                    .on_resend_request(h.seq, h.poss_dup, h.begin_seq, h.end_seq, now),
+                false,
+            ),
+            b"3" => (
+                self.state.on_reject(h.seq, h.poss_dup, h.ref_seq, now),
+                false,
+            ),
+            b"4" => (
+                self.state
+                    .on_sequence_reset(h.seq, h.new_seq_no, h.gap_fill, now),
+                false,
+            ),
+            _ => (self.state.on_app(h.seq, h.poss_dup, now), true),
         };
 
         self.flush_out(out)?;
@@ -460,13 +426,24 @@ impl<S: Read + Write> FixConnection<S> {
             };
             if ok.is_err() {
                 flush_to(stream, writer)?;
-                let retry = match item {
+                match item {
                     ReplayItem::GapFill { seq, new_seq } => {
                         encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq)
+                            .map_err(|()| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
                     }
-                    ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
-                };
-                retry.map_err(|()| Error::FrameTooLarge(writer.remaining().saturating_add(1)))?;
+                    ReplayItem::App(orig) => {
+                        if reframe_app(writer, orig, &ts, begin_string).is_err() {
+                            // frame exceeds writer capacity; reframe into a heap buffer and write through
+                            let mut tmp = vec![0u8; orig.len() + 512];
+                            let (start, len) =
+                                reframe_app_into(&mut tmp, orig, &ts, begin_string)
+                                    .ok_or_else(|| Error::FrameTooLarge(orig.len()))?;
+                            tmp.copy_within(start..start + len, 0);
+                            tmp.truncate(len);
+                            write_through(stream, writer, &tmp)?;
+                        }
+                    }
+                }
             }
         }
         flush_to(stream, writer)
@@ -556,11 +533,22 @@ fn reframe_app(
     ts: &[u8],
     begin_string: &'static [u8],
 ) -> Result<(), ()> {
+    let spare = writer.spare();
+    let (start, len) = reframe_app_into(spare, orig, ts, begin_string).ok_or(())?;
+    writer.commit(start, len);
+    Ok(())
+}
+
+fn reframe_app_into(
+    buf: &mut [u8],
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Option<(usize, usize)> {
     let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
     let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
 
-    let spare = writer.spare();
-    let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+    let mut fmt = FrameFormatter::new(buf, begin_string, msg_type);
     let mut poss_dup_done = false;
 
     for field in FieldReader::new(orig, 0) {
@@ -585,9 +573,90 @@ fn reframe_app(
         }
     }
 
-    let (start, len) = fmt.finish().map_err(|_| ())?;
-    writer.commit(start, len);
-    Ok(())
+    fmt.finish().ok()
+}
+
+struct FrameHeader<'a> {
+    sender: &'a [u8],
+    target: &'a [u8],
+    msg_type: &'a [u8],
+    seq: u32,
+    poss_dup: bool,
+    heart_bt_int: u32,
+    reset: bool,
+    test_req_id: &'a [u8],
+    begin_seq: u32,
+    end_seq: u32,
+    ref_seq: u32,
+    new_seq_no: u32,
+    gap_fill: bool,
+}
+
+fn parse_frame_header(frame: &[u8]) -> Option<FrameHeader<'_>> {
+    let mut sender: &[u8] = b"";
+    let mut target: &[u8] = b"";
+    let mut msg_type = None::<&[u8]>;
+    let mut seq = None::<u32>;
+    let mut poss_dup = false;
+    let mut heart_bt_int = 30u32;
+    let mut reset = false;
+    let mut test_req_id: &[u8] = b"";
+    let mut begin_seq = 0u32;
+    let mut end_seq = 0u32;
+    let mut ref_seq = 0u32;
+    let mut new_seq_no = 0u32;
+    let mut gap_fill = false;
+
+    for field in FieldReader::new(frame, 0) {
+        match field.tag {
+            35 => msg_type = Some(field.value.slice(frame)),
+            34 => seq = parse_fix_seqnum(field.value.slice(frame)).ok().map(|s| s as u32),
+            49 => sender = field.value.slice(frame),
+            56 => target = field.value.slice(frame),
+            43 => poss_dup = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
+            108 => heart_bt_int = parse_fix_uint(field.value.slice(frame)).unwrap_or(30),
+            141 => reset = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
+            112 => test_req_id = field.value.slice(frame),
+            7 => {
+                begin_seq = parse_fix_seqnum(field.value.slice(frame))
+                    .ok()
+                    .map_or(0, |s| s as u32)
+            }
+            16 => {
+                end_seq = parse_fix_seqnum(field.value.slice(frame))
+                    .ok()
+                    .map_or(0, |s| s as u32)
+            }
+            45 => {
+                ref_seq = parse_fix_seqnum(field.value.slice(frame))
+                    .ok()
+                    .map_or(0, |s| s as u32)
+            }
+            36 => {
+                new_seq_no = parse_fix_seqnum(field.value.slice(frame))
+                    .ok()
+                    .map_or(0, |s| s as u32)
+            }
+            123 => gap_fill = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
+            _ => {}
+        }
+    }
+
+    Some(FrameHeader {
+        sender,
+        target,
+        msg_type: msg_type?,
+        seq: seq?,
+        poss_dup,
+        heart_bt_int,
+        reset,
+        test_req_id,
+        begin_seq,
+        end_seq,
+        ref_seq,
+        new_seq_no,
+        gap_fill,
+    })
 }
 
 fn is_timeout(e: &io::Error) -> bool {


### PR DESCRIPTION
Closes #537.

Three items:

- Resendable cap: when reframe_app fails even after flushing (frame exceeds writer capacity), falls back to a heap buffer and writes through directly. Makes "can send" == "can resend" for oversized messages.
- Single-pass dispatch: replace five separate find_tag scans per inbound message with one FieldReader pass that collects all header and type-specific fields.
- examples/blocking_session.rs: minimal initiator + acceptor recipe driving the recv loop on a blocking socket.