### PR TITLE
fix(fix-engine): reject lying BodyLength as Garbage in try_parse

### DIFF
--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -283,6 +283,10 @@ impl FrameReader {
             return ParseResult::Incomplete;
         }
 
+        if !data[message_end - CHECKSUM_LEN..message_end].starts_with(b"10=") {
+            return ParseResult::Garbage;
+        }
+
         if validate_checksum(&data[..message_end]).is_err() {
             return ParseResult::Garbage;
         }
@@ -807,6 +811,24 @@ mod tests {
 
         let frame = reader.next().unwrap().unwrap();
         assert_eq!(frame, msg.as_slice());
+    }
+
+    #[test]
+    fn garbage_lying_body_length() {
+        // BodyLength=5 but real body is longer; message_end lands before 10=.
+        let lying = b"8=FIX.4.4\x019=5\x0135=0\x0149=S\x0156=T\x0110=123\x01";
+        let valid = heartbeat();
+        let mut data = lying.to_vec();
+        data.extend_from_slice(&valid);
+
+        let mut reader = FrameReader::builder().build();
+        reader.read(&data).unwrap();
+
+        let err = reader.next().unwrap_err();
+        assert!(matches!(err, FrameError::Garbage { .. }));
+
+        let frame = reader.next().unwrap().unwrap();
+        assert_eq!(frame, valid.as_slice());
     }
 
     // ---- message too large ----


### PR DESCRIPTION
Fixes #585.

`try_parse` computed `message_end = body_start + body_len + CHECKSUM_LEN` and passed `&data[..message_end]` to `validate_checksum`. When `BodyLength` under-declares the body, `message_end` lands inside the real body, before the `10=` trailer. `validate_checksum` finds no tag 10 and returns `Ok(())` (the latent `map_or(Ok(()), ...)` hole), so `try_parse` yields `ParseResult::Complete` for a truncated frame. The frame is dispatched, has no `MsgSeqNum(34)`, and `transport.rs` returns `Err(MissingMsgSeqNum)`, dropping the session.

Fix: check `data[message_end - CHECKSUM_LEN..message_end].starts_with(b"10=")` before calling `validate_checksum`. A lying BodyLength places `message_end` before the real checksum tag, so this guard returns `ParseResult::Garbage` and the transport resyncs.

Also adds `frame::tests::garbage_lying_body_length`: send a lying-BodyLength frame followed by a valid message, assert Garbage then correct parse.

The `map_or(Ok(()), ...)` hole in `validate_checksum` is left for a follow-up (refs #585).
