### PR TITLE
feat(fix-engine): FIX conformance harness (#519)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,17 @@ jobs:
     - name: Verify Rust matches LightGBM
       run: cargo test -p nexus-inference --features loader-lightgbm --test lightgbm_integration
 
+  verify-fix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: FIX conformance tests (Python peer + Rust engine)
+      run: cargo test -p nexus-fix-engine --test fix_conformance
+
   loom:
     runs-on: ubuntu-latest
     steps:

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -37,7 +37,9 @@ fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
 
 fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream> {
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
-    stream.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
     FixConnection::from_parts(
         stream,
         SessionState::new(Duration::from_secs(30)),

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -1,0 +1,135 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, FixConnection, FixJournal, SessionConfig, SessionState, State,
+};
+
+const BEGIN: &[u8] = b"FIX.4.4";
+const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
+
+fn tmp_dir(suffix: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("nexus_fix_conf_{}_{}", std::process::id(), suffix));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
+    let mut child = Command::new("python3")
+        .arg(PEER)
+        .arg(scenario)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("python3 not found");
+    let stdout = child.stdout.take().unwrap();
+    let mut line = String::new();
+    BufReader::new(stdout).read_line(&mut line).unwrap();
+    let port: u16 = line.trim().parse().unwrap();
+    (child, port)
+}
+
+fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream> {
+    let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    FixConnection::from_parts(
+        stream,
+        SessionState::new(Duration::from_secs(30)),
+        SessionConfig {
+            sender: CompId::new(b"ENGINE").unwrap(),
+            target: CompId::new(b"PEER").unwrap(),
+        },
+        FixJournal::open(dir, 256).unwrap(),
+        BEGIN,
+    )
+}
+
+fn drive(conn: &mut FixConnection<TcpStream>) -> DisconnectReason {
+    loop {
+        if let Some(r) = conn.recv(Instant::now(), &mut |_| {}).unwrap() {
+            return r;
+        }
+    }
+}
+
+fn new_order(seq: u32) -> Vec<u8> {
+    let mut buf = [0u8; 512];
+    let mut seq_buf = [0u8; 10];
+    let n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    fmt.field(34, &seq_buf[..n]);
+    fmt.field(49, b"ENGINE");
+    fmt.field(56, b"PEER");
+    fmt.field(52, b"20260101-00:00:00.000");
+    fmt.field(11, b"ORD-1");
+    let (start, len) = fmt.finish().unwrap();
+    buf[start..start + len].to_vec()
+}
+
+#[test]
+fn conformance_logon_logout() {
+    let dir = tmp_dir("logon_logout");
+    let (mut child, port) = spawn_peer("logon_logout");
+    let mut conn = connect(port, &dir);
+    conn.connect(Instant::now()).unwrap();
+    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
+fn conformance_heartbeat() {
+    let dir = tmp_dir("heartbeat");
+    let (mut child, port) = spawn_peer("heartbeat");
+    let mut conn = connect(port, &dir);
+    conn.connect(Instant::now()).unwrap();
+    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
+fn conformance_resend() {
+    let dir = tmp_dir("resend");
+    let (mut child, port) = spawn_peer("resend");
+    let mut conn = connect(port, &dir);
+    conn.connect(Instant::now()).unwrap();
+
+    loop {
+        match conn.recv(Instant::now(), &mut |_| {}).unwrap() {
+            Some(r) => panic!("disconnected before active: {r:?}"),
+            None if conn.state().state() == State::Active => break,
+            None => {}
+        }
+    }
+
+    let seq = conn.allocate_seq();
+    conn.send_app(seq, &new_order(seq)).unwrap();
+
+    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
+fn conformance_gap_fill() {
+    let dir = tmp_dir("gap_fill");
+    let (mut child, port) = spawn_peer("gap_fill");
+    let mut conn = connect(port, &dir);
+    conn.connect(Instant::now()).unwrap();
+    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
+fn conformance_seq_reset() {
+    let dir = tmp_dir("seq_reset");
+    let (mut child, port) = spawn_peer("seq_reset");
+    let mut conn = connect(port, &dir);
+    conn.connect(Instant::now()).unwrap();
+    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}

--- a/nexus-fix-engine/tests/fixtures/fix_peer.py
+++ b/nexus-fix-engine/tests/fixtures/fix_peer.py
@@ -1,0 +1,167 @@
+"""FIX 4.4 conformance peer. Accepts one connection, runs one scenario, exits."""
+
+import socket
+import sys
+
+SENDER = "PEER"
+TARGET = "ENGINE"
+TS = "20260101-00:00:00.000"
+
+
+def checksum(data: bytes) -> int:
+    return sum(data) % 256
+
+
+def build(msg_type: str, seq: int, extra: list = None) -> bytes:
+    body = (
+        f"35={msg_type}\x01"
+        f"49={SENDER}\x01"
+        f"56={TARGET}\x01"
+        f"34={seq}\x01"
+        f"52={TS}\x01"
+    )
+    if extra:
+        for tag, val in extra:
+            body += f"{tag}={val}\x01"
+    body_b = body.encode()
+    header = f"8=FIX.4.4\x019={len(body_b)}\x01".encode()
+    ck = checksum(header + body_b)
+    return header + body_b + f"10={ck:03d}\x01".encode()
+
+
+def recv_msg(conn: socket.socket) -> dict:
+    buf = b""
+    body_len = None
+    header_end = 0
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise EOFError("connection closed")
+        buf += chunk
+        if body_len is None:
+            i = buf.find(b"\x019=")
+            if i >= 0:
+                j = buf.find(b"\x01", i + 3)
+                if j >= 0:
+                    body_len = int(buf[i + 3 : j])
+                    header_end = j + 1
+        if body_len is not None and len(buf) >= header_end + body_len + 7:
+            msg_bytes = buf[: header_end + body_len + 7]
+            fields = {}
+            for field in msg_bytes.split(b"\x01"):
+                if b"=" in field:
+                    k, _, v = field.partition(b"=")
+                    fields[k.decode()] = v.decode()
+            return fields
+
+
+def logon_logout(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A", f"expected Logon, got {msg.get('35')}"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5", f"expected Logout, got {msg.get('35')}"
+
+
+def heartbeat(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("1", seq, [(112, "TEST1")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("35") == "0" and msg.get("112") == "TEST1":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def resend(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "D", f"expected NewOrder, got {msg.get('35')}"
+    conn.sendall(build("2", seq, [(7, "2"), (16, "2")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("43") == "Y":
+            assert msg.get("122"), "OrigSendingTime (122) must be set on PossDup replay"
+            break
+        if msg.get("35") == "4":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def gap_fill(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(123, "Y"), (36, "5")]))
+    seq = 5
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def seq_reset(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(36, "10")]))
+    seq = 10
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+SCENARIOS = {
+    "logon_logout": logon_logout,
+    "heartbeat": heartbeat,
+    "resend": resend,
+    "gap_fill": gap_fill,
+    "seq_reset": seq_reset,
+}
+
+if __name__ == "__main__":
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "logon_logout"
+    fn = SCENARIOS.get(scenario)
+    if fn is None:
+        print(f"unknown scenario: {scenario}", file=sys.stderr)
+        sys.exit(1)
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+    print(port, flush=True)
+
+    conn, _ = srv.accept()
+    conn.settimeout(10.0)
+    try:
+        fn(conn)
+    finally:
+        conn.close()
+        srv.close()


### PR DESCRIPTION
Closes #519.

Python FIX 4.4 peer (`tests/fixtures/fix_peer.py`, pure stdlib) runs as an acceptor subprocess. Rust integration test (`tests/fix_conformance.rs`) connects our `FixConnection` as the initiator and drives five scenarios:

- `logon_logout` — basic session setup and teardown
- `heartbeat` — peer sends TestRequest, engine replies with matching Heartbeat
- `resend` — peer sends ResendRequest for an app message, engine replays with PossDup=Y and OrigSendingTime
- `gap_fill` — peer sends SequenceReset GapFill, engine advances expected seq and accepts Logout at new seq
- `seq_reset` — peer sends SequenceReset Reset, engine jumps expected seq and accepts Logout at new seq

New `verify-fix` CI job: Python 3.12, no extra deps (stdlib only), runs `cargo test -p nexus-fix-engine --test fix_conformance`.