### PR TITLE
feat(fix-harness): E5 stale-seqnum coverage for TestRequest/ResendRequest/SequenceReset/Reject

### DIFF
--- a/tools/fix-harness/features/adversarial.feature
+++ b/tools/fix-harness/features/adversarial.feature
@@ -33,6 +33,30 @@ Feature: FIX session adversarial input
     And the peer sends a Heartbeat with seqnum 1
     Then the engine closes the connection
 
+  Scenario: TestRequest with duplicate seqnum is rejected (E5)
+    Given a raw FIX 4.4 peer connects to the harness
+    When the peer performs a Logon handshake
+    And the peer sends a TestRequest with seqnum 1
+    Then the engine closes the connection
+
+  Scenario: ResendRequest with duplicate seqnum is rejected (E5)
+    Given a raw FIX 4.4 peer connects to the harness
+    When the peer performs a Logon handshake
+    And the peer sends a ResendRequest with seqnum 1
+    Then the engine closes the connection
+
+  Scenario: SequenceReset with duplicate seqnum is rejected (E5)
+    Given a raw FIX 4.4 peer connects to the harness
+    When the peer performs a Logon handshake
+    And the peer sends a SequenceReset with seqnum 1
+    Then the engine closes the connection
+
+  Scenario: Reject with duplicate seqnum is rejected (E5)
+    Given a raw FIX 4.4 peer connects to the harness
+    When the peer performs a Logon handshake
+    And the peer sends a Reject with seqnum 1
+    Then the engine closes the connection
+
   Scenario: unbounded ResendRequest is clamped, not crashed (E2)
     Given a raw FIX 4.4 peer connects to the harness
     When the peer performs a Logon handshake

--- a/tools/fix-harness/features/steps/adversarial_steps.py
+++ b/tools/fix-harness/features/steps/adversarial_steps.py
@@ -136,6 +136,26 @@ def step_raw_explicit_seq(context, n):
     context.raw_peer.send("0", seq=n)
 
 
+@when("the peer sends a TestRequest with seqnum {n:d}")
+def step_raw_test_request_seq(context, n):
+    context.raw_peer.send("1", [(112, "PROBE")], seq=n)
+
+
+@when("the peer sends a ResendRequest with seqnum {n:d}")
+def step_raw_resend_request_seq(context, n):
+    context.raw_peer.send("2", [(7, "1"), (16, "2")], seq=n)
+
+
+@when("the peer sends a SequenceReset with seqnum {n:d}")
+def step_raw_sequence_reset_seq(context, n):
+    context.raw_peer.send("4", [(36, "10")], seq=n)
+
+
+@when("the peer sends a Reject with seqnum {n:d}")
+def step_raw_reject_seq(context, n):
+    context.raw_peer.send("3", [(45, "1")], seq=n)
+
+
 @when("the peer sends a ResendRequest with EndSeqNo {n:d}")
 def step_raw_resend_request(context, n):
     context.raw_peer.send("2", [(7, "1"), (16, str(n))])


### PR DESCRIPTION
Depends on #587 and #588.

#588 fixed `Event::Disconnected` propagation for five arms: Heartbeat, TestRequest, ResendRequest, SequenceReset, Reject. The existing E5 scenarios only covered the Heartbeat arm. This adds the missing four: each sends the respective message type at seqnum=1 (duplicate, after logon) and asserts the engine closes the connection.

New step definitions: `the peer sends a TestRequest/ResendRequest/SequenceReset/Reject with seqnum {n}` -- all pass `seq=` explicitly so `_seq` is not incremented, consistent with the existing E5 steps.
