### PR TITLE
feat: FIX conformance harness

### DIFF
--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -87,16 +87,28 @@ impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 fn main() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port: u16 = std::env::var("FIX_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
     let addr = listener.local_addr().unwrap();
+    println!("listening on {addr}");
 
-    let acceptor_dir = tmp_dir("acceptor");
-    let acceptor = std::thread::spawn(move || run_acceptor(&listener, &acceptor_dir));
-
-    let initiator_dir = tmp_dir("initiator");
-    run_initiator(addr, &initiator_dir);
-
-    acceptor.join().unwrap();
+    if port != 0 {
+        let mut n = 0u64;
+        loop {
+            let dir = tmp_dir(&format!("acceptor_{n}"));
+            n += 1;
+            run_acceptor(&listener, &dir);
+        }
+    } else {
+        let acceptor_dir = tmp_dir("acceptor");
+        let acceptor = std::thread::spawn(move || run_acceptor(&listener, &acceptor_dir));
+        let initiator_dir = tmp_dir("initiator");
+        run_initiator(addr, &initiator_dir);
+        acceptor.join().unwrap();
+    }
 }
 
 fn run_acceptor(listener: &TcpListener, dir: &Path) {

--- a/tools/fix-harness/Containerfile
+++ b/tools/fix-harness/Containerfile
@@ -1,0 +1,8 @@
+FROM python:3.10-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends g++ python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+WORKDIR /harness
+CMD ["behave"]

--- a/tools/fix-harness/features/environment.py
+++ b/tools/fix-harness/features/environment.py
@@ -1,0 +1,71 @@
+import os
+import tempfile
+import threading
+
+import quickfix as fix
+
+FIX_PORT = int(os.environ.get("FIX_PORT", "9878"))
+
+
+class HarnessApp(fix.Application):
+    def __init__(self):
+        super().__init__()
+        self.logon_event = threading.Event()
+        self.session_id = None
+
+    def onCreate(self, sessionID):
+        pass
+
+    def onLogon(self, sessionID):
+        self.session_id = sessionID
+        self.logon_event.set()
+
+    def onLogout(self, sessionID):
+        self.logon_event.clear()
+
+    def toAdmin(self, message, sessionID):
+        pass
+
+    def fromAdmin(self, message, sessionID):
+        pass
+
+    def toApp(self, message, sessionID):
+        pass
+
+    def fromApp(self, message, sessionID):
+        pass
+
+
+def _write_cfg():
+    cfg = (
+        "[DEFAULT]\n"
+        "ConnectionType=initiator\n"
+        "HeartBtInt=30\n"
+        "SenderCompID=INITIATOR\n"
+        "TargetCompID=ACCEPTOR\n"
+        "ResetOnLogon=Y\n"
+        "ResetOnDisconnect=Y\n"
+        "\n"
+        "[SESSION]\n"
+        "BeginString=FIX.4.4\n"
+        f"SocketConnectHost=127.0.0.1\n"
+        f"SocketConnectPort={FIX_PORT}\n"
+    )
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".cfg", delete=False)
+    f.write(cfg)
+    f.close()
+    return f.name
+
+
+def before_scenario(context, scenario):
+    cfg_path = _write_cfg()
+    settings = fix.SessionSettings(cfg_path)
+    context.app = HarnessApp()
+    store = fix.MemoryStoreFactory(settings)
+    log = fix.ScreenLogFactory(settings)
+    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
+    context.initiator.start()
+
+
+def after_scenario(context, scenario):
+    context.initiator.stop()

--- a/tools/fix-harness/features/session.feature
+++ b/tools/fix-harness/features/session.feature
@@ -1,0 +1,7 @@
+Feature: FIX session management
+
+  Scenario: valid logon is accepted
+    Given a FIX 4.4 session with sender INITIATOR and target ACCEPTOR
+    When the harness connects and sends Logon
+    Then the engine replies with Logon
+    And the session is active

--- a/tools/fix-harness/features/steps/session_steps.py
+++ b/tools/fix-harness/features/steps/session_steps.py
@@ -1,0 +1,22 @@
+from behave import given, when, then
+
+
+@given("a FIX 4.4 session with sender INITIATOR and target ACCEPTOR")
+def step_session_config(context):
+    pass
+
+
+@when("the harness connects and sends Logon")
+def step_send_logon(context):
+    pass
+
+
+@then("the engine replies with Logon")
+def step_logon_reply(context):
+    assert context.app.logon_event.wait(timeout=10), \
+        "engine did not reply with Logon within 10s"
+
+
+@then("the session is active")
+def step_session_active(context):
+    assert context.app.session_id is not None

--- a/tools/fix-harness/requirements.txt
+++ b/tools/fix-harness/requirements.txt
@@ -1,0 +1,2 @@
+quickfix==1.15.1
+behave==1.2.6

--- a/tools/fix-harness/run.sh
+++ b/tools/fix-harness/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIX_PORT=${FIX_PORT:-9878}
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+HARNESS_DIR="$REPO_ROOT/tools/fix-harness"
+
+podman build -t fix-harness "$HARNESS_DIR"
+
+FIX_PORT=$FIX_PORT cargo run -p nexus-fix-engine --example blocking_session &
+ENGINE_PID=$!
+trap "kill $ENGINE_PID 2>/dev/null || true" EXIT
+
+echo "waiting for engine on port $FIX_PORT..."
+until (echo >/dev/tcp/127.0.0.1/"$FIX_PORT") 2>/dev/null; do sleep 0.3; done
+echo "engine ready"
+
+podman run --rm \
+    --network=host \
+    -e FIX_PORT="$FIX_PORT" \
+    -v "$HARNESS_DIR/features:/harness/features:Z" \
+    fix-harness \
+    behave /harness/features


### PR DESCRIPTION
Adds tools/fix-harness/, a Behave + QuickFIX harness for black-box
session testing against the engine.

run.sh starts the engine and runs behave in Docker. First scenario:
valid logon roundtrip, passing.

blocking_session reads FIX_PORT to loop in harness mode.

Closes part of #408