### PR TITLE
fix: new_unchecked contract doc+assert; example SeqNumExhausted handling

### DIFF
--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -30,7 +30,10 @@ impl FixDecimal {
         Some(Self { mantissa, scale })
     }
 
+    /// Construct without checking `scale <= 19`. Caller must ensure the
+    /// invariant; violating it causes incorrect output from `encode`/`Display`.
     pub const fn new_unchecked(mantissa: i64, scale: u8) -> Self {
+        debug_assert!(scale <= 19, "scale must be <= 19");
         Self { mantissa, scale }
     }
 

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -14,7 +14,7 @@ use nexus_fix_codec::{
     encode_fix_uint, find_tag,
 };
 use nexus_fix_engine::{
-    CompId, FixConnection, FixJournal, Message, SessionConfig, SessionState, State,
+    CompId, FixConnection, FixJournal, Message, SessionConfig, SessionError, SessionState, State,
 };
 
 // ── minimal FIX 4.4 dictionary ───────────────────────────────────────────────
@@ -164,7 +164,17 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
         }
     }
 
-    let seq = conn.allocate_seq().unwrap();
+    let seq = match conn.allocate_seq() {
+        Ok(s) => s,
+        Err(SessionError::SeqNumExhausted) => {
+            eprintln!("initiator: sequence number exhausted; force a sequence reset");
+            return;
+        }
+        Err(e) => {
+            eprintln!("initiator: allocate_seq error: {e}");
+            return;
+        }
+    };
     let msg = new_order(seq);
     conn.send_app(seq, &msg).unwrap();
 


### PR DESCRIPTION
Addresses review feedback from #556 and #557.

- `FixDecimal::new_unchecked`: add one-line doc stating the `scale <= 19` invariant and a `debug_assert!` to catch misuse early
- `blocking_session.rs`: replace `.unwrap()` on `allocate_seq` with explicit `SeqNumExhausted` handling so the example models the error path callers should implement

Closes part of #560.