### PR TITLE
fix(fix-engine): journal all outbound messages; add reset_seq_nums

### DIFF
--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -166,6 +166,13 @@ impl SessionState {
         Some(s)
     }
 
+    /// Restores outbound and inbound sequence numbers from a recovered journal.
+    /// Call before connecting to resume a prior session without gaps.
+    pub fn reset_seq_nums(&mut self, next_outbound: u32, next_inbound: u32) {
+        self.next_outbound = next_outbound;
+        self.next_inbound = next_inbound;
+    }
+
     /// Earliest instant at which [`on_timeout`](Self::on_timeout) has work.
     pub fn next_timeout(&self) -> Option<Instant> {
         match self.state {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -10,7 +10,7 @@ use nexus_fix_codec::{
 use crate::frame::{FrameError, FrameWriter};
 use crate::framework::{Message, MessageReader, MessageWriter, SessionConfig, SessionError};
 use crate::persist::{FixJournal, ReplayItem};
-use crate::session::{DisconnectReason, Event, SessionState, State};
+use crate::session::{AdminMsg, DisconnectReason, Event, SessionState, State};
 use crate::timestamp::UTC_TIMESTAMP_LEN;
 
 #[derive(Debug)]
@@ -202,7 +202,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
         let out = self.state.connect(now);
         for admin in out.admin_messages() {
-            self.writer.encode_admin(admin, &self.config);
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
         }
         if !self.writer.is_empty() {
             self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -220,7 +220,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
         let out = self.state.logout(now);
         for admin in out.admin_messages() {
-            self.writer.encode_admin(admin, &self.config);
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
         }
         if !self.writer.is_empty() {
             self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -249,7 +249,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                             Err(e) if is_timeout(&e) => {
                                 let out = self.state.on_timeout(now);
                                 for admin in out.admin_messages() {
-                                    self.writer.encode_admin(admin, &self.config);
+                                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                                 }
                                 if !self.writer.is_empty() {
                                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -306,7 +306,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         if !sender_ok || !target_ok {
             let out = self.state.on_comp_id_mismatch(now);
             for admin in out.admin_messages() {
-                self.writer.encode_admin(admin, &self.config);
+                store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
             }
             if !self.writer.is_empty() {
                 self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -332,7 +332,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 let was_logon_sent = self.state.state() == State::LogonSent;
                 let out = self.state.on_logon(seq, hbi, reset, !was_logon_sent, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -352,7 +352,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 let was_logout_pending = self.state.state() == State::LogoutPending;
                 let out = self.state.on_logout(seq, poss_dup, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -371,7 +371,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
             b"0" => {
                 let out = self.state.on_heartbeat(seq, poss_dup, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -385,7 +385,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     find_tag(frame, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(frame));
                 let out = self.state.on_test_request(seq, poss_dup, test_req_id, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -403,7 +403,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     .map_or(0, |v| v as u32);
                 let out = self.state.on_resend_request(seq, poss_dup, begin, end, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -436,7 +436,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     .unwrap_or(false);
                 let out = self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -451,7 +451,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                     .map_or(0, |v| v as u32);
                 let out = self.state.on_reject(seq, poss_dup, ref_seq, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -463,7 +463,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
             _ => {
                 let out = self.state.on_app(seq, poss_dup, now);
                 for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
@@ -543,6 +543,31 @@ fn do_resend<S: Write, D: FixDictionary>(
         }
     }
     writer.flush_to(stream).map_err(Error::Io)
+}
+
+fn store_admin<D: FixDictionary>(
+    admin: AdminMsg,
+    writer: &mut MessageWriter<D>,
+    journal: &mut FixJournal,
+    config: &SessionConfig,
+) -> Result<(), Error> {
+    let seq = match admin {
+        AdminMsg::Logon { seq, .. }
+        | AdminMsg::Logout { seq }
+        | AdminMsg::Heartbeat { seq, .. }
+        | AdminMsg::TestRequest { seq, .. }
+        | AdminMsg::ResendRequest { seq, .. }
+        | AdminMsg::SequenceReset { seq, .. } => seq,
+    };
+    let before = writer.inner.data().len();
+    writer.encode_admin(admin, config);
+    let frame = &writer.inner.data()[before..];
+    if !frame.is_empty() {
+        journal
+            .store(seq, frame)
+            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+    }
+    Ok(())
 }
 
 fn write_through<S: Write>(

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -249,7 +249,12 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                             Err(e) if is_timeout(&e) => {
                                 let out = self.state.on_timeout(now);
                                 for admin in out.admin_messages() {
-                                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                                    store_admin(
+                                        admin,
+                                        &mut self.writer,
+                                        &mut self.journal,
+                                        &self.config,
+                                    )?;
                                 }
                                 if !self.writer.is_empty() {
                                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -648,3 +648,41 @@ fn overflowed_tag_34_yields_missing_seq_num() {
         "expected MissingMsgSeqNum"
     );
 }
+
+#[test]
+fn journal_recovers_admin_seqnums() {
+    let dir = tmp_dir("journal_admin_seqnums");
+    let (client_sock, server_sock) = loopback_pair();
+    client_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(server_sock, target(), sender());
+        let mut buf = [0u8; 512];
+        let _ = peer.recv_msg(&mut buf);
+        peer.send_logon(30);
+        peer.send_logout();
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(sender(), target()),
+        journal(&dir),
+    );
+    conn.connect(Instant::now()).unwrap();
+    let reason = drive(&mut conn).unwrap();
+    assert_eq!(reason, DisconnectReason::Logout);
+    handle.join().unwrap();
+    drop(conn);
+
+    // seq=1 logon + seq=2 logout-ack → next_outbound must be 3 after recovery
+    let recovered = FixJournal::open(&dir, 256).unwrap();
+    assert_eq!(
+        recovered.next_outbound(),
+        3,
+        "journal must include admin seqnums"
+    );
+}


### PR DESCRIPTION
Fixes the E8 seqnum drift from #561.

- `transport.rs`: every outbound admin message (Logon, Logout, Heartbeat, TestRequest, ResendRequest, SequenceReset) now goes through `journal.store()` via a free function `store_admin`. Previously only app messages were journaled, so `journal.next_outbound` diverged from `state.next_outbound` after any admin activity. Resend behavior is unaffected — `ResendIter` already gap-fills admin by `MsgType`.
- `session/mod.rs`: adds `SessionState::reset_seq_nums(next_outbound, next_inbound)` so callers can restore sequence numbers from a recovered journal before reconnecting.
- `tests/transport.rs`: `journal_recovers_admin_seqnums` — runs a logon+logout session, reopens the journal, asserts `next_outbound == 3` (logon seq=1, logout-ack seq=2).

Closes #561.