### PR TITLE
fix(session): Reject (35=3) generation

### DIFF
--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -294,6 +294,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             AdminMsg::TestRequest { .. } => b"1",
             AdminMsg::ResendRequest { .. } => b"2",
             AdminMsg::SequenceReset { .. } => b"4",
+            AdminMsg::Reject { .. } => b"3",
         };
 
         let seq = match admin {
@@ -302,7 +303,8 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             | AdminMsg::Heartbeat { seq, .. }
             | AdminMsg::TestRequest { seq, .. }
             | AdminMsg::ResendRequest { seq, .. }
-            | AdminMsg::SequenceReset { seq, .. } => seq,
+            | AdminMsg::SequenceReset { seq, .. }
+            | AdminMsg::Reject { seq, .. } => seq,
         };
 
         let begin_string = self.begin_string;
@@ -350,6 +352,21 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(new_seq, &mut buf);
                     fmt.field(36, &buf[..n]);
+                }
+                AdminMsg::Reject {
+                    ref_seq_num,
+                    ref_tag_id,
+                    session_reject_reason,
+                    ..
+                } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(ref_seq_num, &mut buf);
+                    fmt.field(45, &buf[..n]);
+                    if let Some(tag) = ref_tag_id {
+                        let n = encode_fix_uint(tag, &mut buf);
+                        fmt.field(371, &buf[..n]);
+                    }
+                    fmt.field(373, &[b'0' + session_reject_reason]);
                 }
             }
 

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -279,7 +279,8 @@ impl<D: FixDictionary> MessageWriter<D> {
                         let n = encode_fix_uint(tag, &mut buf);
                         fmt.field(371, &buf[..n]);
                     }
-                    fmt.field(373, &[b'0' + session_reject_reason]);
+                    let n = encode_fix_uint(session_reject_reason as u32, &mut buf);
+                    fmt.field(373, &buf[..n]);
                 }
             }
 

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -207,6 +207,7 @@ impl<D: FixDictionary> MessageWriter<D> {
             AdminMsg::TestRequest { .. } => b"1",
             AdminMsg::ResendRequest { .. } => b"2",
             AdminMsg::SequenceReset { .. } => b"4",
+            AdminMsg::Reject { .. } => b"3",
         };
 
         let seq = match admin {
@@ -215,7 +216,8 @@ impl<D: FixDictionary> MessageWriter<D> {
             | AdminMsg::Heartbeat { seq, .. }
             | AdminMsg::TestRequest { seq, .. }
             | AdminMsg::ResendRequest { seq, .. }
-            | AdminMsg::SequenceReset { seq, .. } => seq,
+            | AdminMsg::SequenceReset { seq, .. }
+            | AdminMsg::Reject { seq, .. } => seq,
         };
 
         let begin_string = D::BEGIN_STRING;
@@ -263,6 +265,21 @@ impl<D: FixDictionary> MessageWriter<D> {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(new_seq, &mut buf);
                     fmt.field(36, &buf[..n]);
+                }
+                AdminMsg::Reject {
+                    ref_seq_num,
+                    ref_tag_id,
+                    session_reject_reason,
+                    ..
+                } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(ref_seq_num, &mut buf);
+                    fmt.field(45, &buf[..n]);
+                    if let Some(tag) = ref_tag_id {
+                        let n = encode_fix_uint(tag, &mut buf);
+                        fmt.field(371, &buf[..n]);
+                    }
+                    fmt.field(373, &[b'0' + session_reject_reason]);
                 }
             }
 

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -545,11 +545,13 @@ impl SessionState {
 
     /// Sends a session-level Reject (35=3) for a received message that cannot be processed.
     ///
-    /// Advances `next_inbound` past `inbound_seq` so the sequence counter stays in sync.
-    /// The session remains alive. No-op if the session is not in an active state.
+    /// Validates `inbound_seq` and, if in-sequence, sends a Reject and advances `next_inbound`.
+    /// A gap triggers a ResendRequest instead; a too-low seq triggers Logout.
+    /// The session remains alive on in-sequence rejection. No-op if not in an active state.
     pub fn on_reject_inbound(
         &mut self,
         inbound_seq: u32,
+        poss_dup: bool,
         ref_tag_id: Option<u32>,
         session_reject_reason: u8,
         now: Instant,
@@ -562,6 +564,9 @@ impl SessionState {
         }
         self.last_received = Some(now);
         let mut out = Out::EMPTY;
+        if !self.validate_seq(inbound_seq, poss_dup, now, &mut out) {
+            return out;
+        }
         let Some(seq) = self.bump_outbound(now, &mut out) else {
             return out;
         };
@@ -571,7 +576,6 @@ impl SessionState {
             ref_tag_id,
             session_reject_reason,
         });
-        self.next_inbound = self.next_inbound.saturating_add(1);
         out
     }
 
