### PR TITLE
feat(fix-engine): multi-session FixJournal under one directory

### DIFF
--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -47,7 +47,7 @@ async fn connect(port: u16, dir: &Path) -> AsyncFixConnection<TcpStream> {
             sender: CompId::new(b"ENGINE").unwrap(),
             target: CompId::new(b"PEER").unwrap(),
         },
-        FixJournal::open(dir, 256).unwrap(),
+        FixJournal::open(dir, 0, 256).unwrap(),
         BEGIN,
     )
 }

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -112,7 +112,7 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
             sender: CompId::new(b"ACCEPTOR").unwrap(),
             target: CompId::new(b"INITIATOR").unwrap(),
         },
-        FixJournal::open(dir, 256).unwrap(),
+        FixJournal::open(dir, 0, 256).unwrap(),
     );
 
     let mut n = 0usize;
@@ -141,7 +141,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
                 sender: CompId::new(b"INITIATOR").unwrap(),
                 target: CompId::new(b"ACCEPTOR").unwrap(),
             },
-            FixJournal::open(dir, 256).unwrap(),
+            FixJournal::open(dir, 0, 256).unwrap(),
         )
         .unwrap();
 

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -86,15 +86,10 @@ impl FixJournal {
     ///
     /// One session per journal: if a session already exists under `dir`, the
     /// first one is reopened; otherwise a new session is created.
-    pub fn open(dir: impl AsRef<Path>, window: usize) -> Result<Self, OpenError> {
+    pub fn open(dir: impl AsRef<Path>, session_id: u32, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;
-        let existing = conductor.sessions_on_disk()?;
-        let journal = if let Some(&id) = existing.first() {
-            conductor.session().session_id(id).open()?
-        } else {
-            conductor.session().open()?
-        };
+        let journal: RotatingJournal = conductor.session().session_id(session_id).open()?;
         let mut this = Self {
             journal,
             _conductor: conductor,

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -218,7 +218,7 @@ mod tests {
         let dir = tmp_dir("store-resend");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         for seq in 1..=5u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -239,13 +239,13 @@ mod tests {
         cleanup(&dir);
 
         {
-            let mut j = FixJournal::open(&dir, 64).unwrap();
+            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
             for seq in 1..=7u32 {
                 j.store(seq, &fix_msg(seq)).unwrap();
             }
         }
 
-        let j = FixJournal::open(&dir, 64).unwrap();
+        let j = FixJournal::open(&dir, 0, 64).unwrap();
         assert_eq!(j.next_outbound(), 8);
 
         cleanup(&dir);
@@ -256,7 +256,7 @@ mod tests {
         let dir = tmp_dir("gapfill");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
 
         match j.resend_one(2) {
@@ -272,7 +272,7 @@ mod tests {
         let dir = tmp_dir("straddle");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         for seq in [1u32, 3, 5] {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -290,7 +290,7 @@ mod tests {
         let dir = tmp_dir("inbound");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         assert_eq!(j.next_inbound(), 1);
         j.advance_inbound();
         j.advance_inbound();
@@ -306,7 +306,7 @@ mod tests {
         let dir = tmp_dir("rr-admin-skip");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         j.store(1, &fix_admin(1, "A")).unwrap();
         j.store(2, &fix_admin(2, "0")).unwrap();
         j.store(3, &fix_admin(3, "5")).unwrap();
@@ -326,7 +326,7 @@ mod tests {
         let dir = tmp_dir("rr-holes");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         for seq in [1u32, 3, 5] {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -353,7 +353,7 @@ mod tests {
         let dir = tmp_dir("rr-straddle");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 4).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 4).unwrap();
         for seq in 1..=8u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -377,7 +377,7 @@ mod tests {
         let dir = tmp_dir("rr-original");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         let msg = fix_msg_with_time(1, "20240101-12:00:00");
         j.store(1, &msg).unwrap();
 
@@ -396,7 +396,7 @@ mod tests {
         let dir = tmp_dir("rr-coalesced");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
         j.store(5, &fix_msg(5)).unwrap();
 
@@ -417,7 +417,7 @@ mod tests {
         let dir = tmp_dir("rr-allgap");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         j.store(1, &fix_admin(1, "A")).unwrap();
         j.store(2, &fix_admin(2, "1")).unwrap();
         j.store(3, &fix_admin(3, "2")).unwrap();
@@ -437,7 +437,7 @@ mod tests {
         let dir = tmp_dir("rr-endzero");
         cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 64).unwrap();
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
         for seq in 1..=3u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -448,4 +448,33 @@ mod tests {
 
         cleanup(&dir);
     }
+
+    #[test]
+    fn two_sessions_in_one_directory_are_independent() {
+        let dir = tmp_dir("two-sessions");
+        cleanup(&dir);
+
+        {
+            let mut j0 = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j1 = FixJournal::open(&dir, 1, 64).unwrap();
+
+            for seq in 1..=3u32 {
+                j0.store(seq, &fix_msg(seq)).unwrap();
+            }
+            for seq in 1..=5u32 {
+                j1.store(seq, &fix_msg(seq)).unwrap();
+            }
+
+            assert_eq!(j0.next_outbound(), 4);
+            assert_eq!(j1.next_outbound(), 6);
+        }
+
+        // Reopen both and verify each recovers its own next_outbound independently.
+        let j0 = FixJournal::open(&dir, 0, 64).unwrap();
+        let j1 = FixJournal::open(&dir, 1, 64).unwrap();
+        assert_eq!(j0.next_outbound(), 4);
+        assert_eq!(j1.next_outbound(), 6);
+
+        cleanup(&dir);
+    }
 }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -79,13 +79,16 @@ impl<'a> Iterator for ResendIter<'a> {
 }
 
 impl FixJournal {
-    /// Open (or recover) the journal for a single session under `dir`.
+    /// Open (or create) the journal for `session_id` under `dir`.
+    ///
+    /// If a manifest for `session_id` already exists under `dir`, the session
+    /// is recovered and `next_outbound` is restored from the stored messages.
+    /// If no manifest exists, a fresh session is created. Multiple sessions
+    /// can coexist under the same `dir` with distinct `session_id` values,
+    /// each with independent sequence number state.
     ///
     /// `window` is the resend horizon in messages (must be a power of two): the
     /// last `window` sequence numbers are replayable, older ones are gap-filled.
-    ///
-    /// One session per journal: if a session already exists under `dir`, the
-    /// first one is reopened; otherwise a new session is created.
     pub fn open(dir: impl AsRef<Path>, session_id: u32, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -134,7 +134,7 @@ fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream, MockDict> {
             sender: CompId::new(b"ENGINE").unwrap(),
             target: CompId::new(b"PEER").unwrap(),
         },
-        FixJournal::open(dir, 256).unwrap(),
+        FixJournal::open(dir, 0, 256).unwrap(),
     )
 }
 

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -95,7 +95,7 @@ fn session_cfg(sender: CompId, target: CompId) -> SessionConfig {
 }
 
 fn journal(dir: &PathBuf) -> FixJournal {
-    FixJournal::open(dir, 256).unwrap()
+    FixJournal::open(dir, 0, 256).unwrap()
 }
 
 fn loopback_pair() -> (TcpStream, TcpStream) {

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -679,7 +679,7 @@ fn journal_recovers_admin_seqnums() {
     drop(conn);
 
     // seq=1 logon + seq=2 logout-ack → next_outbound must be 3 after recovery
-    let recovered = FixJournal::open(&dir, 256).unwrap();
+    let recovered = FixJournal::open(&dir, 0, 256).unwrap();
     assert_eq!(
         recovered.next_outbound(),
         3,


### PR DESCRIPTION
`FixJournal::open` hardcodes `sessions_on_disk().first()`, limiting one process to one session per directory. This PR wires up the `session_id` that `Conductor` already supports, allowing N independent sessions under a single directory.

**`FixJournal::open` now takes an explicit `session_id: u32`** (`persist.rs`)
Replaces the `.first()` heuristic with a caller-supplied ID. `conductor.session().session_id(id).open()` handles both recovery (manifest exists) and fresh creation (no manifest) in a single call, so the old `if/else` is removed. `recover_from_journal()` is unchanged — it already replays only the messages belonging to the opened session.

**All call sites updated to pass `0`** (`transport.rs`, `fix_conformance.rs`, `async_conformance.rs`, `blocking_session.rs`, internal tests in `persist.rs`)
Single-session callers each use their own directory, so `0` is the correct and conventional choice.

**Test: two concurrent sessions in one directory** (`persist.rs`)
Opens two `FixJournal` instances under the same directory with session IDs `0` and `1`, stores a different number of messages in each, confirms `next_outbound` is independent, drops both, reopens, and verifies each recovers its own sequence number without interference.

Related to #518