### PR TITLE
fix(async-fix-engine): use encode_fix_uint for SessionRejectReason (tag 373)

### DIFF
--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -366,7 +366,8 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                         let n = encode_fix_uint(tag, &mut buf);
                         fmt.field(371, &buf[..n]);
                     }
-                    fmt.field(373, &[b'0' + session_reject_reason]);
+                    let n = encode_fix_uint(session_reject_reason as u32, &mut buf);
+                    fmt.field(373, &buf[..n]);
                 }
             }
 


### PR DESCRIPTION
Mirrors the sync engine fix from #566. The async encode_admin was still
encoding field 373 as b'0' + session_reject_reason, which produces
garbage for reasons >= 10. Switch to encode_fix_uint.