### PR TITLE
fix(fix-engine): persist next_inbound across restart

### DIFF
--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -3,6 +3,29 @@ use std::path::Path;
 use nexus_fix_codec::{find_tag, parse_fix_seqnum};
 use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
 
+const INBOUND_MARKER: &[u8] = b"NI=";
+
+fn encode_inbound_checkpoint(seq: u32, buf: &mut [u8; 13]) -> usize {
+    buf[0] = b'N';
+    buf[1] = b'I';
+    buf[2] = b'=';
+    if seq == 0 {
+        buf[3] = b'0';
+        return 4;
+    }
+    let mut tmp = [0u8; 10];
+    let mut len = 0;
+    let mut n = seq;
+    while n > 0 {
+        tmp[len] = b'0' + (n % 10) as u8;
+        len += 1;
+        n /= 10;
+    }
+    tmp[..len].reverse();
+    buf[3..3 + len].copy_from_slice(&tmp[..len]);
+    3 + len
+}
+
 enum ResendPlan<'a> {
     Replay(Frame<'a>),
     GapFill,
@@ -108,9 +131,14 @@ impl FixJournal {
     fn recover_from_journal(&mut self) {
         let mut pos = self.journal.read_start();
         let mut last_seq: Option<u32> = None;
+        let mut last_inbound: Option<u32> = None;
         while let Some(frame) = self.journal.read_next(&mut pos) {
             let p = frame.payload();
-            if let Some(span) = find_tag(p, 0, 34)
+            if let Some(rest) = p.strip_prefix(INBOUND_MARKER) {
+                if let Some(n) = std::str::from_utf8(rest).ok().and_then(|s| s.parse().ok()) {
+                    last_inbound = Some(n);
+                }
+            } else if let Some(span) = find_tag(p, 0, 34)
                 && let Ok(seq) = parse_fix_seqnum(span.slice(p))
             {
                 last_seq = Some(seq as u32);
@@ -118,6 +146,9 @@ impl FixJournal {
         }
         if let Some(seq) = last_seq {
             self.next_outbound = seq.wrapping_add(1);
+        }
+        if let Some(n) = last_inbound {
+            self.next_inbound = n;
         }
     }
 
@@ -175,11 +206,17 @@ impl FixJournal {
     }
 
     pub fn advance_inbound(&mut self) {
-        self.next_inbound = self.next_inbound.wrapping_add(1);
+        self.set_next_inbound(self.next_inbound.wrapping_add(1));
     }
 
     pub fn set_next_inbound(&mut self, seq: u32) {
+        if seq == self.next_inbound {
+            return;
+        }
         self.next_inbound = seq;
+        let mut buf = [0u8; 13];
+        let len = encode_inbound_checkpoint(seq, &mut buf);
+        let _ = self.journal.append(&buf[..len]);
     }
 }
 
@@ -250,6 +287,26 @@ mod tests {
 
         let j = FixJournal::open(&dir, 0, 64).unwrap();
         assert_eq!(j.next_outbound(), 8);
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn open_recovers_next_inbound() {
+        let dir = tmp_dir("recover-inbound");
+        cleanup(&dir);
+
+        {
+            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            j.store(1, &fix_msg(1)).unwrap();
+            j.advance_inbound();
+            j.advance_inbound();
+            j.set_next_inbound(42);
+        }
+
+        let j = FixJournal::open(&dir, 0, 64).unwrap();
+        assert_eq!(j.next_inbound(), 42);
+        assert_eq!(j.next_outbound(), 2);
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -251,6 +251,11 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     }
 
     pub fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        let n = self.state.next_inbound_seq();
+        if n != self.journal.next_inbound() {
+            self.journal.set_next_inbound(n);
+        }
+
         loop {
             if self.reader.inner.should_compact() {
                 self.reader.inner.compact();


### PR DESCRIPTION
Closes #577.

`FixJournal` journaled outbound only. `next_inbound` reset to 1 on every restart because neither `advance_inbound` nor `set_next_inbound` wrote anything to disk, and `recover_from_journal` never read it back.

Two changes:

`persist.rs` -- `set_next_inbound` now appends a compact `NI={seq}` checkpoint record to the journal (no-op when the value is unchanged). `advance_inbound` delegates through it. `recover_from_journal` scans for these records alongside the existing outbound-seqnum scan, taking the last value found. The sentinel prefix `NI=` is unambiguous -- all real FIX messages start with `8=`.

`transport.rs` -- `recv` syncs `journal.set_next_inbound(state.next_inbound_seq())` at its top, before the read loop. This is deferred-by-one: the previous dispatch's advancement is checkpointed at the start of the next call. After a crash the engine is at most one message behind; the peer resends on reconnect, which FIX already handles.

Test: `open_recovers_next_inbound` in `persist::tests` -- advances inbound, reopens the journal, asserts the value survives.