### PR TITLE
feat(fix-harness): dedicated harness-server binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 	"nexus-fix-codegen-tests",
 	"nexus-fix-engine",
 	"nexus-async-fix-engine",
+	"nexus-fix-harness",
 	"nexus-platform",
 ]
 

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -87,28 +87,15 @@ impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 fn main() {
-    let port: u16 = std::env::var("FIX_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0);
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
     let addr = listener.local_addr().unwrap();
     println!("listening on {addr}");
 
-    if port != 0 {
-        let mut n = 0u64;
-        loop {
-            let dir = tmp_dir(&format!("acceptor_{n}"));
-            n += 1;
-            run_acceptor(&listener, &dir);
-        }
-    } else {
-        let acceptor_dir = tmp_dir("acceptor");
-        let acceptor = std::thread::spawn(move || run_acceptor(&listener, &acceptor_dir));
-        let initiator_dir = tmp_dir("initiator");
-        run_initiator(addr, &initiator_dir);
-        acceptor.join().unwrap();
-    }
+    let acceptor_dir = tmp_dir("acceptor");
+    let acceptor = std::thread::spawn(move || run_acceptor(&listener, &acceptor_dir));
+    let initiator_dir = tmp_dir("initiator");
+    run_initiator(addr, &initiator_dir);
+    acceptor.join().unwrap();
 }
 
 fn run_acceptor(listener: &TcpListener, dir: &Path) {

--- a/nexus-fix-harness/Cargo.toml
+++ b/nexus-fix-harness/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nexus-fix-harness"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "FIX conformance harness server"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-fix-codec = { path = "../nexus-fix-codec" }
+nexus-fix-engine = { path = "../nexus-fix-engine" }

--- a/nexus-fix-harness/src/main.rs
+++ b/nexus-fix-harness/src/main.rs
@@ -5,7 +5,9 @@ use std::net::TcpListener;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{AsciiTextStr, FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag};
+use nexus_fix_codec::{
+    AsciiTextStr, FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag,
+};
 use nexus_fix_engine::{CompId, FixConnection, FixJournal, Message, SessionConfig, SessionState};
 
 struct Fix44;

--- a/nexus-fix-harness/src/main.rs
+++ b/nexus-fix-harness/src/main.rs
@@ -1,30 +1,42 @@
-#![cfg(unix)]
+#[cfg(not(unix))]
+fn main() {}
 
+#[cfg(unix)]
 use std::fs;
+#[cfg(unix)]
 use std::net::TcpListener;
+#[cfg(unix)]
 use std::path::Path;
+#[cfg(unix)]
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
 use nexus_fix_codec::{
     AsciiTextStr, FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag,
 };
+#[cfg(unix)]
 use nexus_fix_engine::{CompId, FixConnection, FixJournal, Message, SessionConfig, SessionState};
 
+#[cfg(unix)]
 struct Fix44;
 
+#[cfg(unix)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Fix44MsgType {}
 
+#[cfg(unix)]
 struct Decoder<'buf> {
     _buf: &'buf [u8],
 }
 
+#[cfg(unix)]
 impl<'buf> FixAdminMsg<'buf> for Decoder<'buf> {
     fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
         Ok(Self { _buf: buf })
     }
 }
 
+#[cfg(unix)]
 impl FixDictionary for Fix44 {
     type MsgType = Fix44MsgType;
     type Header<'buf> = Fix44Header<'buf>;
@@ -41,10 +53,12 @@ impl FixDictionary for Fix44 {
     }
 }
 
+#[cfg(unix)]
 struct Fix44Header<'buf> {
     buf: &'buf [u8],
 }
 
+#[cfg(unix)]
 impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
     fn decode(buf: &'buf [u8]) -> Self {
         Self { buf }
@@ -75,11 +89,13 @@ impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
     }
 }
 
+#[cfg(unix)]
 fn reset_journal(dir: &Path) {
     fs::remove_dir_all(dir).ok();
     fs::create_dir_all(dir).expect("failed to create journal dir");
 }
 
