### PR TITLE
fix(fix-codec): harden FixDecimal against scale overflow

### DIFF
--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -1579,10 +1579,10 @@ mod decimal_conv {
 
             let scaled = if D >= d.scale {
                 d.mantissa
-                    .checked_mul(10_i64.pow((D - d.scale) as u32))
+                    .checked_mul(10_i64.checked_pow((D - d.scale) as u32).ok_or_else(err)?)
                     .ok_or_else(err)?
             } else {
-                d.mantissa / 10_i64.pow((d.scale - D) as u32)
+                d.mantissa / 10_i64.checked_pow((d.scale - D) as u32).ok_or_else(err)?
             };
             Ok(Self::from_raw(scaled))
         }
@@ -1603,10 +1603,10 @@ mod decimal_conv {
 
             let scaled = if D >= d.scale {
                 d.mantissa
-                    .checked_mul(10_i64.pow((D - d.scale) as u32))
+                    .checked_mul(10_i64.checked_pow((D - d.scale) as u32).ok_or_else(err)?)
                     .ok_or_else(err)?
             } else {
-                d.mantissa / 10_i64.pow((d.scale - D) as u32)
+                d.mantissa / 10_i64.checked_pow((d.scale - D) as u32).ok_or_else(err)?
             };
             let narrow = i32::try_from(scaled).map_err(|_| err())?;
             Ok(Self::from_raw(narrow))

--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -18,11 +18,23 @@ use crate::error::FixValueError;
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FixDecimal {
-    pub mantissa: i64,
-    pub scale: u8,
+    mantissa: i64,
+    scale: u8,
 }
 
 impl FixDecimal {
+
+    pub fn new(mantissa: i64, scale: u8) -> Result<Self, FixValueError> {
+        if scale > 19 {
+            return Err(FixValueError::Overflow);
+        }
+        
+        Ok(Self {
+            mantissa,
+            scale,
+        })
+    }
+
     /// Parse a FIX decimal from wire bytes.
     ///
     /// Accepts: optional sign, digits, optional `.` + fractional digits.

--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -23,16 +23,12 @@ pub struct FixDecimal {
 }
 
 impl FixDecimal {
-
     pub fn new(mantissa: i64, scale: u8) -> Result<Self, FixValueError> {
         if scale > 19 {
             return Err(FixValueError::Overflow);
         }
-        
-        Ok(Self {
-            mantissa,
-            scale,
-        })
+
+        Ok(Self { mantissa, scale })
     }
 
     /// Parse a FIX decimal from wire bytes.
@@ -142,6 +138,11 @@ impl FixDecimal {
 
         let abs = self.mantissa.unsigned_abs();
 
+        debug_assert!(
+            self.scale <= 19,
+            "FixDecimal::encode: scale over 19 ({}) will result in an integer overflow",
+            self.scale
+        );
         if self.scale == 0 {
             pos += encode_u64(abs, &mut buf[pos..]);
             return pos;
@@ -177,6 +178,11 @@ impl From<FixDecimal> for f32 {
 
 impl fmt::Display for FixDecimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        debug_assert!(
+            self.scale <= 19,
+            "<FixDecimal as std::fmt::Display>::fmt: scale over 19 ({}) will result in an integer overflow",
+            self.scale
+        );
         if self.scale == 0 {
             return write!(f, "{}", self.mantissa);
         }

--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -1541,19 +1541,26 @@ mod decimal_conv {
 
     impl std::error::Error for DecimalConvError {}
 
-    // i128 backing: infallible — i128 always has headroom for i64 mantissa rescale.
-    impl<const D: u8> From<FixDecimal> for Decimal<i128, D>
+    impl<const D: u8> TryFrom<FixDecimal> for Decimal<i128, D>
     where
         i128: Backing,
     {
-        fn from(d: FixDecimal) -> Self {
+        type Error = DecimalConvError;
+
+        fn try_from(d: FixDecimal) -> Result<Self, Self::Error> {
+            let err = || DecimalConvError {
+                mantissa: d.mantissa,
+                scale: d.scale,
+            };
             let mantissa = d.mantissa as i128;
             let scaled = if D >= d.scale {
-                mantissa * 10_i128.pow((D - d.scale) as u32)
+                mantissa
+                    .checked_mul(10_i128.checked_pow((D - d.scale) as u32).ok_or_else(err)?)
+                    .ok_or_else(err)?
             } else {
-                mantissa / 10_i128.pow((d.scale - D) as u32)
+                mantissa / 10_i128.checked_pow((d.scale - D) as u32).ok_or_else(err)?
             };
-            Self::from_raw(scaled)
+            Ok(Self::from_raw(scaled))
         }
     }
 
@@ -3114,14 +3121,14 @@ mod tests {
         #[test]
         fn to_i128_decimal_widening() {
             let d = FixDecimal::parse(b"123.45").unwrap();
-            let dec: Decimal<i128, 8> = d.into();
+            let dec: Decimal<i128, 8> = d.try_into().unwrap();
             assert_eq!(dec.to_raw(), 12_345_000_000);
         }
 
         #[test]
         fn to_i128_decimal_narrowing() {
             let d = FixDecimal::parse(b"1.123456789").unwrap();
-            let dec: Decimal<i128, 4> = d.into();
+            let dec: Decimal<i128, 4> = d.try_into().unwrap();
             assert_eq!(dec.to_raw(), 11234);
         }
 

--- a/nexus-fix-codec/tests/property.rs
+++ b/nexus-fix-codec/tests/property.rs
@@ -9,8 +9,9 @@
 use core::num::NonZeroU32;
 use nexus_fix_codec::{
     FixDate, FixDecimal, FixMonthYear, FixTenor, FixTime, FixTimestamp, FixTzTime, FixTzTimestamp,
-    TenorUnit, parse_fix_bool, parse_fix_char, parse_fix_day_of_month, parse_fix_int,
-    parse_fix_multi_char, parse_fix_multi_string, parse_fix_seqnum, parse_fix_text, parse_fix_uint,
+    FixValueError, TenorUnit, parse_fix_bool, parse_fix_char, parse_fix_day_of_month,
+    parse_fix_int, parse_fix_multi_char, parse_fix_multi_string, parse_fix_seqnum, parse_fix_text,
+    parse_fix_uint,
 };
 use proptest::prelude::*;
 
@@ -48,6 +49,14 @@ proptest! {
     }
 
     // -- Round-trip: construct -> encode -> parse --
+
+    #[test]
+    fn decimal_roundtrip_reject_overflow(mantissa in any::<i64>(), scale in 20..=255u8) {
+        prop_assert!(matches!(
+            FixDecimal::new(mantissa, scale),
+            Err(FixValueError::Overflow)
+        ));
+    }
 
     #[test]
     fn decimal_roundtrip(mantissa in any::<i64>(), scale in 0u8..=19) {

--- a/nexus-fix-codec/tests/property.rs
+++ b/nexus-fix-codec/tests/property.rs
@@ -51,7 +51,7 @@ proptest! {
 
     #[test]
     fn decimal_roundtrip(mantissa in any::<i64>(), scale in 0u8..=19) {
-        let d = FixDecimal { mantissa, scale };
+        let d = FixDecimal::new( mantissa, scale).unwrap();
         let mut buf = [0u8; 22];
         let n = d.encode(&mut buf);
         prop_assert_eq!(FixDecimal::parse(&buf[..n]).unwrap(), d);

--- a/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
+++ b/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
@@ -110,18 +110,9 @@ fn build_alpha_nos_no_groups() -> Vec<u8> {
 
 fn build_beta_md_with_groups() -> Vec<u8> {
     let mut buf = [0u8; 512];
-    let px_bid = nexus_fix_codec::FixDecimal {
-        mantissa: 11050,
-        scale: 4,
-    };
-    let px_offer = nexus_fix_codec::FixDecimal {
-        mantissa: 11052,
-        scale: 4,
-    };
-    let sz = nexus_fix_codec::FixDecimal {
-        mantissa: 1_000_000,
-        scale: 0,
-    };
+    let px_bid = nexus_fix_codec::FixDecimal::new(11050, 4).unwrap();
+    let px_offer = nexus_fix_codec::FixDecimal::new(11052, 4).unwrap();
+    let sz = nexus_fix_codec::FixDecimal::new(1_000_000, 0).unwrap();
     let (start, len) = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)
         .header_encoder()
         .finish()
@@ -262,18 +253,9 @@ fn main() {
         black_box(len)
     });
 
-    let px_bid = nexus_fix_codec::FixDecimal {
-        mantissa: 11050,
-        scale: 4,
-    };
-    let px_offer = nexus_fix_codec::FixDecimal {
-        mantissa: 11052,
-        scale: 4,
-    };
-    let sz = nexus_fix_codec::FixDecimal {
-        mantissa: 1_000_000,
-        scale: 0,
-    };
+    let px_bid = nexus_fix_codec::FixDecimal::new(11050, 4).unwrap();
+    let px_offer = nexus_fix_codec::FixDecimal::new(11052, 4).unwrap();
+    let sz = nexus_fix_codec::FixDecimal::new(1_000_000, 0).unwrap();
     measure("beta MD encode  (2 entries)", || {
         let mut buf = [0u8; 512];
         let (_, len) =

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -793,18 +793,9 @@ fn alpha_nested_group_encode_round_trip() {
 
 #[test]
 fn beta_group_encode_round_trip() {
-    let px_bid = nexus_fix_codec::FixDecimal::new(
-        11050,
-        4,
-    ).unwrap();
-    let px_offer = nexus_fix_codec::FixDecimal::new(
-        11052,
-        4,
-    ).unwrap();
-    let sz = nexus_fix_codec::FixDecimal::new(
-        1_000_000,
-        0,
-    ).unwrap();
+    let px_bid = nexus_fix_codec::FixDecimal::new(11050, 4).unwrap();
+    let px_offer = nexus_fix_codec::FixDecimal::new(11052, 4).unwrap();
+    let sz = nexus_fix_codec::FixDecimal::new(1_000_000, 0).unwrap();
 
     let mut buf = [0u8; 512];
     let (start, len) = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -8,10 +8,7 @@ fn alpha_decodes_scalar_fields_and_enum() {
     assert_eq!(m.symbol().unwrap().as_bytes(), &b"BTC-USD"[..]);
     assert_eq!(
         m.order_qty().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 10,
-            scale: 0,
-        }
+        nexus_fix_codec::FixDecimal::new(10, 0,).unwrap()
     );
     assert_eq!(m.side(), Some(venue_alpha::fields::Side::BUY));
 }
@@ -110,17 +107,11 @@ fn alpha_decodes_execution_report() {
     assert_eq!(m.ord_status(), Some(venue_alpha::fields::OrdStatus::FILLED));
     assert_eq!(
         m.last_qty().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 5,
-            scale: 0,
-        }
+        nexus_fix_codec::FixDecimal::new(5, 0,).unwrap()
     );
     assert_eq!(
         m.last_px().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 10050,
-            scale: 2,
-        }
+        nexus_fix_codec::FixDecimal::new(10050, 2,).unwrap()
     );
 }
 
@@ -174,10 +165,7 @@ fn alpha_encodes_round_trip() {
 
 #[test]
 fn alpha_encodes_typed_decimal_and_optional_header() {
-    let qty = nexus_fix_codec::FixDecimal {
-        mantissa: 1050,
-        scale: 1,
-    };
+    let qty = nexus_fix_codec::FixDecimal::new(1050, 1).unwrap();
     let mut buf = [0u8; 256];
     let (start, len) = venue_alpha::encoders::NewOrderSingleEncoder::wrap(&mut buf)
         .header_encoder()
@@ -234,10 +222,7 @@ fn beta_decodes_market_data_group() {
     );
     assert_eq!(
         entries[0].md_entry_px().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 11050,
-            scale: 4,
-        }
+        nexus_fix_codec::FixDecimal::new(11050, 4,).unwrap()
     );
     assert_eq!(
         entries[1].md_entry_type(),
@@ -245,10 +230,7 @@ fn beta_decodes_market_data_group() {
     );
     assert_eq!(
         entries[1].md_entry_size().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 2_000_000,
-            scale: 0,
-        }
+        nexus_fix_codec::FixDecimal::new(2_000_000, 0,).unwrap()
     );
 }
 
@@ -380,10 +362,7 @@ fn alpha_raw_matches_typed_for_qty() {
     assert_eq!(m.order_qty().unwrap().as_bytes(), &b"12345.67"[..]);
     assert_eq!(
         m.order_qty().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 1_234_567,
-            scale: 2,
-        }
+        nexus_fix_codec::FixDecimal::new(1_234_567, 2,).unwrap()
     );
 }
 
@@ -562,10 +541,7 @@ fn alpha_exec_report_typed_and_raw_consistency() {
     assert_eq!(m.last_px().unwrap().as_bytes(), &b"50.25"[..]);
     assert_eq!(
         m.last_px().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 5025,
-            scale: 2,
-        }
+        nexus_fix_codec::FixDecimal::new(5025, 2,).unwrap()
     );
     assert_eq!(m.side(), Some(venue_alpha::fields::Side::SELL));
     assert_eq!(m.exec_type(), Some(venue_alpha::fields::ExecType::NEW));
@@ -620,18 +596,12 @@ fn beta_group_entry_typed_accessors() {
     );
     assert_eq!(
         entries[0].md_entry_px().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 4_200_050,
-            scale: 2,
-        }
+        nexus_fix_codec::FixDecimal::new(4_200_050, 2,).unwrap()
     );
     assert_eq!(entries[0].md_entry_size().unwrap().as_bytes(), &b"3"[..]);
     assert_eq!(
         entries[0].md_entry_size().unwrap().get(),
-        nexus_fix_codec::FixDecimal {
-            mantissa: 3,
-            scale: 0,
-        }
+        nexus_fix_codec::FixDecimal::new(3, 0,).unwrap()
     );
 }
 
@@ -823,18 +793,18 @@ fn alpha_nested_group_encode_round_trip() {
 
 #[test]
 fn beta_group_encode_round_trip() {
-    let px_bid = nexus_fix_codec::FixDecimal {
-        mantissa: 11050,
-        scale: 4,
-    };
-    let px_offer = nexus_fix_codec::FixDecimal {
-        mantissa: 11052,
-        scale: 4,
-    };
-    let sz = nexus_fix_codec::FixDecimal {
-        mantissa: 1_000_000,
-        scale: 0,
-    };
+    let px_bid = nexus_fix_codec::FixDecimal::new(
+        11050,
+        4,
+    ).unwrap();
+    let px_offer = nexus_fix_codec::FixDecimal::new(
+        11052,
+        4,
+    ).unwrap();
+    let sz = nexus_fix_codec::FixDecimal::new(
+        1_000_000,
+        0,
+    ).unwrap();
 
     let mut buf = [0u8; 512];
     let (start, len) = venue_beta::encoders::MarketDataSnapshotFullRefreshEncoder::wrap(&mut buf)


### PR DESCRIPTION
Related to #546 

This PR is associated with `Decimal encode overflow` subject in the issue.

**1. Private fields + validated constructor** (`types.rs`)
Make `mantissa` and `scale` private. Add `new()` enforcing `scale ≤ 19` — the ceiling where `10u64.pow(scale)` still fits in u64. Direct struct construction previously bypassed this, allowing `encode()` and `Display` to overflow silently in release or panic in debug.

**2. `debug_assert` in `encode()` and `Display`** (`types.rs`)
Add `debug_assert!(self.scale <= 19)` before the `10u64.pow(scale)` call in both. Catches any future regression in test builds at zero cost in release.

**3. `From<FixDecimal> for Decimal<i128, D>` → `TryFrom`** (`types.rs`)
The infallible `From` impl was unsound: `10_i128.pow(D - scale)` overflows at exponent ≥ 39 and the multiply can overflow too. Converted to `TryFrom` with `checked_pow` and `checked_mul`/`checked_div`.

**4. `checked_pow` in `TryFrom` for `Decimal<i64, D>` and `Decimal<i32, D>`** (`types.rs`)
`checked_mul` guarded the multiply but unchecked pow ran before it, making the guard ineffective for large exponents. Both branches now use `checked_pow`.

**Tests added:** updated `decimal_roundtrip` proptest in `property.rs`; added `decimal_roundtrip_reject_overflow` covering all mantissa values and all out-of-range scales (`20..=255`). Construction sites in `nexus-fix-codegen-tests` updated to `FixDecimal::new()`.
