### PR TITLE
feat(fix-codec): FixDecimal const getters, const new, new_unchecked (#555)

### DIFF
--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -23,12 +23,23 @@ pub struct FixDecimal {
 }
 
 impl FixDecimal {
-    pub fn new(mantissa: i64, scale: u8) -> Result<Self, FixValueError> {
+    pub const fn new(mantissa: i64, scale: u8) -> Option<Self> {
         if scale > 19 {
-            return Err(FixValueError::Overflow);
+            return None;
         }
+        Some(Self { mantissa, scale })
+    }
 
-        Ok(Self { mantissa, scale })
+    pub const fn new_unchecked(mantissa: i64, scale: u8) -> Self {
+        Self { mantissa, scale }
+    }
+
+    pub const fn mantissa(&self) -> i64 {
+        self.mantissa
+    }
+
+    pub const fn scale(&self) -> u8 {
+        self.scale
     }
 
     /// Parse a FIX decimal from wire bytes.

--- a/nexus-fix-codec/tests/property.rs
+++ b/nexus-fix-codec/tests/property.rs
@@ -9,9 +9,8 @@
 use core::num::NonZeroU32;
 use nexus_fix_codec::{
     FixDate, FixDecimal, FixMonthYear, FixTenor, FixTime, FixTimestamp, FixTzTime, FixTzTimestamp,
-    FixValueError, TenorUnit, parse_fix_bool, parse_fix_char, parse_fix_day_of_month,
-    parse_fix_int, parse_fix_multi_char, parse_fix_multi_string, parse_fix_seqnum, parse_fix_text,
-    parse_fix_uint,
+    TenorUnit, parse_fix_bool, parse_fix_char, parse_fix_day_of_month, parse_fix_int,
+    parse_fix_multi_char, parse_fix_multi_string, parse_fix_seqnum, parse_fix_text, parse_fix_uint,
 };
 use proptest::prelude::*;
 
@@ -52,10 +51,7 @@ proptest! {
 
     #[test]
     fn decimal_roundtrip_reject_overflow(mantissa in any::<i64>(), scale in 20..=255u8) {
-        prop_assert!(matches!(
-            FixDecimal::new(mantissa, scale),
-            Err(FixValueError::Overflow)
-        ));
+        prop_assert!(FixDecimal::new(mantissa, scale).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #555.

- `pub const fn mantissa(&self) -> i64` and `pub const fn scale(&self) -> u8` — restores read access after #551 privatized the fields
- `new` → `const fn -> Option<Self>` (was `Result<Self, FixValueError>`; all `.unwrap()` call sites unchanged)
- `pub const fn new_unchecked(mantissa: i64, scale: u8) -> Self` for statically-valid hot-path construction

`property.rs`: updates `Err(FixValueError::Overflow)` match → `.is_none()` and drops the now-unused `FixValueError` import.