+#[cfg(unix)]
 fn main() {
     let port: u16 = std::env::var("FIX_PORT")
         .ok()

--- a/nexus-fix-harness/src/main.rs
+++ b/nexus-fix-harness/src/main.rs
@@ -1,0 +1,132 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use nexus_fix_codec::{AsciiTextStr, FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag};
+use nexus_fix_engine::{CompId, FixConnection, FixJournal, Message, SessionConfig, SessionState};
+
+struct Fix44;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Fix44MsgType {}
+
+struct Decoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for Decoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for Fix44 {
+    type MsgType = Fix44MsgType;
+    type Header<'buf> = Fix44Header<'buf>;
+    type Logon<'buf> = Decoder<'buf>;
+    type Logout<'buf> = Decoder<'buf>;
+    type Heartbeat<'buf> = Decoder<'buf>;
+    type TestRequest<'buf> = Decoder<'buf>;
+    type ResendRequest<'buf> = Decoder<'buf>;
+    type SequenceReset<'buf> = Decoder<'buf>;
+    type Reject<'buf> = Decoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: Fix44MsgType) -> bool {
+        false
+    }
+}
+
+struct Fix44Header<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for Fix44Header<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+fn reset_journal(dir: &Path) {
+    fs::remove_dir_all(dir).ok();
+    fs::create_dir_all(dir).expect("failed to create journal dir");
+}
+
+fn main() {
+    let port: u16 = std::env::var("FIX_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(9878);
+
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind failed");
+    println!("listening on {}", listener.local_addr().unwrap());
+
+    let dir = {
+        let mut p = std::env::temp_dir();
+        p.push("nexus_harness");
+        p
+    };
+
+    loop {
+        reset_journal(&dir);
+        let (stream, peer) = listener.accept().expect("accept failed");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set_read_timeout failed");
+        println!("accepted {peer}");
+
+        let mut conn: FixConnection<_, Fix44> = FixConnection::builder().accept(
+            stream,
+            SessionState::new(Duration::from_secs(30)),
+            SessionConfig {
+                sender: CompId::new(b"ACCEPTOR").unwrap(),
+                target: CompId::new(b"INITIATOR").unwrap(),
+            },
+            FixJournal::open(&dir, 0, 256).unwrap(),
+        );
+
+        let mut app_msgs = 0usize;
+        loop {
+            match conn.recv(Instant::now()) {
+                Ok(Some(Message::Disconnected { reason })) => {
+                    println!("disconnected: {reason:?}, {app_msgs} app message(s)");
+                    break;
+                }
+                Ok(Some(Message::Application { .. })) => {
+                    app_msgs += 1;
+                }
+                Ok(Some(_) | None) => {}
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/tools/fix-harness/features/environment.py
+++ b/tools/fix-harness/features/environment.py
@@ -1,71 +1,10 @@
-import os
-import tempfile
-import threading
-
-import quickfix as fix
-
-FIX_PORT = int(os.environ.get("FIX_PORT", "9878"))
-
-
-class HarnessApp(fix.Application):
-    def __init__(self):
-        super().__init__()
-        self.logon_event = threading.Event()
-        self.session_id = None
-
-    def onCreate(self, sessionID):
-        pass
-
-    def onLogon(self, sessionID):
-        self.session_id = sessionID
-        self.logon_event.set()
-
-    def onLogout(self, sessionID):
-        self.logon_event.clear()
-
-    def toAdmin(self, message, sessionID):
-        pass
-
-    def fromAdmin(self, message, sessionID):
-        pass
-
-    def toApp(self, message, sessionID):
-        pass
-
-    def fromApp(self, message, sessionID):
-        pass
-
-
-def _write_cfg():
-    cfg = (
-        "[DEFAULT]\n"
-        "ConnectionType=initiator\n"
-        "HeartBtInt=30\n"
-        "SenderCompID=INITIATOR\n"
-        "TargetCompID=ACCEPTOR\n"
-        "ResetOnLogon=Y\n"
-        "ResetOnDisconnect=Y\n"
-        "\n"
-        "[SESSION]\n"
-        "BeginString=FIX.4.4\n"
-        f"SocketConnectHost=127.0.0.1\n"
-        f"SocketConnectPort={FIX_PORT}\n"
-    )
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".cfg", delete=False)
-    f.write(cfg)
-    f.close()
-    return f.name
-
-
 def before_scenario(context, scenario):
-    cfg_path = _write_cfg()
-    settings = fix.SessionSettings(cfg_path)
-    context.app = HarnessApp()
-    store = fix.MemoryStoreFactory(settings)
-    log = fix.ScreenLogFactory(settings)
-    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
-    context.initiator.start()
+    context.app = None
+    context.initiator = None
+    context.sender = "INITIATOR"
+    context.target = "ACCEPTOR"
 
 
 def after_scenario(context, scenario):
-    context.initiator.stop()
+    if context.initiator is not None:
+        context.initiator.stop()

--- a/tools/fix-harness/features/session.feature
+++ b/tools/fix-harness/features/session.feature
@@ -5,3 +5,25 @@ Feature: FIX session management
     When the harness connects and sends Logon
     Then the engine replies with Logon
     And the session is active
+
+  Scenario: clean logout
+    Given a FIX 4.4 session with sender INITIATOR and target ACCEPTOR
+    When the harness connects and sends Logon
+    Then the engine replies with Logon
+    When the harness sends Logout
+    Then the session ends cleanly
+
+  Scenario: heartbeat exchange
+    Given a FIX 4.4 session with sender INITIATOR and target ACCEPTOR
+    When the harness connects and sends Logon
+    Then the engine replies with Logon
+    When the harness sends a TestRequest with id "TC-1"
+    Then the engine replies with Heartbeat echoing "TC-1"
+
+  Scenario: sequence reset via reconnect
+    Given a FIX 4.4 session with sender INITIATOR and target ACCEPTOR
+    When the harness connects and sends Logon
+    Then the engine replies with Logon
+    When the harness disconnects and reconnects with ResetSeqNumFlag
+    Then the engine replies with Logon
+    And the session is active

--- a/tools/fix-harness/features/steps/session_steps.py
+++ b/tools/fix-harness/features/steps/session_steps.py
@@ -1,8 +1,10 @@
 import os
 import tempfile
 import threading
+import time
 
 import quickfix as fix
+import quickfix44 as fix44
 from behave import given, when, then
 
 FIX_PORT = int(os.environ.get("FIX_PORT", "9878"))
@@ -12,6 +14,9 @@ class HarnessApp(fix.Application):
     def __init__(self):
         super().__init__()
         self.logon_event = threading.Event()
+        self.logout_event = threading.Event()
+        self.heartbeat_event = threading.Event()
+        self.last_heartbeat_req_id = None
         self.session_id = None
 
     def onCreate(self, sessionID):
@@ -19,16 +24,27 @@ class HarnessApp(fix.Application):
 
     def onLogon(self, sessionID):
         self.session_id = sessionID
+        self.logout_event.clear()
         self.logon_event.set()
 
     def onLogout(self, sessionID):
         self.logon_event.clear()
+        self.logout_event.set()
 
     def toAdmin(self, message, sessionID):
         pass
 
     def fromAdmin(self, message, sessionID):
-        pass
+        msg_type = fix.MsgType()
+        message.getHeader().getField(msg_type)
+        if msg_type.getValue() == fix.MsgType_Heartbeat:
+            try:
+                req_id = fix.TestReqID()
+                message.getField(req_id)
+                self.last_heartbeat_req_id = req_id.getValue()
+            except fix.FieldNotFound:
+                pass
+            self.heartbeat_event.set()
 
     def toApp(self, message, sessionID):
         pass
@@ -58,6 +74,16 @@ def _make_cfg(sender, target, port):
     return f.name
 
 
+def _start_initiator(context):
+    cfg_path = _make_cfg(context.sender, context.target, FIX_PORT)
+    settings = fix.SessionSettings(cfg_path)
+    context.app = HarnessApp()
+    store = fix.MemoryStoreFactory(settings)
+    log = fix.ScreenLogFactory(settings)
+    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
+    context.initiator.start()
+
+
 @given("a FIX 4.4 session with sender {sender} and target {target}")
 def step_session_config(context, sender, target):
     context.sender = sender
@@ -66,13 +92,7 @@ def step_session_config(context, sender, target):
 
 @when("the harness connects and sends Logon")
 def step_send_logon(context):
-    cfg_path = _make_cfg(context.sender, context.target, FIX_PORT)
-    settings = fix.SessionSettings(cfg_path)
-    context.app = HarnessApp()
-    store = fix.MemoryStoreFactory(settings)
-    log = fix.ScreenLogFactory(settings)
-    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
-    context.initiator.start()
+    _start_initiator(context)
 
 
 @then("the engine replies with Logon")
@@ -84,3 +104,39 @@ def step_logon_reply(context):
 @then("the session is active")
 def step_session_active(context):
     assert context.app.session_id is not None
+
+
+@when("the harness sends Logout")
+def step_send_logout(context):
+    fix.Session.sendToTarget(fix44.Logout(), context.app.session_id)
+
+
+@then("the session ends cleanly")
+def step_session_ends(context):
+    assert context.app.logout_event.wait(timeout=10), \
+        "engine did not acknowledge Logout within 10s"
+
+
+@when('the harness sends a TestRequest with id "{req_id}"')
+def step_send_test_request(context, req_id):
+    context.app.heartbeat_event.clear()
+    context.app.last_heartbeat_req_id = None
+    msg = fix44.TestRequest()
+    msg.setField(fix.TestReqID(req_id))
+    fix.Session.sendToTarget(msg, context.app.session_id)
+
+
+@then('the engine replies with Heartbeat echoing "{req_id}"')
+def step_heartbeat_echo(context, req_id):
+    assert context.app.heartbeat_event.wait(timeout=10), \
+        "engine did not reply with Heartbeat within 10s"
+    assert context.app.last_heartbeat_req_id == req_id, \
+        f"expected TestReqID {req_id!r}, got {context.app.last_heartbeat_req_id!r}"
+
+
+@when("the harness disconnects and reconnects with ResetSeqNumFlag")
+def step_reconnect_reset(context):
+    context.initiator.stop()
+    context.app.logon_event.clear()
+    time.sleep(0.5)
+    _start_initiator(context)

--- a/tools/fix-harness/features/steps/session_steps.py
+++ b/tools/fix-harness/features/steps/session_steps.py
@@ -1,14 +1,78 @@
+import os
+import tempfile
+import threading
+
+import quickfix as fix
 from behave import given, when, then
 
+FIX_PORT = int(os.environ.get("FIX_PORT", "9878"))
 
-@given("a FIX 4.4 session with sender INITIATOR and target ACCEPTOR")
-def step_session_config(context):
-    pass
+
+class HarnessApp(fix.Application):
+    def __init__(self):
+        super().__init__()
+        self.logon_event = threading.Event()
+        self.session_id = None
+
+    def onCreate(self, sessionID):
+        pass
+
+    def onLogon(self, sessionID):
+        self.session_id = sessionID
+        self.logon_event.set()
+
+    def onLogout(self, sessionID):
+        self.logon_event.clear()
+
+    def toAdmin(self, message, sessionID):
+        pass
+
+    def fromAdmin(self, message, sessionID):
+        pass
+
+    def toApp(self, message, sessionID):
+        pass
+
+    def fromApp(self, message, sessionID):
+        pass
+
+
+def _make_cfg(sender, target, port):
+    cfg = (
+        "[DEFAULT]\n"
+        "ConnectionType=initiator\n"
+        "HeartBtInt=30\n"
+        f"SenderCompID={sender}\n"
+        f"TargetCompID={target}\n"
+        "ResetOnLogon=Y\n"
+        "ResetOnDisconnect=Y\n"
+        "\n"
+        "[SESSION]\n"
+        "BeginString=FIX.4.4\n"
+        "SocketConnectHost=127.0.0.1\n"
+        f"SocketConnectPort={port}\n"
+    )
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".cfg", delete=False)
+    f.write(cfg)
+    f.close()
+    return f.name
+
+
+@given("a FIX 4.4 session with sender {sender} and target {target}")
+def step_session_config(context, sender, target):
+    context.sender = sender
+    context.target = target
 
 
 @when("the harness connects and sends Logon")
 def step_send_logon(context):
-    pass
+    cfg_path = _make_cfg(context.sender, context.target, FIX_PORT)
+    settings = fix.SessionSettings(cfg_path)
+    context.app = HarnessApp()
+    store = fix.MemoryStoreFactory(settings)
+    log = fix.ScreenLogFactory(settings)
+    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
+    context.initiator.start()
 
 
 @then("the engine replies with Logon")

--- a/tools/fix-harness/run.sh
+++ b/tools/fix-harness/run.sh
@@ -7,7 +7,7 @@ HARNESS_DIR="$REPO_ROOT/tools/fix-harness"
 
 podman build -t fix-harness "$HARNESS_DIR"
 
-FIX_PORT=$FIX_PORT cargo run -p nexus-fix-engine --example blocking_session &
+FIX_PORT=$FIX_PORT cargo run -p nexus-fix-harness &
 ENGINE_PID=$!
 trap "kill $ENGINE_PID 2>/dev/null || true" EXIT
 


### PR DESCRIPTION
Adds nexus-fix-harness as a standalone binary crate. Replaces the harness mode in blocking_session (which leaked an acceptor_{n} tmp dir per connection) with a server that resets a single journal dir between sessions.

- New nexus-fix-harness workspace crate with accept loop
- Journal dir wiped and recreated per connection so each Behave scenario starts with fresh sequence numbers
- run.sh updated to cargo run -p nexus-fix-harness

Part of #578.