### PR TITLE
feat(fix-engine): typed MessageReader/MessageWriter; delete Session<D>

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,6 +116,17 @@ jobs:
     - name: FIX conformance tests (Python peer + Rust engine)
       run: cargo test -p nexus-fix-engine --test fix_conformance
 
+  verify-async-fix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Async FIX conformance tests (Python peer + tokio adapter)
+      run: cargo test -p nexus-async-fix-engine --test async_conformance
+
   loom:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
 	"nexus-fix-codegen",
 	"nexus-fix-codegen-tests",
 	"nexus-fix-engine",
+	"nexus-async-fix-engine",
 	"nexus-platform",
 ]
 

--- a/nexus-async-fix-engine/Cargo.toml
+++ b/nexus-async-fix-engine/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nexus-async-fix-engine"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Tokio async adapter for the sans-IO FIX session layer"
+repository.workspace = true
+keywords = ["fix", "protocol", "session", "async", "tokio"]
+categories = ["network-programming", "finance", "asynchronous"]
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-fix-engine = { path = "../nexus-fix-engine" }
+nexus-fix-codec = { path = "../nexus-fix-codec" }
+tokio = { version = "1", features = ["io-util", "net", "rt", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -1,0 +1,601 @@
+//! Tokio async adapter for the sans-IO FIX session layer.
+//!
+//! [`AsyncFixConnection`] drives [`SessionState`] over a tokio `AsyncRead +
+//! AsyncWrite` stream, mirroring [`FixConnection`](nexus_fix_engine::FixConnection)
+//! with `.await` on socket I/O and `tokio::time` for heartbeat/TestRequest timers.
+
+#![cfg(unix)]
+
+use std::io;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use nexus_fix_codec::{
+    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
+    parse_fix_uint,
+};
+use nexus_fix_engine::{
+    AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
+    Out, ReplayItem, SessionConfig, SessionState, State,
+};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::time::timeout_at;
+
+const TS_LEN: usize = 21;
+
+/// Error from [`AsyncFixConnection`].
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    FrameTooLarge(usize),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O: {e}"),
+            Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Async FIX session transport over any `AsyncRead + AsyncWrite` stream.
+///
+/// Wraps [`SessionState`] with tokio I/O and timers. The session core is
+/// identical to [`FixConnection`](nexus_fix_engine::FixConnection); only the
+/// transport layer is async.
+pub struct AsyncFixConnection<S> {
+    stream: S,
+    reader: FrameReader,
+    writer: FrameWriter,
+    state: SessionState,
+    journal: FixJournal,
+    config: SessionConfig,
+    begin_string: &'static [u8],
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
+    pub fn from_parts(
+        stream: S,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> Self {
+        Self {
+            stream,
+            reader: FrameReader::builder().build(),
+            writer: FrameWriter::builder().build(),
+            state,
+            journal,
+            config,
+            begin_string,
+        }
+    }
+
+    pub fn state(&self) -> &SessionState {
+        &self.state
+    }
+
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        &mut self.state
+    }
+
+    pub fn allocate_seq(&mut self) -> u32 {
+        self.state.allocate_seq(Instant::now())
+    }
+
+    pub fn wants_read(&self) -> bool {
+        self.state.state() != State::Disconnected
+    }
+
+    pub fn wants_write(&self) -> bool {
+        !self.writer.is_empty()
+    }
+
+    /// Initiates a session: encodes and sends the opening Logon.
+    pub async fn connect(&mut self) -> Result<(), Error> {
+        let out = self.state.connect(Instant::now());
+        self.flush_out(out).await
+    }
+
+    /// Receives one batch of bytes, dispatches all complete frames, and
+    /// fires any due timers. Returns `Some(reason)` when the session ends.
+    pub async fn recv<H>(&mut self, on_app: &mut H) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let deadline = self
+            .state
+            .next_timeout()
+            .map(tokio::time::Instant::from_std)
+            .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(60));
+
+        let mut tmp = [0u8; 8192];
+        let n = match timeout_at(deadline, self.stream.read(&mut tmp)).await {
+            Ok(Ok(0)) => return Ok(Some(DisconnectReason::Logout)),
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(Error::Io(e)),
+            Err(_elapsed) => {
+                let now = Instant::now();
+                let out = self.state.on_timeout(now);
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    self.flush_out(out).await?;
+                    return Ok(Some(reason));
+                }
+                self.flush_out(out).await?;
+                return Ok(None);
+            }
+        };
+
+        self.reader
+            .read(&tmp[..n])
+            .map_err(|_| Error::FrameTooLarge(n))?;
+
+        let now = Instant::now();
+        loop {
+            match self.reader.next() {
+                Ok(Some(frame)) => {
+                    let frame = frame.to_vec();
+                    if let Some(reason) = self.dispatch(&frame, now, on_app).await? {
+                        return Ok(Some(reason));
+                    }
+                }
+                Ok(None) => break,
+                Err(FrameError::MessageTooLarge { size }) => {
+                    return Err(Error::FrameTooLarge(size));
+                }
+                Err(FrameError::Garbage { .. }) => {}
+            }
+        }
+
+        if self.reader.should_compact() {
+            self.reader.compact();
+        }
+
+        Ok(None)
+    }
+
+    /// Stores the frame in the journal and writes it to the stream.
+    pub async fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        self.journal
+            .store(seq, frame)
+            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        self.write_through(frame).await
+    }
+
+    /// Initiates a clean logout.
+    pub async fn logout(&mut self) -> Result<(), Error> {
+        let out = self.state.logout(Instant::now());
+        self.flush_out(out).await
+    }
+
+    async fn dispatch<H>(
+        &mut self,
+        frame: &[u8],
+        now: Instant,
+        on_app: &mut H,
+    ) -> Result<Option<DisconnectReason>, Error>
+    where
+        H: FnMut(&[u8]),
+    {
+        let sender_ok = find_tag(frame, 0, 49)
+            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok = find_tag(frame, 0, 56)
+            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        if !sender_ok || !target_ok {
+            let out = self.state.on_comp_id_mismatch(now);
+            self.flush_out(out).await?;
+            return Ok(Some(DisconnectReason::CompIdMismatch));
+        }
+
+        let seq = match find_tag(frame, 0, 34)
+            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+        {
+            Some(s) => s as u32,
+            None => return Ok(None),
+        };
+
+        let poss_dup = find_tag(frame, 0, 43)
+            .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+            .unwrap_or(false);
+
+        let msg_type = match find_tag(frame, 0, 35) {
+            Some(s) => s.slice(frame),
+            None => return Ok(None),
+        };
+
+        let (out, is_app) = match msg_type {
+            b"A" => {
+                let hbi = find_tag(frame, 0, 108)
+                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
+                    .unwrap_or(30);
+                let reset = find_tag(frame, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                (
+                    self.state.on_logon(seq, hbi, reset, !was_logon_sent, now),
+                    false,
+                )
+            }
+            b"5" => (self.state.on_logout(seq, poss_dup, now), false),
+            b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
+            b"1" => {
+                let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
+                (self.state.on_test_request(seq, poss_dup, id, now), false)
+            }
+            b"2" => {
+                let begin = find_tag(frame, 0, 7)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let end = find_tag(frame, 0, 16)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (
+                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
+                    false,
+                )
+            }
+            b"3" => {
+                let ref_seq = find_tag(frame, 0, 45)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                (self.state.on_reject(seq, poss_dup, ref_seq, now), false)
+            }
+            b"4" => {
+                let new_seq = find_tag(frame, 0, 36)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .unwrap_or(0) as u32;
+                let gap_fill = find_tag(frame, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                (
+                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
+                    false,
+                )
+            }
+            _ => (self.state.on_app(seq, poss_dup, now), true),
+        };
+
+        self.flush_out(out).await?;
+
+        match out.event() {
+            Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
+            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end).await?,
+            Some(Event::App { .. }) if is_app => on_app(frame),
+            _ => {}
+        }
+
+        Ok(None)
+    }
+
+    async fn flush_out(&mut self, out: Out) -> Result<(), Error> {
+        for admin in out.admin_messages() {
+            self.encode_admin(admin);
+        }
+        if !self.writer.is_empty() {
+            self.flush_writer().await?;
+        }
+        Ok(())
+    }
+
+    fn encode_admin(&mut self, admin: AdminMsg) {
+        let ts = make_ts();
+
+        let msg_type: &[u8] = match admin {
+            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logout { .. } => b"5",
+            AdminMsg::Heartbeat { .. } => b"0",
+            AdminMsg::TestRequest { .. } => b"1",
+            AdminMsg::ResendRequest { .. } => b"2",
+            AdminMsg::SequenceReset { .. } => b"4",
+        };
+
+        let seq = match admin {
+            AdminMsg::Logon { seq, .. }
+            | AdminMsg::Logout { seq }
+            | AdminMsg::Heartbeat { seq, .. }
+            | AdminMsg::TestRequest { seq, .. }
+            | AdminMsg::ResendRequest { seq, .. }
+            | AdminMsg::SequenceReset { seq, .. } => seq,
+        };
+
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
+
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+
+        let (start, len) = {
+            let spare = self.writer.spare();
+            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+            fmt.field(34, &seq_buf[..seq_n]);
+            fmt.field(49, sender.as_bytes());
+            fmt.field(56, target.as_bytes());
+            fmt.field(52, &ts);
+
+            match admin {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                }
+                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
+                AdminMsg::Heartbeat {
+                    echo: Some((id, id_len)),
+                    ..
+                } => {
+                    fmt.field(112, &id[..id_len as usize]);
+                }
+                AdminMsg::TestRequest { id, .. } => {
+                    let mut buf = [0u8; 20];
+                    let n = encode_u64(id, &mut buf);
+                    fmt.field(112, &buf[..n]);
+                }
+                AdminMsg::ResendRequest { begin, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(begin, &mut buf);
+                    fmt.field(7, &buf[..n]);
+                    fmt.field(16, b"0");
+                }
+                AdminMsg::SequenceReset { new_seq, .. } => {
+                    fmt.field(43, b"Y");
+                    fmt.field(123, b"Y");
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(new_seq, &mut buf);
+                    fmt.field(36, &buf[..n]);
+                }
+            }
+
+            match fmt.finish() {
+                Ok(sl) => sl,
+                Err(_) => return,
+            }
+        };
+
+        self.writer.commit(start, len);
+    }
+
+    async fn flush_writer(&mut self) -> Result<(), Error> {
+        while !self.writer.is_empty() {
+            let n = self.stream.write(self.writer.data()).await?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
+            }
+            self.writer.advance(n);
+        }
+        self.stream.flush().await?;
+        Ok(())
+    }
+
+    async fn write_through(&mut self, frame: &[u8]) -> Result<(), Error> {
+        if self.writer.remaining() < frame.len() {
+            self.flush_writer().await?;
+        }
+        if self.writer.remaining() >= frame.len() {
+            let spare = self.writer.spare();
+            spare[..frame.len()].copy_from_slice(frame);
+            self.writer.commit(0, frame.len());
+        } else {
+            self.stream.write_all(frame).await?;
+            self.stream.flush().await?;
+            return Ok(());
+        }
+        self.flush_writer().await
+    }
+
+    async fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
+        enum Item {
+            Gap(u32, u32),
+            App(Vec<u8>),
+        }
+
+        let ts = make_ts();
+        let begin_string = self.begin_string;
+        let sender = self.config.sender;
+        let target = self.config.target;
+
+        let items: Vec<Item> = self
+            .journal
+            .resend(begin, end)
+            .map(|r| match r {
+                ReplayItem::GapFill { seq, new_seq } => Item::Gap(seq, new_seq),
+                ReplayItem::App(d) => Item::App(d.to_vec()),
+            })
+            .collect();
+
+        for item in items {
+            let ok = match &item {
+                Item::Gap(seq, new_seq) => encode_gap_fill(
+                    &mut self.writer,
+                    begin_string,
+                    sender,
+                    target,
+                    &ts,
+                    *seq,
+                    *new_seq,
+                ),
+                Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
+            };
+            if ok.is_err() {
+                self.flush_writer().await?;
+                let retry = match &item {
+                    Item::Gap(seq, new_seq) => encode_gap_fill(
+                        &mut self.writer,
+                        begin_string,
+                        sender,
+                        target,
+                        &ts,
+                        *seq,
+                        *new_seq,
+                    ),
+                    Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
+                };
+                retry.map_err(|()| {
+                    Error::FrameTooLarge(self.writer.remaining().saturating_add(1))
+                })?;
+            }
+        }
+        self.flush_writer().await
+    }
+}
+
+impl AsyncFixConnection<tokio::net::TcpStream> {
+    /// Connects a TCP stream, enables `TCP_NODELAY`, and wraps it.
+    pub async fn tcp_connect(
+        addr: std::net::SocketAddr,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+        begin_string: &'static [u8],
+    ) -> io::Result<Self> {
+        let stream = tokio::net::TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(Self::from_parts(stream, state, config, journal, begin_string))
+    }
+}
+
+fn make_ts() -> [u8; TS_LEN] {
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i128;
+    let mut ts = [0u8; TS_LEN];
+    format_utc_timestamp(unix_nanos, &mut ts);
+    ts
+}
+
+fn format_utc_timestamp(unix_nanos: i128, out: &mut [u8; TS_LEN]) {
+    let secs = unix_nanos.div_euclid(1_000_000_000) as i64;
+    let millis = (unix_nanos.rem_euclid(1_000_000_000) / 1_000_000) as u32;
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400) as u32;
+    let (y, m, d) = civil_from_days(days);
+
+    write_digits(&mut out[0..4], y.max(0) as u32);
+    write_digits(&mut out[4..6], m);
+    write_digits(&mut out[6..8], d);
+    out[8] = b'-';
+    write_digits(&mut out[9..11], sod / 3600);
+    out[11] = b':';
+    write_digits(&mut out[12..14], sod / 60 % 60);
+    out[14] = b':';
+    write_digits(&mut out[15..17], sod % 60);
+    out[17] = b'.';
+    write_digits(&mut out[18..21], millis);
+}
+
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    (y + i64::from(m <= 2), m, d)
+}
+
+fn write_digits(out: &mut [u8], mut v: u32) {
+    for slot in out.iter_mut().rev() {
+        *slot = b'0' + (v % 10) as u8;
+        v /= 10;
+    }
+}
+
+fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
+    if v == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    let mut tmp = [0u8; 20];
+    let mut n = 0;
+    let mut x = v;
+    while x > 0 {
+        tmp[n] = b'0' + (x % 10) as u8;
+        x /= 10;
+        n += 1;
+    }
+    for i in 0..n {
+        out[i] = tmp[n - 1 - i];
+    }
+    n
+}
+
+fn encode_gap_fill(
+    writer: &mut FrameWriter,
+    begin_string: &'static [u8],
+    sender: CompId,
+    target: CompId,
+    ts: &[u8],
+    seq: u32,
+    new_seq: u32,
+) -> Result<(), ()> {
+    let spare = writer.spare();
+    let mut seq_buf = [0u8; 10];
+    let seq_n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
+    fmt.field(34, &seq_buf[..seq_n]);
+    fmt.field(49, sender.as_bytes());
+    fmt.field(56, target.as_bytes());
+    fmt.field(52, ts);
+    fmt.field(43, b"Y");
+    fmt.field(123, b"Y");
+    let mut nsq_buf = [0u8; 10];
+    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
+    fmt.field(36, &nsq_buf[..nsq_n]);
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
+}
+
+fn reframe_app(
+    writer: &mut FrameWriter,
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Result<(), ()> {
+    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
+    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
+
+    let spare = writer.spare();
+    let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(orig, 0) {
+        match field.tag {
+            8 | 9 | 10 | 35 | 43 | 122 => {}
+            52 => {
+                fmt.field(52, ts);
+                fmt.field(43, b"Y");
+                if let Some(t) = orig_time {
+                    fmt.field(122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => fmt.field(field.tag, field.value.slice(orig)),
+        }
+    }
+
+    if !poss_dup_done {
+        fmt.field(43, b"Y");
+        if let Some(t) = orig_time {
+            fmt.field(122, t);
+        }
+    }
+
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
+}

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -186,19 +186,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let sender_ok = find_tag(frame, 0, 49)
-            .is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
-        let target_ok = find_tag(frame, 0, 56)
-            .is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
+        let sender_ok =
+            find_tag(frame, 0, 49).is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
+        let target_ok =
+            find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
         if !sender_ok || !target_ok {
             let out = self.state.on_comp_id_mismatch(now);
             self.flush_out(out).await?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
         }
 
-        let seq = match find_tag(frame, 0, 34)
-            .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-        {
+        let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
             Some(s) => s as u32,
             None => return Ok(None),
         };
@@ -460,7 +458,13 @@ impl AsyncFixConnection<tokio::net::TcpStream> {
     ) -> io::Result<Self> {
         let stream = tokio::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;
-        Ok(Self::from_parts(stream, state, config, journal, begin_string))
+        Ok(Self::from_parts(
+            stream,
+            state,
+            config,
+            journal,
+            begin_string,
+        ))
     }
 }
 

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -112,11 +112,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     where
         H: FnMut(&[u8]),
     {
-        let deadline = self
-            .state
-            .next_timeout()
-            .map(tokio::time::Instant::from_std)
-            .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(60));
+        let deadline = self.state.next_timeout().map_or_else(
+            || tokio::time::Instant::now() + Duration::from_secs(60),
+            tokio::time::Instant::from_std,
+        );
 
         let mut tmp = [0u8; 8192];
         let n = match timeout_at(deadline, self.stream.read(&mut tmp)).await {

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -1,0 +1,139 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State,
+};
+use nexus_async_fix_engine::AsyncFixConnection;
+use tokio::net::TcpStream;
+
+const BEGIN: &[u8] = b"FIX.4.4";
+const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
+
+fn tmp_dir(suffix: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "nexus_async_fix_conf_{}_{}",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
+    let mut child = Command::new("python3")
+        .arg(PEER)
+        .arg(scenario)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("python3 not found");
+    let stdout = child.stdout.take().unwrap();
+    let mut line = String::new();
+    BufReader::new(stdout).read_line(&mut line).unwrap();
+    let port: u16 = line.trim().parse().unwrap();
+    (child, port)
+}
+
+async fn connect(port: u16, dir: &Path) -> AsyncFixConnection<TcpStream> {
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+    AsyncFixConnection::from_parts(
+        stream,
+        SessionState::new(Duration::from_secs(30)),
+        SessionConfig {
+            sender: CompId::new(b"ENGINE").unwrap(),
+            target: CompId::new(b"PEER").unwrap(),
+        },
+        FixJournal::open(dir, 256).unwrap(),
+        BEGIN,
+    )
+}
+
+async fn drive(conn: &mut AsyncFixConnection<TcpStream>) -> DisconnectReason {
+    loop {
+        if let Some(r) = conn.recv(&mut |_| {}).await.unwrap() {
+            return r;
+        }
+    }
+}
+
+fn new_order(seq: u32) -> Vec<u8> {
+    let mut buf = [0u8; 512];
+    let mut seq_buf = [0u8; 10];
+    let n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    fmt.field(34, &seq_buf[..n]);
+    fmt.field(49, b"ENGINE");
+    fmt.field(56, b"PEER");
+    fmt.field(52, b"20260101-00:00:00.000");
+    fmt.field(11, b"ORD-1");
+    let (start, len) = fmt.finish().unwrap();
+    buf[start..start + len].to_vec()
+}
+
+#[tokio::test]
+async fn conformance_logon_logout() {
+    let dir = tmp_dir("logon_logout");
+    let (mut child, port) = spawn_peer("logon_logout");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_heartbeat() {
+    let dir = tmp_dir("heartbeat");
+    let (mut child, port) = spawn_peer("heartbeat");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_resend() {
+    let dir = tmp_dir("resend");
+    let (mut child, port) = spawn_peer("resend");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+
+    loop {
+        match conn.recv(&mut |_| {}).await.unwrap() {
+            Some(r) => panic!("disconnected before active: {r:?}"),
+            None if conn.state().state() == State::Active => break,
+            None => {}
+        }
+    }
+
+    let seq = conn.allocate_seq();
+    conn.send_app(seq, &new_order(seq)).await.unwrap();
+
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_gap_fill() {
+    let dir = tmp_dir("gap_fill");
+    let (mut child, port) = spawn_peer("gap_fill");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn conformance_seq_reset() {
+    let dir = tmp_dir("seq_reset");
+    let (mut child, port) = spawn_peer("seq_reset");
+    let mut conn = connect(port, &dir).await;
+    conn.connect().await.unwrap();
+    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    assert!(child.wait().unwrap().success());
+}

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -5,11 +5,9 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
-use nexus_fix_engine::{
-    CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State,
-};
 use nexus_async_fix_engine::AsyncFixConnection;
+use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_engine::{CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State};
 use tokio::net::TcpStream;
 
 const BEGIN: &[u8] = b"FIX.4.4";

--- a/nexus-async-fix-engine/tests/fixtures/fix_peer.py
+++ b/nexus-async-fix-engine/tests/fixtures/fix_peer.py
@@ -1,0 +1,167 @@
+"""FIX 4.4 conformance peer. Accepts one connection, runs one scenario, exits."""
+
+import socket
+import sys
+
+SENDER = "PEER"
+TARGET = "ENGINE"
+TS = "20260101-00:00:00.000"
+
+
+def checksum(data: bytes) -> int:
+    return sum(data) % 256
+
+
+def build(msg_type: str, seq: int, extra: list = None) -> bytes:
+    body = (
+        f"35={msg_type}\x01"
+        f"49={SENDER}\x01"
+        f"56={TARGET}\x01"
+        f"34={seq}\x01"
+        f"52={TS}\x01"
+    )
+    if extra:
+        for tag, val in extra:
+            body += f"{tag}={val}\x01"
+    body_b = body.encode()
+    header = f"8=FIX.4.4\x019={len(body_b)}\x01".encode()
+    ck = checksum(header + body_b)
+    return header + body_b + f"10={ck:03d}\x01".encode()
+
+
+def recv_msg(conn: socket.socket) -> dict:
+    buf = b""
+    body_len = None
+    header_end = 0
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise EOFError("connection closed")
+        buf += chunk
+        if body_len is None:
+            i = buf.find(b"\x019=")
+            if i >= 0:
+                j = buf.find(b"\x01", i + 3)
+                if j >= 0:
+                    body_len = int(buf[i + 3 : j])
+                    header_end = j + 1
+        if body_len is not None and len(buf) >= header_end + body_len + 7:
+            msg_bytes = buf[: header_end + body_len + 7]
+            fields = {}
+            for field in msg_bytes.split(b"\x01"):
+                if b"=" in field:
+                    k, _, v = field.partition(b"=")
+                    fields[k.decode()] = v.decode()
+            return fields
+
+
+def logon_logout(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A", f"expected Logon, got {msg.get('35')}"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5", f"expected Logout, got {msg.get('35')}"
+
+
+def heartbeat(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("1", seq, [(112, "TEST1")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("35") == "0" and msg.get("112") == "TEST1":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def resend(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "D", f"expected NewOrder, got {msg.get('35')}"
+    conn.sendall(build("2", seq, [(7, "2"), (16, "2")]))
+    seq += 1
+    while True:
+        msg = recv_msg(conn)
+        if msg.get("43") == "Y":
+            assert msg.get("122"), "OrigSendingTime (122) must be set on PossDup replay"
+            break
+        if msg.get("35") == "4":
+            break
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def gap_fill(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(123, "Y"), (36, "5")]))
+    seq = 5
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+def seq_reset(conn: socket.socket):
+    seq = 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "A"
+    conn.sendall(build("A", seq, [(108, "30")]))
+    seq += 1
+    conn.sendall(build("4", seq, [(36, "10")]))
+    seq = 10
+    conn.sendall(build("5", seq))
+    seq += 1
+    msg = recv_msg(conn)
+    assert msg.get("35") == "5"
+
+
+SCENARIOS = {
+    "logon_logout": logon_logout,
+    "heartbeat": heartbeat,
+    "resend": resend,
+    "gap_fill": gap_fill,
+    "seq_reset": seq_reset,
+}
+
+if __name__ == "__main__":
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "logon_logout"
+    fn = SCENARIOS.get(scenario)
+    if fn is None:
+        print(f"unknown scenario: {scenario}", file=sys.stderr)
+        sys.exit(1)
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+    print(port, flush=True)
+
+    conn, _ = srv.accept()
+    conn.settimeout(10.0)
+    try:
+        fn(conn)
+    finally:
+        conn.close()
+        srv.close()

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -123,7 +123,7 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
                 break;
             }
             Ok(Some(Message::Application { .. })) => n += 1,
-            Ok(Some(_)) | Ok(None) => {}
+            Ok(Some(_) | None) => {}
             Err(e) => {
                 eprintln!("acceptor error: {e}");
                 break;
@@ -157,7 +157,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
                 eprintln!("initiator error: {e}");
                 return;
             }
-            Ok(Some(_)) | Ok(None) => {}
+            Ok(Some(_) | None) => {}
         }
         if conn.state().state() == State::Active {
             break;

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -9,10 +9,82 @@ use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
-use nexus_fix_engine::{CompId, FixConnection, FixJournal, SessionConfig, SessionState, State};
+use nexus_fix_codec::{
+    FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
+    encode_fix_uint, find_tag,
+};
+use nexus_fix_engine::{
+    CompId, FixConnection, FixJournal, Message, SessionConfig, SessionState, State,
+};
 
-const BEGIN: &[u8] = b"FIX.4.4";
+// ── minimal FIX 4.4 dictionary ───────────────────────────────────────────────
+
+struct Fix44;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Fix44MsgType {}
+
+struct Decoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for Decoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for Fix44 {
+    type MsgType = Fix44MsgType;
+    type Header<'buf> = Fix44Header<'buf>;
+    type Logon<'buf> = Decoder<'buf>;
+    type Logout<'buf> = Decoder<'buf>;
+    type Heartbeat<'buf> = Decoder<'buf>;
+    type TestRequest<'buf> = Decoder<'buf>;
+    type ResendRequest<'buf> = Decoder<'buf>;
+    type SequenceReset<'buf> = Decoder<'buf>;
+    type Reject<'buf> = Decoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: Fix44MsgType) -> bool {
+        false
+    }
+}
+
+struct Fix44Header<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
 
 fn main() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -33,7 +105,7 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
 
-    let mut conn = FixConnection::builder().accept(
+    let mut conn: FixConnection<_, Fix44> = FixConnection::builder().accept(
         stream,
         SessionState::new(Duration::from_secs(30)),
         SessionConfig {
@@ -41,17 +113,17 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
             target: CompId::new(b"INITIATOR").unwrap(),
         },
         FixJournal::open(dir, 256).unwrap(),
-        BEGIN,
     );
 
     let mut n = 0usize;
     loop {
-        match conn.recv(Instant::now(), &mut |_: &[u8]| n += 1) {
-            Ok(Some(reason)) => {
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { reason })) => {
                 println!("acceptor: {reason:?}, {n} app message(s) received");
                 break;
             }
-            Ok(None) => {}
+            Ok(Some(Message::Application { .. })) => n += 1,
+            Ok(Some(_)) | Ok(None) => {}
             Err(e) => {
                 eprintln!("acceptor error: {e}");
                 break;
@@ -61,7 +133,7 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
 }
 
 fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
-    let mut conn = FixConnection::builder()
+    let mut conn: FixConnection<_, Fix44> = FixConnection::builder()
         .connect(
             addr,
             SessionState::new(Duration::from_secs(30)),
@@ -70,37 +142,35 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
                 target: CompId::new(b"ACCEPTOR").unwrap(),
             },
             FixJournal::open(dir, 256).unwrap(),
-            BEGIN,
         )
         .unwrap();
 
     conn.connect(Instant::now()).unwrap();
 
-    // recv until session is active
     loop {
-        match conn.recv(Instant::now(), &mut |_| {}) {
-            Ok(Some(r)) => {
-                eprintln!("initiator: disconnected before active ({r:?})");
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { reason })) => {
+                eprintln!("initiator: disconnected before active ({reason:?})");
                 return;
             }
             Err(e) => {
                 eprintln!("initiator error: {e}");
                 return;
             }
-            Ok(None) if conn.state().state() == State::Active => break,
-            Ok(None) => {}
+            Ok(Some(_)) | Ok(None) => {}
+        }
+        if conn.state().state() == State::Active {
+            break;
         }
     }
 
-    // send one NewOrder
     let seq = conn.allocate_seq();
     let msg = new_order(seq);
     conn.send_app(seq, &msg).unwrap();
 
-    // logout
     conn.logout(Instant::now()).unwrap();
     loop {
-        match conn.recv(Instant::now(), &mut |_| {}) {
+        match conn.recv(Instant::now()) {
             Ok(Some(_)) | Err(_) => break,
             Ok(None) => {}
         }
@@ -111,7 +181,7 @@ fn new_order(seq: u32) -> Vec<u8> {
     let mut buf = [0u8; 512];
     let mut seq_buf = [0u8; 10];
     let n = encode_fix_uint(seq, &mut seq_buf);
-    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
     fmt.field(34, &seq_buf[..n]);
     fmt.field(49, b"INITIATOR");
     fmt.field(56, b"ACCEPTOR");

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -1,12 +1,11 @@
 use core::marker::PhantomData;
-use std::time::Instant;
+use std::io::Write;
 
-use nexus_fix_codec::{
-    FixAdminMsg, FixDictionary, FixHeader, find_tag, parse_fix_bool, parse_fix_seqnum,
-    parse_fix_uint,
-};
+use nexus_fix_codec::FixDictionary;
+use nexus_net::wire::ParserSink;
 
-use crate::{DisconnectReason, SessionState, State};
+use crate::frame::{FrameReader, FrameWriter};
+use crate::session::AdminMsg;
 
 const COMP_ID_CAP: usize = 20;
 
@@ -43,7 +42,7 @@ pub struct SessionConfig {
     pub target: CompId,
 }
 
-/// Error returned by [`Session::on_message`].
+/// Error returned by the framework layer when decoding fails.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SessionError {
     /// Tag 35 (MsgType) absent.
@@ -72,7 +71,7 @@ impl core::fmt::Display for SessionError {
 
 impl core::error::Error for SessionError {}
 
-/// Typed inbound message returned by [`Session::on_message`].
+/// Typed inbound message returned by the transport layer.
 ///
 /// Admin messages carry the dictionary's zero-copy decoder for the message type
 /// so callers can read any field — protocol-required or venue-specific — without
@@ -100,162 +99,214 @@ pub enum Message<'buf, D: FixDictionary> {
     /// Business message. Route by `header.raw_msg_type()` and decode the body.
     Application { header: D::Header<'buf> },
     /// Session disconnected (CompID mismatch, timeout, or protocol violation).
-    Disconnected { reason: DisconnectReason },
+    Disconnected { reason: crate::DisconnectReason },
 }
 
-/// Dictionary-powered FIX session router.
-///
-/// Wraps [`SessionState`] with a codec layer: decodes the header via
-/// `D::Header::decode`, validates CompIDs, routes by raw `MsgType` bytes, and
-/// dispatches to the appropriate [`SessionState`] handler. Returns a typed
-/// [`Message`] so the caller owns both encoding and venue-specific logic.
-pub struct Session<D: FixDictionary> {
-    state: SessionState,
-    config: SessionConfig,
-    _dict: PhantomData<D>,
+/// Zero-copy FIX frame reader, dictionary-aware via `D::Header`.
+pub struct MessageReader<D: FixDictionary> {
+    pub(crate) inner: FrameReader,
+    pub(crate) frame: Vec<u8>,
+    _dict: PhantomData<fn() -> D>,
 }
 
-impl<D: FixDictionary> Session<D> {
-    pub fn new(state: SessionState, config: SessionConfig) -> Self {
+impl<D: FixDictionary> MessageReader<D> {
+    pub fn new() -> Self {
         Self {
-            state,
-            config,
+            inner: FrameReader::builder().build(),
+            frame: Vec::new(),
             _dict: PhantomData,
         }
     }
 
-    pub fn state(&self) -> &SessionState {
-        &self.state
-    }
-
-    pub fn state_mut(&mut self) -> &mut SessionState {
-        &mut self.state
-    }
-
-    /// Route an inbound message.
-    ///
-    /// Decodes the header, validates CompIDs, and dispatches to the matching
-    /// [`SessionState`] handler. Returns a [`Message`] carrying either the
-    /// decoded admin message or the application header.
-    pub fn on_message<'buf>(
-        &mut self,
-        buf: &'buf [u8],
-        now: Instant,
-    ) -> Result<Message<'buf, D>, SessionError> {
-        let header = D::Header::decode(buf);
-
-        // CompID validation — mismatch → disconnect.
-        let sender_ok = header
-            .sender_comp_id()
-            .is_some_and(|v| v.as_bytes() == self.config.target.as_bytes());
-        let target_ok = header
-            .target_comp_id()
-            .is_some_and(|v| v.as_bytes() == self.config.sender.as_bytes());
-        if !sender_ok || !target_ok {
-            self.state.on_comp_id_mismatch(now);
-            return Ok(Message::Disconnected {
-                reason: DisconnectReason::CompIdMismatch,
-            });
-        }
-
-        let seq = header
-            .msg_seq_num()
-            .ok_or(SessionError::MissingMsgSeqNum)?
-            .checked()
-            .map_err(|_| SessionError::MalformedField { tag: 34 })? as u32;
-
-        let poss_dup = header
-            .poss_dup_flag()
-            .and_then(|v| v.checked().ok())
-            .unwrap_or(false);
-
-        match header.raw_msg_type().map(|v| v.as_bytes()) {
-            Some(b"A") => {
-                let hbi = find_tag(buf, 0, 108).ok_or(SessionError::MissingField { tag: 108 })?;
-                let heart_bt_int = parse_fix_uint(hbi.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 108 })?;
-                let reset = find_tag(buf, 0, 141)
-                    .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
-                    .unwrap_or(false);
-                let was_logon_sent = self.state.state() == State::LogonSent;
-                let send_reply = !was_logon_sent;
-                self.state
-                    .on_logon(seq, heart_bt_int, reset, send_reply, now);
-                let msg = D::Logon::decode(buf).map_err(|_| SessionError::MalformedMessage)?;
-                Ok(if was_logon_sent {
-                    Message::LogonAcknowledged { msg }
-                } else {
-                    Message::LogonRequest { msg }
-                })
-            }
-            Some(b"5") => {
-                let was_logout_pending = self.state.state() == State::LogoutPending;
-                self.state.on_logout(seq, poss_dup, now);
-                let msg = D::Logout::decode(buf).map_err(|_| SessionError::MalformedMessage)?;
-                Ok(if was_logout_pending {
-                    Message::LogoutAcknowledged { msg }
-                } else {
-                    Message::LogoutRequest { msg }
-                })
-            }
-            Some(b"0") => {
-                self.state.on_heartbeat(seq, poss_dup, now);
-                Ok(Message::Heartbeat {
-                    msg: D::Heartbeat::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
-                })
-            }
-            Some(b"1") => {
-                let test_req_id =
-                    find_tag(buf, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(buf));
-                self.state.on_test_request(seq, poss_dup, test_req_id, now);
-                Ok(Message::TestRequest {
-                    msg: D::TestRequest::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
-                })
-            }
-            Some(b"2") => {
-                let begin = find_tag(buf, 0, 7).ok_or(SessionError::MissingField { tag: 7 })?;
-                let begin = parse_fix_seqnum(begin.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 7 })?
-                    as u32;
-                let end = find_tag(buf, 0, 16).ok_or(SessionError::MissingField { tag: 16 })?;
-                let end = parse_fix_seqnum(end.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 16 })?
-                    as u32;
-                self.state.on_resend_request(seq, poss_dup, begin, end, now);
-                Ok(Message::ResendRequest {
-                    msg: D::ResendRequest::decode(buf)
-                        .map_err(|_| SessionError::MalformedMessage)?,
-                })
-            }
-            Some(b"4") => {
-                let new_seq = find_tag(buf, 0, 36).ok_or(SessionError::MissingField { tag: 36 })?;
-                let new_seq = parse_fix_seqnum(new_seq.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 36 })?
-                    as u32;
-                let gap_fill = find_tag(buf, 0, 123)
-                    .and_then(|s| parse_fix_bool(s.slice(buf)).ok())
-                    .unwrap_or(false);
-                self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
-                Ok(Message::SequenceReset {
-                    msg: D::SequenceReset::decode(buf)
-                        .map_err(|_| SessionError::MalformedMessage)?,
-                })
-            }
-            Some(b"3") => {
-                let ref_seq = find_tag(buf, 0, 45).ok_or(SessionError::MissingField { tag: 45 })?;
-                let ref_seq = parse_fix_seqnum(ref_seq.slice(buf))
-                    .map_err(|_| SessionError::MalformedField { tag: 45 })?
-                    as u32;
-                self.state.on_reject(seq, poss_dup, ref_seq, now);
-                Ok(Message::Reject {
-                    msg: D::Reject::decode(buf).map_err(|_| SessionError::MalformedMessage)?,
-                })
-            }
-            Some(_) => {
-                self.state.on_app(seq, poss_dup, now);
-                Ok(Message::Application { header })
-            }
-            None => Err(SessionError::MissingMsgType),
+    pub fn with_frame_reader(inner: FrameReader) -> Self {
+        Self {
+            inner,
+            frame: Vec::new(),
+            _dict: PhantomData,
         }
     }
+}
+
+impl<D: FixDictionary> Default for MessageReader<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<D: FixDictionary> ParserSink for MessageReader<D> {
+    fn spare(&mut self) -> &mut [u8] {
+        self.inner.spare()
+    }
+
+    fn filled(&mut self, n: usize) {
+        self.inner.filled(n);
+    }
+}
+
+/// Outbound FIX message writer, dictionary-aware via `D::BEGIN_STRING`.
+pub struct MessageWriter<D: FixDictionary> {
+    pub(crate) inner: FrameWriter,
+    _dict: PhantomData<fn() -> D>,
+}
+
+impl<D: FixDictionary> MessageWriter<D> {
+    pub fn new() -> Self {
+        Self {
+            inner: FrameWriter::builder().build(),
+            _dict: PhantomData,
+        }
+    }
+
+    pub fn with_frame_writer(inner: FrameWriter) -> Self {
+        Self {
+            inner,
+            _dict: PhantomData,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn data(&self) -> &[u8] {
+        self.inner.data()
+    }
+
+    pub fn advance(&mut self, n: usize) {
+        self.inner.advance(n);
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.inner.remaining()
+    }
+
+    pub fn flush_to<S: Write>(&mut self, stream: &mut S) -> std::io::Result<()> {
+        while !self.inner.is_empty() {
+            let n = stream.write(self.inner.data())?;
+            if n == 0 {
+                return Err(std::io::Error::other("write returned 0"));
+            }
+            self.inner.advance(n);
+        }
+        stream.flush()
+    }
+
+    #[cfg(unix)]
+    pub fn encode_admin(&mut self, admin: AdminMsg, config: &SessionConfig) {
+        use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+
+        let ts = make_ts();
+
+        let msg_type: &[u8] = match admin {
+            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logout { .. } => b"5",
+            AdminMsg::Heartbeat { .. } => b"0",
+            AdminMsg::TestRequest { .. } => b"1",
+            AdminMsg::ResendRequest { .. } => b"2",
+            AdminMsg::SequenceReset { .. } => b"4",
+        };
+
+        let seq = match admin {
+            AdminMsg::Logon { seq, .. }
+            | AdminMsg::Logout { seq }
+            | AdminMsg::Heartbeat { seq, .. }
+            | AdminMsg::TestRequest { seq, .. }
+            | AdminMsg::ResendRequest { seq, .. }
+            | AdminMsg::SequenceReset { seq, .. } => seq,
+        };
+
+        let begin_string = D::BEGIN_STRING;
+        let sender = config.sender;
+        let target = config.target;
+
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+
+        let (start, len) = {
+            let spare = self.inner.spare();
+            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
+            fmt.field(34, &seq_buf[..seq_n]);
+            fmt.field(49, sender.as_bytes());
+            fmt.field(56, target.as_bytes());
+            fmt.field(52, &ts);
+
+            match admin {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                }
+                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
+                AdminMsg::Heartbeat {
+                    echo: Some((id, id_len)),
+                    ..
+                } => {
+                    fmt.field(112, &id[..id_len as usize]);
+                }
+                AdminMsg::TestRequest { id, .. } => {
+                    let mut buf = [0u8; 20];
+                    let n = encode_u64(id, &mut buf);
+                    fmt.field(112, &buf[..n]);
+                }
+                AdminMsg::ResendRequest { begin, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(begin, &mut buf);
+                    fmt.field(7, &buf[..n]);
+                    fmt.field(16, b"0");
+                }
+                AdminMsg::SequenceReset { new_seq, .. } => {
+                    fmt.field(43, b"Y");
+                    fmt.field(123, b"Y");
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(new_seq, &mut buf);
+                    fmt.field(36, &buf[..n]);
+                }
+            }
+
+            match fmt.finish() {
+                Ok(sl) => sl,
+                Err(_) => return,
+            }
+        };
+
+        self.inner.commit(start, len);
+    }
+}
+
+impl<D: FixDictionary> Default for MessageWriter<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(unix)]
+fn make_ts() -> [u8; crate::timestamp::UTC_TIMESTAMP_LEN] {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i128;
+    let mut ts = [0u8; crate::timestamp::UTC_TIMESTAMP_LEN];
+    crate::timestamp::format_utc_timestamp(unix_nanos, &mut ts);
+    ts
+}
+
+pub(crate) fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
+    if v == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    let mut tmp = [0u8; 20];
+    let mut n = 0;
+    let mut x = v;
+    while x > 0 {
+        tmp[n] = b'0' + (x % 10) as u8;
+        x /= 10;
+        n += 1;
+    }
+    for i in 0..n {
+        out[i] = tmp[n - 1 - i];
+    }
+    n
 }

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -20,7 +20,7 @@ pub mod transport;
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
 };
-pub use framework::{CompId, Message, Session, SessionConfig, SessionError};
+pub use framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig, SessionError};
 #[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -306,7 +306,10 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
             }));
         }
 
-        let raw_type = find_tag(frame, 0, 35).map_or(b"" as &[u8], |s| s.slice(frame));
+        let raw_type = match find_tag(frame, 0, 35) {
+            Some(s) => s.slice(frame),
+            None => return Err(Error::Protocol(SessionError::MissingMsgType)),
+        };
 
         match raw_type {
             b"A" => {
@@ -345,9 +348,6 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
                 }
                 if let Some(Event::Disconnected { reason }) = out.event() {
-                    let msg = D::Logout::decode(frame)
-                        .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                    let _ = msg;
                     return Ok(Some(Message::Disconnected { reason }));
                 }
                 let msg = D::Logout::decode(frame)
@@ -456,9 +456,12 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 if let Some(Event::Disconnected { reason }) = out.event() {
                     return Ok(Some(Message::Disconnected { reason }));
                 }
-                Ok(Some(Message::Application {
-                    header: D::Header::decode(frame),
-                }))
+                if matches!(out.event(), Some(Event::App { .. })) {
+                    return Ok(Some(Message::Application {
+                        header: D::Header::decode(frame),
+                    }));
+                }
+                Ok(None) // gap: ResendRequest queued, nothing to surface
             }
         }
     }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -1,22 +1,23 @@
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use nexus_fix_codec::{
-    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
-    parse_fix_uint,
+    FieldReader, FixAdminMsg, FixDictionary, FixHeader, FrameFormatter, encode_fix_uint, find_tag,
+    parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
 };
 
-use crate::frame::{FrameError, FrameReader, FrameWriter};
-use crate::framework::{CompId, SessionConfig};
+use crate::frame::{FrameError, FrameWriter};
+use crate::framework::{Message, MessageReader, MessageWriter, SessionConfig, SessionError};
 use crate::persist::{FixJournal, ReplayItem};
-use crate::session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
-use crate::timestamp::{UTC_TIMESTAMP_LEN, format_utc_timestamp};
+use crate::session::{DisconnectReason, Event, SessionState, State};
+use crate::timestamp::UTC_TIMESTAMP_LEN;
 
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
     FrameTooLarge(usize),
+    Protocol(SessionError),
 }
 
 impl std::fmt::Display for Error {
@@ -24,6 +25,7 @@ impl std::fmt::Display for Error {
         match self {
             Self::Io(e) => write!(f, "I/O: {e}"),
             Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
+            Self::Protocol(e) => write!(f, "protocol: {e}"),
         }
     }
 }
@@ -36,24 +38,24 @@ impl From<io::Error> for Error {
     }
 }
 
