### PR TITLE
feat(journal): open_existing -- error instead of silently creating a fresh session

### DIFF
--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -105,6 +105,33 @@ impl FixJournal {
         Ok(this)
     }
 
+    /// Open an existing session journal, returning [`OpenError::SessionNotFound`]
+    /// when no manifest exists for `session_id`.
+    ///
+    /// Unlike [`open`](Self::open) this never creates a new session. Use for
+    /// reconnect callers that must recover state — a wrong `session_id` is an
+    /// error rather than a silent fresh start.
+    pub fn open_existing(
+        dir: impl AsRef<Path>,
+        session_id: u32,
+        window: usize,
+    ) -> Result<Self, OpenError> {
+        assert!(window.is_power_of_two());
+        let mut conductor = Conductor::open(dir)?;
+        let journal: RotatingJournal =
+            conductor.session().session_id(session_id).open_existing()?;
+        let mut this = Self {
+            journal,
+            _conductor: conductor,
+            offsets: vec![None; window].into_boxed_slice(),
+            window,
+            next_outbound: 1,
+            next_inbound: 1,
+        };
+        this.recover_from_journal();
+        Ok(this)
+    }
+
     fn recover_from_journal(&mut self) {
         let mut pos = self.journal.read_start();
         let mut last_seq: Option<u32> = None;
@@ -214,6 +241,49 @@ mod tests {
 
     fn collect_range(j: &FixJournal, begin: u32, end: u32) -> Vec<ReplayItem<'_>> {
         j.resend(begin, end).collect()
+    }
+
+    #[test]
+    fn open_existing_missing_returns_not_found() {
+        let dir = tmp_dir("oe-missing");
+        cleanup(&dir);
+        let result = FixJournal::open_existing(&dir, 0, 64);
+        assert!(
+            matches!(result, Err(OpenError::SessionNotFound { .. })),
+            "expected SessionNotFound"
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn open_existing_wrong_id_returns_not_found() {
+        let dir = tmp_dir("oe-wrongid");
+        cleanup(&dir);
+        {
+            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            j.store(1, &fix_msg(1)).unwrap();
+        }
+        let result = FixJournal::open_existing(&dir, 1, 64);
+        assert!(
+            matches!(result, Err(OpenError::SessionNotFound { .. })),
+            "expected SessionNotFound for wrong id"
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn open_existing_recovers_correct_session() {
+        let dir = tmp_dir("oe-recover");
+        cleanup(&dir);
+        {
+            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            for seq in 1..=3u32 {
+                j.store(seq, &fix_msg(seq)).unwrap();
+            }
+        }
+        let j = FixJournal::open_existing(&dir, 0, 64).unwrap();
+        assert_eq!(j.next_outbound(), 4);
+        cleanup(&dir);
     }
 
     #[test]

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -126,6 +126,26 @@ impl<'a> RotatingJournalBuilder<'a> {
         self.open_inner(true)
     }
 
+    /// Open an existing session log.
+    ///
+    /// Returns [`OpenError::SessionNotFound`] when no manifest exists for
+    /// the requested `session_id`. Unlike [`open`](Self::open), this never
+    /// creates a new session — a wrong or typo'd id is an error, not a silent
+    /// fresh start that drops all replay state.
+    ///
+    /// Requires [`session_id`](Self::session_id) to have been set; without it
+    /// the call returns `SessionNotFound { session_id: 0 }`.
+    pub fn open_existing(self) -> Result<RotatingJournal, OpenError> {
+        let id = self
+            .session_id
+            .ok_or(OpenError::SessionNotFound { session_id: 0 })?;
+        let session_dir = self.conductor.dir().join(id.to_string());
+        if !manifest_path(&session_dir).exists() {
+            return Err(OpenError::SessionNotFound { session_id: id });
+        }
+        self.open_inner(false)
+    }
+
     fn open_inner(self, strict: bool) -> Result<RotatingJournal, OpenError> {
         let id = match self.session_id {
             Some(id) => {

--- a/nexus-journal/src/rotating/tests.rs
+++ b/nexus-journal/src/rotating/tests.rs
@@ -1215,3 +1215,44 @@ fn session_id_mismatch_on_corrupted_directory() {
         })
     ));
 }
+
+#[test]
+fn open_existing_missing_session_returns_not_found() {
+    let d = TempDir::new("oe-missing");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let result = c.session().session_id(99).open_existing();
+    assert!(
+        matches!(result, Err(OpenError::SessionNotFound { session_id: 99 })),
+        "expected SessionNotFound(99)"
+    );
+}
+
+#[test]
+fn open_existing_wrong_id_returns_not_found() {
+    let d = TempDir::new("oe-wrongid");
+    let mut c = Conductor::open(d.path()).unwrap();
+    // Create session 1
+    let _log = open_id(&mut c, 1 << 16, 1);
+    drop(_log);
+    // Reopen conductor; session 2 doesn't exist
+    let mut c2 = Conductor::open(d.path()).unwrap();
+    let result = c2.session().session_id(2).open_existing();
+    assert!(
+        matches!(result, Err(OpenError::SessionNotFound { session_id: 2 })),
+        "expected SessionNotFound(2)"
+    );
+}
+
+#[test]
+fn open_existing_recovers_existing_session() {
+    let d = TempDir::new("oe-recover");
+    let mut c = Conductor::open(d.path()).unwrap();
+    {
+        let mut log = open_id(&mut c, 1 << 16, 5);
+        log.append(b"hello").unwrap();
+    }
+    let mut c2 = Conductor::open(d.path()).unwrap();
+    let log = c2.session().session_id(5).open_existing().unwrap();
+    let mut pos = log.read_start();
+    assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"hello");
+}


### PR DESCRIPTION
Closes #576.

`RotatingJournalBuilder::open` (and `FixJournal::open`) is open-or-create: a wrong session_id silently starts a fresh journal and drops all replay state. `open_strict` doesn't help -- it only guards against a structural config mismatch when a manifest already exists; an absent manifest still creates fresh either way.

New `open_existing` method on `RotatingJournalBuilder` checks whether the manifest exists before creating directories or acquiring the session lock, and returns `OpenError::SessionNotFound { session_id }` if it doesn't. The happy path falls through to the same `open_inner(false)` as `open`. `FixJournal::open_existing` mirrors it.

Tests:
- typo id on an empty directory: `SessionNotFound`
- wrong id when another session exists: `SessionNotFound`
- correct id: recovers and reads back previously written data
- all three at both the `nexus-journal` and `nexus-fix-engine` layers