### PR TITLE
fix(fix-engine): surface Event::Disconnected for all admin message arms

### DIFF
--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -415,6 +415,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
                 }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
+                }
                 let msg = D::Heartbeat::decode(frame)
                     .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 Ok(Some(Message::Heartbeat { msg }))
@@ -428,6 +431,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
                 }
                 let msg = D::TestRequest::decode(frame)
                     .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
@@ -446,6 +452,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
                 }
                 if let Some(Event::ResendRange { begin: rb, end: re }) = out.event() {
                     let re = if re == 0 {
@@ -480,6 +489,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
                 }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
+                }
                 let msg = D::SequenceReset::decode(frame)
                     .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 Ok(Some(Message::SequenceReset { msg }))
@@ -494,6 +506,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 }
                 if !self.writer.is_empty() {
                     self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(Some(Message::Disconnected { reason }));
                 }
                 let msg = D::Reject::decode(frame)
                     .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;


### PR DESCRIPTION
Fixes #584.

`FixConnection::recv` dispatched by message type and checked `out.event()` for `Event::Disconnected` in the Logon, Logout, and App arms -- but not in the Heartbeat, TestRequest, ResendRequest, SequenceReset, or Reject arms. When `validate_seq` triggers a teardown on one of those message types (e.g. a Heartbeat with a stale seqnum setting `state = Disconnected, reason = SeqNumTooLow`), the arm flushed the outbound Logout and then returned the message variant instead of `Message::Disconnected`. The session was internally dead but the socket stayed open; subsequent `recv` calls spun against a dead session.

Fix: add the same `Event::Disconnected` early-return to the five missing arms, matching the pattern already used in Logon/Logout/App.
