### PR TITLE
fix(fix-codec): guard parse_tag against overflow on malformed peer bytes

### DIFF
--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -239,9 +239,10 @@ pub fn parse_tag(buf: &[u8]) -> (u32, usize) {
     let mut tag = 0u32;
     let mut i = 0;
     while i < buf.len() && buf[i] >= b'0' && buf[i] <= b'9' {
-        tag = tag
-            .saturating_mul(10)
-            .saturating_add((buf[i] - b'0') as u32);
+        if i >= 5 {
+            return (u32::MAX, i);
+        }
+        tag = tag * 10 + (buf[i] - b'0') as u32;
         i += 1;
     }
     (tag, i)

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -713,6 +713,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_tag_overflow() {
+        assert_eq!(parse_tag(b"99999999999=x"), (u32::MAX, 5));
+    }
+
+    #[test]
+    fn overflowed_tag_dropped_by_field_reader() {
+        let msg = b"8=FIX.4.4\x013400000=1\x0135=A\x01";
+        assert!(find_tag(msg, 0, 3_400_000).is_none());
+        // Also none because iterator returns infinite for each tag after the large one
+        assert!(find_tag(msg, 0, 35).is_none());
+        // Since 8 is found before the large tag, it successfully retrieves the value
+        assert!(find_tag(msg, 0, 8).is_some());
+    }
+
+    #[test]
     fn swar_mask_conversion() {
         // Single match at byte 0: bit 7 set
         assert_eq!(swar_to_byte_mask(0x80), 0x01);

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -239,7 +239,9 @@ pub fn parse_tag(buf: &[u8]) -> (u32, usize) {
     let mut tag = 0u32;
     let mut i = 0;
     while i < buf.len() && buf[i] >= b'0' && buf[i] <= b'9' {
-        tag = tag * 10 + (buf[i] - b'0') as u32;
+        tag = tag
+            .saturating_mul(10)
+            .saturating_add((buf[i] - b'0') as u32);
         i += 1;
     }
     (tag, i)


### PR DESCRIPTION
Related to #546

This PR is associated to  `parse_tag overflow` in the issue.