@@ -701,7 +705,7 @@ mod tests {
         let now = Instant::now();
         s.connect(now);
         s.on_logon(1, 30, false, false, now);
-        let out = s.on_reject_inbound(2, Some(35), 1, now);
+        let out = s.on_reject_inbound(2, false, Some(35), 1, now);
         let admins: Vec<_> = out.admin_messages().collect();
         assert_eq!(admins.len(), 1);
         assert!(
@@ -717,5 +721,21 @@ mod tests {
             "expected Reject, got {admins:?}"
         );
         assert_eq!(s.next_inbound_seq(), 3);
+    }
+
+    #[test]
+    fn reject_inbound_gap_sends_resend_request() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+        let out = s.on_reject_inbound(5, false, Some(35), 1, now);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(
+            matches!(admins[0], AdminMsg::ResendRequest { begin: 2, .. }),
+            "expected ResendRequest, got {admins:?}"
+        );
+        assert_eq!(s.next_inbound_seq(), 2, "next_inbound must not advance on gap");
     }
 }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -735,6 +735,10 @@ mod tests {
             matches!(admins[0], AdminMsg::ResendRequest { begin: 2, .. }),
             "expected ResendRequest, got {admins:?}"
         );
-        assert_eq!(s.next_inbound_seq(), 2, "next_inbound must not advance on gap");
+        assert_eq!(
+            s.next_inbound_seq(),
+            2,
+            "next_inbound must not advance on gap"
+        );
     }
 }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -545,9 +545,8 @@ impl SessionState {
 
     /// Sends a session-level Reject (35=3) for a received message that cannot be processed.
     ///
-    /// Validates `inbound_seq` and, if in-sequence, sends a Reject and advances `next_inbound`.
-    /// A gap triggers a ResendRequest instead; a too-low seq triggers Logout.
-    /// The session remains alive on in-sequence rejection. No-op if not in an active state.
+    /// Validates sequence then sends a Reject for `inbound_seq`. A gap sends ResendRequest instead.
+    /// The session remains alive. No-op if the session is not in an active state.
     pub fn on_reject_inbound(
         &mut self,
         inbound_seq: u32,

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -43,6 +43,14 @@ pub enum AdminMsg {
         seq: u32,
         new_seq: u32,
     },
+    /// Session-level Reject (35=3). Sent in response to a malformed or
+    /// semantically invalid inbound message. Keeps the session alive.
+    Reject {
+        seq: u32,
+        ref_seq_num: u32,
+        ref_tag_id: Option<u32>,
+        session_reject_reason: u8,
+    },
 }
 
 /// Output of a [`SessionState`] handler call.
@@ -473,6 +481,14 @@ impl SessionState {
         let mut out = Out::EMPTY;
         if !gap_fill {
             if new_seq == 0 || new_seq < self.next_inbound {
+                if let Some(reject_seq) = self.bump_outbound(now, &mut out) {
+                    out.push_admin(AdminMsg::Reject {
+                        seq: reject_seq,
+                        ref_seq_num: seq,
+                        ref_tag_id: Some(36),
+                        session_reject_reason: 5,
+                    });
+                }
                 return out;
             }
             self.next_inbound = new_seq;
@@ -524,6 +540,38 @@ impl SessionState {
             });
             self.check_resend_done();
         }
+        out
+    }
+
+    /// Sends a session-level Reject (35=3) for a received message that cannot be processed.
+    ///
+    /// Advances `next_inbound` past `inbound_seq` so the sequence counter stays in sync.
+    /// The session remains alive. No-op if the session is not in an active state.
+    pub fn on_reject_inbound(
+        &mut self,
+        inbound_seq: u32,
+        ref_tag_id: Option<u32>,
+        session_reject_reason: u8,
+        now: Instant,
+    ) -> Out {
+        if !matches!(
+            self.state,
+            State::Active | State::Resending | State::LogoutPending
+        ) {
+            return Out::EMPTY;
+        }
+        self.last_received = Some(now);
+        let mut out = Out::EMPTY;
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
+        out.push_admin(AdminMsg::Reject {
+            seq,
+            ref_seq_num: inbound_seq,
+            ref_tag_id,
+            session_reject_reason,
+        });
+        self.next_inbound = self.next_inbound.saturating_add(1);
         out
     }
 
@@ -621,5 +669,53 @@ mod tests {
                 reason: DisconnectReason::SeqNumExhausted
             })
         );
