### PR TITLE
fix(fix-codec): harden parse_tag against u32 overflow (#546)

### DIFF
--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -239,7 +239,7 @@ pub fn parse_tag(buf: &[u8]) -> (u32, usize) {
     let mut tag = 0u32;
     let mut i = 0;
     while i < buf.len() && buf[i] >= b'0' && buf[i] <= b'9' {
-        tag = tag * 10 + (buf[i] - b'0') as u32;
+        tag = tag.saturating_mul(10).saturating_add((buf[i] - b'0') as u32);
         i += 1;
     }
     (tag, i)
@@ -707,6 +707,14 @@ mod tests {
     fn parse_tag_empty() {
         assert_eq!(parse_tag(b""), (0, 0));
         assert_eq!(parse_tag(b"=value"), (0, 0));
+    }
+
+    #[test]
+    fn parse_tag_overflow_saturates() {
+        // 11-digit tag overflows u32; saturates to MAX and consumes all digits.
+        assert_eq!(parse_tag(b"99999999999=x"), (u32::MAX, 11));
+        // Digits still consumed past the saturation point.
+        assert_eq!(parse_tag(b"123456789012345=v"), (u32::MAX, 15));
     }
 
     #[test]

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -239,7 +239,9 @@ pub fn parse_tag(buf: &[u8]) -> (u32, usize) {
     let mut tag = 0u32;
     let mut i = 0;
     while i < buf.len() && buf[i] >= b'0' && buf[i] <= b'9' {
-        tag = tag.saturating_mul(10).saturating_add((buf[i] - b'0') as u32);
+        tag = tag
+            .saturating_mul(10)
+            .saturating_add((buf[i] - b'0') as u32);
         i += 1;
     }
     (tag, i)

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -10,8 +10,8 @@ use nexus_fix_codec::{
     encode_fix_uint, find_tag,
 };
 use nexus_fix_engine::{
-    CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionState,
-    State, TransportError,
+    CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionError,
+    SessionState, State, TransportError,
 };
 
 // ── mock dictionary ──────────────────────────────────────────────────────────
@@ -593,4 +593,53 @@ fn sequence_reset_backward_ignored() {
         "backward/zero SequenceReset Reset must not rewind next_inbound"
     );
     handle.join().unwrap();
+}
+
+#[test]
+fn overflowed_tag_34_yields_missing_seq_num() {
+    let dir = tmp_dir("overflow_tag34");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+
+    // Build a raw FIX frame where tag 34 is written with an overflowing digit
+    // sequence (9999999999 > u32::MAX). parse_tag returns u32::MAX, so find_tag(34)
+    // returns None → MissingMsgSeqNum.
+    let body: &[u8] = b"35=A\x019999999999=1\x0149=ACCEPTOR\x0156=INITIATOR\x0152=20260615-12:00:00.000\x01108=30\x01";
+    let header = format!("8=FIX.4.4\x019={}\x01", body.len());
+    let precheck: u8 = header
+        .bytes()
+        .chain(body.iter().copied())
+        .fold(0u32, |a, b| a.wrapping_add(b as u32)) as u8;
+    let frame = {
+        let mut v = header.into_bytes();
+        v.extend_from_slice(body);
+        v.extend_from_slice(format!("10={precheck:03}\x01").as_bytes());
+        v
+    };
+
+    let handle = std::thread::spawn(move || {
+        let mut s = client_sock;
+        s.write_all(&frame).unwrap();
+        s.flush().unwrap();
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir),
+    );
+
+    let result = conn.recv(Instant::now());
+    handle.join().unwrap();
+
+    assert!(
+        matches!(
+            result,
+            Err(TransportError::Protocol(SessionError::MissingMsgSeqNum))
+        ),
+        "expected MissingMsgSeqNum, got {result:?}"
+    );
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -640,6 +640,6 @@ fn overflowed_tag_34_yields_missing_seq_num() {
             result,
             Err(TransportError::Protocol(SessionError::MissingMsgSeqNum))
         ),
-        "expected MissingMsgSeqNum, got {result:?}"
+        "expected MissingMsgSeqNum"
     );
 }


### PR DESCRIPTION
Closes part of #546.

- `reader.rs`: `tag * 10 + d` → `tag.saturating_mul(10).saturating_add(d)`; excess digits consumed so parsing continues past the bad field, u32::MAX sentinel is ignored by all valid tag lookups
- Added `parse_tag_overflow_saturates` unit test
- Added transport test: frame with overflowed tag 34 → `MissingMsgSeqNum`