### PR TITLE
fix(fix-engine): seqnum limit at i32::MAX + recover() folded into open() (#545)

### DIFF
--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -15,7 +15,7 @@ use nexus_fix_codec::{
 };
 use nexus_fix_engine::{
     AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
-    Out, ReplayItem, SessionConfig, SessionState, State,
+    Out, ReplayItem, SessionConfig, SessionError, SessionState, State,
 };
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout_at;
@@ -88,7 +88,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         &mut self.state
     }
 
-    pub fn allocate_seq(&mut self) -> u32 {
+    pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
         self.state.allocate_seq(Instant::now())
     }
 

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -109,7 +109,7 @@ async fn conformance_resend() {
         }
     }
 
-    let seq = conn.allocate_seq();
+    let seq = conn.allocate_seq().unwrap();
     conn.send_app(seq, &new_order(seq)).await.unwrap();
 
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -164,7 +164,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
         }
     }
 
-    let seq = conn.allocate_seq();
+    let seq = conn.allocate_seq().unwrap();
     let msg = new_order(seq);
     conn.send_app(seq, &msg).unwrap();
 

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -55,6 +55,8 @@ pub enum SessionError {
     MalformedField { tag: u32 },
     /// Admin message decoder failed.
     MalformedMessage,
+    /// Outbound sequence number reached i32::MAX; caller must force a sequence reset.
+    SeqNumExhausted,
 }
 
 impl core::fmt::Display for SessionError {
@@ -65,6 +67,7 @@ impl core::fmt::Display for SessionError {
             Self::MissingField { tag } => write!(f, "required tag {tag} missing"),
             Self::MalformedField { tag } => write!(f, "tag {tag} malformed"),
             Self::MalformedMessage => write!(f, "admin message malformed"),
+            Self::SeqNumExhausted => write!(f, "outbound sequence number exhausted (i32::MAX)"),
         }
     }
 }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -95,17 +95,19 @@ impl FixJournal {
         } else {
             conductor.session().open()?
         };
-        Ok(Self {
+        let mut this = Self {
             journal,
             _conductor: conductor,
             offsets: vec![None; window].into_boxed_slice(),
             window,
             next_outbound: 1,
             next_inbound: 1,
-        })
+        };
+        this.recover_from_journal();
+        Ok(this)
     }
 