+    }
+
+    #[test]
+    fn sequence_reset_backward_sends_reject() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+        let out = s.on_sequence_reset(100, 1, false, now);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(
+            matches!(
+                admins[0],
+                AdminMsg::Reject {
+                    ref_seq_num: 100,
+                    ref_tag_id: Some(36),
+                    session_reject_reason: 5,
+                    ..
+                }
+            ),
+            "expected Reject, got {admins:?}"
+        );
+        assert_eq!(s.next_inbound_seq(), 2, "next_inbound must not advance");
+    }
+
+    #[test]
+    fn reject_inbound_sends_reject_and_advances_seq() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+        let out = s.on_reject_inbound(2, Some(35), 1, now);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(
+            matches!(
+                admins[0],
+                AdminMsg::Reject {
+                    ref_seq_num: 2,
+                    ref_tag_id: Some(35),
+                    session_reject_reason: 1,
+                    ..
+                }
+            ),
+            "expected Reject, got {admins:?}"
+        );
+        assert_eq!(s.next_inbound_seq(), 3);
     }
 }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -323,7 +323,16 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
 
         let raw_type = match find_tag(frame, 0, 35) {
             Some(s) => s.slice(frame),
-            None => return Err(Error::Protocol(SessionError::MissingMsgType)),
+            None => {
+                let out = self.state.on_reject_inbound(seq, Some(35), 1, now);
+                for admin in out.admin_messages() {
+                    self.writer.encode_admin(admin, &self.config);
+                }
+                if !self.writer.is_empty() {
+                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                return Ok(None);
+            }
         };
 
         match raw_type {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -324,7 +324,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
             s.slice(frame)
         } else {
-            let out = self.state.on_reject_inbound(seq, poss_dup, Some(35), 1, now);
+            let out = self
+                .state
+                .on_reject_inbound(seq, poss_dup, Some(35), 1, now);
             for admin in out.admin_messages() {
                 self.writer.encode_admin(admin, &self.config);
             }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -321,18 +321,17 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
             }));
         }
 
-        let raw_type = match find_tag(frame, 0, 35) {
-            Some(s) => s.slice(frame),
-            None => {
-                let out = self.state.on_reject_inbound(seq, Some(35), 1, now);
-                for admin in out.admin_messages() {
-                    self.writer.encode_admin(admin, &self.config);
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                return Ok(None);
+        let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
+            s.slice(frame)
+        } else {
+            let out = self.state.on_reject_inbound(seq, Some(35), 1, now);
+            for admin in out.admin_messages() {
+                self.writer.encode_admin(admin, &self.config);
             }
+            if !self.writer.is_empty() {
+                self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+            }
+            return Ok(None);
         };
 
         match raw_type {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -570,7 +570,8 @@ fn store_admin<D: FixDictionary>(
         | AdminMsg::Heartbeat { seq, .. }
         | AdminMsg::TestRequest { seq, .. }
         | AdminMsg::ResendRequest { seq, .. }
-        | AdminMsg::SequenceReset { seq, .. } => seq,
+        | AdminMsg::SequenceReset { seq, .. }
+        | AdminMsg::Reject { seq, .. } => seq,
     };
     let before = writer.inner.data().len();
     writer.encode_admin(admin, config);

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -324,7 +324,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
             s.slice(frame)
         } else {
-            let out = self.state.on_reject_inbound(seq, Some(35), 1, now);
+            let out = self.state.on_reject_inbound(seq, poss_dup, Some(35), 1, now);
             for admin in out.admin_messages() {
                 self.writer.encode_admin(admin, &self.config);
             }


### PR DESCRIPTION
Closes part of #562.

**What**

- `AdminMsg::Reject` variant (`seq`, `ref_seq_num`, `ref_tag_id: Option<u32>`, `session_reject_reason: u8`)
- `SessionState::on_reject_inbound` — validates seq first (gap → ResendRequest, too-low → Logout/dup-ignore), then allocates outbound seq, sends Reject, advances `next_inbound` via `validate_seq`
- `on_sequence_reset`: backward Reset (new_seq < next_inbound or new_seq == 0) now sends Reject (RefTagID=36, reason=5) instead of silent no-op
- `encode_admin`: Reject encodes tags 45 (RefSeqNum), 371 (RefTagID, omitted if `None`), 373 (SessionRejectReason via `encode_fix_uint`)
- `transport::recv`: missing tag 35 → `on_reject_inbound(seq, poss_dup, Some(35), 1)` + flush; returns `Ok(None)` so session stays alive

**Tests**

- `sequence_reset_backward_sends_reject` — unit
- `reject_inbound_sends_reject_and_advances_seq` — unit
- `reject_inbound_gap_sends_resend_request` — unit