### PR TITLE
feat(async-fix-engine): tokio async adapter (#521)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,6 +116,17 @@ jobs:
     - name: FIX conformance tests (Python peer + Rust engine)
       run: cargo test -p nexus-fix-engine --test fix_conformance
 
+  verify-async-fix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Async FIX conformance tests (Python peer + tokio adapter)
+      run: cargo test -p nexus-async-fix-engine --test async_conformance
+
   loom:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
 	"nexus-fix-codegen",
 	"nexus-fix-codegen-tests",
 	"nexus-fix-engine",
+	"nexus-async-fix-engine",
 	"nexus-platform",
 ]
 

--- a/nexus-async-fix-engine/Cargo.toml
+++ b/nexus-async-fix-engine/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nexus-async-fix-engine"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Tokio async adapter for the sans-IO FIX session layer"
+repository.workspace = true
+keywords = ["fix", "protocol", "session", "async", "tokio"]
+categories = ["network-programming", "finance", "asynchronous"]
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-fix-engine = { path = "../nexus-fix-engine" }
+nexus-fix-codec = { path = "../nexus-fix-codec" }
+tokio = { version = "1", features = ["io-util", "net", "rt", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -1,0 +1,601 @@
+//! Tokio async adapter for the sans-IO FIX session layer.
+//!
+//! [`AsyncFixConnection`] drives [`SessionState`] over a tokio `AsyncRead +
+//! AsyncWrite` stream, mirroring [`FixConnection`](nexus_fix_engine::FixConnection)
+//! with `.await` on socket I/O and `tokio::time` for heartbeat/TestRequest timers.
+
+#![cfg(unix)]
+
+use std::io;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use nexus_fix_codec::{
+    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
+    parse_fix_uint,
+};
+use nexus_fix_engine::{
+    AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
+    Out, ReplayItem, SessionConfig, SessionState, State,
+};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::time::timeout_at;
+
+const TS_LEN: usize = 21;
+
+/// Error from [`AsyncFixConnection`].
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    FrameTooLarge(usize),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O: {e}"),
+            Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Async FIX session transport over any `AsyncRead + AsyncWrite` stream.
+///
+/// Wraps [`SessionState`] with tokio I/O and timers. The session core is
+/// identical to [`FixConnection`](nexus_fix_engine::FixConnection); only the
+/// transport layer is async.
+pub struct AsyncFixConnection<S> {
+    stream: S,
+    reader: FrameReader,
+    writer: FrameWriter,
+    state: SessionState,
+    journal: FixJournal,
+    config: SessionConfig,
+    begin_string: &'static [u8],
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
+    pub fn from_parts(
+        stream: S,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> Self {
+        Self {
+            stream,
+            reader: FrameReader::builder().build(),
+            writer: FrameWriter::builder().build(),
+            state,
+            journal,
+            config,
+            begin_string,
+        }
+    }
+
+    pub fn state(&self) -> &SessionState {
+        &self.state
+    }
+
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        &mut self.state
+    }
+
+    pub fn allocate_seq(&mut self) -> u32 {
+        self.state.allocate_seq(Instant::now())
+    }
+
+    pub fn wants_read(&self) -> bool {
+        self.state.state() != State::Disconnected
+    }
+
+    pub fn wants_write(&self) -> bool {
+        !self.writer.is_empty()
+    }
+
+    /// Initiates a session: encodes and sends the opening Logon.
+    pub async fn connect(&mut self) -> Result<(), Error> {
+        let out = self.state.connect(Instant::now());
+        self.flush_out(out).await
+    }
+
+    /// Receives one batch of bytes, dispatches all complete frames, and
+    /// fires any due timers. Returns `Some(reason)` when the session ends.
+    pub async fn recv<H>(&mut self, on_app: &mut H) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let deadline = self
+            .state
+            .next_timeout()
+            .map(tokio::time::Instant::from_std)
+            .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(60));
+
+        let mut tmp = [0u8; 8192];
+        let n = match timeout_at(deadline, self.stream.read(&mut tmp)).await {
+            Ok(Ok(0)) => return Ok(Some(DisconnectReason::Logout)),
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(Error::Io(e)),
+            Err(_elapsed) => {
+                let now = Instant::now();
+                let out = self.state.on_timeout(now);
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    self.flush_out(out).await?;
+                    return Ok(Some(reason));
+                }
+                self.flush_out(out).await?;
+                return Ok(None);
+            }
+        };
+
+        self.reader
+            .read(&tmp[..n])
+            .map_err(|_| Error::FrameTooLarge(n))?;
+
+        let now = Instant::now();
+        loop {
+            match self.reader.next() {
+                Ok(Some(frame)) => {
+                    let frame = frame.to_vec();
+                    if let Some(reason) = self.dispatch(&frame, now, on_app).await? {
+                        return Ok(Some(reason));
+                    }
+                }
+                Ok(None) => break,
+                Err(FrameError::MessageTooLarge { size }) => {
+                    return Err(Error::FrameTooLarge(size));
+                }
+                Err(FrameError::Garbage { .. }) => {}
+            }
+        }
+
+        if self.reader.should_compact() {
+            self.reader.compact();
+        }
+
+        Ok(None)
+    }
+
+    /// Stores the frame in the journal and writes it to the stream.
+    pub async fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        self.journal
+            .store(seq, frame)
+            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        self.write_through(frame).await
+    }
+
+    /// Initiates a clean logout.
+    pub async fn logout(&mut self) -> Result<(), Error> {
+        let out = self.state.logout(Instant::now());
+        self.flush_out(out).await
+    }
+
+    async fn dispatch<H>(
+        &mut self,
+        frame: &[u8],
+        now: Instant,
+        on_app: &mut H,
+    ) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let sender_ok = find_tag(frame, 0, 49)
+            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok = find_tag(frame, 0, 56)
+            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        if !sender_ok || !target_ok {
+            let out = self.state.on_comp_id_mismatch(now);
+            self.flush_out(out).await?;
+            return Ok(Some(DisconnectReason::CompIdMismatch));
+        }
+
+        let seq = match find_tag(frame, 0, 34)
+            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+        {
+            Some(s) => s as u32,
+            None => return Ok(None),
+        };
+
+        let poss_dup = find_tag(frame, 0, 43)
+            .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+            .unwrap_or(false);
+
+        let msg_type = match find_tag(frame, 0, 35) {
+            Some(s) => s.slice(frame),
+            None => return Ok(None),
+        };
+
+        let (out, is_app) = match msg_type {
+            b"A" => {
+                let hbi = find_tag(frame, 0, 108)
+                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
+                    .unwrap_or(30);
+                let reset = find_tag(frame, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                (
+                    self.state.on_logon(seq, hbi, reset, !was_logon_sent, now),
+                    false,
+                )
+            }
+            b"5" => (self.state.on_logout(seq, poss_dup, now), false),
+            b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
+            b"1" => {
+                let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
+                (self.state.on_test_request(seq, poss_dup, id, now), false)
+            }
+            b"2" => {
+                let begin = find_tag(frame, 0, 7)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let end = find_tag(frame, 0, 16)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (
+                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
+                    false,
+                )
+            }
+            b"3" => {
+                let ref_seq = find_tag(frame, 0, 45)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (self.state.on_reject(seq, poss_dup, ref_seq, now), false)
+            }
+            b"4" => {
+                let new_seq = find_tag(frame, 0, 36)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let gap_fill = find_tag(frame, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                (
+                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
+                    false,
+                )
+            }
+            _ => (self.state.on_app(seq, poss_dup, now), true),
+        };
+
+        self.flush_out(out).await?;
+
+        match out.event() {
+            Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
+            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end).await?,
+            Some(Event::App { .. }) if is_app => on_app(frame),
+            _ => {}
+        }
+
+        Ok(None)
+    }
+
+    async fn flush_out(&mut self, out: Out) -> Result<(), Error> {
+        for admin in out.admin_messages() {
+            self.encode_admin(admin);
+        }
+        if !self.writer.is_empty() {
+            self.flush_writer().await?;
+        }
+        Ok(())
+    }
+
+    fn encode_admin(&mut self, admin: AdminMsg) {
+        let ts = make_ts();
+
+        let msg_type: &[u8] = match admin {
+            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logout { .. } => b"5",
+            AdminMsg::Heartbeat { .. } => b"0",
+            AdminMsg::TestRequest { .. } => b"1",
+            AdminMsg::ResendRequest { .. } => b"2",
+            AdminMsg::SequenceReset { .. } => b"4",
+        };
+
+        let seq = match admin {
+            AdminMsg::Logon { seq, .. }
+            | AdminMsg::Logout { seq }
+            | AdminMsg::Heartbeat { seq, .. }
+            | AdminMsg::TestRequest { seq, .. }
+            | AdminMsg::ResendRequest { seq, .. }
+            | AdminMsg::SequenceReset { seq, .. } => seq,
+        };
+
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
+
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+
+        let (start, len) = {
+            let spare = self.writer.spare();
+            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+            fmt.field(34, &seq_buf[..seq_n]);
+            fmt.field(49, sender.as_bytes());
+            fmt.field(56, target.as_bytes());
+            fmt.field(52, &ts);
+
+            match admin {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                }
+                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
+                AdminMsg::Heartbeat {
+                    echo: Some((id, id_len)),
+                    ..
+                } => {
+                    fmt.field(112, &id[..id_len as usize]);
+                }
+                AdminMsg::TestRequest { id, .. } => {
+                    let mut buf = [0u8; 20];
+                    let n = encode_u64(id, &mut buf);
+                    fmt.field(112, &buf[..n]);
+                }
+                AdminMsg::ResendRequest { begin, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(begin, &mut buf);
+                    fmt.field(7, &buf[..n]);
+                    fmt.field(16, b"0");
+                }
+                AdminMsg::SequenceReset { new_seq, .. } => {
+                    fmt.field(43, b"Y");
+                    fmt.field(123, b"Y");
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(new_seq, &mut buf);
+                    fmt.field(36, &buf[..n]);
+                }
+            }
+
+            match fmt.finish() {
+                Ok(sl) => sl,
+                Err(_) => return,
+            }
+        };
+
+        self.writer.commit(start, len);
+    }
+
+    async fn flush_writer(&mut self) -> Result<(), Error> {
+        while !self.writer.is_empty() {
+            let n = self.stream.write(self.writer.data()).await?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
+            }
+            self.writer.advance(n);
+        }
+        self.stream.flush().await?;
+        Ok(())
+    }
+
+    async fn write_through(&mut self, frame: &[u8]) -> Result<(), Error> {
+        if self.writer.remaining() < frame.len() {
+            self.flush_writer().await?;
+        }
+        if self.writer.remaining() >= frame.len() {
+            let spare = self.writer.spare();
+            spare[..frame.len()].copy_from_slice(frame);
+            self.writer.commit(0, frame.len());
+        } else {
+            self.stream.write_all(frame).await?;
+            self.stream.flush().await?;
+            return Ok(());
+        }
+        self.flush_writer().await
+    }
+
+    async fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
+        enum Item {
+            Gap(u32, u32),
+            App(Vec<u8>),
+        }
+
+        let ts = make_ts();
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
+
+        let items: Vec<Item> = self
+            .journal
+            .resend(begin, end)
+            .map(|r| match r {
+                ReplayItem::GapFill { seq, new_seq } => Item::Gap(seq, new_seq),
+                ReplayItem::App(d) => Item::App(d.to_vec()),
+            })
+            .collect();
+
+        for item in items {
+            let ok = match &item {
+                Item::Gap(seq, new_seq) => encode_gap_fill(
+                    &mut self.writer,
+                    begin_string,
+                    sender,
+                    target,
+                    &ts,
+                    *seq,
+                    *new_seq,
+                ),
+                Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
+            };
+            if ok.is_err() {
+                self.flush_writer().await?;
+                let retry = match &item {
+                    Item::Gap(seq, new_seq) => encode_gap_fill(
+                        &mut self.writer,
+                        begin_string,
+                        sender,
+                        target,
+                        &ts,
+                        *seq,
+                        *new_seq,
+                    ),
+                    Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
+                };
+                retry.map_err(|()| {
+                    Error::FrameTooLarge(self.writer.remaining().saturating_add(1))
+                })?;
+            }
+        }
+        self.flush_writer().await
+    }
+}
+
+impl AsyncFixConnection<tokio::net::TcpStream> {
+    /// Connects a TCP stream, enables `TCP_NODELAY`, and wraps it.
+    pub async fn tcp_connect(
+        addr: std::net::SocketAddr,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> io::Result<Self> {
+        let stream = tokio::net::TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(Self::from_parts(stream, state, config, journal, begin_string))
+    }
+}
+
+fn make_ts() -> [u8; TS_LEN] {
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i128;
+    let mut ts = [0u8; TS_LEN];
+    format_utc_timestamp(unix_nanos, &mut ts);
+    ts
+}
+
+fn format_utc_timestamp(unix_nanos: i128, out: &mut [u8; TS_LEN]) {
+    let secs = unix_nanos.div_euclid(1_000_000_000) as i64;
+    let millis = (unix_nanos.rem_euclid(1_000_000_000) / 1_000_000) as u32;
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400) as u32;
+    let (y, m, d) = civil_from_days(days);
+
+    write_digits(&mut out[0..4], y.max(0) as u32);
+    write_digits(&mut out[4..6], m);
+    write_digits(&mut out[6..8], d);
+    out[8] = b'-';
+    write_digits(&mut out[9..11], sod / 3600);
+    out[11] = b':';
+    write_digits(&mut out[12..14], sod / 60 % 60);
+    out[14] = b':';
+    write_digits(&mut out[15..17], sod % 60);
+    out[17] = b'.';
+    write_digits(&mut out[18..21], millis);
+}
+
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    (y + i64::from(m <= 2), m, d)
+}
+
+fn write_digits(out: &mut [u8], mut v: u32) {
+    for slot in out.iter_mut().rev() {
+        *slot = b'0' + (v % 10) as u8;
+        v /= 10;
+    }
+}
+
+fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
+    if v == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    let mut tmp = [0u8; 20];
+    let mut n = 0;
+    let mut x = v;
+    while x > 0 {
+        tmp[n] = b'0' + (x % 10) as u8;
+        x /= 10;
+        n += 1;
+    }
+    for i in 0..n {
+        out[i] = tmp[n - 1 - i];
+    }
+    n
+}
+
+fn encode_gap_fill(
+    writer: &mut FrameWriter,
+    begin_string: &'static [u8],
+    sender: CompId,
+    target: CompId,
+    ts: &[u8],
+    seq: u32,
+    new_seq: u32,
+) -> Result<(), ()> {
+    let spare = writer.spare();
+    let mut seq_buf = [0u8; 10];
+    let seq_n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
+    fmt.field(34, &seq_buf[..seq_n]);
+    fmt.field(49, sender.as_bytes());
+    fmt.field(56, target.as_bytes());
+    fmt.field(52, ts);
+    fmt.field(43, b"Y");
+    fmt.field(123, b"Y");
+    let mut nsq_buf = [0u8; 10];
+    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
+    fmt.field(36, &nsq_buf[..nsq_n]);
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
+}
+
+fn reframe_app(
+    writer: &mut FrameWriter,
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Result<(), ()> {
+    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
+    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
+
+    let spare = writer.spare();
+    let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(orig, 0) {
+        match field.tag {
+            8 | 9 | 10 | 35 | 43 | 122 => {}
+            52 => {
+                fmt.field(52, ts);
+                fmt.field(43, b"Y");
+                if let Some(t) = orig_time {
+                    fmt.field(122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => fmt.field(field.tag, field.value.slice(orig)),
+        }
+    }
+
+    if !poss_dup_done {
+        fmt.field(43, b"Y");
+        if let Some(t) = orig_time {
+            fmt.field(122, t);
+        }
+    }
+
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
+}

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -186,19 +186,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let sender_ok = find_tag(frame, 0, 49)
-            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
-        let target_ok = find_tag(frame, 0, 56)
-            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        let sender_ok =
+            find_tag(frame, 0, 49).is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok =
+            find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
         if !sender_ok || !target_ok {
             let out = self.state.on_comp_id_mismatch(now);
             self.flush_out(out).await?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
         }
 
-        let seq = match find_tag(frame, 0, 34)
-            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-        {
+        let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
             Some(s) => s as u32,
             None => return Ok(None),
         };
@@ -460,7 +458,13 @@ impl AsyncFixConnection<tokio::net::TcpStream> {
     ) -> io::Result<Self> {
         let stream = tokio::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;
-        Ok(Self::from_parts(stream, state, config, journal, begin_string))
+        Ok(Self::from_parts(
+            stream,
+            state,
+            config,
+            journal,
+            begin_string,
+        ))
     }
 }
 

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -112,11 +112,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let deadline = self
-            .state
-            .next_timeout()
-            .map(tokio::time::Instant::from_std)
-            .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(60));
+        let deadline = self.state.next_timeout().map_or_else(
+            || tokio::time::Instant::now() + Duration::from_secs(60),
+            tokio::time::Instant::from_std,
+        );
 
         let mut tmp = [0u8; 8192];
         let n = match timeout_at(deadline, self.stream.read(&mut tmp)).await {

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -1,0 +1,139 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State,
+};
+use nexus_async_fix_engine::AsyncFixConnection;
+use tokio::net::TcpStream;
+
+const BEGIN: &[u8] = b"FIX.4.4";
+const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
+
+fn tmp_dir(suffix: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "nexus_async_fix_conf_{}_{}",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
+    let mut child = Command::new("python3")
+        .arg(PEER)
+        .arg(scenario)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("python3 not found");
+    let stdout = child.stdout.take().unwrap();
+    let mut line = String::new();
+    BufReader::new(stdout).read_line(&mut line).unwrap();
+    let port: u16 = line.trim().parse().unwrap();
+    (child, port)
+}
+
+async fn connect(port: u16, dir: &Path) -> AsyncFixConnection<TcpStream> {
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+    AsyncFixConnection::from_parts(
+        stream,
+        SessionState::new(Duration::from_secs(30)),
+        SessionConfig {
+            sender: CompId::new(b"ENGINE").unwrap(),
+            target: CompId::new(b"PEER").unwrap(),
+        },
+        FixJournal::open(dir, 256).unwrap(),
+        BEGIN,
+    )
+}
+
+async fn drive(conn: &mut AsyncFixConnection<TcpStream>) -> DisconnectReason {
+    loop {
+        if let Some(r) = conn.recv(&mut |_| {}).await.unwrap() {
+            return r;
+        }
+    }
+}
+
+fn new_order(seq: u32) -> Vec<u8> {
+    let mut buf = [0u8; 512];
+    let mut seq_buf = [0u8; 10];
+    let n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    fmt.field(34, &seq_buf[..n]);
+    fmt.field(49, b"ENGINE");
+    fmt.field(56, b"PEER");
+    fmt.field(52, b"20260101-00:00:00.000");
+    fmt.field(11, b"ORD-1");
+    let (start, len) = fmt.finish().unwrap();
+    buf[start..start + len].to_vec()
+}
+
+#[tokio::test]
+async fn conformance_logon_logout() {
+    let dir = tmp_dir("logon_logout");
+    let (mut child, port) = spawn_peer("logon_logout");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_heartbeat() {
+    let dir = tmp_dir("heartbeat");
+    let (mut child, port) = spawn_peer("heartbeat");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_resend() {
+    let dir = tmp_dir("resend");
+    let (mut child, port) = spawn_peer("resend");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+
+    loop {
+        match conn.recv(&mut |_| {}).await.unwrap() {
+            Some(r) => panic!("disconnected before active: {r:?}"),
+            None if conn.state().state() == State::Active => break,
+            None => {}
+        }
+    }
+
+    let seq = conn.allocate_seq();
+    conn.send_app(seq, &new_order(seq)).await.unwrap();
+
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_gap_fill() {
+    let dir = tmp_dir("gap_fill");
+    let (mut child, port) = spawn_peer("gap_fill");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_seq_reset() {
+    let dir = tmp_dir("seq_reset");
+    let (mut child, port) = spawn_peer("seq_reset");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -5,11 +5,9 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
-use nexus_fix_engine::{
-    CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State,
-};
 use nexus_async_fix_engine::AsyncFixConnection;
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State};
 use tokio::net::TcpStream;
 
 const BEGIN: &[u8] = b"FIX.4.4";

--- a/nexus-async-fix-engine/tests/fixtures/fix_peer.py
+++ b/nexus-async-fix-engine/tests/fixtures/fix_peer.py
@@ -1,0 +1,167 @@
+"""FIX 4.4 conformance peer. Accepts one connection, runs one scenario, exits."""
+
+import socket
+import sys
+
+SENDER = "PEER"
+TARGET = "ENGINE"
+TS = "20260101-00:00:00.000"
+
+
+def checksum(data: bytes) -> int:
+    return sum(data) % 256
+
+
+def build(msg_type: str, seq: int, extra: list = None) -> bytes:
+    body = (
+        f"35={msg_type}\x01"
+        f"49={SENDER}\x01"
+        f"56={TARGET}\x01"
+        f"34={seq}\x01"
+        f"52={TS}\x01"
+    )
+    if extra:
+        for tag, val in extra:
+            body += f"{tag}={val}\x01"
+    body_b = body.encode()
+    header = f"8=FIX.4.4\x019={len(body_b)}\x01".encode()
+    ck = checksum(header + body_b)
+    return header + body_b + f"10={ck:03d}\x01".encode()
+
+
+def recv_msg(conn: socket.socket) -> dict:
+    buf = b""
+    body_len = None
+    header_end = 0
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise EOFError("connection closed")
+        buf += chunk
+        if body_len is None:
+            i = buf.find(b"\x019=")
+            if i >= 0:
+                j = buf.find(b"\x01", i + 3)
+                if j >= 0:
+                    body_len = int(buf[i + 3 : j])
+                    header_end = j + 1
+        if body_len is not None and len(buf) >= header_end + body_len + 7:
+            msg_bytes = buf[: header_end + body_len + 7]
+            fields = {}
+            for field in msg_bytes.split(b"\x01"):
+                if b"=" in field:
+                    k, _, v = field.partition(b"=")
+                    fields[k.decode()] = v.decode()
+            return fields
+
+
+def logon_logout(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A", f"expected Logon, got {msg.get('35')}"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5", f"expected Logout, got {msg.get('35')}"
+
+
+def heartbeat(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("1", seq, [(112, "TEST1")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("35") == "0" and msg.get("112") == "TEST1":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def resend(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "D", f"expected NewOrder, got {msg.get('35')}"
+    conn.sendall(build("2", seq, [(7, "2"), (16, "2")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("43") == "Y":
+            assert msg.get("122"), "OrigSendingTime (122) must be set on PossDup replay"
+            break
+        if msg.get("35") == "4":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def gap_fill(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(123, "Y"), (36, "5")]))
+    seq = 5
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def seq_reset(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(36, "10")]))
+    seq = 10
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+SCENARIOS = {
+    "logon_logout": logon_logout,
+    "heartbeat": heartbeat,
+    "resend": resend,
+    "gap_fill": gap_fill,
+    "seq_reset": seq_reset,
+}
+
+if __name__ == "__main__":
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "logon_logout"
+    fn = SCENARIOS.get(scenario)
+    if fn is None:
+        print(f"unknown scenario: {scenario}", file=sys.stderr)
+        sys.exit(1)
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+    print(port, flush=True)
+
+    conn, _ = srv.accept()
+    conn.settimeout(10.0)
+    try:
+        fn(conn)
+    finally:
+        conn.close()
+        srv.close()


### PR DESCRIPTION
Closes #521.

New crate `nexus-async-fix-engine`: tokio async adapter over the sans-IO FIX session layer.

## What

- `AsyncFixConnection<S>` where `S: AsyncRead + AsyncWrite + Unpin` — mirrors `FixConnection` with `.await` on socket I/O
- `tokio::time::timeout_at` drives heartbeat/TestRequest/logon timeouts from `SessionState::next_timeout()`
- Same dispatch, encoding, and resend logic as the sync transport; only the I/O layer differs
- `AsyncFixConnection::tcp_connect` convenience constructor for tokio `TcpStream`
- 5 async conformance tests against the same Python FIX peer (logon/logout, heartbeat, resend, gap-fill, seq-reset)
- `verify-async-fix` CI job

## Design

Reuses all public types from `nexus-fix-engine` (`SessionState`, `FrameReader`, `FrameWriter`, `AdminMsg`, `Out`, `FixJournal`). The async-specific difference: reads land in a 8 KiB stack buffer fed into `FrameReader::read()` to avoid holding a borrow across await points. Resend items are collected into a `Vec` before async-flushing for the same reason.