### PR TITLE
feat(fix-engine): bounded sequence numbers (#559)

### DIFF
--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -111,7 +111,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         let out = self
             .state
             .connect_reset(Instant::now())
-            .map_err(|()| Error::Io(io::Error::other("connect_reset: session not disconnected")))?;
+            .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
         self.flush_out(out).await
     }
 
@@ -120,7 +120,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         let out = self
             .state
             .reset_sequence(Instant::now())
-            .map_err(|()| Error::Io(io::Error::other("reset_sequence: session not active")))?;
+            .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
         self.flush_out(out).await
     }
 

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -10,8 +10,8 @@ use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use nexus_fix_codec::{
-    encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint, FieldReader,
-    FrameFormatter,
+    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
+    parse_fix_uint,
 };
 use nexus_fix_engine::{
     AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -346,16 +346,11 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                AdminMsg::Logon { heart_bt_int_s, .. }
+                | AdminMsg::LogonReset { heart_bt_int_s, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
-                }
-                AdminMsg::LogonReset { heart_bt_int_s, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
-                    fmt.field(108, &buf[..n]);
-                    fmt.field(141, b"Y");
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -101,8 +101,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     }
 
     /// Initiates a session: encodes and sends the opening Logon.
-    pub async fn connect(&mut self) -> Result<(), Error> {
-        let out = self.state.connect(Instant::now());
+    ///
+    /// Set `reset = true` to send `ResetSeqNumFlag(141)=Y`.
+    pub async fn connect(&mut self, reset: bool) -> Result<(), Error> {
+        let out = self.state.connect(reset, Instant::now());
         self.flush_out(out).await
     }
 
@@ -323,10 +325,13 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                AdminMsg::Logon { heart_bt_int_s, reset, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
+                    if reset {
+                        fmt.field(141, b"Y");
+                    }
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -10,8 +10,8 @@ use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use nexus_fix_codec::{
-    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
-    parse_fix_uint,
+    encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum, parse_fix_uint, FieldReader,
+    FrameFormatter,
 };
 use nexus_fix_engine::{
     AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
@@ -329,7 +329,11 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, reset, .. } => {
+                AdminMsg::Logon {
+                    heart_bt_int_s,
+                    reset,
+                    ..
+                } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -101,10 +101,14 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
     }
 
     /// Initiates a session: encodes and sends the opening Logon.
-    ///
-    /// Set `reset = true` to send `ResetSeqNumFlag(141)=Y`.
-    pub async fn connect(&mut self, reset: bool) -> Result<(), Error> {
-        let out = self.state.connect(reset, Instant::now());
+    pub async fn connect(&mut self) -> Result<(), Error> {
+        let out = self.state.connect(Instant::now());
+        self.flush_out(out).await
+    }
+
+    /// Initiates a session with `ResetSeqNumFlag(141)=Y`.
+    pub async fn connect_reset(&mut self) -> Result<(), Error> {
+        let out = self.state.connect_reset(Instant::now());
         self.flush_out(out).await
     }
 

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -108,7 +108,19 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
     /// Initiates a session with `ResetSeqNumFlag(141)=Y`.
     pub async fn connect_reset(&mut self) -> Result<(), Error> {
-        let out = self.state.connect_reset(Instant::now());
+        let out = self
+            .state
+            .connect_reset(Instant::now())
+            .map_err(|()| Error::Io(io::Error::other("connect_reset: session not disconnected")))?;
+        self.flush_out(out).await
+    }
+
+    /// Initiates an in-session sequence reset.
+    pub async fn reset_sequence(&mut self) -> Result<(), Error> {
+        let out = self
+            .state
+            .reset_sequence(Instant::now())
+            .map_err(|()| Error::Io(io::Error::other("reset_sequence: session not active")))?;
         self.flush_out(out).await
     }
 
@@ -230,7 +242,12 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                 )
             }
             b"5" => (self.state.on_logout(seq, poss_dup, now), false),
-            b"0" => (self.state.on_heartbeat(seq, poss_dup, now), false),
+            b"0" => {
+                let echo_id = find_tag(frame, 0, 112)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map(|v| v as u64);
+                (self.state.on_heartbeat(seq, poss_dup, echo_id, now), false)
+            }
             b"1" => {
                 let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
                 (self.state.on_test_request(seq, poss_dup, id, now), false)
@@ -294,7 +311,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         let ts = make_ts();
 
         let msg_type: &[u8] = match admin {
-            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logon { .. } | AdminMsg::LogonReset { .. } => b"A",
             AdminMsg::Logout { .. } => b"5",
             AdminMsg::Heartbeat { .. } => b"0",
             AdminMsg::TestRequest { .. } => b"1",
@@ -305,6 +322,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
         let seq = match admin {
             AdminMsg::Logon { seq, .. }
+            | AdminMsg::LogonReset { seq, .. }
             | AdminMsg::Logout { seq }
             | AdminMsg::Heartbeat { seq, .. }
             | AdminMsg::TestRequest { seq, .. }
@@ -329,17 +347,16 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon {
-                    heart_bt_int_s,
-                    reset,
-                    ..
-                } => {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
-                    if reset {
-                        fmt.field(141, b"Y");
-                    }
+                }
+                AdminMsg::LogonReset { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                    fmt.field(141, b"Y");
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -243,9 +243,8 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             }
             b"5" => (self.state.on_logout(seq, poss_dup, now), false),
             b"0" => {
-                let echo_id = find_tag(frame, 0, 112)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map(|v| v as u64);
+                let echo_id =
+                    find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
                 (self.state.on_heartbeat(seq, poss_dup, echo_id, now), false)
             }
             b"1" => {

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -200,7 +200,7 @@ impl<D: FixDictionary> MessageWriter<D> {
 
     #[cfg(unix)]
     pub fn encode_admin(&mut self, admin: AdminMsg, config: &SessionConfig) {
-        use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
+        use nexus_fix_codec::{encode_fix_uint, FrameFormatter};
 
         let ts = make_ts();
 
@@ -240,7 +240,11 @@ impl<D: FixDictionary> MessageWriter<D> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, reset, .. } => {
+                AdminMsg::Logon {
+                    heart_bt_int_s,
+                    reset,
+                    ..
+                } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -60,6 +60,8 @@ pub enum SessionError {
     SeqNumExhausted,
     /// An in-session reset is already in progress; outbound allocation is blocked.
     ResetInProgress,
+    /// Operation not valid in the current session state.
+    InvalidState,
 }
 
 impl core::fmt::Display for SessionError {
@@ -72,6 +74,7 @@ impl core::fmt::Display for SessionError {
             Self::MalformedMessage => write!(f, "admin message malformed"),
             Self::SeqNumExhausted => write!(f, "outbound sequence number exhausted (i32::MAX)"),
             Self::ResetInProgress => write!(f, "in-session reset in progress"),
+            Self::InvalidState => write!(f, "operation not valid in current session state"),
         }
     }
 }
@@ -205,7 +208,7 @@ impl<D: FixDictionary> MessageWriter<D> {
         let ts = make_ts();
 
         let msg_type: &[u8] = match admin {
-            AdminMsg::Logon { .. } => b"A",
+            AdminMsg::Logon { .. } | AdminMsg::LogonReset { .. } => b"A",
             AdminMsg::Logout { .. } => b"5",
             AdminMsg::Heartbeat { .. } => b"0",
             AdminMsg::TestRequest { .. } => b"1",
@@ -216,6 +219,7 @@ impl<D: FixDictionary> MessageWriter<D> {
 
         let seq = match admin {
             AdminMsg::Logon { seq, .. }
+            | AdminMsg::LogonReset { seq, .. }
             | AdminMsg::Logout { seq }
             | AdminMsg::Heartbeat { seq, .. }
             | AdminMsg::TestRequest { seq, .. }
@@ -240,17 +244,16 @@ impl<D: FixDictionary> MessageWriter<D> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon {
-                    heart_bt_int_s,
-                    reset,
-                    ..
-                } => {
+                AdminMsg::Logon { heart_bt_int_s, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
-                    if reset {
-                        fmt.field(141, b"Y");
-                    }
+                }
+                AdminMsg::LogonReset { heart_bt_int_s, .. } => {
+                    let mut buf = [0u8; 10];
+                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
+                    fmt.field(108, &buf[..n]);
+                    fmt.field(141, b"Y");
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -5,6 +5,7 @@ use nexus_fix_codec::FixDictionary;
 use nexus_net::wire::ParserSink;
 
 use crate::frame::{FrameReader, FrameWriter};
+#[cfg(unix)]
 use crate::session::AdminMsg;
 
 const COMP_ID_CAP: usize = 20;
@@ -57,6 +58,8 @@ pub enum SessionError {
     MalformedMessage,
     /// Outbound sequence number reached i32::MAX; caller must force a sequence reset.
     SeqNumExhausted,
+    /// An in-session reset is already in progress; outbound allocation is blocked.
+    ResetInProgress,
 }
 
 impl core::fmt::Display for SessionError {
@@ -68,6 +71,7 @@ impl core::fmt::Display for SessionError {
             Self::MalformedField { tag } => write!(f, "tag {tag} malformed"),
             Self::MalformedMessage => write!(f, "admin message malformed"),
             Self::SeqNumExhausted => write!(f, "outbound sequence number exhausted (i32::MAX)"),
+            Self::ResetInProgress => write!(f, "in-session reset in progress"),
         }
     }
 }
@@ -236,10 +240,13 @@ impl<D: FixDictionary> MessageWriter<D> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                AdminMsg::Logon { heart_bt_int_s, reset, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
+                    if reset {
+                        fmt.field(141, b"Y");
+                    }
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {
@@ -313,6 +320,7 @@ fn make_ts() -> [u8; crate::timestamp::UTC_TIMESTAMP_LEN] {
     ts
 }
 
+#[cfg(unix)]
 pub(crate) fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
     if v == 0 {
         out[0] = b'0';

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -200,7 +200,7 @@ impl<D: FixDictionary> MessageWriter<D> {
 
     #[cfg(unix)]
     pub fn encode_admin(&mut self, admin: AdminMsg, config: &SessionConfig) {
-        use nexus_fix_codec::{encode_fix_uint, FrameFormatter};
+        use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
 
         let ts = make_ts();
 

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -244,16 +244,11 @@ impl<D: FixDictionary> MessageWriter<D> {
             fmt.field(52, &ts);
 
             match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
+                AdminMsg::Logon { heart_bt_int_s, .. }
+                | AdminMsg::LogonReset { heart_bt_int_s, .. } => {
                     let mut buf = [0u8; 10];
                     let n = encode_fix_uint(heart_bt_int_s, &mut buf);
                     fmt.field(108, &buf[..n]);
-                }
-                AdminMsg::LogonReset { heart_bt_int_s, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
-                    fmt.field(108, &buf[..n]);
-                    fmt.field(141, b"Y");
                 }
                 AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
                 AdminMsg::Heartbeat {

--- a/nexus-fix-engine/src/session/event.rs
+++ b/nexus-fix-engine/src/session/event.rs
@@ -11,6 +11,10 @@ pub enum State {
     Resending,
     /// Logout sent, awaiting the counterparty's Logout confirm.
     LogoutPending,
+    /// In-session reset initiated: TestRequest sent, awaiting Heartbeat to confirm drain.
+    AwaitingResetDrain,
+    /// Drain confirmed: Logon(141=Y) sent, awaiting counterparty's Logon(141=Y) ack.
+    AwaitingResetAck,
 }
 
 /// Why the session disconnected.
@@ -32,6 +36,8 @@ pub enum DisconnectReason {
     ProtocolViolation,
     /// Outbound sequence number reached i32::MAX; caller must force a sequence reset.
     SeqNumExhausted,
+    /// Counterparty did not complete the reset handshake within the timeout.
+    ResetTimeout,
 }
 
 /// Session event returned in [`Out::event`](super::Out::event).

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -20,6 +20,8 @@ pub enum AdminMsg {
     Logon {
         seq: u32,
         heart_bt_int_s: u32,
+        /// `ResetSeqNumFlag(141)=Y` — both sides reset to seqnum 1.
+        reset: bool,
     },
     Logout {
         seq: u32,
@@ -148,12 +150,25 @@ impl SessionState {
         self.next_outbound
     }
 
+    /// Restores outbound and inbound sequence numbers from a recovered journal.
+    /// Call before connecting to resume a prior session without gaps.
+    pub fn reset_seq_nums(&mut self, next_outbound: u32, next_inbound: u32) {
+        self.next_outbound = next_outbound;
+        self.next_inbound = next_inbound;
+    }
+
     /// Allocates the next outbound sequence number for an application message
     /// and updates the outbound activity timestamp used by the heartbeat timer.
     ///
     /// Returns `Err(SeqNumExhausted)` when `next_outbound` has reached `i32::MAX`.
-    /// The caller must initiate a sequence reset or logout before sending further messages.
+    /// Returns `Err(ResetInProgress)` while an in-session reset handshake is active.
     pub fn allocate_seq(&mut self, now: Instant) -> Result<u32, SessionError> {
+        if matches!(
+            self.state,
+            State::AwaitingResetDrain | State::AwaitingResetAck
+        ) {
+            return Err(SessionError::ResetInProgress);
+        }
         if self.next_outbound > SEQ_MAX {
             return Err(SessionError::SeqNumExhausted);
         }
@@ -174,18 +189,14 @@ impl SessionState {
         Some(s)
     }
 
-    /// Restores outbound and inbound sequence numbers from a recovered journal.
-    /// Call before connecting to resume a prior session without gaps.
-    pub fn reset_seq_nums(&mut self, next_outbound: u32, next_inbound: u32) {
-        self.next_outbound = next_outbound;
-        self.next_inbound = next_inbound;
-    }
-
     /// Earliest instant at which [`on_timeout`](Self::on_timeout) has work.
     pub fn next_timeout(&self) -> Option<Instant> {
         match self.state {
             State::Disconnected => None,
-            State::LogonSent | State::LogoutPending => self.state_entered.map(|t| t + self.hb),
+            State::LogonSent
+            | State::LogoutPending
+            | State::AwaitingResetDrain
+            | State::AwaitingResetAck => self.state_entered.map(|t| t + self.hb),
             State::Active | State::Resending => {
                 let outbound = self.last_sent.map(|t| t + self.hb);
                 let inbound = self.test_request_sent.map_or_else(
@@ -211,11 +222,60 @@ impl SessionState {
         };
         out.push_admin(AdminMsg::Logon {
             seq,
+            reset: false,
             heart_bt_int_s: self.hb.as_secs() as u32,
         });
         self.state = State::LogonSent;
         self.state_entered = Some(now);
         self.last_received = Some(now);
+        out
+    }
+
+    /// Initiates a session with `ResetSeqNumFlag(141)=Y`: resets both sequence
+    /// counters to 1 and sends a Logon. No-op if not disconnected.
+    pub fn connect_reset(&mut self, now: Instant) -> Out {
+        if self.state != State::Disconnected {
+            return Out::EMPTY;
+        }
+        self.next_outbound = 1;
+        self.next_inbound = 1;
+        let mut out = Out::EMPTY;
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
+        out.push_admin(AdminMsg::Logon {
+            seq,
+            reset: true,
+            heart_bt_int_s: self.hb.as_secs() as u32,
+        });
+        self.state = State::LogonSent;
+        self.state_entered = Some(now);
+        self.last_received = Some(now);
+        out
+    }
+
+    /// Initiates an in-session sequence reset. Only valid while `Active`.
+    ///
+    /// Sends a TestRequest to drain in-flight messages. On the Heartbeat reply
+    /// the engine sends `Logon(141=Y, seqNum=1)` and enters `AwaitingResetAck`.
+    /// The reset completes when the counterparty's `Logon(141=Y)` arrives.
+    /// `allocate_seq` returns `ResetInProgress` until the handshake completes.
+    pub fn reset_sequence(&mut self, now: Instant) -> Out {
+        if self.state != State::Active {
+            return Out::EMPTY;
+        }
+        let mut out = Out::EMPTY;
+        self.test_req_counter += 1;
+        let Some(seq) = self.bump_outbound(now, &mut out) else {
+            return out;
+        };
+        out.push_admin(AdminMsg::TestRequest {
+            seq,
+            id: self.test_req_counter,
+        });
+        self.test_request_sent = Some(now);
+        self.state = State::AwaitingResetDrain;
+        self.state_entered = Some(now);
         out
     }
 
@@ -234,7 +294,7 @@ impl SessionState {
         out
     }
 
-    /// Fires due timers: logon/logout timeouts, heartbeat emission, and
+    /// Fires due timers: logon/logout/reset timeouts, heartbeat emission, and
     /// TestRequest probing. Call at or after [`next_timeout`](Self::next_timeout).
     pub fn on_timeout(&mut self, now: Instant) -> Out {
         let mut out = Out::EMPTY;
@@ -252,6 +312,13 @@ impl SessionState {
                     && now.duration_since(t) >= self.hb
                 {
                     self.disconnect(DisconnectReason::LogoutTimeout, &mut out);
+                }
+            }
+            State::AwaitingResetDrain | State::AwaitingResetAck => {
+                if let Some(t) = self.state_entered
+                    && now.duration_since(t) >= self.hb
+                {
+                    self.disconnect(DisconnectReason::ResetTimeout, &mut out);
                 }
             }
             State::Active | State::Resending => {
@@ -302,6 +369,47 @@ impl SessionState {
         send_reply: bool,
         now: Instant,
     ) -> Out {
+        let mut out = Out::EMPTY;
+        self.last_received = Some(now);
+        self.test_request_sent = None;
+
+        // Reset ack: we initiated the reset and peer is confirming.
+        if self.state == State::AwaitingResetAck {
+            if !reset_seq_num || seq != 1 {
+                self.disconnect(DisconnectReason::ProtocolViolation, &mut out);
+                return out;
+            }
+            self.hb = Duration::from_secs(u64::from(heart_bt_int_s));
+            self.next_inbound = 2;
+            self.state = State::Active;
+            self.state_entered = None;
+            out.push_event(Event::Established { heart_bt_int_s });
+            return out;
+        }
+
+        // Peer-initiated reset while we are active.
+        if matches!(self.state, State::Active | State::Resending) && reset_seq_num {
+            if seq != 1 {
+                self.disconnect(DisconnectReason::ProtocolViolation, &mut out);
+                return out;
+            }
+            self.hb = Duration::from_secs(u64::from(heart_bt_int_s));
+            self.next_outbound = 1;
+            let Some(reply_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
+            out.push_admin(AdminMsg::Logon {
+                seq: reply_seq,
+                reset: true,
+                heart_bt_int_s: self.hb.as_secs() as u32,
+            });
+            self.next_inbound = 2;
+            self.state = State::Active;
+            out.push_event(Event::Established { heart_bt_int_s });
+            return out;
+        }
+
+        // Normal logon: acceptor or initiator's ack.
         let valid = if send_reply {
             self.state == State::Disconnected
         } else {
@@ -310,8 +418,7 @@ impl SessionState {
         if !valid {
             return Out::EMPTY;
         }
-        self.last_received = Some(now);
-        self.test_request_sent = None;
+
         if reset_seq_num {
             self.next_inbound = 1;
             if send_reply {
@@ -320,13 +427,13 @@ impl SessionState {
         }
         self.hb = Duration::from_secs(u64::from(heart_bt_int_s));
 
-        let mut out = Out::EMPTY;
         if send_reply {
             let Some(reply_seq) = self.bump_outbound(now, &mut out) else {
                 return out;
             };
             out.push_admin(AdminMsg::Logon {
                 seq: reply_seq,
+                reset: reset_seq_num,
                 heart_bt_int_s,
             });
         }
@@ -384,15 +491,32 @@ impl SessionState {
 
     /// Handles a received Heartbeat.
     pub fn on_heartbeat(&mut self, seq: u32, poss_dup: bool, now: Instant) -> Out {
+        self.last_received = Some(now);
+        self.test_request_sent = None;
+        let mut out = Out::EMPTY;
+
+        if self.state == State::AwaitingResetDrain {
+            // Any heartbeat confirms the link is alive — proceed with the reset Logon.
+            self.next_outbound = 1;
+            let Some(logon_seq) = self.bump_outbound(now, &mut out) else {
+                return out;
+            };
+            out.push_admin(AdminMsg::Logon {
+                seq: logon_seq,
+                reset: true,
+                heart_bt_int_s: self.hb.as_secs() as u32,
+            });
+            self.state = State::AwaitingResetAck;
+            self.state_entered = Some(now);
+            return out;
+        }
+
         if !matches!(
             self.state,
             State::Active | State::Resending | State::LogoutPending
         ) {
             return Out::EMPTY;
         }
-        self.last_received = Some(now);
-        self.test_request_sent = None;
-        let mut out = Out::EMPTY;
         if self.validate_seq(seq, poss_dup, now, &mut out) {
             self.check_resend_done();
         }
@@ -648,12 +772,16 @@ impl SessionState {
 mod tests {
     use super::*;
 
+    fn establish(s: &mut SessionState, now: Instant) {
+        s.connect(now);
+        s.on_logon(1, 30, false, false, now);
+    }
+
     #[test]
     fn allocate_seq_errors_at_i32_max() {
         let mut s = SessionState::new(Duration::from_secs(30));
         let now = Instant::now();
-        s.connect(now);
-        s.on_logon(1, 30, false, false, now);
+        establish(&mut s, now);
         s.next_outbound = SEQ_MAX + 1;
         assert_eq!(s.allocate_seq(now), Err(SessionError::SeqNumExhausted));
     }
@@ -662,14 +790,136 @@ mod tests {
     fn bump_outbound_disconnects_at_i32_max() {
         let mut s = SessionState::new(Duration::from_secs(30));
         let now = Instant::now();
-        s.connect(now);
-        s.on_logon(1, 30, false, false, now);
+        establish(&mut s, now);
         s.next_outbound = SEQ_MAX + 1;
         let out = s.logout(now);
         assert_eq!(
             out.event(),
             Some(Event::Disconnected {
                 reason: DisconnectReason::SeqNumExhausted
+            })
+        );
+    }
+
+    #[test]
+    fn connect_reset_clears_seqnums() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.allocate_seq(now).unwrap();
+        s.on_logout(2, false, now);
+        assert_eq!(s.state(), State::Disconnected);
+        let out = s.connect_reset(now);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(matches!(
+            admins[0],
+            AdminMsg::Logon {
+                seq: 1,
+                reset: true,
+                ..
+            }
+        ));
+        assert_eq!(s.next_outbound_seq(), 2);
+        assert_eq!(s.next_inbound_seq(), 1);
+    }
+
+    #[test]
+    fn in_session_reset_initiator_roundtrip() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.allocate_seq(now).unwrap(); // seq 2
+        s.allocate_seq(now).unwrap(); // seq 3
+
+        // Initiate reset: sends TestRequest, enters AwaitingResetDrain.
+        let out = s.reset_sequence(now);
+        assert_eq!(s.state(), State::AwaitingResetDrain);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(matches!(admins[0], AdminMsg::TestRequest { .. }));
+
+        // allocate_seq blocked.
+        assert_eq!(s.allocate_seq(now), Err(SessionError::ResetInProgress));
+
+        // Drain heartbeat arrives: sends Logon(141=Y, seq=1), enters AwaitingResetAck.
+        let out = s.on_heartbeat(2, false, now);
+        assert_eq!(s.state(), State::AwaitingResetAck);
+        assert_eq!(s.next_outbound_seq(), 2); // Logon consumed seq 1
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(matches!(
+            admins[0],
+            AdminMsg::Logon {
+                seq: 1,
+                reset: true,
+                ..
+            }
+        ));
+
+        // Peer acks with Logon(141=Y, seq=1): reset complete, → Active.
+        let out = s.on_logon(1, 30, true, true, now);
+        assert_eq!(s.state(), State::Active);
+        assert_eq!(s.next_inbound_seq(), 2);
+        assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
+    }
+
+    #[test]
+    fn in_session_reset_responder() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.allocate_seq(now).unwrap(); // seq 2
+        s.allocate_seq(now).unwrap(); // seq 3
+
+        // Peer sends Logon(141=Y, seq=1) while we are Active.
+        let out = s.on_logon(1, 30, true, true, now);
+        assert_eq!(s.state(), State::Active);
+        assert_eq!(s.next_outbound_seq(), 2); // reply Logon consumed seq 1
+        assert_eq!(s.next_inbound_seq(), 2);
+        let admins: Vec<_> = out.admin_messages().collect();
+        assert_eq!(admins.len(), 1);
+        assert!(matches!(
+            admins[0],
+            AdminMsg::Logon {
+                seq: 1,
+                reset: true,
+                ..
+            }
+        ));
+        assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
+    }
+
+    #[test]
+    fn reset_ack_without_flag_disconnects() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.reset_sequence(now);
+        s.on_heartbeat(2, false, now); // → AwaitingResetAck
+
+        // Peer replies without 141=Y.
+        let out = s.on_logon(1, 30, false, false, now);
+        assert_eq!(
+            out.event(),
+            Some(Event::Disconnected {
+                reason: DisconnectReason::ProtocolViolation
+            })
+        );
+    }
+
+    #[test]
+    fn reset_timeout_disconnects() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.reset_sequence(now);
+        s.on_heartbeat(2, false, now); // → AwaitingResetAck
+        let out = s.on_timeout(now + Duration::from_secs(31));
+        assert_eq!(
+            out.event(),
+            Some(Event::Disconnected {
+                reason: DisconnectReason::ResetTimeout
             })
         );
     }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -20,8 +20,11 @@ pub enum AdminMsg {
     Logon {
         seq: u32,
         heart_bt_int_s: u32,
-        /// `ResetSeqNumFlag(141)=Y` — both sides reset to seqnum 1.
-        reset: bool,
+    },
+    /// Logon with `ResetSeqNumFlag(141)=Y` — both sides reset to seqnum 1.
+    LogonReset {
+        seq: u32,
+        heart_bt_int_s: u32,
     },
     Logout {
         seq: u32,
@@ -222,7 +225,6 @@ impl SessionState {
         };
         out.push_admin(AdminMsg::Logon {
             seq,
-            reset: false,
             heart_bt_int_s: self.hb.as_secs() as u32,
         });
         self.state = State::LogonSent;
@@ -232,26 +234,25 @@ impl SessionState {
     }
 
     /// Initiates a session with `ResetSeqNumFlag(141)=Y`: resets both sequence
-    /// counters to 1 and sends a Logon. No-op if not disconnected.
-    pub fn connect_reset(&mut self, now: Instant) -> Out {
+    /// counters to 1 and sends a Logon. Returns `Err(())` if not disconnected.
+    pub fn connect_reset(&mut self, now: Instant) -> Result<Out, ()> {
         if self.state != State::Disconnected {
-            return Out::EMPTY;
+            return Err(());
         }
         self.next_outbound = 1;
         self.next_inbound = 1;
         let mut out = Out::EMPTY;
         let Some(seq) = self.bump_outbound(now, &mut out) else {
-            return out;
+            return Ok(out);
         };
-        out.push_admin(AdminMsg::Logon {
+        out.push_admin(AdminMsg::LogonReset {
             seq,
-            reset: true,
             heart_bt_int_s: self.hb.as_secs() as u32,
         });
         self.state = State::LogonSent;
         self.state_entered = Some(now);
         self.last_received = Some(now);
-        out
+        Ok(out)
     }
 
     /// Initiates an in-session sequence reset. Only valid while `Active`.
@@ -260,14 +261,15 @@ impl SessionState {
     /// the engine sends `Logon(141=Y, seqNum=1)` and enters `AwaitingResetAck`.
     /// The reset completes when the counterparty's `Logon(141=Y)` arrives.
     /// `allocate_seq` returns `ResetInProgress` until the handshake completes.
-    pub fn reset_sequence(&mut self, now: Instant) -> Out {
+    /// Returns `Err(())` if not Active.
+    pub fn reset_sequence(&mut self, now: Instant) -> Result<Out, ()> {
         if self.state != State::Active {
-            return Out::EMPTY;
+            return Err(());
         }
         let mut out = Out::EMPTY;
         self.test_req_counter += 1;
         let Some(seq) = self.bump_outbound(now, &mut out) else {
-            return out;
+            return Ok(out);
         };
         out.push_admin(AdminMsg::TestRequest {
             seq,
@@ -276,7 +278,7 @@ impl SessionState {
         self.test_request_sent = Some(now);
         self.state = State::AwaitingResetDrain;
         self.state_entered = Some(now);
-        out
+        Ok(out)
     }
 
     /// Initiates a clean logout. No-op unless in an active state.
@@ -398,9 +400,8 @@ impl SessionState {
             let Some(reply_seq) = self.bump_outbound(now, &mut out) else {
                 return out;
             };
-            out.push_admin(AdminMsg::Logon {
+            out.push_admin(AdminMsg::LogonReset {
                 seq: reply_seq,
-                reset: true,
                 heart_bt_int_s: self.hb.as_secs() as u32,
             });
             self.next_inbound = 2;
@@ -431,11 +432,17 @@ impl SessionState {
             let Some(reply_seq) = self.bump_outbound(now, &mut out) else {
                 return out;
             };
-            out.push_admin(AdminMsg::Logon {
-                seq: reply_seq,
-                reset: reset_seq_num,
-                heart_bt_int_s,
-            });
+            if reset_seq_num {
+                out.push_admin(AdminMsg::LogonReset {
+                    seq: reply_seq,
+                    heart_bt_int_s,
+                });
+            } else {
+                out.push_admin(AdminMsg::Logon {
+                    seq: reply_seq,
+                    heart_bt_int_s,
+                });
+            }
         }
 
         if seq < self.next_inbound {
@@ -489,31 +496,45 @@ impl SessionState {
         out
     }
 
-    /// Handles a received Heartbeat.
-    pub fn on_heartbeat(&mut self, seq: u32, poss_dup: bool, now: Instant) -> Out {
+    /// Handles a received Heartbeat. `echo_id` is `TestReqID(112)` parsed as `u64`, if present.
+    pub fn on_heartbeat(
+        &mut self,
+        seq: u32,
+        poss_dup: bool,
+        echo_id: Option<u64>,
+        now: Instant,
+    ) -> Out {
         self.last_received = Some(now);
         self.test_request_sent = None;
         let mut out = Out::EMPTY;
 
         if self.state == State::AwaitingResetDrain {
-            // Any heartbeat confirms the link is alive — proceed with the reset Logon.
-            self.next_outbound = 1;
-            let Some(logon_seq) = self.bump_outbound(now, &mut out) else {
+            let echo_matches = echo_id == Some(self.test_req_counter);
+            if echo_matches && seq == self.next_inbound {
+                // Drain confirmed: all in-flight messages received, send LogonReset.
+                self.next_inbound += 1;
+                self.next_outbound = 1;
+                let Some(logon_seq) = self.bump_outbound(now, &mut out) else {
+                    return out;
+                };
+                out.push_admin(AdminMsg::LogonReset {
+                    seq: logon_seq,
+                    heart_bt_int_s: self.hb.as_secs() as u32,
+                });
+                self.state = State::AwaitingResetAck;
+                self.state_entered = Some(now);
                 return out;
-            };
-            out.push_admin(AdminMsg::Logon {
-                seq: logon_seq,
-                reset: true,
-                heart_bt_int_s: self.hb.as_secs() as u32,
-            });
-            self.state = State::AwaitingResetAck;
-            self.state_entered = Some(now);
+            }
+            // Not the drain confirm: validate sequence normally.
+            if self.validate_seq(seq, poss_dup, now, &mut out) {
+                self.check_resend_done();
+            }
             return out;
         }
 
         if !matches!(
             self.state,
-            State::Active | State::Resending | State::LogoutPending
+            State::Active | State::Resending | State::LogoutPending | State::AwaitingResetAck
         ) {
             return Out::EMPTY;
         }
@@ -533,7 +554,11 @@ impl SessionState {
     ) -> Out {
         if !matches!(
             self.state,
-            State::Active | State::Resending | State::LogoutPending
+            State::Active
+                | State::Resending
+                | State::LogoutPending
+                | State::AwaitingResetDrain
+                | State::AwaitingResetAck
         ) {
             return Out::EMPTY;
         }
@@ -650,7 +675,11 @@ impl SessionState {
     pub fn on_app(&mut self, seq: u32, poss_dup: bool, now: Instant) -> Out {
         if !matches!(
             self.state,
-            State::Active | State::Resending | State::LogoutPending
+            State::Active
+                | State::Resending
+                | State::LogoutPending
+                | State::AwaitingResetDrain
+                | State::AwaitingResetAck
         ) {
             return Out::EMPTY;
         }
@@ -809,19 +838,29 @@ mod tests {
         s.allocate_seq(now).unwrap();
         s.on_logout(2, false, now);
         assert_eq!(s.state(), State::Disconnected);
-        let out = s.connect_reset(now);
+        let out = s.connect_reset(now).unwrap();
         let admins: Vec<_> = out.admin_messages().collect();
         assert_eq!(admins.len(), 1);
-        assert!(matches!(
-            admins[0],
-            AdminMsg::Logon {
-                seq: 1,
-                reset: true,
-                ..
-            }
-        ));
+        assert!(matches!(admins[0], AdminMsg::LogonReset { seq: 1, .. }));
         assert_eq!(s.next_outbound_seq(), 2);
         assert_eq!(s.next_inbound_seq(), 1);
+    }
+
+    #[test]
+    fn connect_reset_wrong_state_returns_err() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        assert!(s.connect_reset(now).is_err());
+    }
+
+    #[test]
+    fn reset_sequence_wrong_state_returns_err() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        assert!(s.reset_sequence(now).is_err()); // Disconnected
+        s.connect(now);
+        assert!(s.reset_sequence(now).is_err()); // LogonSent
     }
 
     #[test]
@@ -833,35 +872,56 @@ mod tests {
         s.allocate_seq(now).unwrap(); // seq 3
 
         // Initiate reset: sends TestRequest, enters AwaitingResetDrain.
-        let out = s.reset_sequence(now);
+        let out = s.reset_sequence(now).unwrap();
         assert_eq!(s.state(), State::AwaitingResetDrain);
         let admins: Vec<_> = out.admin_messages().collect();
         assert_eq!(admins.len(), 1);
-        assert!(matches!(admins[0], AdminMsg::TestRequest { .. }));
+        assert!(matches!(admins[0], AdminMsg::TestRequest { id: 1, .. }));
 
         // allocate_seq blocked.
         assert_eq!(s.allocate_seq(now), Err(SessionError::ResetInProgress));
 
-        // Drain heartbeat arrives: sends Logon(141=Y, seq=1), enters AwaitingResetAck.
-        let out = s.on_heartbeat(2, false, now);
+        // Non-drain heartbeat: wrong echo — drain NOT triggered.
+        let out = s.on_heartbeat(2, false, None, now);
+        assert_eq!(s.state(), State::AwaitingResetDrain);
+        assert_eq!(out.admin_messages().count(), 0);
+
+        // Drain heartbeat: correct echo + seq in order → sends LogonReset(seq=1), → AwaitingResetAck.
+        let out = s.on_heartbeat(3, false, Some(1), now);
         assert_eq!(s.state(), State::AwaitingResetAck);
-        assert_eq!(s.next_outbound_seq(), 2); // Logon consumed seq 1
+        assert_eq!(s.next_outbound_seq(), 2); // LogonReset consumed seq 1
         let admins: Vec<_> = out.admin_messages().collect();
         assert_eq!(admins.len(), 1);
-        assert!(matches!(
-            admins[0],
-            AdminMsg::Logon {
-                seq: 1,
-                reset: true,
-                ..
-            }
-        ));
+        assert!(matches!(admins[0], AdminMsg::LogonReset { seq: 1, .. }));
 
         // Peer acks with Logon(141=Y, seq=1): reset complete, → Active.
-        let out = s.on_logon(1, 30, true, true, now);
+        let out = s.on_logon(1, 30, true, false, now);
         assert_eq!(s.state(), State::Active);
         assert_eq!(s.next_inbound_seq(), 2);
         assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
+    }
+
+    #[test]
+    fn in_flight_app_delivered_during_drain() {
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        s.allocate_seq(now).unwrap(); // seq 2
+
+        s.reset_sequence(now).unwrap(); // → AwaitingResetDrain
+        assert_eq!(s.state(), State::AwaitingResetDrain);
+
+        // App message arrives with old inbound seq while draining.
+        let out = s.on_app(2, false, now);
+        assert_eq!(
+            out.event(),
+            Some(Event::App {
+                seq_num: 2,
+                poss_dup: false
+            })
+        );
+        assert_eq!(s.next_inbound_seq(), 3);
+        assert_eq!(s.state(), State::AwaitingResetDrain);
     }
 
     #[test]
@@ -879,14 +939,7 @@ mod tests {
         assert_eq!(s.next_inbound_seq(), 2);
         let admins: Vec<_> = out.admin_messages().collect();
         assert_eq!(admins.len(), 1);
-        assert!(matches!(
-            admins[0],
-            AdminMsg::Logon {
-                seq: 1,
-                reset: true,
-                ..
-            }
-        ));
+        assert!(matches!(admins[0], AdminMsg::LogonReset { seq: 1, .. }));
         assert_eq!(out.event(), Some(Event::Established { heart_bt_int_s: 30 }));
     }
 
@@ -895,8 +948,8 @@ mod tests {
         let mut s = SessionState::new(Duration::from_secs(30));
         let now = Instant::now();
         establish(&mut s, now);
-        s.reset_sequence(now);
-        s.on_heartbeat(2, false, now); // → AwaitingResetAck
+        s.reset_sequence(now).unwrap();
+        s.on_heartbeat(2, false, Some(1), now); // → AwaitingResetAck
 
         // Peer replies without 141=Y.
         let out = s.on_logon(1, 30, false, false, now);
@@ -913,8 +966,8 @@ mod tests {
         let mut s = SessionState::new(Duration::from_secs(30));
         let now = Instant::now();
         establish(&mut s, now);
-        s.reset_sequence(now);
-        s.on_heartbeat(2, false, now); // → AwaitingResetAck
+        s.reset_sequence(now).unwrap();
+        s.on_heartbeat(2, false, Some(1), now); // → AwaitingResetAck
         let out = s.on_timeout(now + Duration::from_secs(31));
         assert_eq!(
             out.event(),

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -234,10 +234,10 @@ impl SessionState {
     }
 
     /// Initiates a session with `ResetSeqNumFlag(141)=Y`: resets both sequence
-    /// counters to 1 and sends a Logon. Returns `Err(())` if not disconnected.
-    pub fn connect_reset(&mut self, now: Instant) -> Result<Out, ()> {
+    /// counters to 1 and sends a Logon. Returns `Err(InvalidState)` if not disconnected.
+    pub fn connect_reset(&mut self, now: Instant) -> Result<Out, SessionError> {
         if self.state != State::Disconnected {
-            return Err(());
+            return Err(SessionError::InvalidState);
         }
         self.next_outbound = 1;
         self.next_inbound = 1;
@@ -261,10 +261,10 @@ impl SessionState {
     /// the engine sends `Logon(141=Y, seqNum=1)` and enters `AwaitingResetAck`.
     /// The reset completes when the counterparty's `Logon(141=Y)` arrives.
     /// `allocate_seq` returns `ResetInProgress` until the handshake completes.
-    /// Returns `Err(())` if not Active.
-    pub fn reset_sequence(&mut self, now: Instant) -> Result<Out, ()> {
+    /// Returns `Err(InvalidState)` if not Active.
+    pub fn reset_sequence(&mut self, now: Instant) -> Result<Out, SessionError> {
         if self.state != State::Active {
-            return Err(());
+            return Err(SessionError::InvalidState);
         }
         let mut out = Out::EMPTY;
         self.test_req_counter += 1;

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -406,9 +406,8 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 }))
             }
             b"0" => {
-                let echo_id = find_tag(frame, 0, 112)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map(|v| v as u64);
+                let echo_id =
+                    find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
                 let out = self.state.on_heartbeat(seq, poss_dup, echo_id, now);
                 for admin in out.admin_messages() {
                     store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -211,7 +211,24 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     }
 
     pub fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.connect_reset(now);
+        let out = self
+            .state
+            .connect_reset(now)
+            .map_err(|()| Error::Protocol(SessionError::InvalidState))?;
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        if !self.writer.is_empty() {
+            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+        }
+        Ok(())
+    }
+
+    pub fn reset_sequence(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self
+            .state
+            .reset_sequence(now)
+            .map_err(|()| Error::Protocol(SessionError::InvalidState))?;
         for admin in out.admin_messages() {
             store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
         }
@@ -395,7 +412,10 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 }))
             }
             b"0" => {
-                let out = self.state.on_heartbeat(seq, poss_dup, now);
+                let echo_id = find_tag(frame, 0, 112)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map(|v| v as u64);
+                let out = self.state.on_heartbeat(seq, poss_dup, echo_id, now);
                 for admin in out.admin_messages() {
                     store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
                 }
@@ -579,6 +599,7 @@ fn store_admin<D: FixDictionary>(
 ) -> Result<(), Error> {
     let seq = match admin {
         AdminMsg::Logon { seq, .. }
+        | AdminMsg::LogonReset { seq, .. }
         | AdminMsg::Logout { seq }
         | AdminMsg::Heartbeat { seq, .. }
         | AdminMsg::TestRequest { seq, .. }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -210,6 +210,17 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         Ok(())
     }
 
+    pub fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.connect_reset(now);
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        if !self.writer.is_empty() {
+            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+        }
+        Ok(())
+    }
+
     pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
         self.journal
             .store(seq, frame)

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -211,10 +211,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     }
 
     pub fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self
-            .state
-            .connect_reset(now)
-            .map_err(|()| Error::Protocol(SessionError::InvalidState))?;
+        let out = self.state.connect_reset(now).map_err(Error::Protocol)?;
         for admin in out.admin_messages() {
             store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
         }
@@ -225,10 +222,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     }
 
     pub fn reset_sequence(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self
-            .state
-            .reset_sequence(now)
-            .map_err(|()| Error::Protocol(SessionError::InvalidState))?;
+        let out = self.state.reset_sequence(now).map_err(Error::Protocol)?;
         for admin in out.admin_messages() {
             store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
         }

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -152,6 +152,7 @@ mod unix_tests {
             AdminMsg::Logon {
                 seq: 1,
                 heart_bt_int_s: 30,
+                reset: false,
             },
             &config,
         );

--- a/nexus-fix-engine/tests/framework.rs
+++ b/nexus-fix-engine/tests/framework.rs
@@ -152,7 +152,6 @@ mod unix_tests {
             AdminMsg::Logon {
                 seq: 1,
                 heart_bt_int_s: 30,
-                reset: false,
             },
             &config,
         );

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -73,7 +73,7 @@ fn logon_reset_seq_num_flag() {
     assert_eq!(s.state(), State::Active);
     let admins = admin_msgs(out);
     assert_eq!(admins.len(), 1);
-    assert!(matches!(admins[0], AdminMsg::Logon { seq: 1, .. }));
+    assert!(matches!(admins[0], AdminMsg::LogonReset { seq: 1, .. }));
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn probe_answered_keeps_session_alive() {
 
     let probe_at = now + Duration::from_secs(36);
     s.on_timeout(probe_at);
-    s.on_heartbeat(2, false, probe_at + Duration::from_secs(1));
+    s.on_heartbeat(2, false, None, probe_at + Duration::from_secs(1));
 
     s.on_timeout(probe_at + HB);
     assert_eq!(s.state(), State::Active);

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -31,7 +31,8 @@ fn initiator_handshake() {
         admins[0],
         AdminMsg::Logon {
             seq: 1,
-            heart_bt_int_s: 30
+            heart_bt_int_s: 30,
+            ..
         }
     ));
 
@@ -57,7 +58,8 @@ fn acceptor_handshake() {
         admins[0],
         AdminMsg::Logon {
             seq: 1,
-            heart_bt_int_s: 15
+            heart_bt_int_s: 15,
+            ..
         }
     ));
 }


### PR DESCRIPTION
Closes #559.

Adds in-session sequence reset (`reset_sequence`/`connect_reset`) and
removes the warning-based approach. The reset handshake uses two new
states: `AwaitingResetDrain` and `AwaitingResetAck`.

Changes:

- `session/event.rs`: add `AwaitingResetDrain`, `AwaitingResetAck` states;
  add `ResetTimeout` disconnect reason; drop `SeqNumWarning`
- `session/mod.rs`: full state machine rewrite
  - `connect(now)` - normal logon, no reset param
  - `connect_reset(now)` - logon with `ResetSeqNumFlag(141)=Y`
  - `reset_sequence(now)` - in-session reset: sends TestRequest to drain,
    then `Logon(141=Y)` on Heartbeat reply, transitions through
    `AwaitingResetDrain` -> `AwaitingResetAck` -> `Active`
  - `allocate_seq` returns `Err(ResetInProgress)` during reset window
  - peer-initiated reset handled in `on_logon` while `Active`
  - remove `seq_limit`, `warn_threshold`, `warn_fired` and related methods
- `framework.rs`: add `ResetInProgress` to `SessionError`; remove
  `SeqNumWarning` from `Message`
- `transport.rs`: update `connect` API; add `connect_reset`; remove
  `approaching_seq_limit`
- `nexus-async-fix-engine`: same connect API update

Pending buffer helpers for callers managing in-flight messages during a
reset are deferred to a follow-up issue (#574).