### PR TITLE
fix(fix-harness): MemoryStoreFactory takes no args in quickfix 1.15.1

### DIFF
--- a/tools/fix-harness/features/steps/session_steps.py
+++ b/tools/fix-harness/features/steps/session_steps.py
@@ -78,7 +78,7 @@ def _start_initiator(context):
     cfg_path = _make_cfg(context.sender, context.target, FIX_PORT)
     settings = fix.SessionSettings(cfg_path)
     context.app = HarnessApp()
-    store = fix.MemoryStoreFactory(settings)
+    store = fix.MemoryStoreFactory()
     log = fix.ScreenLogFactory(settings)
     context.initiator = fix.SocketInitiator(context.app, store, log, settings)
     context.initiator.start()


### PR DESCRIPTION
Closes #586.

Drop the settings argument from MemoryStoreFactory(). The in-memory store is not settings-driven; only the persistent factories (FileStoreFactory) take a settings object. quickfix 1.15.1 enforces this -- the zeroth constructor arg is self, so passing settings raises TypeError.