### PR TITLE
fix(fix-engine): session/transport hardening (#543)

### DIFF
--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -6,6 +6,7 @@
 //! tags `8=` (BeginString), `9=` (BodyLength), and `10=` (CheckSum) that
 //! are invariant across all FIX versions.
 
+use nexus_fix_codec::validate_checksum;
 use nexus_net::buf::{ReadBuf, WriteBuf};
 use nexus_net::wire::ParserSink;
 
@@ -280,6 +281,10 @@ impl FrameReader {
 
         if data.len() < message_end {
             return ParseResult::Incomplete;
+        }
+
+        if validate_checksum(&data[..message_end]).is_err() {
+            return ParseResult::Garbage;
         }
 
         ParseResult::Complete(message_end)
@@ -979,5 +984,30 @@ mod tests {
         // data() should start right at the message — no gap.
         assert!(writer.data().starts_with(b"8=FIX.4.4\x01"));
         assert_eq!(writer.data().len(), len);
+    }
+
+    // ---- checksum validation ----
+
+    #[test]
+    fn corrupt_checksum_rejected() {
+        let mut msg = heartbeat();
+        let n = msg.len();
+        msg[n - 2] ^= 1; // flip the last checksum digit
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&msg).unwrap();
+        let err = reader.next().unwrap_err();
+        assert!(
+            matches!(err, FrameError::Garbage { .. }),
+            "corrupt checksum must be treated as garbage"
+        );
+    }
+
+    #[test]
+    fn valid_checksum_accepted() {
+        let msg = heartbeat();
+        let mut reader = FrameReader::builder().build();
+        reader.read(&msg).unwrap();
+        assert!(reader.next().unwrap().is_some());
     }
 }

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -90,7 +90,7 @@ impl std::error::Error for FrameError {}
 ///     .build();
 ///
 /// // A complete Heartbeat message.
-/// let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+/// let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=163\x01";
 /// reader.read(msg).unwrap();
 ///
 /// let frame = reader.next().unwrap().unwrap();

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -50,7 +50,7 @@ impl<'a> Iterator for ResendIter<'a> {
                 });
             }
             let seq = self.seq;