-    pub fn recover(&mut self) {
+    fn recover_from_journal(&mut self) {
         let mut pos = self.journal.read_start();
         let mut last_seq: Option<u32> = None;
         while let Some(frame) = self.journal.read_next(&mut pos) {
@@ -237,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    fn recover_sets_next_outbound() {
+    fn open_recovers_next_outbound() {
         let dir = tmp_dir("recover");
         cleanup(&dir);
 
@@ -248,9 +250,7 @@ mod tests {
             }
         }
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
-        assert_eq!(j.next_outbound(), 1);
-        j.recover();
+        let j = FixJournal::open(&dir, 64).unwrap();
         assert_eq!(j.next_outbound(), 8);
 
         cleanup(&dir);

--- a/nexus-fix-engine/src/session/event.rs
+++ b/nexus-fix-engine/src/session/event.rs
@@ -30,6 +30,8 @@ pub enum DisconnectReason {
     SeqNumTooLow,
     /// Counterparty violated the session protocol.
     ProtocolViolation,
+    /// Outbound sequence number reached i32::MAX; caller must force a sequence reset.
+    SeqNumExhausted,
 }
 
 /// Session event returned in [`Out::event`](super::Out::event).

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -4,6 +4,10 @@ use std::time::{Duration, Instant};
 
 pub use event::{DisconnectReason, Event, State};
 
+use crate::framework::SessionError;
+
+const SEQ_MAX: u32 = i32::MAX as u32;
+
 const TEST_REQ_ID_CAP: usize = 64;
 
 /// An outbound admin message that the framework must sequence and encode.
@@ -138,11 +142,28 @@ impl SessionState {
 
     /// Allocates the next outbound sequence number for an application message
     /// and updates the outbound activity timestamp used by the heartbeat timer.
-    pub fn allocate_seq(&mut self, now: Instant) -> u32 {
+    ///
+    /// Returns `Err(SeqNumExhausted)` when `next_outbound` has reached `i32::MAX`.
+    /// The caller must initiate a sequence reset or logout before sending further messages.
+    pub fn allocate_seq(&mut self, now: Instant) -> Result<u32, SessionError> {
+        if self.next_outbound > SEQ_MAX {
+            return Err(SessionError::SeqNumExhausted);
+        }
         let s = self.next_outbound;
         self.next_outbound += 1;
         self.last_sent = Some(now);
-        s
+        Ok(s)
+    }
+
+    fn bump_outbound(&mut self, now: Instant, out: &mut Out) -> Option<u32> {
+        if self.next_outbound > SEQ_MAX {
+            self.disconnect(DisconnectReason::SeqNumExhausted, out);
+            return None;
+        }
+        let s = self.next_outbound;
+        self.next_outbound += 1;
+        self.last_sent = Some(now);
+        Some(s)
     }
 
     /// Earliest instant at which [`on_timeout`](Self::on_timeout) has work.
@@ -170,9 +191,9 @@ impl SessionState {
             return Out::EMPTY;
         }
         let mut out = Out::EMPTY;
-        let seq = self.next_outbound;
-        self.next_outbound += 1;
-        self.last_sent = Some(now);
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
         out.push_admin(AdminMsg::Logon {
             seq,
             heart_bt_int_s: self.hb.as_secs() as u32,
@@ -189,9 +210,9 @@ impl SessionState {
             return Out::EMPTY;
         }
         let mut out = Out::EMPTY;
-        let seq = self.next_outbound;
-        self.next_outbound += 1;
-        self.last_sent = Some(now);
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
         out.push_admin(AdminMsg::Logout { seq });
         self.state = State::LogoutPending;
         self.state_entered = Some(now);
@@ -221,9 +242,9 @@ impl SessionState {
             State::Active | State::Resending => {
                 if let Some(t) = self.test_request_sent {
                     if now.duration_since(t) >= self.hb {
-                        let seq = self.next_outbound;
-                        self.next_outbound += 1;
-                        self.last_sent = Some(now);
+                        let Some(seq) = self.bump_outbound(now, &mut out) else {
+                            return out;
+                        };
                         out.push_admin(AdminMsg::Logout { seq });
                         self.disconnect(DisconnectReason::TestRequestTimeout, &mut out);
                         return out;
@@ -232,9 +253,9 @@ impl SessionState {
                     && now.duration_since(t) >= self.inbound_grace()
                 {
                     self.test_req_counter += 1;
-                    let seq = self.next_outbound;
-                    self.next_outbound += 1;
-                    self.last_sent = Some(now);
+                    let Some(seq) = self.bump_outbound(now, &mut out) else {
+                        return out;
+                    };
                     out.push_admin(AdminMsg::TestRequest {
                         seq,
                         id: self.test_req_counter,
@@ -244,9 +265,9 @@ impl SessionState {
                 if let Some(t) = self.last_sent
                     && now.duration_since(t) >= self.hb
                 {
-                    let seq = self.next_outbound;
-                    self.next_outbound += 1;
-                    self.last_sent = Some(now);
+                    let Some(seq) = self.bump_outbound(now, &mut out) else {
+                        return out;
+                    };
                     out.push_admin(AdminMsg::Heartbeat { seq, echo: None });
                 }
             }
@@ -286,9 +307,9 @@ impl SessionState {
 
         let mut out = Out::EMPTY;
         if send_reply {
-            let reply_seq = self.next_outbound;
-            self.next_outbound += 1;
-            self.last_sent = Some(now);
+            let Some(reply_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
             out.push_admin(AdminMsg::Logon {
                 seq: reply_seq,
                 heart_bt_int_s,
@@ -296,9 +317,9 @@ impl SessionState {
         }
 
         if seq < self.next_inbound {
-            let logout_seq = self.next_outbound;
-            self.next_outbound += 1;
-            self.last_sent = Some(now);
+            let Some(logout_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
             out.push_admin(AdminMsg::Logout { seq: logout_seq });
             self.disconnect(DisconnectReason::SeqNumTooLow, &mut out);
             return out;
@@ -308,9 +329,9 @@ impl SessionState {
 
         if seq > self.next_inbound {
             self.gap_high = seq;
-            let rr_seq = self.next_outbound;
-            self.next_outbound += 1;
-            self.last_sent = Some(now);
+            let Some(rr_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
             out.push_admin(AdminMsg::ResendRequest {
                 seq: rr_seq,
                 begin: self.next_inbound,
@@ -336,9 +357,9 @@ impl SessionState {
         ) && self.validate_seq(seq, poss_dup, now, &mut out)
         {
             if self.state != State::LogoutPending {
-                let logout_seq = self.next_outbound;
-                self.next_outbound += 1;
-                self.last_sent = Some(now);
+                let Some(logout_seq) = self.bump_outbound(now, &mut out) else {
+                    return out;
+                };
                 out.push_admin(AdminMsg::Logout { seq: logout_seq });
             }
             self.disconnect(DisconnectReason::Logout, &mut out);
@@ -384,9 +405,9 @@ impl SessionState {
             let mut echo = [0u8; TEST_REQ_ID_CAP];
             let id_len = test_req_id.len().min(TEST_REQ_ID_CAP);
             echo[..id_len].copy_from_slice(&test_req_id[..id_len]);
-            let hb_seq = self.next_outbound;
-            self.next_outbound += 1;
-            self.last_sent = Some(now);
+            let Some(hb_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
             out.push_admin(AdminMsg::Heartbeat {
                 seq: hb_seq,
                 echo: Some((echo, id_len as u8)),
@@ -505,9 +526,9 @@ impl SessionState {
             return Out::EMPTY;
         }
         let mut out = Out::EMPTY;
-        let seq = self.next_outbound;
-        self.next_outbound += 1;
-        self.last_sent = Some(now);
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
         out.push_admin(AdminMsg::Logout { seq });
         self.disconnect(DisconnectReason::CompIdMismatch, &mut out);
         out
@@ -519,9 +540,9 @@ impl SessionState {
                 self.gap_high = seq;
             }
             if self.state != State::Resending {
-                let rr_seq = self.next_outbound;
-                self.next_outbound += 1;
-                self.last_sent = Some(now);
+                let Some(rr_seq) = self.bump_outbound(now, out) else {
+                    return false;
+                };
                 out.push_admin(AdminMsg::ResendRequest {
                     seq: rr_seq,
                     begin: self.next_inbound,
@@ -536,9 +557,9 @@ impl SessionState {
             if poss_dup {
                 return false;
             }
-            let logout_seq = self.next_outbound;
-            self.next_outbound += 1;
-            self.last_sent = Some(now);
+            let Some(logout_seq) = self.bump_outbound(now, out) else {
+                return false;
+            };
             out.push_admin(AdminMsg::Logout { seq: logout_seq });
             self.disconnect(DisconnectReason::SeqNumTooLow, out);
             return false;
@@ -562,5 +583,36 @@ impl SessionState {
 
     fn inbound_grace(&self) -> Duration {
         self.hb + self.hb / 5
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_seq_errors_at_i32_max() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+        s.next_outbound = SEQ_MAX + 1;
+        assert_eq!(s.allocate_seq(now), Err(SessionError::SeqNumExhausted));
+    }
+
+    #[test]
+    fn bump_outbound_disconnects_at_i32_max() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+        s.next_outbound = SEQ_MAX + 1;
+        let out = s.logout(now);
+        assert_eq!(
+            out.event(),
+            Some(Event::Disconnected {
+                reason: DisconnectReason::SeqNumExhausted
+            })
+        );
     }
 }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -183,7 +183,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         self.garbage_frames
     }
 
-    pub fn allocate_seq(&mut self) -> u32 {
+    pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
         self.state.allocate_seq(Instant::now())
     }
 

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -198,7 +198,7 @@ fn conformance_resend() {
         }
     }
 
-    let seq = conn.allocate_seq();
+    let seq = conn.allocate_seq().unwrap();
     conn.send_app(seq, &new_order(seq)).unwrap();
 
     assert_eq!(drive(&mut conn), DisconnectReason::Logout);

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -235,8 +235,8 @@ fn resend_request_surfaces_event() {
     let mut s = new_session();
     let now = Instant::now();
     establish(&mut s, now);
-    s.allocate_seq(now); // seq 2
-    s.allocate_seq(now); // seq 3
+    s.allocate_seq(now).unwrap(); // seq 2
+    s.allocate_seq(now).unwrap(); // seq 3
 
     let out = s.on_resend_request(2, false, 2, 3, now);
     assert_eq!(out.event(), Some(Event::ResendRange { begin: 2, end: 3 }));
@@ -386,7 +386,7 @@ fn seq_nums_survive_reconnect() {
     let mut s = new_session();
     let now = Instant::now();
     establish(&mut s, now);
-    s.allocate_seq(now); // outbound seq 2
+    s.allocate_seq(now).unwrap(); // outbound seq 2
 
     s.on_logout(2, false, now); // counterparty logout at inbound seq 2; session replies (seq 3), disconnects
 


### PR DESCRIPTION
Closes part of #545.

**Recover fold**: `recover()` folded into `open()` — removed as a separate public call. Crash-restart no longer silently starts at `next_outbound=1`.

**Seqnum limit at `i32::MAX`**: outbound seqnums capped at `i32::MAX` for signed-int interoperability (Java/Python). `allocate_seq` returns `Result<u32, SessionError::SeqNumExhausted>` so the app layer can force a sequence reset or logout. Internal admin sends disconnect with `DisconnectReason::SeqNumExhausted` on breach via a private `bump_outbound` helper.