-pub struct FixConnection<S> {
+pub struct FixConnection<S, D: FixDictionary> {
     stream: S,
-    reader: FrameReader,
-    writer: FrameWriter,
+    reader: MessageReader<D>,
+    writer: MessageWriter<D>,
     state: SessionState,
     journal: FixJournal,
     config: SessionConfig,
-    begin_string: &'static [u8],
 }
 
-pub struct FixConnectionBuilder {
+pub struct FixConnectionBuilder<D: FixDictionary> {
     reader_cap: usize,
     writer_cap: usize,
     nodelay: bool,
     connect_timeout: Option<Duration>,
+    _dict: std::marker::PhantomData<fn() -> D>,
 }
 
-impl FixConnectionBuilder {
+impl<D: FixDictionary> FixConnectionBuilder<D> {
     pub fn reader_capacity(mut self, n: usize) -> Self {
         self.reader_cap = n;
         self
@@ -80,8 +82,7 @@ impl FixConnectionBuilder {
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
-        begin_string: &'static [u8],
-    ) -> io::Result<FixConnection<TcpStream>> {
+    ) -> io::Result<FixConnection<TcpStream, D>> {
         let stream = match self.connect_timeout {
             Some(t) => {
                 let addrs: Vec<_> = addr.to_socket_addrs()?.collect();
@@ -95,16 +96,19 @@ impl FixConnectionBuilder {
         stream.set_nodelay(self.nodelay)?;
         Ok(FixConnection {
             stream,
-            reader: FrameReader::builder()
-                .buffer_capacity(self.reader_cap)
-                .build(),
-            writer: FrameWriter::builder()
-                .buffer_capacity(self.writer_cap)
-                .build(),
+            reader: MessageReader::with_frame_reader(
+                crate::frame::FrameReader::builder()
+                    .buffer_capacity(self.reader_cap)
+                    .build(),
+            ),
+            writer: MessageWriter::with_frame_writer(
+                FrameWriter::builder()
+                    .buffer_capacity(self.writer_cap)
+                    .build(),
+            ),
             state,
             journal,
             config,
-            begin_string,
         })
     }
 
@@ -114,51 +118,52 @@ impl FixConnectionBuilder {
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
-        begin_string: &'static [u8],
-    ) -> FixConnection<S> {
+    ) -> FixConnection<S, D> {
         FixConnection {
             stream,
-            reader: FrameReader::builder()
-                .buffer_capacity(self.reader_cap)
-                .build(),
-            writer: FrameWriter::builder()
-                .buffer_capacity(self.writer_cap)
-                .build(),
+            reader: MessageReader::with_frame_reader(
+                crate::frame::FrameReader::builder()
+                    .buffer_capacity(self.reader_cap)
+                    .build(),
+            ),
+            writer: MessageWriter::with_frame_writer(
+                FrameWriter::builder()
+                    .buffer_capacity(self.writer_cap)
+                    .build(),
+            ),
             state,
             journal,
             config,
-            begin_string,
         }
     }
 }
 
-impl FixConnection<TcpStream> {
-    pub fn builder() -> FixConnectionBuilder {
+impl<D: FixDictionary> FixConnection<TcpStream, D> {
+    pub fn builder() -> FixConnectionBuilder<D> {
         FixConnectionBuilder {
             reader_cap: 64 * 1024,
             writer_cap: 64 * 1024,
             nodelay: true,
             connect_timeout: None,
+            _dict: std::marker::PhantomData,
         }
     }
 }
 
-impl<S: Read + Write> FixConnection<S> {
+impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     pub fn from_parts(
         stream: S,
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
-        begin_string: &'static [u8],
     ) -> Self {
         Self {
             stream,
-            reader: FrameReader::builder().build(),
-            writer: FrameWriter::builder().build(),
+            reader: MessageReader::new(),
+            writer: MessageWriter::new(),
             state,
             journal,
             config,
-            begin_string,
         }
     }
 
@@ -174,59 +179,6 @@ impl<S: Read + Write> FixConnection<S> {
         self.state.allocate_seq(Instant::now())
     }
 
-    pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.connect(now);
-        self.flush_out(out)
-    }
-
-    pub fn recv<H>(
-        &mut self,
-        now: Instant,
-        on_app: &mut H,
-    ) -> Result<Option<DisconnectReason>, Error>
-    where
-        H: FnMut(&[u8]),
-    {
-        let spare = self.reader.spare();
-        let n = match self.stream.read(spare) {
-            Ok(0) => return Ok(Some(DisconnectReason::Logout)),
-            Ok(n) => n,
-            Err(e) if is_timeout(&e) => {
-                let out = self.state.on_timeout(now);
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    self.flush_out(out)?;
-                    return Ok(Some(reason));
-                }
-                self.flush_out(out)?;
-                return Ok(None);
-            }
-            Err(e) => return Err(Error::Io(e)),
-        };
-        self.reader.filled(n);
-
-        loop {
-            match self.reader.next() {
-                Ok(Some(frame)) => {
-                    let frame = frame.to_vec();
-                    if let Some(reason) = self.dispatch(&frame, now, on_app)? {
-                        return Ok(Some(reason));
-                    }
-                }
-                Ok(None) => break,
-                Err(FrameError::MessageTooLarge { size }) => {
-                    return Err(Error::FrameTooLarge(size));
-                }
-                Err(FrameError::Garbage { .. }) => {}
-            }
-        }
-
-        if self.reader.should_compact() {
-            self.reader.compact();
-        }
-
-        Ok(None)
-    }
-
     pub fn wants_read(&self) -> bool {
         self.state.state() != State::Disconnected
     }
@@ -236,241 +188,343 @@ impl<S: Read + Write> FixConnection<S> {
     }
 
     pub fn flush(&mut self) -> Result<(), Error> {
-        self.flush_writer()
+        self.writer.flush_to(&mut self.stream).map_err(Error::Io)
+    }
+
+    pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.connect(now);
+        for admin in out.admin_messages() {
+            self.writer.encode_admin(admin, &self.config);
+        }
+        if !self.writer.is_empty() {
+            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+        }
+        Ok(())
     }
 
     pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
-        write_through(&mut self.stream, &mut self.writer, frame)
+        write_through(&mut self.stream, &mut self.writer.inner, frame)
     }
 
     pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
         let out = self.state.logout(now);
-        self.flush_out(out)
-    }
-
-    fn dispatch<H>(
-        &mut self,
-        frame: &[u8],
-        now: Instant,
-        on_app: &mut H,
-    ) -> Result<Option<DisconnectReason>, Error>
-    where
-        H: FnMut(&[u8]),
-    {
-        let Some(h) = parse_frame_header(frame) else {
-            return Ok(None);
-        };
-
-        if h.sender != self.config.target.as_bytes() || h.target != self.config.sender.as_bytes() {
-            let out = self.state.on_comp_id_mismatch(now);
-            self.flush_out(out)?;
-            return Ok(Some(DisconnectReason::CompIdMismatch));
-        }
-
-        let (out, is_app) = match h.msg_type {
-            b"A" => {
-                let was_logon_sent = self.state.state() == State::LogonSent;
-                (
-                    self.state
-                        .on_logon(h.seq, h.heart_bt_int, h.reset, !was_logon_sent, now),
-                    false,
-                )
-            }
-            b"5" => (self.state.on_logout(h.seq, h.poss_dup, now), false),
-            b"0" => (self.state.on_heartbeat(h.seq, h.poss_dup, now), false),
-            b"1" => (
-                self.state
-                    .on_test_request(h.seq, h.poss_dup, h.test_req_id, now),
-                false,
-            ),
-            b"2" => (
-                self.state
-                    .on_resend_request(h.seq, h.poss_dup, h.begin_seq, h.end_seq, now),
-                false,
-            ),
-            b"3" => (
-                self.state.on_reject(h.seq, h.poss_dup, h.ref_seq, now),
-                false,
-            ),
-            b"4" => (
-                self.state
-                    .on_sequence_reset(h.seq, h.new_seq_no, h.gap_fill, now),
-                false,
-            ),
-            _ => (self.state.on_app(h.seq, h.poss_dup, now), true),
-        };
-
-        self.flush_out(out)?;
-
-        match out.event() {
-            Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
-            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end)?,
-            Some(Event::App { .. }) if is_app => on_app(frame),
-            _ => {}
-        }
-
-        Ok(None)
-    }
-
-    fn flush_out(&mut self, out: Out) -> Result<(), Error> {
         for admin in out.admin_messages() {
-            self.encode_admin(admin);
+            self.writer.encode_admin(admin, &self.config);
         }
         if !self.writer.is_empty() {
-            self.flush_writer()?;
+            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
         }
         Ok(())
     }
 
-    fn encode_admin(&mut self, admin: AdminMsg) {
-        let ts = make_ts();
-
-        let msg_type: &[u8] = match admin {
-            AdminMsg::Logon { .. } => b"A",
-            AdminMsg::Logout { .. } => b"5",
-            AdminMsg::Heartbeat { .. } => b"0",
-            AdminMsg::TestRequest { .. } => b"1",
-            AdminMsg::ResendRequest { .. } => b"2",
-            AdminMsg::SequenceReset { .. } => b"4",
-        };
-
-        let seq = match admin {
-            AdminMsg::Logon { seq, .. }
-            | AdminMsg::Logout { seq }
-            | AdminMsg::Heartbeat { seq, .. }
-            | AdminMsg::TestRequest { seq, .. }
-            | AdminMsg::ResendRequest { seq, .. }
-            | AdminMsg::SequenceReset { seq, .. } => seq,
-        };
-
-        let begin_string = self.begin_string;
-        let sender = self.config.sender;
-        let target = self.config.target;
-
-        let mut seq_buf = [0u8; 10];
-        let seq_n = encode_fix_uint(seq, &mut seq_buf);
-
-        let (start, len) = {
-            let spare = self.writer.spare();
-            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
-            fmt.field(34, &seq_buf[..seq_n]);
-            fmt.field(49, sender.as_bytes());
-            fmt.field(56, target.as_bytes());
-            fmt.field(52, &ts);
-
-            match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
-                    fmt.field(108, &buf[..n]);
-                }
-                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
-                AdminMsg::Heartbeat {
-                    echo: Some((id, id_len)),
-                    ..
-                } => {
-                    fmt.field(112, &id[..id_len as usize]);
-                }
-                AdminMsg::TestRequest { id, .. } => {
-                    let mut buf = [0u8; 20];
-                    let n = encode_u64(id, &mut buf);
-                    fmt.field(112, &buf[..n]);
-                }
-                AdminMsg::ResendRequest { begin, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(begin, &mut buf);
-                    fmt.field(7, &buf[..n]);
-                    fmt.field(16, b"0");
-                }
-                AdminMsg::SequenceReset { new_seq, .. } => {
-                    fmt.field(43, b"Y");
-                    fmt.field(123, b"Y");
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(new_seq, &mut buf);
-                    fmt.field(36, &buf[..n]);
-                }
+    pub fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        loop {
+            if self.reader.inner.should_compact() {
+                self.reader.inner.compact();
             }
 
-            match fmt.finish() {
-                Ok(sl) => sl,
-                Err(_) => return,
-            }
-        };
-
-        self.writer.commit(start, len);
-    }
-
-    fn flush_writer(&mut self) -> Result<(), Error> {
-        flush_to(&mut self.stream, &mut self.writer)
-    }
-
-    fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
-        let ts = make_ts();
-        let begin_string = self.begin_string;
-        let sender = self.config.sender;
-        let target = self.config.target;
-
-        let iter = self.journal.resend(begin, end);
-        let writer = &mut self.writer;
-        let stream = &mut self.stream;
-
-        for item in iter {
-            let ok = match &item {
-                ReplayItem::GapFill { seq, new_seq } => {
-                    encode_gap_fill(writer, begin_string, sender, target, &ts, *seq, *new_seq)
+            match self.reader.inner.next() {
+                Err(FrameError::MessageTooLarge { size }) => {
+                    return Err(Error::FrameTooLarge(size));
                 }
-                ReplayItem::App(orig) => reframe_app(writer, orig, &ts, begin_string),
-            };
-            if ok.is_err() {
-                flush_to(stream, writer)?;
-                match item {
-                    ReplayItem::GapFill { seq, new_seq } => {
-                        encode_gap_fill(writer, begin_string, sender, target, &ts, seq, new_seq)
-                            .map_err(|()| {
-                                Error::FrameTooLarge(writer.remaining().saturating_add(1))
-                            })?;
-                    }
-                    ReplayItem::App(orig) => {
-                        if reframe_app(writer, orig, &ts, begin_string).is_err() {
-                            // frame exceeds writer capacity; reframe into a heap buffer and write through
-                            let mut tmp = vec![0u8; orig.len() + 512];
-                            let (start, len) = reframe_app_into(&mut tmp, orig, &ts, begin_string)
-                                .ok_or(Error::FrameTooLarge(orig.len()))?;
-                            tmp.copy_within(start..start + len, 0);
-                            tmp.truncate(len);
-                            write_through(stream, writer, &tmp)?;
+                Err(FrameError::Garbage { .. }) => {}
+                Ok(None) => {
+                    let n = {
+                        let spare = self.reader.inner.spare();
+                        match self.stream.read(spare) {
+                            Ok(n) => n,
+                            Err(e) if is_timeout(&e) => {
+                                let out = self.state.on_timeout(now);
+                                for admin in out.admin_messages() {
+                                    self.writer.encode_admin(admin, &self.config);
+                                }
+                                if !self.writer.is_empty() {
+                                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                                }
+                                if let Some(Event::Disconnected { reason }) = out.event() {
+                                    return Ok(Some(Message::Disconnected { reason }));
+                                }
+                                return Ok(None);
+                            }
+                            Err(e) => return Err(Error::Io(e)),
                         }
+                    };
+                    if n == 0 {
+                        return Ok(Some(Message::Disconnected {
+                            reason: DisconnectReason::Logout,
+                        }));
                     }
+                    self.reader.inner.filled(n);
+                }
+                Ok(Some(raw)) => {
+                    self.reader.frame.clear();
+                    self.reader.frame.extend_from_slice(raw);
+                    break;
                 }
             }
         }
-        flush_to(stream, writer)
+
+        let frame = &self.reader.frame[..];
+
+        let (sender_ok, target_ok, seq, poss_dup) = {
+            let hdr = D::Header::decode(frame);
+            let sender_ok = hdr
+                .sender_comp_id()
+                .is_some_and(|fv| fv.as_bytes() == self.config.target.as_bytes());
+            let target_ok = hdr
+                .target_comp_id()
+                .is_some_and(|fv| fv.as_bytes() == self.config.sender.as_bytes());
+            let seq = match hdr.msg_seq_num() {
+                Some(fv) => match fv.checked() {
+                    Ok(num) => num as u32,
+                    Err(_) => {
+                        return Err(Error::Protocol(SessionError::MalformedField { tag: 34 }));
+                    }
+                },
+                None => return Err(Error::Protocol(SessionError::MissingMsgSeqNum)),
+            };
+            let poss_dup = hdr
+                .poss_dup_flag()
+                .and_then(|fv| fv.checked().ok())
+                .unwrap_or(false);
+            (sender_ok, target_ok, seq, poss_dup)
+        };
+
+        if !sender_ok || !target_ok {
+            let out = self.state.on_comp_id_mismatch(now);
+            for admin in out.admin_messages() {
+                self.writer.encode_admin(admin, &self.config);
+            }
+            if !self.writer.is_empty() {
+                self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+            }
+            return Ok(Some(Message::Disconnected {
+                reason: DisconnectReason::CompIdMismatch,
+            }));
+        }
+
+        let raw_type = find_tag(frame, 0, 35).map_or(b"" as &[u8], |s| s.slice(frame));
+
+        match raw_type {
+            b"A" => {
+                let hbi = find_tag(frame, 0, 108)
+                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
+                    .unwrap_or(30);
+                let reset = find_tag(frame, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                let out = self.state.on_logon(seq, hbi, reset, !was_logon_sent, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
+                }
+                let msg = D::Logon::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(if was_logon_sent {
+                    Message::LogonAcknowledged { msg }
+                } else {
+                    Message::LogonRequest { msg }
+                }))
+            }
+            b"5" => {
+                let was_logout_pending = self.state.state() == State::LogoutPending;
+                let out = self.state.on_logout(seq, poss_dup, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    let msg = D::Logout::decode(frame)
+                        .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                    let _ = msg;
+                    return Ok(Some(Message::Disconnected { reason }));
+                }
+                let msg = D::Logout::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(if was_logout_pending {
+                    Message::LogoutAcknowledged { msg }
+                } else {
+                    Message::LogoutRequest { msg }
+                }))
+            }
+            b"0" => {
+                let out = self.state.on_heartbeat(seq, poss_dup, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                let msg = D::Heartbeat::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(Message::Heartbeat { msg }))
+            }
+            b"1" => {
+                let test_req_id =
+                    find_tag(frame, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(frame));
+                let out = self.state.on_test_request(seq, poss_dup, test_req_id, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                let msg = D::TestRequest::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(Message::TestRequest { msg }))
+            }
+            b"2" => {
+                let begin = find_tag(frame, 0, 7)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let end = find_tag(frame, 0, 16)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let out = self.state.on_resend_request(seq, poss_dup, begin, end, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::ResendRange { begin: rb, end: re }) = out.event() {
+                    do_resend::<S, D>(
+                        rb,
+                        re,
+                        &self.journal,
+                        &mut self.writer,
+                        &mut self.stream,
+                        &self.config,
+                    )?;
+                }
+                let msg = D::ResendRequest::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(Message::ResendRequest { msg }))
+            }
+            b"4" => {
+                let new_seq = find_tag(frame, 0, 36)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let gap_fill = find_tag(frame, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let out = self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                let msg = D::SequenceReset::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(Message::SequenceReset { msg }))
+            }
+            b"3" => {
+                let ref_seq = find_tag(frame, 0, 45)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let out = self.state.on_reject(seq, poss_dup, ref_seq, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                let msg = D::Reject::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
+                Ok(Some(Message::Reject { msg }))
+            }
+            _ => {
+                let out = self.state.on_app(seq, poss_dup, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
+                }
+                Ok(Some(Message::Application {
+                    header: D::Header::decode(frame),
+                }))
+            }
+        }
     }
 }
 
-fn make_ts() -> [u8; UTC_TIMESTAMP_LEN] {
+fn do_resend<S: Write, D: FixDictionary>(
+    begin: u32,
+    end: u32,
+    journal: &FixJournal,
+    writer: &mut MessageWriter<D>,
+    stream: &mut S,
+    config: &SessionConfig,
+) -> Result<(), Error> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     let unix_nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as i128;
     let mut ts = [0u8; UTC_TIMESTAMP_LEN];
-    format_utc_timestamp(unix_nanos, &mut ts);
-    ts
-}
+    crate::timestamp::format_utc_timestamp(unix_nanos, &mut ts);
 
-fn flush_to<S: Write>(stream: &mut S, writer: &mut FrameWriter) -> Result<(), Error> {
-    while !writer.is_empty() {
-        let n = stream.write(writer.data())?;
-        if n == 0 {
-            return Err(Error::Io(io::Error::other("write returned 0")));
+    let iter = journal.resend(begin, end);
+
+    for item in iter {
+        let ok = match &item {
+            ReplayItem::GapFill { seq, new_seq } => encode_gap_fill(
+                &mut writer.inner,
+                D::BEGIN_STRING,
+                config,
+                &ts,
+                *seq,
+                *new_seq,
+            ),
+            ReplayItem::App(orig) => reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING),
+        };
+        if ok.is_err() {
+            writer.flush_to(stream).map_err(Error::Io)?;
+            match item {
+                ReplayItem::GapFill { seq, new_seq } => {
+                    encode_gap_fill(
+                        &mut writer.inner,
+                        D::BEGIN_STRING,
+                        config,
+                        &ts,
+                        seq,
+                        new_seq,
+                    )
+                    .map_err(|()| {
+                        Error::FrameTooLarge(writer.inner.remaining().saturating_add(1))
+                    })?;
+                }
+                ReplayItem::App(orig) => {
+                    if reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING).is_err() {
+                        let mut tmp = vec![0u8; orig.len() + 512];
+                        let (start, len) = reframe_app_into(&mut tmp, orig, &ts, D::BEGIN_STRING)
+                            .ok_or(Error::FrameTooLarge(orig.len()))?;
+                        tmp.copy_within(start..start + len, 0);
+                        tmp.truncate(len);
+                        write_through(stream, &mut writer.inner, &tmp)?;
+                    }
+                }
+            }
         }
-        writer.advance(n);
     }
-    stream.flush()?;
-    Ok(())
+    writer.flush_to(stream).map_err(Error::Io)
 }
 
 fn write_through<S: Write>(
@@ -486,7 +540,6 @@ fn write_through<S: Write>(
         spare[..frame.len()].copy_from_slice(frame);
         writer.commit(0, frame.len());
     } else {
-        // frame exceeds writer capacity — write directly (writer is empty after flush)
         let mut off = 0;
         while off < frame.len() {
             let n = stream.write(&frame[off..]).map_err(Error::Io)?;
@@ -501,11 +554,22 @@ fn write_through<S: Write>(
     flush_to(stream, writer)
 }
 
+fn flush_to<S: Write>(stream: &mut S, writer: &mut FrameWriter) -> Result<(), Error> {
+    while !writer.is_empty() {
+        let n = stream.write(writer.data())?;
+        if n == 0 {
+            return Err(Error::Io(io::Error::other("write returned 0")));
+        }
+        writer.advance(n);
+    }
+    stream.flush()?;
+    Ok(())
+}
+
 fn encode_gap_fill(
     writer: &mut FrameWriter,
     begin_string: &'static [u8],
-    sender: CompId,
-    target: CompId,
+    config: &SessionConfig,
     ts: &[u8],
     seq: u32,
     new_seq: u32,
@@ -515,8 +579,8 @@ fn encode_gap_fill(
     let seq_n = encode_fix_uint(seq, &mut seq_buf);
     let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
     fmt.field(34, &seq_buf[..seq_n]);
-    fmt.field(49, sender.as_bytes());
-    fmt.field(56, target.as_bytes());
+    fmt.field(49, config.sender.as_bytes());
+    fmt.field(56, config.target.as_bytes());
     fmt.field(52, ts);
     fmt.field(43, b"Y");
     fmt.field(123, b"Y");
@@ -577,115 +641,9 @@ fn reframe_app_into(
     fmt.finish().ok()
 }
 
-struct FrameHeader<'a> {
-    sender: &'a [u8],
-    target: &'a [u8],
-    msg_type: &'a [u8],
-    seq: u32,
-    poss_dup: bool,
-    heart_bt_int: u32,
-    reset: bool,
-    test_req_id: &'a [u8],
-    begin_seq: u32,
-    end_seq: u32,
-    ref_seq: u32,
-    new_seq_no: u32,
-    gap_fill: bool,
-}
-
-fn parse_frame_header(frame: &[u8]) -> Option<FrameHeader<'_>> {
-    let mut sender: &[u8] = b"";
-    let mut target: &[u8] = b"";
-    let mut msg_type = None::<&[u8]>;
-    let mut seq = None::<u32>;
-    let mut poss_dup = false;
-    let mut heart_bt_int = 30u32;
-    let mut reset = false;
-    let mut test_req_id: &[u8] = b"";
-    let mut begin_seq = 0u32;
-    let mut end_seq = 0u32;
-    let mut ref_seq = 0u32;
-    let mut new_seq_no = 0u32;
-    let mut gap_fill = false;
-
-    for field in FieldReader::new(frame, 0) {
-        match field.tag {
-            35 => msg_type = Some(field.value.slice(frame)),
-            34 => {
-                seq = parse_fix_seqnum(field.value.slice(frame))
-                    .ok()
-                    .map(|s| s as u32)
-            }
-            49 => sender = field.value.slice(frame),
-            56 => target = field.value.slice(frame),
-            43 => poss_dup = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
-            108 => heart_bt_int = parse_fix_uint(field.value.slice(frame)).unwrap_or(30),
-            141 => reset = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
-            112 => test_req_id = field.value.slice(frame),
-            7 => {
-                begin_seq = parse_fix_seqnum(field.value.slice(frame))
-                    .ok()
-                    .map_or(0, |s| s as u32)
-            }
-            16 => {
-                end_seq = parse_fix_seqnum(field.value.slice(frame))
-                    .ok()
-                    .map_or(0, |s| s as u32)
-            }
-            45 => {
-                ref_seq = parse_fix_seqnum(field.value.slice(frame))
-                    .ok()
-                    .map_or(0, |s| s as u32)
-            }
-            36 => {
-                new_seq_no = parse_fix_seqnum(field.value.slice(frame))
-                    .ok()
-                    .map_or(0, |s| s as u32)
-            }
-            123 => gap_fill = parse_fix_bool(field.value.slice(frame)).unwrap_or(false),
-            _ => {}
-        }
-    }
-
-    Some(FrameHeader {
-        sender,
-        target,
-        msg_type: msg_type?,
-        seq: seq?,
-        poss_dup,
-        heart_bt_int,
-        reset,
-        test_req_id,
-        begin_seq,
-        end_seq,
-        ref_seq,
-        new_seq_no,
-        gap_fill,
-    })
-}
-
 fn is_timeout(e: &io::Error) -> bool {
     matches!(
         e.kind(),
         io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
-}
-
-fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
-    if v == 0 {
-        out[0] = b'0';
-        return 1;
-    }
-    let mut tmp = [0u8; 20];
-    let mut n = 0;
-    let mut x = v;
-    while x > 0 {
-        tmp[n] = b'0' + (x % 10) as u8;
-        x /= 10;
-        n += 1;
-    }
-    for i in 0..n {
-        out[i] = tmp[n - 1 - i];
-    }
-    n
 }

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -1,17 +1,90 @@
 #![cfg(unix)]
 
-use std::io::{BufRead, BufReader};
+use std::io::BufRead;
+use std::io::BufReader;
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_codec::{
+    FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
+    encode_fix_uint, find_tag,
+};
 use nexus_fix_engine::{
-    CompId, DisconnectReason, FixConnection, FixJournal, SessionConfig, SessionState, State,
+    CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionState,
+    State,
 };
 
-const BEGIN: &[u8] = b"FIX.4.4";
+// ── mock dictionary ──────────────────────────────────────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+struct AdminDecoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
 const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
 
 fn tmp_dir(suffix: &str) -> PathBuf {
@@ -35,7 +108,7 @@ fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
     (child, port)
 }
 
-fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream> {
+fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream, MockDict> {
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(10)))
@@ -48,14 +121,14 @@ fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream> {
             target: CompId::new(b"PEER").unwrap(),
         },
         FixJournal::open(dir, 256).unwrap(),
-        BEGIN,
     )
 }
 
-fn drive(conn: &mut FixConnection<TcpStream>) -> DisconnectReason {
+fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> DisconnectReason {
     loop {
-        if let Some(r) = conn.recv(Instant::now(), &mut |_| {}).unwrap() {
-            return r;
+        match conn.recv(Instant::now()).unwrap() {
+            Some(Message::Disconnected { reason }) => return reason,
+            Some(_) | None => {}
         }
     }
 }
@@ -64,7 +137,7 @@ fn new_order(seq: u32) -> Vec<u8> {
     let mut buf = [0u8; 512];
     let mut seq_buf = [0u8; 10];
     let n = encode_fix_uint(seq, &mut seq_buf);
-    let mut fmt = FrameFormatter::new(&mut buf, BEGIN, b"D");
+    let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
     fmt.field(34, &seq_buf[..n]);
     fmt.field(49, b"ENGINE");
     fmt.field(56, b"PEER");
@@ -73,6 +146,8 @@ fn new_order(seq: u32) -> Vec<u8> {
     let (start, len) = fmt.finish().unwrap();
     buf[start..start + len].to_vec()
 }
+
+// ── tests ────────────────────────────────────────────────────────────────────
 
 #[test]
 fn conformance_logon_logout() {
@@ -102,10 +177,14 @@ fn conformance_resend() {
     conn.connect(Instant::now()).unwrap();
 
     loop {
-        match conn.recv(Instant::now(), &mut |_| {}).unwrap() {
-            Some(r) => panic!("disconnected before active: {r:?}"),
-            None if conn.state().state() == State::Active => break,
-            None => {}
+        match conn.recv(Instant::now()).unwrap() {
+            Some(Message::Disconnected { reason }) => {
+                panic!("disconnected before active: {reason:?}")
+            }
+            Some(_) | None => {}
+        }
+        if conn.state().state() == State::Active {
+            break;
         }
     }
 

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -126,9 +126,8 @@ fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream, MockDict> {
 
 fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> DisconnectReason {
     loop {
-        match conn.recv(Instant::now()).unwrap() {
-            Some(Message::Disconnected { reason }) => return reason,
-            Some(_) | None => {}
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
+            return reason;
         }
     }
 }
@@ -177,11 +176,8 @@ fn conformance_resend() {
     conn.connect(Instant::now()).unwrap();
 
     loop {
-        match conn.recv(Instant::now()).unwrap() {
-            Some(Message::Disconnected { reason }) => {
-                panic!("disconnected before active: {reason:?}")
-            }
-            Some(_) | None => {}
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
+            panic!("disconnected before active: {reason:?}");
         }
         if conn.state().state() == State::Active {
             break;

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -1,9 +1,6 @@
-use std::time::{Duration, Instant};
-
 use nexus_fix_codec::{FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag};
-use nexus_fix_engine::{
-    CompId, DisconnectReason, Message, Session, SessionConfig, SessionState, State,
-};
+use nexus_fix_engine::{FrameReader, MessageReader, MessageWriter};
+use nexus_net::wire::ParserSink;
 
 // ── minimal mock dictionary ──────────────────────────────────────────────────
 
@@ -12,36 +9,13 @@ struct MockDict;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum MockMsgType {}
 
-// Minimal find_tag-based admin decoder used for all 7 types in the mock.
 struct AdminDecoder<'buf> {
-    buf: &'buf [u8],
+    _buf: &'buf [u8],
 }
 
 impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
     fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
-        Ok(Self { buf })
-    }
-}
-
-impl<'buf> AdminDecoder<'buf> {
-    fn heart_bt_int(&self) -> Option<FieldView<'buf, u32>> {
-        find_tag(self.buf, 0, 108).and_then(|s| FieldView::new(s, self.buf))
-    }
-
-    fn test_req_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
-        find_tag(self.buf, 0, 112).and_then(|s| FieldView::new(s, self.buf))
-    }
-
-    fn begin_seq_no(&self) -> Option<FieldView<'buf, u64>> {
-        find_tag(self.buf, 0, 7).and_then(|s| FieldView::new(s, self.buf))
-    }
-
-    fn end_seq_no(&self) -> Option<FieldView<'buf, u64>> {
-        find_tag(self.buf, 0, 16).and_then(|s| FieldView::new(s, self.buf))
-    }
-
-    fn new_seq_no(&self) -> Option<FieldView<'buf, u64>> {
-        find_tag(self.buf, 0, 36).and_then(|s| FieldView::new(s, self.buf))
+        Ok(Self { _buf: buf })
     }
 }
 
@@ -97,193 +71,173 @@ impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-const HB: Duration = Duration::from_secs(30);
-
-fn session() -> Session<MockDict> {
-    let state = SessionState::new(HB);
-    let config = SessionConfig {
-        sender: CompId::new(b"SENDER").unwrap(),
-        target: CompId::new(b"TARGET").unwrap(),
-    };
-    Session::new(state, config)
-}
-
-// 49=TARGET (their sender = our target), 56=SENDER (their target = our sender).
-fn logon(seq: u32, hbi: u32) -> Vec<u8> {
-    let mut v = Vec::new();
-    for part in [
-        format!("34={seq}\x01"),
-        "35=A\x01".to_string(),
-        "49=TARGET\x01".to_string(),
-        "56=SENDER\x01".to_string(),
-        format!("108={hbi}\x01"),
-    ] {
-        v.extend_from_slice(part.as_bytes());
-    }
-    v
-}
-
-fn logout(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=5\x0149=TARGET\x0156=SENDER\x01").into_bytes()
-}
-
-fn heartbeat(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=0\x0149=TARGET\x0156=SENDER\x01").into_bytes()
-}
-
-fn test_request(seq: u32, id: &str) -> Vec<u8> {
-    format!("34={seq}\x0135=1\x0149=TARGET\x0156=SENDER\x01112={id}\x01").into_bytes()
-}
-
-fn resend_request(seq: u32, begin: u32, end: u32) -> Vec<u8> {
-    format!("34={seq}\x017={begin}\x0116={end}\x0135=2\x0149=TARGET\x0156=SENDER\x01").into_bytes()
-}
-
-fn sequence_reset(seq: u32, new_seq: u32, gap_fill: bool) -> Vec<u8> {
-    format!(
-        "34={seq}\x0135=4\x0149=TARGET\x0156=SENDER\x0136={new_seq}\x01123={}\x01",
-        if gap_fill { "Y" } else { "N" }
-    )
-    .into_bytes()
-}
-
-fn app_msg(seq: u32) -> Vec<u8> {
-    format!("34={seq}\x0135=D\x0149=TARGET\x0156=SENDER\x01").into_bytes()
+fn feed_bytes<D: FixDictionary>(r: &mut MessageReader<D>, data: &[u8]) {
+    let spare = r.spare();
+    spare[..data.len()].copy_from_slice(data);
+    r.filled(data.len());
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
 
 #[test]
-fn acceptor_logon() {
-    let mut s = session();
-    let msg = logon(1, 30);
-    let m = s.on_message(&msg, Instant::now()).unwrap();
-    assert!(matches!(m, Message::LogonRequest { .. }));
-    assert_eq!(s.state().state(), State::Active);
-    if let Message::LogonRequest { msg } = m {
-        assert_eq!(msg.heart_bt_int().and_then(|v| v.checked().ok()), Some(30));
-    }
+fn frame_reader_yields_complete_frame() {
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let mut fr = FrameReader::builder().build();
+    fr.read(msg).unwrap();
+    let frame = fr.next().unwrap().unwrap();
+    assert_eq!(frame, msg.as_slice());
 }
 
 #[test]
-fn initiator_logon_reply() {
-    let mut s = session();
-    let now = Instant::now();
-    s.state_mut().connect(now);
-    assert_eq!(s.state().state(), State::LogonSent);
-
-    let msg = logon(1, 30);
-    let m = s.on_message(&msg, now).unwrap();
-    assert!(matches!(m, Message::LogonAcknowledged { .. }));
-    assert_eq!(s.state().state(), State::Active);
+fn frame_reader_buffers_partial_then_complete() {
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let mut fr = FrameReader::builder().build();
+    let half = msg.len() / 2;
+    fr.read(&msg[..half]).unwrap();
+    assert!(fr.next().unwrap().is_none());
+    fr.read(&msg[half..]).unwrap();
+    let frame = fr.next().unwrap().unwrap();
+    assert_eq!(frame, msg.as_slice());
 }
 
 #[test]
-fn logout_round_trip() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-
-    let msg = logout(2);
-    let m = s.on_message(&msg, now).unwrap();
-    assert!(matches!(m, Message::LogoutRequest { .. }));
-    assert_eq!(s.state().state(), State::Disconnected);
+fn message_reader_spare_filled_interface() {
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let mut r: MessageReader<MockDict> = MessageReader::new();
+    feed_bytes(&mut r, msg);
+    // The bytes are now in the internal FrameReader. Verify by feeding another message
+    // and confirming the reader accepts more bytes (it didn't OOM).
+    let msg2 = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    feed_bytes(&mut r, msg2);
 }
 
 #[test]
-fn heartbeat_is_handled() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
+fn message_writer_flush_to() {
+    let mut w: MessageWriter<MockDict> = MessageWriter::new();
+    assert!(w.is_empty());
 
-    let hb = heartbeat(2);
-    let m = s.on_message(&hb, now).unwrap();
-    assert!(matches!(m, Message::Heartbeat { .. }));
+    let mut sink = Vec::new();
+    w.flush_to(&mut sink).unwrap();
+    assert_eq!(sink.len(), 0);
 }
 
 #[test]
-fn test_request_surfaces_id() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-
-    let msg = test_request(2, "PROBE1");
-    let m = s.on_message(&msg, now).unwrap();
-    if let Message::TestRequest { msg } = m {
-        let id = msg
-            .test_req_id()
-            .and_then(|v| v.checked().ok())
-            .map(nexus_fix_codec::AsciiTextStr::as_bytes);
-        assert_eq!(id, Some(b"PROBE1".as_ref()));
-    } else {
-        panic!("expected TestRequest");
-    }
+fn message_writer_is_empty_after_flush() {
+    let mut w: MessageWriter<MockDict> = MessageWriter::new();
+    assert!(w.is_empty());
+    assert_eq!(w.remaining(), w.remaining());
+    let mut sink = Vec::new();
+    w.flush_to(&mut sink).unwrap();
+    assert!(w.is_empty());
 }
 
-#[test]
-fn resend_request_fields() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-    s.state_mut().allocate_seq(now); // seq 2
-    s.state_mut().allocate_seq(now); // seq 3
+#[cfg(unix)]
+mod unix_tests {
+    use nexus_fix_engine::{AdminMsg, CompId, MessageWriter, SessionConfig};
 
-    let msg = resend_request(2, 2, 3);
-    let m = s.on_message(&msg, now).unwrap();
-    if let Message::ResendRequest { msg } = m {
-        assert_eq!(msg.begin_seq_no().and_then(|v| v.checked().ok()), Some(2));
-        assert_eq!(msg.end_seq_no().and_then(|v| v.checked().ok()), Some(3));
-    } else {
-        panic!("expected ResendRequest");
-    }
-    assert_eq!(s.state().state(), State::Active);
-}
+    use super::MockDict;
 
-#[test]
-fn sequence_reset_gap_fill() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-
-    // trigger a gap
-    s.on_message(&app_msg(5), now).unwrap();
-    assert_eq!(s.state().state(), State::Resending);
-
-    let msg = sequence_reset(2, 6, true);
-    let m = s.on_message(&msg, now).unwrap();
-    if let Message::SequenceReset { msg } = m {
-        assert_eq!(msg.new_seq_no().and_then(|v| v.checked().ok()), Some(6));
-    } else {
-        panic!("expected SequenceReset");
-    }
-    assert_eq!(s.state().next_inbound_seq(), 6);
-    assert_eq!(s.state().state(), State::Active);
-}
-
-#[test]
-fn app_message_surfaces_header() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-
-    let msg = app_msg(2);
-    let m = s.on_message(&msg, now).unwrap();
-    assert!(matches!(m, Message::Application { .. }));
-}
-
-#[test]
-fn comp_id_mismatch_disconnects() {
-    let mut s = session();
-    let now = Instant::now();
-    s.on_message(&logon(1, 30), now).unwrap();
-
-    let msg = b"34=2\x0135=0\x0149=WRONG\x0156=SENDER\x01";
-    let m = s.on_message(msg, now).unwrap();
-    assert!(matches!(
-        m,
-        Message::Disconnected {
-            reason: DisconnectReason::CompIdMismatch
+    fn config() -> SessionConfig {
+        SessionConfig {
+            sender: CompId::new(b"SENDER").unwrap(),
+            target: CompId::new(b"TARGET").unwrap(),
         }
-    ));
-    assert_eq!(s.state().state(), State::Disconnected);
+    }
+
+    #[test]
+    fn encode_admin_logon_produces_valid_frame() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(
+            AdminMsg::Logon {
+                seq: 1,
+                heart_bt_int_s: 30,
+            },
+            &config,
+        );
+        assert!(!w.is_empty());
+
+        let data = w.data();
+        assert!(data.starts_with(b"8=FIX.4.4\x01"));
+        assert!(data.windows(5).any(|c| c == b"35=A\x01"));
+        assert!(
+            data.windows(b"49=SENDER\x01".len())
+                .any(|c| c == b"49=SENDER\x01")
+        );
+        assert!(
+            data.windows(b"56=TARGET\x01".len())
+                .any(|c| c == b"56=TARGET\x01")
+        );
+        assert!(
+            data.windows(b"108=30\x01".len())
+                .any(|c| c == b"108=30\x01")
+        );
+        assert!(*data.last().unwrap() == b'\x01');
+
+        let mut out = Vec::new();
+        w.flush_to(&mut out).unwrap();
+        assert!(w.is_empty());
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn encode_admin_logout_produces_valid_frame() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(AdminMsg::Logout { seq: 2 }, &config);
+        assert!(!w.is_empty());
+        let data = w.data();
+        assert!(data.starts_with(b"8=FIX.4.4\x01"));
+        assert!(data.windows(5).any(|c| c == b"35=5\x01"));
+    }
+
+    #[test]
+    fn encode_admin_heartbeat_without_echo() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(AdminMsg::Heartbeat { seq: 3, echo: None }, &config);
+        assert!(!w.is_empty());
+        let data = w.data();
+        assert!(data.windows(5).any(|c| c == b"35=0\x01"));
+        assert!(!data.windows(b"112=".len()).any(|c| c == b"112="));
+    }
+
+    #[test]
+    fn encode_admin_resend_request() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(AdminMsg::ResendRequest { seq: 4, begin: 2 }, &config);
+        assert!(!w.is_empty());
+        let data = w.data();
+        assert!(data.windows(5).any(|c| c == b"35=2\x01"));
+        assert!(data.windows(b"7=2\x01".len()).any(|c| c == b"7=2\x01"));
+        assert!(data.windows(b"16=0\x01".len()).any(|c| c == b"16=0\x01"));
+    }
+
+    #[test]
+    fn encode_admin_sequence_reset() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(
+            AdminMsg::SequenceReset {
+                seq: 5,
+                new_seq: 10,
+            },
+            &config,
+        );
+        assert!(!w.is_empty());
+        let data = w.data();
+        assert!(data.windows(5).any(|c| c == b"35=4\x01"));
+        assert!(data.windows(b"36=10\x01".len()).any(|c| c == b"36=10\x01"));
+        assert!(data.windows(b"123=Y\x01".len()).any(|c| c == b"123=Y\x01"));
+    }
+
+    #[test]
+    fn encode_admin_uses_dict_begin_string() {
+        let mut w: MessageWriter<MockDict> = MessageWriter::new();
+        let config = config();
+        w.encode_admin(AdminMsg::Logout { seq: 1 }, &config);
+        let data = w.data();
+        assert!(data.starts_with(b"8=FIX.4.4\x01"));
+    }
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -367,7 +367,7 @@ fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
         match conn.recv(Instant::now()) {
             Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
             Ok(Some(Message::Application { .. })) => saw_app = true,
-            Ok(Some(_)) | Ok(None) => {}
+            Ok(Some(_) | None) => {}
         }
     }
 

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -5,11 +5,83 @@ use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+use nexus_fix_codec::{
+    FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
+    encode_fix_uint, find_tag,
+};
 use nexus_fix_engine::{
-    CompId, DisconnectReason, FixConnection, FixJournal, SessionConfig, SessionState,
+    CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionState,
     TransportError,
 };
+
+// ── mock dictionary ──────────────────────────────────────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+struct AdminDecoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 fn sender() -> CompId {
     CompId::new(b"INITIATOR").unwrap()
@@ -45,16 +117,14 @@ fn tmp_dir(suffix: &str) -> PathBuf {
     p
 }
 
-fn drive<H>(
-    conn: &mut FixConnection<TcpStream>,
-    mut on_app: H,
-) -> Result<DisconnectReason, TransportError>
-where
-    H: FnMut(&[u8]),
-{
+fn drive(
+    conn: &mut FixConnection<TcpStream, MockDict>,
+) -> Result<DisconnectReason, TransportError> {
     loop {
-        if let Some(reason) = conn.recv(Instant::now(), &mut on_app)? {
-            return Ok(reason);
+        match conn.recv(Instant::now())? {
+            Some(Message::Disconnected { reason }) => return Ok(reason),
+            Some(_) => {}
+            None => {}
         }
     }
 }
@@ -136,6 +206,8 @@ impl Peer {
     }
 }
 
+// ── tests ────────────────────────────────────────────────────────────────────
+
 #[test]
 fn initiator_logon_and_logout() {
     let dir = tmp_dir("logon_logout");
@@ -157,16 +229,15 @@ fn initiator_logon_and_logout() {
         let _ = peer.recv_msg(&mut buf);
     });
 
-    let mut conn = FixConnection::from_parts(
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(t_sender, t_target),
         journal(&dir),
-        b"FIX.4.4",
     );
     conn.connect(Instant::now()).unwrap();
 
-    let reason = drive(&mut conn, |_| {}).unwrap();
+    let reason = drive(&mut conn).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
 
     handle.join().unwrap();
@@ -190,20 +261,27 @@ fn acceptor_receives_app_message() {
         let _ = peer.recv_msg(&mut buf);
     });
 
-    let mut received: Vec<Vec<u8>> = Vec::new();
+    let mut received_app = 0usize;
     let dir2 = tmp_dir("acceptor_app_srv");
-    let mut conn = FixConnection::from_parts(
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
         journal(&dir2),
-        b"FIX.4.4",
     );
 
-    let reason = drive(&mut conn, |frame| received.push(frame.to_vec())).unwrap();
+    let reason = loop {
+        match conn.recv(Instant::now()).unwrap() {
+            Some(Message::Disconnected { reason }) => break reason,
+            Some(Message::Application { header: _ }) => {
+                received_app += 1;
+            }
+            Some(_) | None => {}
+        }
+    };
+
     assert_eq!(reason, DisconnectReason::Logout);
-    assert_eq!(received.len(), 1);
-    assert!(received[0].starts_with(b"8=FIX.4.4"));
+    assert_eq!(received_app, 1);
 
     handle.join().unwrap();
     let _ = dir;
@@ -245,16 +323,15 @@ fn resend_request_triggers_gap_fill() {
         let _ = peer.recv_msg(&mut buf);
     });
 
-    let mut conn = FixConnection::from_parts(
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(sender(), target()),
         journal(&dir_cli),
-        b"FIX.4.4",
     );
     conn.connect(Instant::now()).unwrap();
 
-    let reason = drive(&mut conn, |_| {}).unwrap();
+    let reason = drive(&mut conn).unwrap();
     assert_eq!(reason, DisconnectReason::Logout);
 
     handle.join().unwrap();

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -11,7 +11,7 @@ use nexus_fix_codec::{
 };
 use nexus_fix_engine::{
     CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionState,
-    TransportError,
+    State, TransportError,
 };
 
 // ── mock dictionary ──────────────────────────────────────────────────────────
@@ -334,4 +334,49 @@ fn resend_request_triggers_gap_fill() {
 
     handle.join().unwrap();
     let _ = dir_srv;
+}
+
+#[test]
+fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
+    let dir_cli = tmp_dir("inbound_gap");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    // Peer sends logon, then a gap app message, then drops (EOF to engine).
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        let mut buf = [0u8; 512];
+        peer.send_logon(30);
+        let _ = peer.recv_msg(&mut buf); // consume logon ack
+        peer.next_out = 5;
+        peer.send_app(11, b"ORD-GAP"); // seq=5, gap (expected 2)
+        // Drop peer — engine sees EOF; no need to read ResendRequest here.
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir_cli),
+    );
+
+    let mut saw_app = false;
+    loop {
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::Application { .. })) => saw_app = true,
+            Ok(Some(_)) | Ok(None) => {}
+        }
+    }
+
+    assert!(!saw_app, "out-of-sequence app must not be surfaced");
+    assert_eq!(
+        conn.state().state(),
+        State::Resending,
+        "engine must enter Resending state (= ResendRequest sent) on inbound gap"
+    );
+
+    handle.join().unwrap();
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -121,10 +121,8 @@ fn drive(
     conn: &mut FixConnection<TcpStream, MockDict>,
 ) -> Result<DisconnectReason, TransportError> {
     loop {
-        match conn.recv(Instant::now())? {
-            Some(Message::Disconnected { reason }) => return Ok(reason),
-            Some(_) => {}
-            None => {}
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now())? {
+            return Ok(reason);
         }
     }
 }


### PR DESCRIPTION
Fixes #542.

**Problem:** `Session<D>::on_message` called every `SessionState` handler but discarded the returned `Out`, so the engine never sent Logon ack, Heartbeat echo, ResendRequest-on-gap, or Logout as acceptor.

**Changes:**

- `MessageReader<D>` — wraps `FrameReader` + owned frame buffer; implements `ParserSink`; dictionary-aware via `D::Header`
- `MessageWriter<D>` — wraps `FrameWriter`; `encode_admin` uses `D::BEGIN_STRING` (no stored `begin_string` field)
- `FixConnection<S, D>` — generic over dictionary; `begin_string` field removed; `from_parts` / builder `connect` / `accept` drop the `begin_string` arg
- `recv(&mut self, now) -> Result<Option<Message<'_, D>>, Error>` — returns typed message directly; `Out` auto-flushed on every frame
- `do_resend` extracted as free function (split-borrow safe while frame slice is live)
- `Error::Protocol(SessionError)` variant for decode failures
- `Session<D>` deleted
- Tests rewritten; example updated
