### PR TITLE
fix(fix-engine): conformance harness cleanups (#547)

### DIFF
--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -94,7 +94,21 @@ fn tmp_dir(suffix: &str) -> PathBuf {
     p
 }
 
-fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
+struct ChildGuard(std::process::Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+impl ChildGuard {
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.0.wait()
+    }
+}
+
+fn spawn_peer(scenario: &str) -> (ChildGuard, u16) {
     let mut child = Command::new("python3")
         .arg(PEER)
         .arg(scenario)
@@ -105,7 +119,7 @@ fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
     let mut line = String::new();
     BufReader::new(stdout).read_line(&mut line).unwrap();
     let port: u16 = line.trim().parse().unwrap();
-    (child, port)
+    (ChildGuard(child), port)
 }
 
 fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream, MockDict> {

--- a/nexus-fix-engine/tests/fixtures/fix_peer.py
+++ b/nexus-fix-engine/tests/fixtures/fix_peer.py
@@ -95,13 +95,9 @@ def resend(conn: socket.socket):
     assert msg.get("35") == "D", f"expected NewOrder, got {msg.get('35')}"
     conn.sendall(build("2", seq, [(7, "2"), (16, "2")]))
     seq += 1
-    while True:
-        msg = recv_msg(conn)
-        if msg.get("43") == "Y":
-            assert msg.get("122"), "OrigSendingTime (122) must be set on PossDup replay"
-            break
-        if msg.get("35") == "4":
-            break
+    msg = recv_msg(conn)
+    assert msg.get("43") == "Y", f"expected replay (43=Y), got 35={msg.get('35')}"
+    assert msg.get("122"), "OrigSendingTime (122) must be set on PossDup replay"
     conn.sendall(build("5", seq))
     seq += 1
     msg = recv_msg(conn)
@@ -119,7 +115,7 @@ def gap_fill(conn: socket.socket):
     conn.sendall(build("5", seq))
     seq += 1
     msg = recv_msg(conn)
-    assert msg.get("35") == "5"
+    assert msg.get("35") == "5", f"expected Logout, got 35={msg.get('35')}"
 
 
 def seq_reset(conn: socket.socket):
@@ -133,7 +129,7 @@ def seq_reset(conn: socket.socket):
     conn.sendall(build("5", seq))
     seq += 1
     msg = recv_msg(conn)
-    assert msg.get("35") == "5"
+    assert msg.get("35") == "5", f"expected Logout, got 35={msg.get('35')}"
 
 
 SCENARIOS = {


### PR DESCRIPTION
Closes #547.

- `fix_peer.py/resend`: drop gap-fill escape for begin=end=2; require replay (43=Y)
- `fix_peer.py/gap_fill`, `seq_reset`: add failure messages to bare asserts
- `fix_conformance.rs`: `ChildGuard` kills child on drop so a Rust-side panic doesn't leave the Python peer running for 10s