-            self.seq += 1;
+            self.seq = self.seq.saturating_add(1);
             let is_gap = match self.journal.resend_one(seq) {
                 ResendPlan::GapFill => true,
                 ResendPlan::Replay(frame) => {
@@ -154,7 +154,7 @@ impl FixJournal {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
         } else {
-            end.min(self.next_outbound.saturating_sub(1))
+            end
         };
         ResendIter {
             journal: self,
@@ -450,39 +450,6 @@ mod tests {
         let items = collect_range(&j, 1, 0);
         assert_eq!(items.len(), 3);
         assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
-
-        cleanup(&dir);
-    }
-
-    #[test]
-    fn resend_peer_end_clamped_to_next_outbound() {
-        let dir = tmp_dir("rr-clamp");
-        cleanup(&dir);
-
-        let mut j = FixJournal::open(&dir, 64).unwrap();
-        j.store(1, &fix_msg(1)).unwrap();
-        j.store(2, &fix_msg(2)).unwrap();
-        // next_outbound = 3; peer sends EndSeqNo = 4_000_000_000
-        let items = collect_range(&j, 1, 4_000_000_000);
-        assert_eq!(items.len(), 2, "end must be clamped to next_outbound-1");
-        assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
-
-        cleanup(&dir);
-    }
-
-    #[test]
-    fn resend_begin_after_clamped_end_yields_empty() {
-        let dir = tmp_dir("rr-empty");
-        cleanup(&dir);
-
-        // next_outbound = 1 (nothing stored); peer requests begin=1, end=4B → clamped high=0
-        let j = FixJournal::open(&dir, 64).unwrap();
-        let items = collect_range(&j, 1, 4_000_000_000);
-        assert_eq!(
-            items.len(),
-            0,
-            "begin > clamped high must yield empty iterator"
-        );
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -154,7 +154,7 @@ impl FixJournal {
         let high = if end == 0 {
             self.next_outbound.saturating_sub(1)
         } else {
-            end
+            end.min(self.next_outbound.saturating_sub(1))
         };
         ResendIter {
             journal: self,
@@ -450,6 +450,35 @@ mod tests {
         let items = collect_range(&j, 1, 0);
         assert_eq!(items.len(), 3);
         assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_peer_end_clamped_to_next_outbound() {
+        let dir = tmp_dir("rr-clamp");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 64).unwrap();
+        j.store(1, &fix_msg(1)).unwrap();
+        j.store(2, &fix_msg(2)).unwrap();
+        // next_outbound = 3; peer sends EndSeqNo = 4_000_000_000
+        let items = collect_range(&j, 1, 4_000_000_000);
+        assert_eq!(items.len(), 2, "end must be clamped to next_outbound-1");
+        assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resend_begin_after_clamped_end_yields_empty() {
+        let dir = tmp_dir("rr-empty");
+        cleanup(&dir);
+
+        // next_outbound = 1 (nothing stored); peer requests begin=1, end=4B → clamped high=0
+        let j = FixJournal::open(&dir, 64).unwrap();
+        let items = collect_range(&j, 1, 4_000_000_000);
+        assert_eq!(items.len(), 0, "begin > clamped high must yield empty iterator");
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -478,7 +478,11 @@ mod tests {
         // next_outbound = 1 (nothing stored); peer requests begin=1, end=4B → clamped high=0
         let j = FixJournal::open(&dir, 64).unwrap();
         let items = collect_range(&j, 1, 4_000_000_000);
-        assert_eq!(items.len(), 0, "begin > clamped high must yield empty iterator");
+        assert_eq!(
+            items.len(),
+            0,
+            "begin > clamped high must yield empty iterator"
+        );
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -444,6 +444,9 @@ impl SessionState {
         self.test_request_sent = None;
         let mut out = Out::EMPTY;
         if !gap_fill {
+            if new_seq == 0 || new_seq < self.next_inbound {
+                return out;
+            }
             self.next_inbound = new_seq;
             out.push_event(Event::SequenceReset { new_seq });
             self.check_resend_done();

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -412,7 +412,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     let re = if re == 0 {
                         self.state.next_outbound_seq().saturating_sub(1)
                     } else {
-                        re.min(self.state.next_outbound_seq())
+                        re.min(self.state.next_outbound_seq().saturating_sub(1))
                     };
                     do_resend::<S, D>(
                         rb,

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -45,6 +45,7 @@ pub struct FixConnection<S, D: FixDictionary> {
     state: SessionState,
     journal: FixJournal,
     config: SessionConfig,
+    garbage_frames: u64,
 }
 
 pub struct FixConnectionBuilder<D: FixDictionary> {
@@ -109,6 +110,7 @@ impl<D: FixDictionary> FixConnectionBuilder<D> {
             state,
             journal,
             config,
+            garbage_frames: 0,
         })
     }
 
@@ -134,6 +136,7 @@ impl<D: FixDictionary> FixConnectionBuilder<D> {
             state,
             journal,
             config,
+            garbage_frames: 0,
         }
     }
 }
@@ -164,6 +167,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
             state,
             journal,
             config,
+            garbage_frames: 0,
         }
     }
 
@@ -173,6 +177,10 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
 
     pub fn state_mut(&mut self) -> &mut SessionState {
         &mut self.state
+    }
+
+    pub fn garbage_frame_count(&self) -> u64 {
+        self.garbage_frames
     }
 
     pub fn allocate_seq(&mut self) -> u32 {
@@ -230,7 +238,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 Err(FrameError::MessageTooLarge { size }) => {
                     return Err(Error::FrameTooLarge(size));
                 }
-                Err(FrameError::Garbage { .. }) => {}
+                Err(FrameError::Garbage { .. }) => {
+                    self.garbage_frames += 1;
+                }
                 Ok(None) => {
                     let n = {
                         let spare = self.reader.inner.spare();

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -409,6 +409,11 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
                 }
                 if let Some(Event::ResendRange { begin: rb, end: re }) = out.event() {
+                    let re = if re == 0 {
+                        self.state.next_outbound_seq().saturating_sub(1)
+                    } else {
+                        re.min(self.state.next_outbound_seq())
+                    };
                     do_resend::<S, D>(
                         rb,
                         re,

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -81,7 +81,7 @@ fn feed_bytes<D: FixDictionary>(r: &mut MessageReader<D>, data: &[u8]) {
 
 #[test]
 fn frame_reader_yields_complete_frame() {
-    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=163\x01";
     let mut fr = FrameReader::builder().build();
     fr.read(msg).unwrap();
     let frame = fr.next().unwrap().unwrap();
@@ -90,7 +90,7 @@ fn frame_reader_yields_complete_frame() {
 
 #[test]
 fn frame_reader_buffers_partial_then_complete() {
-    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=163\x01";
     let mut fr = FrameReader::builder().build();
     let half = msg.len() / 2;
     fr.read(&msg[..half]).unwrap();
@@ -102,12 +102,12 @@ fn frame_reader_buffers_partial_then_complete() {
 
 #[test]
 fn message_reader_spare_filled_interface() {
-    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=163\x01";
     let mut r: MessageReader<MockDict> = MessageReader::new();
     feed_bytes(&mut r, msg);
     // The bytes are now in the internal FrameReader. Verify by feeding another message
     // and confirming the reader accepts more bytes (it didn't OOM).
-    let msg2 = b"8=FIX.4.4\x019=5\x0135=0\x0110=162\x01";
+    let msg2 = b"8=FIX.4.4\x019=5\x0135=0\x0110=163\x01";
     feed_bytes(&mut r, msg2);
 }
 

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -202,6 +202,65 @@ impl Peer {
     fn recv_msg(&mut self, buf: &mut [u8]) -> usize {
         self.stream.read(buf).unwrap()
     }
+
+    fn send_resend_request(&mut self, begin: u32, end: u32) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 256];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut begin_buf = [0u8; 10];
+        let begin_n = encode_fix_uint(begin, &mut begin_buf);
+        let mut end_buf = [0u8; 10];
+        let end_n = encode_fix_uint(end, &mut end_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"2");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(7, &begin_buf[..begin_n]);
+        fmt.field(16, &end_buf[..end_n]);
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn send_sequence_reset_reset(&mut self, new_seq: u32) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 256];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut nsq_buf = [0u8; 10];
+        let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"4");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(36, &nsq_buf[..nsq_n]);
+        // No GapFillFlag(123) → Reset mode
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn send_corrupt_heartbeat(&mut self) {
+        let seq = self.next_out;
+        self.next_out += 1;
+        let mut buf = [0u8; 256];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"0");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        let (start, len) = fmt.finish().unwrap();
+        buf[start + len - 2] ^= 1; // corrupt last checksum digit
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
@@ -378,5 +437,160 @@ fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
         "engine must enter Resending state (= ResendRequest sent) on inbound gap"
     );
 
+    handle.join().unwrap();
+}
+
+#[test]
+fn resend_request_huge_end_seq_clamped() {
+    // Fix 1: peer sends EndSeqNo=4_000_000_000; engine must clamp to next_outbound-1
+    // and respond immediately (not iterate 4B times).
+    let dir = tmp_dir("resend_huge");
+    let (client_sock, server_sock) = loopback_pair();
+    client_sock
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(server_sock, target(), sender());
+        let mut buf = [0u8; 4096];
+        let _ = peer.recv_msg(&mut buf); // initiator logon
+        peer.send_logon(30);
+        peer.send_resend_request(1, 4_000_000_000); // seq=2, begin=1, end=4B
+        let n = peer.recv_msg(&mut buf); // must receive GapFill quickly
+        assert!(n > 0, "engine must respond to clamped ResendRequest");
+        peer.send_logout();
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(sender(), target()),
+        journal(&dir),
+    );
+    conn.connect(Instant::now()).unwrap();
+    let reason = drive(&mut conn).unwrap();
+    assert_eq!(reason, DisconnectReason::Logout);
+    handle.join().unwrap();
+}
+
+#[test]
+fn corrupt_checksum_frame_counted_as_garbage() {
+    // Fix 2: a frame with a bad checksum must be detected at the frame boundary
+    // and counted in garbage_frame_count.
+    let dir = tmp_dir("corrupt_cs");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        let mut buf = [0u8; 512];
+        peer.send_logon(30);
+        let _ = peer.recv_msg(&mut buf);
+        peer.send_corrupt_heartbeat();
+        // Drop peer
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir),
+    );
+
+    loop {
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            _ => {}
+        }
+    }
+
+    assert!(
+        conn.garbage_frame_count() > 0,
+        "corrupt checksum must increment garbage_frame_count"
+    );
+    handle.join().unwrap();
+}
+
+#[test]
+fn garbage_bytes_increment_counter() {
+    // Fix 3: raw non-FIX bytes from a misbehaving peer must be counted.
+    let dir = tmp_dir("garbage_count");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        let mut buf = [0u8; 512];
+        peer.send_logon(30);
+        let _ = peer.recv_msg(&mut buf);
+        peer.stream.write_all(b"GARBAGE_NOT_FIX").unwrap();
+        peer.stream.flush().unwrap();
+        // Drop peer
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir),
+    );
+
+    loop {
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            _ => {}
+        }
+    }
+
+    assert!(
+        conn.garbage_frame_count() > 0,
+        "raw garbage bytes must increment garbage_frame_count"
+    );
+    handle.join().unwrap();
+}
+
+#[test]
+fn sequence_reset_backward_ignored() {
+    // Fix 4: SequenceReset Reset-mode with new_seq < next_inbound must be ignored.
+    let dir = tmp_dir("seqreset_bwd");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        let mut buf = [0u8; 512];
+        peer.send_logon(30); // seq=1; server next_inbound becomes 2
+        let _ = peer.recv_msg(&mut buf);
+        peer.send_sequence_reset_reset(1); // new_seq=1 < next_inbound=2 → ignored
+        peer.send_sequence_reset_reset(0); // new_seq=0 → ignored
+        // Drop peer
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir),
+    );
+
+    loop {
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        conn.state().next_inbound_seq(),
+        2,
+        "backward/zero SequenceReset Reset must not rewind next_inbound"
+    );
     handle.join().unwrap();
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -366,8 +366,8 @@ fn resend_request_triggers_gap_fill() {
         fmt.field(49, b"ACCEPTOR");
         fmt.field(56, b"INITIATOR");
         fmt.field(52, b"20260615-12:00:00.000");
-        fmt.field(7, b"2");
-        fmt.field(16, b"3");
+        fmt.field(7, b"1");
+        fmt.field(16, b"1");
         let (start, len) = fmt.finish().unwrap();
         peer.stream.write_all(&rbuf[start..start + len]).unwrap();
         peer.stream.flush().unwrap();


### PR DESCRIPTION
Closes #543.

Four peer-facing hardening fixes from the 2026-06 audit, each with an adversarial test.

**1. Resend hang / u32 overflow** (`persist.rs`)
Clamp `end` to `next_outbound.saturating_sub(1)` in `resend()`. A peer sending `EndSeqNo=4000000000` no longer causes a ~4B-iteration loop.

**2. Inbound checksum validation** (`frame.rs`)
Call `validate_checksum` at the frame boundary in `try_parse()`. Frames with a wrong checksum are now surfaced as `FrameError::Garbage` instead of being silently accepted.

**3. Garbage frame counter** (`transport.rs`)
Add `garbage_frames: u64` field, incremented on every `FrameError::Garbage`. Exposed via `garbage_frame_count()`. Misbehaving peers are now observable without log scraping.

**4. SequenceReset Reset-mode guard** (`session/mod.rs`)
Reject `new_seq == 0 || new_seq < next_inbound` before applying a Reset-mode SequenceReset. Prevents peers from rewinding or zeroing the inbound sequence counter.

**Tests added:** unit tests in `frame.rs` and `persist.rs`; four adversarial integration tests in `tests/transport.rs` covering each fix.