### PR TITLE
FIX stack hardening: OpenMode, strict checksum, reframe headroom, CI-gated harness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,6 +127,28 @@ jobs:
     - name: Async FIX conformance tests (Python peer + tokio adapter)
       run: cargo test -p nexus-async-fix-engine --test async_conformance
 
+  verify-fix-harness:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.94.0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install harness dependencies (behave + quickfix)
+      run: pip install -r tools/fix-harness/requirements.txt
+    - name: Build harness server
+      run: cargo build -p nexus-fix-harness
+    - name: Run FIX conformance harness (behave)
+      run: |
+        FIX_PORT=9878 cargo run -q -p nexus-fix-harness &
+        trap 'kill %1 2>/dev/null || true' EXIT
+        for _ in $(seq 1 80); do
+          (exec 3<>/dev/tcp/127.0.0.1/9878) 2>/dev/null && { exec 3>&-; break; }
+          sleep 0.25
+        done
+        FIX_PORT=9878 behave tools/fix-harness/features
+
   loom:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,7 +139,7 @@ jobs:
       run: pip install -r tools/fix-harness/requirements.txt
     - name: Build harness server
       run: cargo build -p nexus-fix-harness
-    - name: Run FIX conformance harness (behave)
+    - name: Run adversarial FIX harness (behave)
       run: |
         FIX_PORT=9878 cargo run -q -p nexus-fix-harness &
         trap 'kill %1 2>/dev/null || true' EXIT
@@ -147,7 +147,11 @@ jobs:
           (exec 3<>/dev/tcp/127.0.0.1/9878) 2>/dev/null && { exec 3>&-; break; }
           sleep 0.25
         done
-        FIX_PORT=9878 behave tools/fix-harness/features
+        # Only the adversarial feature is gated: it drives the engine over raw
+        # sockets, so it is deterministic and exits cleanly. session.feature uses
+        # the quickfix client, which segfaults on interpreter shutdown (exit 139)
+        # even when every scenario passes; it stays a local-only smoke test.
+        FIX_PORT=9878 behave tools/fix-harness/features/adversarial.feature
 
   loom:
     runs-on: ubuntu-latest

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -15,7 +15,7 @@ use nexus_fix_codec::{
 };
 use nexus_fix_engine::{
     AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
-    Out, ReplayItem, SessionConfig, SessionError, SessionState, State,
+    Out, REFRAME_HEADROOM, ReplayItem, SessionConfig, SessionError, SessionState, State,
 };
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout_at;
@@ -182,6 +182,12 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
     /// Stores the frame in the journal and writes it to the stream.
     pub async fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        // Every outbound frame must fit the pre-allocated writer, with headroom
+        // for a later resend reframe. Size the buffer up front for larger
+        // messages; see the sync `FixConnection::send_app`.
+        if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
+            return Err(Error::FrameTooLarge(frame.len()));
+        }
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
@@ -425,15 +431,14 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         if self.writer.remaining() < frame.len() {
             self.flush_writer().await?;
         }
-        if self.writer.remaining() >= frame.len() {
-            let spare = self.writer.spare();
-            spare[..frame.len()].copy_from_slice(frame);
-            self.writer.commit(0, frame.len());
-        } else {
-            self.stream.write_all(frame).await?;
-            self.stream.flush().await?;
-            return Ok(());
+        if self.writer.remaining() < frame.len() {
+            // Exceeds the pre-allocated buffer even when empty; `send_app` caps
+            // app frames below this, so this is an undersized-buffer config error.
+            return Err(Error::FrameTooLarge(frame.len()));
         }
+        let spare = self.writer.spare();
+        spare[..frame.len()].copy_from_slice(frame);
+        self.writer.commit(0, frame.len());
         self.flush_writer().await
     }
 

--- a/nexus-fix-codec/src/error.rs
+++ b/nexus-fix-codec/src/error.rs
@@ -51,18 +51,23 @@ impl From<ChecksumError> for DecodeError {
 
 /// Checksum validation failure.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ChecksumError {
-    pub expected: u8,
-    pub computed: u8,
+pub enum ChecksumError {
+    /// A CheckSum (tag 10) is present but its value does not match the checksum
+    /// computed over the message body. A present-but-malformed CheckSum (not
+    /// exactly three digits) also reports here, with `expected` as a placeholder.
+    Mismatch { expected: u8, computed: u8 },
+    /// No CheckSum (tag 10) field is present where one is required.
+    Missing,
 }
 
 impl fmt::Display for ChecksumError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "expected {:03}, computed {:03}",
-            self.expected, self.computed
-        )
+        match self {
+            Self::Mismatch { expected, computed } => {
+                write!(f, "expected {expected:03}, computed {computed:03}")
+            }
+            Self::Missing => f.write_str("CheckSum (tag 10) missing"),
+        }
     }
 }
 
@@ -151,7 +156,7 @@ mod tests {
 
     #[test]
     fn checksum_error_display() {
-        let e = ChecksumError {
+        let e = ChecksumError::Mismatch {
             expected: 178,
             computed: 42,
         };
@@ -160,7 +165,7 @@ mod tests {
 
     #[test]
     fn decode_error_from_checksum() {
-        let ce = ChecksumError {
+        let ce = ChecksumError::Mismatch {
             expected: 1,
             computed: 2,
         };
@@ -184,7 +189,7 @@ mod tests {
             DecodeError::MissingBodyLength.to_string(),
             "missing or misplaced BodyLength (tag 9)"
         );
-        let ce = ChecksumError {
+        let ce = ChecksumError::Mismatch {
             expected: 178,
             computed: 42,
         };
@@ -206,7 +211,7 @@ mod tests {
         assert!(DecodeError::MissingSeparator.source().is_none());
         assert!(DecodeError::InvalidTag.source().is_none());
 
-        let ce = ChecksumError {
+        let ce = ChecksumError::Mismatch {
             expected: 1,
             computed: 2,
         };

--- a/nexus-fix-codec/src/reader.rs
+++ b/nexus-fix-codec/src/reader.rs
@@ -143,16 +143,7 @@ impl<'a> FieldReader<'a> {
     pub fn verify_checksum(&self, checksum_span: FieldSpan) -> Result<(), ChecksumError> {
         let body_end = (checksum_span.offset as usize).saturating_sub(3);
         let computed = checksum(&self.buf[..body_end.min(self.buf.len())]);
-        match parse_checksum_bytes(checksum_span.slice(self.buf)) {
-            Some(expected) if expected == computed => Ok(()),
-            Some(expected) => Err(ChecksumError { expected, computed }),
-            // Malformed CheckSum field (not three digits): reject regardless of
-            // `computed`. `expected` is a placeholder — there is no valid value.
-            None => Err(ChecksumError {
-                expected: 0,
-                computed,
-            }),
-        }
+        compare_checksum(computed, checksum_span.slice(self.buf))
     }
 
     /// Parse the next `tag=value\x01` field.
@@ -277,23 +268,43 @@ pub fn find_tag(buf: &[u8], start: usize, tag: u32) -> Option<FieldSpan> {
 
 /// Validate a FIX message checksum against tag 10.
 ///
-/// Scans for the tag 10 (`CheckSum`) field, then verifies via a single
-/// contiguous checksum pass over the preceding bytes.
+/// The `CheckSum` (tag 10) is always the final field of a FIX message, exactly
+/// `10=DDD\x01` (seven bytes). It is located positionally from the end rather
+/// than by scanning fields: a DATA field value can contain embedded SOH bytes
+/// that a plain SOH scan would mis-split, so a scan could miss tag 10 entirely.
 ///
-/// Returns `Ok(())` if valid, `Err(ChecksumError)` on mismatch.
-/// Returns `Ok(())` if tag 10 is absent (nothing to validate
-/// against — structural validation is the decoder's job).
+/// Returns `Ok(())` if valid, [`Err(ChecksumError::Mismatch)`](ChecksumError::Mismatch)
+/// on a wrong value, and [`Err(ChecksumError::Missing)`](ChecksumError::Missing)
+/// when the message does not end in a well-formed CheckSum field. A message with
+/// no CheckSum is malformed, not implicitly valid — treating absence as `Ok`
+/// would let a truncated or checksumless frame pass verification.
 pub fn validate_checksum(msg: &[u8]) -> Result<(), ChecksumError> {
-    let mut parser = FieldReader::new(msg, 0);
-    let mut expected_span = None;
-
-    while let Some(field) = parser.next_field() {
-        if field.tag == 10 {
-            expected_span = Some(field.value);
-        }
+    const CHECKSUM_FIELD_LEN: usize = 7; // "10=" + three digits + SOH
+    if msg.len() < CHECKSUM_FIELD_LEN {
+        return Err(ChecksumError::Missing);
     }
+    let field_start = msg.len() - CHECKSUM_FIELD_LEN;
+    if &msg[field_start..field_start + 3] != b"10=" || msg[msg.len() - 1] != b'\x01' {
+        return Err(ChecksumError::Missing);
+    }
+    let computed = checksum(&msg[..field_start]);
+    compare_checksum(computed, &msg[field_start + 3..msg.len() - 1])
+}
 
-    expected_span.map_or(Ok(()), |span| parser.verify_checksum(span))
+/// Compare a computed checksum against the raw CheckSum(10) value bytes.
+///
+/// A malformed CheckSum (not exactly three digits) is rejected regardless of
+/// `computed`; the `expected` in the returned error is then a placeholder, as
+/// there is no valid value to report.
+fn compare_checksum(computed: u8, digits: &[u8]) -> Result<(), ChecksumError> {
+    match parse_checksum_bytes(digits) {
+        Some(expected) if expected == computed => Ok(()),
+        Some(expected) => Err(ChecksumError::Mismatch { expected, computed }),
+        None => Err(ChecksumError::Mismatch {
+            expected: 0,
+            computed,
+        }),
+    }
 }
 
 /// Parse a FIX CheckSum (tag 10) value: exactly three ASCII digits.
@@ -813,16 +824,17 @@ mod tests {
     fn validate_checksum_invalid() {
         let msg = b"8=FIX.4.4\x0135=D\x0149=SENDER\x0110=000\x01";
         let result = validate_checksum(msg);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.expected, 0);
-        assert_ne!(err.computed, 0);
+        assert!(matches!(
+            result,
+            Err(ChecksumError::Mismatch { expected: 0, computed }) if computed != 0
+        ));
     }
 
     #[test]
     fn validate_checksum_no_tag10() {
+        // A message with no CheckSum(10) is malformed, not implicitly valid.
         let msg = b"8=FIX.4.4\x0135=D\x01";
-        assert!(validate_checksum(msg).is_ok());
+        assert_eq!(validate_checksum(msg), Err(ChecksumError::Missing));
     }
 
     #[test]
@@ -833,6 +845,39 @@ mod tests {
         let mut msg = body.to_vec();
         msg.extend_from_slice(format!("10={:03}\x01", sum).as_bytes());
         assert!(validate_checksum(&msg).is_ok());
+    }
+
+    #[test]
+    fn validate_checksum_data_field_embedded_soh() {
+        // A DATA field value can contain SOH bytes (here RawData `x\x01y`). The
+        // CheckSum must still validate — it is located positionally, not by an
+        // SOH scan that would mis-split the value and miss tag 10 entirely.
+        let body = b"8=FIX.4.4\x019=20\x0135=D\x0195=3\x0196=x\x01y\x01";
+        let sum = checksum(body);
+        let mut msg = body.to_vec();
+        msg.extend_from_slice(format!("10={sum:03}\x01").as_bytes());
+        assert!(validate_checksum(&msg).is_ok());
+    }
+
+    #[test]
+    fn validate_checksum_too_short() {
+        assert_eq!(validate_checksum(b""), Err(ChecksumError::Missing));
+        assert_eq!(validate_checksum(b"10="), Err(ChecksumError::Missing));
+    }
+
+    #[test]
+    fn validate_checksum_present_but_empty() {
+        // `10=\x01` has no digits — not a well-formed trailing CheckSum field.
+        let msg = b"8=FIX.4.4\x0135=D\x0110=\x01";
+        assert_eq!(validate_checksum(msg), Err(ChecksumError::Missing));
+    }
+
+    #[test]
+    fn validate_checksum_tag10_not_last() {
+        // A field follows the CheckSum, so tag 10 is not the final field and the
+        // trailing bytes are not `10=DDD\x01` — validation must reject it.
+        let msg = b"8=FIX.4.4\x0110=123\x0158=X\x01";
+        assert_eq!(validate_checksum(msg), Err(ChecksumError::Missing));
     }
 
     #[test]

--- a/nexus-fix-codec/src/writer.rs
+++ b/nexus-fix-codec/src/writer.rs
@@ -633,6 +633,26 @@ mod tests {
     }
 
     #[test]
+    fn frame_formatter_checksum_is_last_field() {
+        // The CheckSum (tag 10) must always be the final field — the invariant
+        // `validate_checksum`'s positional lookup relies on.
+        let mut buf = [0u8; 1024];
+        let mut f = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
+        f.field(49, b"SENDER");
+        f.field(56, b"TARGET");
+        f.field(34, b"1");
+        let (start, len) = f.finish().unwrap();
+        let msg = &buf[start..start + len];
+
+        // The trailing bytes are exactly `10=DDD\x01`, and our own reader agrees
+        // the final field is tag 10.
+        assert_eq!(&msg[len - 7..len - 4], b"10=");
+        assert_eq!(msg[len - 1], b'\x01');
+        assert_eq!(crate::FieldReader::new(msg, 0).last().unwrap().tag, 10);
+        assert!(crate::validate_checksum(msg).is_ok());
+    }
+
+    #[test]
     fn frame_buffer_full_no_panic() {
         // Too small even for the prefix — must error, never panic.
         let mut buf = [0u8; 8];

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -435,6 +435,10 @@ fn alpha_checksum_invalid() {
 
 #[test]
 fn alpha_checksum_absent_is_ok() {
+    // `decode` is a field extractor: a bare message body with no CheckSum(10) has
+    // nothing to verify and is accepted. (The frame layer's `validate_checksum`
+    // is the strict gate for complete frames; see the codegen note in
+    // `emit/messages.rs`.)
     let msg = b"8=FIX.4.4\x0135=0\x01112=HB\x01";
     let m = venue_alpha::messages::Heartbeat::decode(msg).unwrap();
     assert_eq!(m.test_req_id().unwrap().as_bytes(), &b"HB"[..]);

--- a/nexus-fix-codegen/src/emit/header.rs
+++ b/nexus-fix-codegen/src/emit/header.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use super::{HEADER, RField, emit_value_accessor, snake};
+use super::{EmitError, HEADER, RField, emit_value_accessor, snake};
 
 /// Tag numbers that are always scanned by the header decoder regardless of
 /// what the dictionary's `<header>` section declares.  These are protocol-
@@ -17,7 +17,7 @@ const SESSION_TAGS: &[u32] = &[
     52, // SendingTime
 ];
 
-pub fn emit(header_fields: &[RField]) -> String {
+pub fn emit(header_fields: &[RField]) -> Result<String, EmitError> {
     let mut s = String::new();
     s.push_str(HEADER);
 
@@ -45,11 +45,11 @@ pub fn emit(header_fields: &[RField]) -> String {
 
     emit_struct(&mut s, &ordered);
     emit_decode(&mut s, &ordered);
-    emit_fix_header_impl(&mut s, &ordered);
+    emit_fix_header_impl(&mut s, &ordered)?;
     emit_msg_type_accessor(&mut s);
     emit_accessors(&mut s, &ordered);
 
-    s
+    Ok(s)
 }
 
 /// Synthesise RField entries for session tags that the dictionary didn't declare.
@@ -136,7 +136,7 @@ fn emit_decode(s: &mut String, fields: &[&RField]) {
     s.push_str("}\n\n");
 }
 
-fn emit_fix_header_impl(s: &mut String, fields: &[&RField]) {
+fn emit_fix_header_impl(s: &mut String, fields: &[&RField]) -> Result<(), EmitError> {
     s.push_str("impl<'buf> nexus_fix_codec::FixHeader<'buf> for HeaderDecoder<'buf> {\n");
     s.push_str("    fn decode(buf: &'buf [u8]) -> Self {\n");
     s.push_str("        Self::decode(buf)\n");
@@ -152,10 +152,10 @@ fn emit_fix_header_impl(s: &mut String, fields: &[&RField]) {
     ];
 
     for &(method, tag, ty) in trait_methods {
-        let field_name = fields.iter().find(|f| f.number == tag).map_or_else(
-            || panic!("session tag {tag} missing from header fields"),
-            |f| snake(&f.name),
-        );
+        let field_name = match fields.iter().find(|f| f.number == tag) {
+            Some(f) => snake(&f.name),
+            None => return Err(EmitError::MissingSessionTag(tag)),
+        };
         let _ = write!(
             s,
             "    fn {method}(&self) -> Option<nexus_fix_codec::FieldView<'buf, {ty}>> {{\n        \
@@ -164,6 +164,7 @@ fn emit_fix_header_impl(s: &mut String, fields: &[&RField]) {
         );
     }
     s.push_str("}\n\n");
+    Ok(())
 }
 
 fn emit_msg_type_accessor(s: &mut String) {

--- a/nexus-fix-codegen/src/emit/messages.rs
+++ b/nexus-fix-codegen/src/emit/messages.rs
@@ -165,10 +165,13 @@ fn emit_wrap(
     );
     s.push_str(&body);
     // Verify the CheckSum iff tag 10 was *seen* (the span is no longer EMPTY),
-    // not iff it has a non-empty value. A present-but-empty CheckSum (`10=\x01`)
-    // is malformed and must be rejected; gating on `is_present()` (len > 0) would
-    // skip it and accept the message, diverging from `validate_checksum`. The
-    // empty value falls into `verify_checksum`, which rejects it.
+    // not iff it has a non-empty value. `decode` is a field extractor: it accepts
+    // a bare message body with no CheckSum (nothing to verify) but rejects a
+    // present-but-empty CheckSum (`10=\x01`), which has a non-EMPTY span and falls
+    // into `verify_checksum`. This intentionally differs from the frame-layer
+    // `validate_checksum`, which is strict about a trailing CheckSum because it
+    // gates complete frames; in production `decode` only ever sees framed messages
+    // that already carry one.
     s.push_str("        if m.checksum != nexus_fix_codec::FieldSpan::EMPTY {\n");
     s.push_str(
         "            m.header.reader.verify_checksum(m.checksum).map_err(nexus_fix_codec::DecodeError::Checksum)?;\n",

--- a/nexus-fix-codegen/src/emit/mod.rs
+++ b/nexus-fix-codegen/src/emit/mod.rs
@@ -15,6 +15,7 @@ pub enum EmitError {
     UnknownComponent(String),
     EmptyGroup(String),
     DataInGroup(String),
+    MissingSessionTag(u32),
 }
 
 impl fmt::Display for EmitError {
@@ -30,6 +31,9 @@ impl fmt::Display for EmitError {
                     f,
                     "group '{n}' contains a DATA field; not supported in this version"
                 )
+            }
+            Self::MissingSessionTag(tag) => {
+                write!(f, "session tag {tag} missing from header fields")
             }
         }
     }
@@ -102,7 +106,7 @@ pub fn generate(dict: &Dictionary) -> Result<Vec<GeneratedFile>, EmitError> {
         },
         GeneratedFile {
             name: "header.rs".to_string(),
-            source: header::emit(&header_fields),
+            source: header::emit(&header_fields)?,
         },
         GeneratedFile {
             name: "messages.rs".to_string(),

--- a/nexus-fix-codegen/src/lib.rs
+++ b/nexus-fix-codegen/src/lib.rs
@@ -1,3 +1,23 @@
+//! Dictionary-driven code generator for `nexus-fix-codec`.
+//!
+//! Reads a FIX XML dictionary and emits typed, zero-copy decode/encode Rust for
+//! its messages, fields, and repeating groups — named message types, named field
+//! accessors, and typed field enums — built on the hand-written codec primitives
+//! (`FieldReader`, `FrameFormatter`, ...).
+//!
+//! Intended to run from a `build.rs`:
+//!
+//! ```no_run
+//! nexus_fix_codegen::generate()
+//!     .dictionary("dict/fix44.xml")
+//!     .out_dir(std::env::var("OUT_DIR").unwrap())
+//!     .run()
+//!     .expect("FIX codegen failed");
+//! ```
+//!
+//! Multiple dictionaries generate into per-dictionary subdirectories. Errors
+//! surface as [`CodegenError`] (I/O, [`ParseError`], or [`EmitError`]).
+
 mod dict;
 mod emit;
 

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -518,6 +518,12 @@ impl FrameWriter {
     pub fn remaining(&self) -> usize {
         self.0.tailroom()
     }
+
+    /// Total buffer capacity in bytes (fixed at construction).
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }
 
 impl FrameWriterBuilder {

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -190,6 +190,11 @@ impl<D: FixDictionary> MessageWriter<D> {
         self.inner.remaining()
     }
 
+    /// Total buffer capacity in bytes (fixed at construction).
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
     pub fn flush_to<S: Write>(&mut self, stream: &mut S) -> std::io::Result<()> {
         while !self.inner.is_empty() {
             let n = stream.write(self.inner.data())?;

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -25,4 +25,6 @@ pub use framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig
 pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
 #[cfg(unix)]
-pub use transport::{Error as TransportError, FixConnection, FixConnectionBuilder};
+pub use transport::{
+    Error as TransportError, FixConnection, FixConnectionBuilder, REFRAME_HEADROOM,
+};

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use nexus_fix_codec::{find_tag, parse_fix_seqnum};
-use nexus_journal::{Conductor, Frame, LogOffset, OpenError, RotatingJournal, WriteError};
+use nexus_journal::{
+    Conductor, Frame, LogOffset, OpenError, OpenMode, RotatingJournal, WriteError,
+};
 
 const INBOUND_MARKER: &[u8] = b"NI=";
 
@@ -115,7 +117,10 @@ impl FixJournal {
     pub fn open(dir: impl AsRef<Path>, session_id: u32, window: usize) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
         let mut conductor = Conductor::open(dir)?;
-        let journal: RotatingJournal = conductor.session().session_id(session_id).open()?;
+        let journal: RotatingJournal = conductor
+            .session()
+            .session_id(session_id)
+            .open(OpenMode::OpenOrCreate)?;
         let mut this = Self {
             journal,
             _conductor: conductor,
@@ -140,9 +145,16 @@ impl FixJournal {
         window: usize,
     ) -> Result<Self, OpenError> {
         assert!(window.is_power_of_two());
+        // No filesystem side-effects when the journal root does not exist: a
+        // typo'd path must not materialize an empty conductor directory.
+        if !dir.as_ref().exists() {
+            return Err(OpenError::SessionNotFound { session_id });
+        }
         let mut conductor = Conductor::open(dir)?;
-        let journal: RotatingJournal =
-            conductor.session().session_id(session_id).open_existing()?;
+        let journal: RotatingJournal = conductor
+            .session()
+            .session_id(session_id)
+            .open(OpenMode::OpenExisting)?;
         let mut this = Self {
             journal,
             _conductor: conductor,

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -77,6 +77,11 @@ impl Out {
         admin_len: 0,
     };
 
+    /// Push an admin message. Capacity is two — the most any handler emits (a
+    /// reply plus a `Logout`/`ResendRequest` on the too-low-seqnum and gap
+    /// paths). The `debug_assert` catches any future handler that exceeds it in
+    /// tests; in release a third push is dropped rather than panicking on the hot
+    /// path, so the two-message invariant must be upheld by the handlers.
     fn push_admin(&mut self, msg: AdminMsg) {
         debug_assert!((self.admin_len as usize) < 2, "Out admin overflow");
         if (self.admin_len as usize) < 2 {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -38,6 +38,19 @@ impl From<io::Error> for Error {
     }
 }
 
+/// Bytes reserved per app message for a later resend reframe.
+///
+/// A reframe adds `PossDupFlag` (`43=Y`), `OrigSendingTime` (`122=<UTC
+/// timestamp>`), and a little `BodyLength` digit growth. `send_app` keeps app
+/// frames this far below the writer capacity so a stored message always
+/// reframes back into the pre-allocated buffer — no runtime allocation on the
+/// resend path.
+///
+/// Exposed so callers sizing a writer via `writer_capacity(...)` know the
+/// per-message reserve: the largest app frame they can send is
+/// `writer_capacity - REFRAME_HEADROOM`.
+pub const REFRAME_HEADROOM: usize = 64;
+
 pub struct FixConnection<S, D: FixDictionary> {
     stream: S,
     reader: MessageReader<D>,
@@ -233,6 +246,12 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     }
 
     pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        // Every outbound frame must fit the pre-allocated writer, with headroom
+        // for a later resend reframe. An application that sends larger messages
+        // sizes the buffer up front via `writer_capacity(...)`.
+        if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
+            return Err(Error::FrameTooLarge(frame.len()));
+        }
         self.journal
             .store(seq, frame)
             .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
@@ -573,32 +592,22 @@ fn do_resend<S: Write, D: FixDictionary>(
             ReplayItem::App(orig) => reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING),
         };
         if ok.is_err() {
+            // Flush what is buffered, then retry into the now-empty buffer.
             writer.flush_to(stream).map_err(Error::Io)?;
-            match item {
-                ReplayItem::GapFill { seq, new_seq } => {
-                    encode_gap_fill(
-                        &mut writer.inner,
-                        D::BEGIN_STRING,
-                        config,
-                        &ts,
-                        seq,
-                        new_seq,
-                    )
-                    .map_err(|()| {
-                        Error::FrameTooLarge(writer.inner.remaining().saturating_add(1))
-                    })?;
-                }
-                ReplayItem::App(orig) => {
-                    if reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING).is_err() {
-                        let mut tmp = vec![0u8; orig.len() + 512];
-                        let (start, len) = reframe_app_into(&mut tmp, orig, &ts, D::BEGIN_STRING)
-                            .ok_or(Error::FrameTooLarge(orig.len()))?;
-                        tmp.copy_within(start..start + len, 0);
-                        tmp.truncate(len);
-                        write_through(stream, &mut writer.inner, &tmp)?;
-                    }
-                }
-            }
+            let retry = match &item {
+                ReplayItem::GapFill { seq, new_seq } => encode_gap_fill(
+                    &mut writer.inner,
+                    D::BEGIN_STRING,
+                    config,
+                    &ts,
+                    *seq,
+                    *new_seq,
+                ),
+                ReplayItem::App(orig) => reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING),
+            };
+            // `send_app`'s headroom guarantees a reframe fits an empty buffer;
+            // a failure here means the writer was sized too small.
+            retry.map_err(|()| Error::FrameTooLarge(writer.inner.remaining().saturating_add(1)))?;
         }
     }
     writer.flush_to(stream).map_err(Error::Io)
@@ -639,22 +648,15 @@ fn write_through<S: Write>(
     if writer.remaining() < frame.len() {
         flush_to(stream, writer)?;
     }
-    if writer.remaining() >= frame.len() {
-        let spare = writer.spare();
-        spare[..frame.len()].copy_from_slice(frame);
-        writer.commit(0, frame.len());
-    } else {
-        let mut off = 0;
-        while off < frame.len() {
-            let n = stream.write(&frame[off..]).map_err(Error::Io)?;
-            if n == 0 {
-                return Err(Error::Io(io::Error::other("write returned 0")));
-            }
-            off += n;
-        }
-        stream.flush().map_err(Error::Io)?;
-        return Ok(());
+    if writer.remaining() < frame.len() {
+        // The frame exceeds the pre-allocated buffer even when empty. `send_app`
+        // caps app frames below this, so reaching here means the buffer is
+        // undersized for the workload — a configuration error, not a fallback.
+        return Err(Error::FrameTooLarge(frame.len()));
     }
+    let spare = writer.spare();
+    spare[..frame.len()].copy_from_slice(frame);
+    writer.commit(0, frame.len());
     flush_to(stream, writer)
 }
 
@@ -750,4 +752,39 @@ fn is_timeout(e: &io::Error) -> bool {
         e.kind(),
         io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use nexus_fix_codec::FrameFormatter;
+
+    #[test]
+    fn reframe_stays_within_headroom() {
+        // A resend reframe adds PossDupFlag (43=Y), OrigSendingTime (122=...),
+        // and a little BodyLength growth. It must never grow a message by more
+        // than REFRAME_HEADROOM, so a stored app frame always reframes back into
+        // the pre-allocated writer buffer without a runtime allocation.
+        let mut orig_buf = [0u8; 512];
+        let (s, l) = {
+            let mut fmt = FrameFormatter::new(&mut orig_buf, b"FIX.4.4", b"D");
+            fmt.field(34, b"5");
+            fmt.field(49, b"SENDER");
+            fmt.field(56, b"TARGET");
+            fmt.field(52, b"20260101-00:00:00.000");
+            fmt.field(11, b"ORDER-1");
+            fmt.finish().unwrap()
+        };
+        let orig = &orig_buf[s..s + l];
+
+        let ts = b"20260102-12:34:56.789";
+        let mut out = [0u8; 1024];
+        let (_start, len) = super::reframe_app_into(&mut out, orig, ts, b"FIX.4.4").unwrap();
+
+        assert!(
+            len <= orig.len() + super::REFRAME_HEADROOM,
+            "reframe grew message by {} bytes, exceeding REFRAME_HEADROOM ({})",
+            len - orig.len(),
+            super::REFRAME_HEADROOM
+        );
+    }
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -182,6 +182,22 @@ impl Peer {
         self.stream.flush().unwrap();
     }
 
+    /// Send a Heartbeat (35=0) with an explicit `MsgSeqNum` (not the auto-counter),
+    /// so a test can drive a stale/too-low seqnum.
+    fn send_heartbeat_seq(&mut self, seq: u32) {
+        let mut buf = [0u8; 256];
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(seq, &mut seq_buf);
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"0");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, self.sender.as_bytes());
+        fmt.field(56, self.target.as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        let (start, len) = fmt.finish().unwrap();
+        self.stream.write_all(&buf[start..start + len]).unwrap();
+        self.stream.flush().unwrap();
+    }
+
     fn send_app(&mut self, extra_tag: u32, extra_val: &[u8]) {
         let seq = self.next_out;
         self.next_out += 1;
@@ -342,6 +358,44 @@ fn acceptor_receives_app_message() {
 
     handle.join().unwrap();
     let _ = dir;
+}
+
+#[test]
+fn heartbeat_stale_seqnum_disconnects() {
+    // Regression for #588: a too-low MsgSeqNum in a Heartbeat must surface as a
+    // SeqNumTooLow disconnect — not be swallowed and returned as a normal
+    // Heartbeat while the session silently dies.
+    let dir = tmp_dir("hb_stale_seq");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        peer.send_logon(30);
+        let mut buf = [0u8; 512];
+        let _ = peer.recv_msg(&mut buf); // engine's Logon reply
+        // Engine now expects inbound seq 2; a Heartbeat at seq 1 is too-low.
+        peer.send_heartbeat_seq(1);
+        let _ = peer.recv_msg(&mut buf); // drain the engine's Logout
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(&dir),
+    );
+
+    let reason = loop {
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
+            break reason;
+        }
+    };
+    assert_eq!(reason, DisconnectReason::SeqNumTooLow);
+
+    handle.join().unwrap();
 }
 
 #[test]

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -686,3 +686,25 @@ fn journal_recovers_admin_seqnums() {
         "journal must include admin seqnums"
     );
 }
+
+#[test]
+fn send_app_rejects_oversized_frame() {
+    // A frame larger than the writer capacity minus reframe headroom is a
+    // configuration error — the caller sizes the writer up front — not a
+    // runtime fallback. The cap fires before any journal or socket write.
+    let dir = tmp_dir("oversized");
+    let (client_sock, _server_sock) = loopback_pair();
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(sender(), target()),
+        journal(&dir),
+    );
+
+    // The default writer is 64 KiB; a 64 KiB frame exceeds cap - headroom.
+    let oversized = vec![0u8; 64 * 1024];
+    assert!(matches!(
+        conn.send_app(1, &oversized),
+        Err(TransportError::FrameTooLarge(_))
+    ));
+}

--- a/nexus-journal/examples/rotating_latency.rs
+++ b/nexus-journal/examples/rotating_latency.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use hdrhistogram::Histogram;
-use nexus_journal::Conductor;
+use nexus_journal::{Conductor, OpenMode};
 
 const SEGMENT_SIZE: usize = 4 * 1024 * 1024;
 const NUM_WRITES: u64 = 100_000;
@@ -21,7 +21,7 @@ fn main() {
         .session()
         .segment_size(SEGMENT_SIZE)
         .pretouch(true)
-        .open()
+        .open(OpenMode::OpenOrCreate)
         .expect("journal open");
 
     let payload = [0xABu8; PAYLOAD_SIZE];

--- a/nexus-journal/examples/rotating_stress.rs
+++ b/nexus-journal/examples/rotating_stress.rs
@@ -1,5 +1,5 @@
 use hdrhistogram::Histogram;
-use nexus_journal::Conductor;
+use nexus_journal::{Conductor, OpenMode};
 use std::time::{Duration, Instant};
 
 fn main() {
@@ -17,7 +17,7 @@ fn main() {
         .session()
         .segment_size(seg_size)
         .pretouch(true)
-        .open()
+        .open(OpenMode::OpenOrCreate)
         .expect("journal open");
 
     let payload = [0xABu8; 64];

--- a/nexus-journal/examples/rotating_tail.rs
+++ b/nexus-journal/examples/rotating_tail.rs
@@ -44,7 +44,7 @@ fn main() {
 )]
 mod imp {
     use hdrhistogram::Histogram;
-    use nexus_journal::{ConductorBuilder, WriteError};
+    use nexus_journal::{ConductorBuilder, OpenMode, WriteError};
 
     const PAGE: u64 = 4096;
     const FRAME_HDR: usize = 8; // mirrors nexus_journal's frame header layout
@@ -130,7 +130,7 @@ mod imp {
             .session()
             .segment_size(seg)
             .pretouch(pretouch)
-            .open()
+            .open(OpenMode::OpenOrCreate)
             .expect("journal open");
 
         let payload = vec![0xABu8; payload_size];

--- a/nexus-journal/src/append/mod.rs
+++ b/nexus-journal/src/append/mod.rs
@@ -24,7 +24,12 @@ const MIN_SEGMENT: usize = 64;
 /// Configuration for opening an append-only journal.
 #[derive(Clone, Copy)]
 pub struct AppendOnlyJournalConfig {
+    /// Size in bytes of each numbered segment file; a new segment is rolled when
+    /// the current one fills. Rounded up to the page size, with a small minimum
+    /// floor. Default: 64 MiB.
     pub segment_size: usize,
+    /// Memory-mapping hints (page pretouch, huge pages) applied to each segment.
+    /// Default: platform default (no pretouch, no huge pages).
     pub hints: MapHints,
 }
 

--- a/nexus-journal/src/lib.rs
+++ b/nexus-journal/src/lib.rs
@@ -13,6 +13,6 @@ pub use append::{
 };
 
 pub use rotating::{
-    Conductor, ConductorBuilder, Frame, LogOffset, OpenError, RotatingJournal,
+    Conductor, ConductorBuilder, Frame, LogOffset, OpenError, OpenMode, RotatingJournal,
     RotatingJournalBuilder, WriteError,
 };

--- a/nexus-journal/src/rotating/error.rs
+++ b/nexus-journal/src/rotating/error.rs
@@ -18,6 +18,14 @@ pub enum OpenError {
     SessionNotFound {
         session_id: u32,
     },
+    /// A manifest exists for the session but the on-disk segments are
+    /// structurally broken (e.g. an active segment file was deleted). Distinct
+    /// from [`SessionNotFound`](Self::SessionNotFound): the session is present
+    /// but unrecoverable, so it is never silently replaced with a fresh one.
+    CorruptSession {
+        session_id: u32,
+        reason: &'static str,
+    },
     SegmentTooLarge {
         size: usize,
     },
@@ -50,6 +58,9 @@ impl fmt::Display for OpenError {
             }
             Self::SessionNotFound { session_id } => {
                 write!(f, "no manifest found for session {session_id}")
+            }
+            Self::CorruptSession { session_id, reason } => {
+                write!(f, "session {session_id} is structurally corrupt: {reason}")
             }
             Self::SegmentTooLarge { size } => {
                 write!(

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -136,9 +136,13 @@ impl<'a> RotatingJournalBuilder<'a> {
     ///
     /// A session id must be set via [`session_id`](Self::session_id) for
     /// [`OpenMode::OpenExisting`]; for the create modes an id is auto-assigned
-    /// when unset. A structural config mismatch against an existing manifest is
-    /// always an error ([`OpenError::ConfigMismatch`]) — there is no lenient
-    /// mode.
+    /// when unset.
+    ///
+    /// Recovering an existing session uses its manifest's stored `segment_size`;
+    /// the builder's value applies only when creating a fresh session, since a
+    /// journal cannot be remapped to a different size. A manifest whose stored
+    /// session id does not match the requested id is rejected with
+    /// [`OpenError::ConfigMismatch`].
     pub fn open(self, mode: OpenMode) -> Result<RotatingJournal, OpenError> {
         let id = match self.session_id {
             Some(id) => id,
@@ -183,6 +187,23 @@ impl<'a> RotatingJournalBuilder<'a> {
             .conductor
             .archive()
             .then(|| session_dir.join("archive"));
+
+        // Overwrite discards any existing session. Delete its on-disk segments
+        // and archive so create_fresh rebuilds them at exactly `size`:
+        // `MappedFileOptions::create` only grows a file, so reusing larger stale
+        // segments would leave them mapped at their old length on the next
+        // recover (wasting address space, and with pretouch, faulted memory).
+        if mode == OpenMode::Overwrite && manifest_exists {
+            for i in 0u8..3 {
+                let seg = seg_path(&session_dir, i);
+                if seg.exists() {
+                    std::fs::remove_file(&seg)?;
+                }
+            }
+            if let Some(ref archive) = archive_dir {
+                std::fs::remove_dir_all(archive).ok();
+            }
+        }
 
         // Overwrite always creates fresh (discarding any existing session); the
         // others recover an existing manifest and only create when absent.

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -55,6 +55,27 @@ unsafe impl Send for Slot {}
 // Public API
 // ---------------------------------------------------------------------------
 
+/// How [`RotatingJournalBuilder::open`] resolves a session.
+///
+/// The existence/creation intent is explicit, mirroring the standard library:
+/// [`OpenExisting`](Self::OpenExisting) is `File::open` (must exist),
+/// [`OpenOrCreate`](Self::OpenOrCreate) is `OpenOptions::create` (open or make),
+/// [`Overwrite`](Self::Overwrite) is `File::create` (fresh, discarding any
+/// existing session).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenMode {
+    /// Recover an existing session. [`OpenError::SessionNotFound`] if no
+    /// manifest exists for the session id, with no filesystem state created on
+    /// that path.
+    OpenExisting,
+    /// Recover the session if it exists, otherwise create it fresh. Never
+    /// discards existing data.
+    OpenOrCreate,
+    /// Create a fresh session, discarding any existing one. Destructive: all
+    /// prior replay state for this session id is lost.
+    Overwrite,
+}
+
 /// Builder for configuring and opening a [`RotatingJournal`].
 ///
 /// Obtained via [`Conductor::session()`]. The conductor tracks session
@@ -111,51 +132,36 @@ impl<'a> RotatingJournalBuilder<'a> {
         self
     }
 
-    /// Open or recover a session log.
+    /// Open a session log with the given [`OpenMode`].
     ///
-    /// If the session directory contains an existing manifest, its structural
-    /// config (segment size) takes precedence over the builder's settings.
-    /// Use [`open_strict`](Self::open_strict) to error on mismatch instead.
-    pub fn open(self) -> Result<RotatingJournal, OpenError> {
-        self.open_inner(false)
-    }
-
-    /// Open or recover a session log, erroring if the manifest's structural
-    /// config does not match the builder's settings.
-    pub fn open_strict(self) -> Result<RotatingJournal, OpenError> {
-        self.open_inner(true)
-    }
-
-    /// Open an existing session log.
-    ///
-    /// Returns [`OpenError::SessionNotFound`] when no manifest exists for
-    /// the requested `session_id`. Unlike [`open`](Self::open), this never
-    /// creates a new session — a wrong or typo'd id is an error, not a silent
-    /// fresh start that drops all replay state.
-    ///
-    /// Requires [`session_id`](Self::session_id) to have been set; without it
-    /// the call returns `SessionNotFound { session_id: 0 }`.
-    pub fn open_existing(self) -> Result<RotatingJournal, OpenError> {
-        let id = self
-            .session_id
-            .ok_or(OpenError::SessionNotFound { session_id: 0 })?;
-        let session_dir = self.conductor.dir().join(id.to_string());
-        if !manifest_path(&session_dir).exists() {
-            return Err(OpenError::SessionNotFound { session_id: id });
-        }
-        self.open_inner(false)
-    }
-
-    fn open_inner(self, strict: bool) -> Result<RotatingJournal, OpenError> {
+    /// A session id must be set via [`session_id`](Self::session_id) for
+    /// [`OpenMode::OpenExisting`]; for the create modes an id is auto-assigned
+    /// when unset. A structural config mismatch against an existing manifest is
+    /// always an error ([`OpenError::ConfigMismatch`]) — there is no lenient
+    /// mode.
+    pub fn open(self, mode: OpenMode) -> Result<RotatingJournal, OpenError> {
         let id = match self.session_id {
-            Some(id) => {
-                self.conductor.register_explicit_id(id)?;
-                id
-            }
-            None => self.conductor.next_session_id()?,
+            Some(id) => id,
+            None => match mode {
+                OpenMode::OpenExisting => {
+                    return Err(OpenError::SessionNotFound { session_id: 0 });
+                }
+                OpenMode::OpenOrCreate | OpenMode::Overwrite => self.conductor.next_session_id()?,
+            },
         };
 
         let session_dir = self.conductor.dir().join(id.to_string());
+        let manifest_exists = manifest_path(&session_dir).exists();
+
+        // OpenExisting must find an existing session — and must not create any
+        // filesystem state (counter bump, directory, lock) when it does not.
+        if mode == OpenMode::OpenExisting && !manifest_exists {
+            return Err(OpenError::SessionNotFound { session_id: id });
+        }
+
+        if self.session_id.is_some() {
+            self.conductor.register_explicit_id(id)?;
+        }
         std::fs::create_dir_all(&session_dir)?;
 
         let session_lock = FileLock::try_lock(session_dir.join(SESSION_LOCK_FILE))?
@@ -173,15 +179,16 @@ impl<'a> RotatingJournalBuilder<'a> {
             wake_thread: self.conductor.wake_thread(),
             session_lock,
         };
-
         let archive_dir = self
             .conductor
             .archive()
             .then(|| session_dir.join("archive"));
 
-        let mpath = manifest_path(&session_dir);
-        if mpath.exists() {
-            RotatingJournal::recover(&session_dir, size, hints, strict, id, res, archive_dir)
+        // Overwrite always creates fresh (discarding any existing session); the
+        // others recover an existing manifest and only create when absent.
+        let recover = manifest_exists && mode != OpenMode::Overwrite;
+        if recover {
+            RotatingJournal::recover(&session_dir, hints, id, res, archive_dir)
         } else {
             RotatingJournal::create_fresh(
                 &session_dir,
@@ -513,9 +520,7 @@ impl RotatingJournal {
 
     fn recover(
         dir: &Path,
-        requested_size: usize,
         hints: MapHints,
-        strict: bool,
         expected_session_id: u32,
         res: SessionResources,
         archive_dir: Option<PathBuf>,
@@ -524,6 +529,8 @@ impl RotatingJournal {
         let manifest_size = manifest.segment_size() as usize;
         let session_id = manifest.session_id();
 
+        // A manifest whose stored id differs from the one requested means the
+        // session directory was renamed or corrupted — never silently adopt it.
         if session_id != expected_session_id {
             return Err(OpenError::ConfigMismatch {
                 field: "session_id",
@@ -532,14 +539,9 @@ impl RotatingJournal {
             });
         }
 
-        if strict && manifest_size != requested_size {
-            return Err(OpenError::ConfigMismatch {
-                field: "segment_size",
-                expected: requested_size as u64,
-                found: manifest_size as u64,
-            });
-        }
-
+        // The stored segment size is authoritative on recovery — a journal
+        // cannot be remapped to a different size. The builder's `segment_size`
+        // only applies when creating a fresh session.
         let size = manifest_size;
         let epoch = manifest.epoch();
 
@@ -553,6 +555,19 @@ impl RotatingJournal {
                 (c, p, s)
             }
         };
+
+        // The active and previous segments hold live journal data and are never
+        // removed during normal operation; a missing one means the session was
+        // tampered with. (The standby may be transiently absent mid-clean in
+        // archive mode, and recover rebuilds it below — so it is not checked.)
+        for slot in [current, prev] {
+            if !seg_path(dir, slot as u8).exists() {
+                return Err(OpenError::CorruptSession {
+                    session_id: expected_session_id,
+                    reason: "active or previous segment file missing",
+                });
+            }
+        }
 
         let total = NonZeroUsize::new(size).expect("segment size is non-zero");
 

--- a/nexus-journal/src/rotating/tests.rs
+++ b/nexus-journal/src/rotating/tests.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use super::conductor::SWAP_CLEAN;
 use super::frame::footprint;
-use super::{Conductor, ConductorBuilder, OpenError, RotatingJournal};
+use super::{Conductor, ConductorBuilder, OpenError, OpenMode, RotatingJournal};
 
 struct TempDir(PathBuf);
 
@@ -25,7 +25,11 @@ impl Drop for TempDir {
 }
 
 fn open(conductor: &mut Conductor, size: usize) -> RotatingJournal {
-    conductor.session().segment_size(size).open().unwrap()
+    conductor
+        .session()
+        .segment_size(size)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap()
 }
 
 fn open_id(conductor: &mut Conductor, size: usize, id: u32) -> RotatingJournal {
@@ -33,7 +37,7 @@ fn open_id(conductor: &mut Conductor, size: usize, id: u32) -> RotatingJournal {
         .session()
         .segment_size(size)
         .session_id(id)
-        .open()
+        .open(OpenMode::OpenOrCreate)
         .unwrap()
 }
 
@@ -215,7 +219,7 @@ fn session_name_roundtrip() {
         .segment_size(1 << 16)
         .session_id(1)
         .name("fix-binance-prod")
-        .open()
+        .open(OpenMode::OpenOrCreate)
         .unwrap();
     assert_eq!(log.session_name(), "fix-binance-prod");
 }
@@ -239,7 +243,7 @@ fn session_name_survives_recovery() {
             .segment_size(1 << 16)
             .session_id(1)
             .name("fix-session-alpha")
-            .open()
+            .open(OpenMode::OpenOrCreate)
             .unwrap();
         log.append(b"data").unwrap();
     }
@@ -602,34 +606,23 @@ fn recover_continues_appending_after_rotation() {
 // ---- builder / conductor options ----
 
 #[test]
-fn open_strict_rejects_mismatch() {
-    let d = TempDir::new("strict");
-
-    {
-        let mut c = Conductor::open(d.path()).unwrap();
-        let _log = open_id(&mut c, 1 << 16, 1);
-    }
-
-    let mut c = Conductor::open(d.path()).unwrap();
-    let result = c
-        .session()
-        .segment_size(1 << 20)
-        .session_id(1)
-        .open_strict();
-    assert!(matches!(result, Err(OpenError::ConfigMismatch { .. })));
-}
-
-#[test]
-fn open_non_strict_uses_manifest_config() {
-    let d = TempDir::new("nonstrict");
+fn reopen_uses_stored_segment_size() {
+    let d = TempDir::new("reopen-size");
 
     {
         let mut c = Conductor::open(d.path()).unwrap();
         let _log = open_id(&mut c, 64, 1);
     }
 
+    // The stored segment size is authoritative on recovery: reopening with a
+    // different builder `segment_size` uses the stored value without error.
     let mut c = Conductor::open(d.path()).unwrap();
-    let mut log = c.session().segment_size(1024).session_id(1).open().unwrap();
+    let mut log = c
+        .session()
+        .segment_size(1024)
+        .session_id(1)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     assert_eq!(log.segment_size(), 64);
     log.append(&[0u8; 8]).unwrap();
 }
@@ -638,7 +631,11 @@ fn open_non_strict_uses_manifest_config() {
 fn builder_creates_fresh() {
     let d = TempDir::new("builder-fresh");
     let mut c = Conductor::open(d.path()).unwrap();
-    let mut log = c.session().segment_size(128).open().unwrap();
+    let mut log = c
+        .session()
+        .segment_size(128)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     let off = log.append(b"test").unwrap();
     assert_eq!(log.read(off).unwrap().payload(), b"test");
 }
@@ -686,7 +683,11 @@ fn conductor_session_in_use_rejected() {
     let mut c = Conductor::open(d.path()).unwrap();
     let _log = open_id(&mut c, 1 << 16, 5);
 
-    let result = c.session().segment_size(1 << 16).session_id(5).open();
+    let result = c
+        .session()
+        .segment_size(1 << 16)
+        .session_id(5)
+        .open(OpenMode::OpenOrCreate);
     assert!(matches!(
         result,
         Err(OpenError::SessionInUse { session_id: 5 })
@@ -721,7 +722,11 @@ fn session_lock_cross_conductor() {
 
     // Conductor 2 (simulating another process) tries the same session
     let mut c2 = Conductor::open(d.path()).unwrap();
-    let result = c2.session().segment_size(1 << 16).session_id(5).open();
+    let result = c2
+        .session()
+        .segment_size(1 << 16)
+        .session_id(5)
+        .open(OpenMode::OpenOrCreate);
     assert!(matches!(
         result,
         Err(OpenError::SessionInUse { session_id: 5 })
@@ -733,11 +738,19 @@ fn conductor_auto_assigns_session_id() {
     let d = TempDir::new("auto-id");
     let mut c = Conductor::open(d.path()).unwrap();
 
-    let log1 = c.session().segment_size(1 << 16).open().unwrap();
+    let log1 = c
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     let id1 = log1.session_id();
     assert!(id1 > 0);
 
-    let log2 = c.session().segment_size(1 << 16).open().unwrap();
+    let log2 = c
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     let id2 = log2.session_id();
     assert_ne!(id1, id2);
 }
@@ -767,7 +780,11 @@ fn conductor_auto_id_skips_existing_on_disk() {
     }
 
     let mut c = Conductor::open(d.path()).unwrap();
-    let log = c.session().segment_size(1 << 16).open().unwrap();
+    let log = c
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     assert!(log.session_id() > 5);
 }
 
@@ -780,8 +797,16 @@ fn two_conductors_no_id_collision() {
     let mut c1 = Conductor::open(d.path()).unwrap();
     let mut c2 = Conductor::open(d.path()).unwrap();
 
-    let log1 = c1.session().segment_size(1 << 16).open().unwrap();
-    let log2 = c2.session().segment_size(1 << 16).open().unwrap();
+    let log1 = c1
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
+    let log2 = c2
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
 
     assert_ne!(log1.session_id(), log2.session_id());
 }
@@ -796,7 +821,11 @@ fn two_conductors_explicit_then_auto() {
 
     // Process 2 auto-assigns — must be > 10
     let mut c2 = Conductor::open(d.path()).unwrap();
-    let log2 = c2.session().segment_size(1 << 16).open().unwrap();
+    let log2 = c2
+        .session()
+        .segment_size(1 << 16)
+        .open(OpenMode::OpenOrCreate)
+        .unwrap();
     assert!(log2.session_id() > 10);
 }
 
@@ -865,7 +894,7 @@ fn builder_pretouch_option() {
         .segment_size(1 << 16)
         .session_id(1)
         .pretouch(true)
-        .open()
+        .open(OpenMode::OpenOrCreate)
         .unwrap();
     let off = log.append(b"pretouched").unwrap();
     assert_eq!(log.read(off).unwrap().payload(), b"pretouched");
@@ -1018,7 +1047,11 @@ fn stress_concurrent_id_assignment() {
                 let mut c = Conductor::open(&p).unwrap();
                 let mut ids = Vec::new();
                 for _ in 0..5 {
-                    let log = c.session().segment_size(1 << 16).open().unwrap();
+                    let log = c
+                        .session()
+                        .segment_size(1 << 16)
+                        .open(OpenMode::OpenOrCreate)
+                        .unwrap();
                     ids.push(log.session_id());
                 }
                 ids
@@ -1206,7 +1239,11 @@ fn session_id_mismatch_on_corrupted_directory() {
 
     // Now try to open session 20 — the manifest inside says session_id=10
     let mut c = Conductor::open(d.path()).unwrap();
-    let result = c.session().segment_size(1 << 16).session_id(20).open();
+    let result = c
+        .session()
+        .segment_size(1 << 16)
+        .session_id(20)
+        .open(OpenMode::OpenOrCreate);
     assert!(matches!(
         result,
         Err(OpenError::ConfigMismatch {
@@ -1220,7 +1257,7 @@ fn session_id_mismatch_on_corrupted_directory() {
 fn open_existing_missing_session_returns_not_found() {
     let d = TempDir::new("oe-missing");
     let mut c = Conductor::open(d.path()).unwrap();
-    let result = c.session().session_id(99).open_existing();
+    let result = c.session().session_id(99).open(OpenMode::OpenExisting);
     assert!(
         matches!(result, Err(OpenError::SessionNotFound { session_id: 99 })),
         "expected SessionNotFound(99)"
@@ -1236,7 +1273,7 @@ fn open_existing_wrong_id_returns_not_found() {
     drop(_log);
     // Reopen conductor; session 2 doesn't exist
     let mut c2 = Conductor::open(d.path()).unwrap();
-    let result = c2.session().session_id(2).open_existing();
+    let result = c2.session().session_id(2).open(OpenMode::OpenExisting);
     assert!(
         matches!(result, Err(OpenError::SessionNotFound { session_id: 2 })),
         "expected SessionNotFound(2)"
@@ -1252,7 +1289,63 @@ fn open_existing_recovers_existing_session() {
         log.append(b"hello").unwrap();
     }
     let mut c2 = Conductor::open(d.path()).unwrap();
-    let log = c2.session().session_id(5).open_existing().unwrap();
+    let log = c2
+        .session()
+        .session_id(5)
+        .open(OpenMode::OpenExisting)
+        .unwrap();
     let mut pos = log.read_start();
     assert_eq!(log.read_next(&mut pos).unwrap().payload(), b"hello");
+}
+
+#[test]
+fn open_existing_leaves_no_fs_state_on_not_found() {
+    let d = TempDir::new("oe-no-side-effect");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let result = c.session().session_id(99).open(OpenMode::OpenExisting);
+    assert!(matches!(
+        result,
+        Err(OpenError::SessionNotFound { session_id: 99 })
+    ));
+    // The not-found path must not have created the session directory.
+    assert!(!d.path().join("99").exists());
+}
+
+#[test]
+fn corrupt_session_missing_active_segment() {
+    let d = TempDir::new("corrupt-seg");
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let mut log = open_id(&mut c, 1 << 16, 5);
+        log.append(b"data").unwrap();
+    }
+    // Delete the active segment file — structural corruption, not a fresh start.
+    std::fs::remove_file(d.path().join("5").join("seg0.dat")).unwrap();
+
+    let mut c = Conductor::open(d.path()).unwrap();
+    let result = c.session().session_id(5).open(OpenMode::OpenExisting);
+    assert!(
+        matches!(result, Err(OpenError::CorruptSession { session_id: 5, .. })),
+        "expected CorruptSession"
+    );
+}
+
+#[test]
+fn overwrite_discards_existing_session() {
+    let d = TempDir::new("overwrite");
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let mut log = open_id(&mut c, 1 << 16, 5);
+        log.append(b"stale").unwrap();
+    }
+    // Overwrite creates a fresh session, discarding the prior data.
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log = c
+        .session()
+        .segment_size(1 << 16)
+        .session_id(5)
+        .open(OpenMode::Overwrite)
+        .unwrap();
+    let mut pos = log.read_start();
+    assert!(log.read_next(&mut pos).is_none());
 }

--- a/nexus-journal/src/rotating/tests.rs
+++ b/nexus-journal/src/rotating/tests.rs
@@ -1349,3 +1349,45 @@ fn overwrite_discards_existing_session() {
     let mut pos = log.read_start();
     assert!(log.read_next(&mut pos).is_none());
 }
+
+#[test]
+fn overwrite_shrinks_reused_segment_files() {
+    let d = TempDir::new("overwrite_shrink");
+    let big = 1 << 20; // 1 MiB
+    let small = 1 << 16; // 64 KiB
+    let session_dir = d.path().join("5");
+
+    // A large session leaves 1 MiB segment files on disk.
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let _ = open_id(&mut c, big, 5);
+    }
+    assert_eq!(
+        std::fs::metadata(super::seg_path(&session_dir, 0))
+            .unwrap()
+            .len(),
+        big as u64,
+    );
+
+    // Overwriting with a smaller segment size must rebuild the files at the new
+    // size. `create` only grows a file, so a stale 1 MiB segment would otherwise
+    // be remapped in full on the next recover.
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let _ = c
+            .session()
+            .segment_size(small)
+            .session_id(5)
+            .open(OpenMode::Overwrite)
+            .unwrap();
+    }
+    for i in 0u8..3 {
+        let len = std::fs::metadata(super::seg_path(&session_dir, i))
+            .unwrap()
+            .len();
+        assert_eq!(
+            len, small as u64,
+            "seg{i} not resized to the new segment_size"
+        );
+    }
+}

--- a/nexus-net/src/buf/write_buf.rs
+++ b/nexus-net/src/buf/write_buf.rs
@@ -201,6 +201,12 @@ impl WriteBuf {
         self.head
     }
 
+    /// Total backing-buffer capacity in bytes (fixed at construction).
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
     /// Bytes available for append.
     #[inline]
     pub fn tailroom(&self) -> usize {

--- a/nexus-platform/src/file_lock/linux.rs
+++ b/nexus-platform/src/file_lock/linux.rs
@@ -17,8 +17,17 @@ fn wrlck() -> libc::flock {
 
 /// Acquire an exclusive OFD lock on `file`, blocking until available.
 pub(super) fn lock_exclusive_blocking(file: &File) -> Result<(), std::io::Error> {
-    fcntl(file.as_fd(), FcntlArg::F_OFD_SETLKW(&wrlck())).map_err(std::io::Error::from)?;
-    Ok(())
+    // `F_OFD_SETLKW` blocks, and a signal can interrupt the wait with `EINTR`.
+    // "Blocking" must mean "blocks until acquired," so retry on interrupt rather
+    // than surface it as a failure.
+    loop {
+        match fcntl(file.as_fd(), FcntlArg::F_OFD_SETLKW(&wrlck())) {
+            Ok(_) => return Ok(()),
+            // Interrupted before the lock was acquired: fall through and retry.
+            Err(Errno::EINTR) => {}
+            Err(e) => return Err(std::io::Error::from(e)),
+        }
+    }
 }
 
 /// Try to acquire an exclusive OFD lock without blocking.

--- a/nexus-shm/src/control.rs
+++ b/nexus-shm/src/control.rs
@@ -60,6 +60,16 @@ impl ControlBlockInner {
     }
 
     pub(crate) fn validate(&self) -> Result<(), ShmError> {
+        // Acquire the creator's `status` publish before reading the non-atomic
+        // header. `write_header` writes magic/layout/data_len and *then* stores
+        // `status = ALIVE` with Release; this paired Acquire load is what makes
+        // those header reads here (and `data_len()` back in `attach`) observe the
+        // creator's writes on weakly-ordered architectures (ARM/POWER). Both
+        // ALIVE and DEAD were published this way, so either is safe to read; a
+        // still-`UNINIT` (0) status means the segment was never published.
+        if self.status.load(Ordering::Acquire) == 0 {
+            return Err(ShmError::BadMagic { found: self.magic });
+        }
         if self.magic != MAGIC {
             return Err(ShmError::BadMagic { found: self.magic });
         }

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -313,6 +313,23 @@ mod tests {
     }
 
     #[test]
+    fn attach_to_uninitialized_rejected() {
+        let path = temp_path("uninit");
+        let _ = std::fs::remove_file(&path);
+
+        // A correctly-sized but never-created (all-zero) mapping: `status` is
+        // still UNINIT and the header is unpopulated, so `attach` rejects it
+        // rather than trusting a zeroed control block.
+        let mf = create_file(&path, 64);
+        assert!(matches!(
+            Segment::attach(mf),
+            Err(ShmError::BadMagic { found: 0 })
+        ));
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
     fn rejects_zero_data_len() {
         let path = temp_path("zero");
         let _ = std::fs::remove_file(&path);

--- a/tools/fix-harness/features/adversarial.feature
+++ b/tools/fix-harness/features/adversarial.feature
@@ -45,12 +45,6 @@ Feature: FIX session adversarial input
     And the peer sends a ResendRequest with seqnum 1
     Then the engine closes the connection
 
-  Scenario: SequenceReset with duplicate seqnum is rejected (E5)
-    Given a raw FIX 4.4 peer connects to the harness
-    When the peer performs a Logon handshake
-    And the peer sends a SequenceReset with seqnum 1
-    Then the engine closes the connection
-
   Scenario: Reject with duplicate seqnum is rejected (E5)
     Given a raw FIX 4.4 peer connects to the harness
     When the peer performs a Logon handshake

--- a/tools/fix-harness/features/session.feature
+++ b/tools/fix-harness/features/session.feature
@@ -1,3 +1,6 @@
+# Local-only smoke test: drives the engine with the quickfix Python client.
+# Not gated in CI because quickfix 1.15.1 segfaults on interpreter shutdown
+# (exit 139) even when every scenario passes. Run manually via tools/fix-harness.
 Feature: FIX session management
 
   Scenario: valid logon is accepted

--- a/tools/fix-harness/features/steps/adversarial_steps.py
+++ b/tools/fix-harness/features/steps/adversarial_steps.py
@@ -146,11 +146,6 @@ def step_raw_resend_request_seq(context, n):
     context.raw_peer.send("2", [(7, "1"), (16, "2")], seq=n)
 
 
-@when("the peer sends a SequenceReset with seqnum {n:d}")
-def step_raw_sequence_reset_seq(context, n):
-    context.raw_peer.send("4", [(36, "10")], seq=n)
-
-
 @when("the peer sends a Reject with seqnum {n:d}")
 def step_raw_reject_seq(context, n):
     context.raw_peer.send("3", [(45, "1")], seq=n)

--- a/tools/fix-harness/features/steps/session_steps.py
+++ b/tools/fix-harness/features/steps/session_steps.py
@@ -57,6 +57,9 @@ def _make_cfg(sender, target, port):
     cfg = (
         "[DEFAULT]\n"
         "ConnectionType=initiator\n"
+        "UseDataDictionary=N\n"
+        "StartTime=00:00:00\n"
+        "EndTime=00:00:00\n"
         "HeartBtInt=30\n"
         f"SenderCompID={sender}\n"
         f"TargetCompID={target}\n"
@@ -80,7 +83,7 @@ def _start_initiator(context):
     context.app = HarnessApp()
     store = fix.MemoryStoreFactory()
     log = fix.ScreenLogFactory(settings)
-    context.initiator = fix.SocketInitiator(context.app, store, log, settings)
+    context.initiator = fix.SocketInitiator(context.app, store, settings, log)
     context.initiator.start()
 
 


### PR DESCRIPTION
## Summary

A correctness and hardening pass across the FIX stack ahead of 1.0, from a full
audit of the FIX code and its `nexus-platform` / `nexus-shm` / `nexus-journal`
dependencies. No new features: every change tightens an existing contract,
removes a hidden footgun, or closes a test gap.

Scope is deliberately bounded to correctness and hardening. Two larger items the
audit surfaced are split out: the session seqnum checkpoint redesign (folded into
a broader journal rework) and the `AdminSink` refactor plus venue Logon auth
(#568), which becomes its own PR.

## Changes

### Journal: `OpenMode` API

Replaces the muddled `open` / `open_strict` / `open_existing` 2x2 (create-vs-error
x strict-vs-lenient) with a single `OpenMode` enum on the existence/creation axis:

- `OpenExisting` (must exist, `SessionNotFound` if absent)
- `OpenOrCreate` (open if present, create fresh if absent, never discards)
- `Overwrite` (create fresh, discarding any existing; a new, loudly-named
  destructive capability for intentional session reset)

Config verification is now always-on (a config mismatch on an existing manifest is
always worth surfacing). `open` checks existence before any filesystem side-effect,
so a typo'd path no longer materializes an empty conductor directory. Adds
corrupt-session detection with a typed `OpenError` variant, and tests for typo id,
empty dir, corrupt session, and successful replay. `FixJournal` migrated to the new
API.

### Codec: strict, positional checksum validation

`validate_checksum` now does a positional lookup of the trailing `CheckSum(10)` and
returns `ChecksumError::Missing` when tag 10 is absent, instead of silently
returning `Ok(())` (the deeper half of #585). The frame-layer `10=` positional
guard (#587) stays as the fast-path reject; `validate_checksum` becomes strict
defense-in-depth. A writer test pins the "CheckSum is always the last field"
invariant the positional lookup relies on.

Generated `decode` stays intentionally lenient (it is a field extractor and accepts
a bare body with no checksum); the layer difference is now documented at both sites.

### Transport: reframe headroom, delete the heap fallback

`send_app` caps outbound app frames at `capacity - REFRAME_HEADROOM` and fails fast
with `FrameTooLarge`, establishing the invariant "if we could send it, we can
resend it" (a resend only adds PossDupFlag plus OrigSendingTime, roughly 30 bytes).
With that invariant the heap-allocation fallback and direct-write path are deleted
from both the sync and async engines, which also collapses a sync/async drift where
the async path aborted a resend the sync path completed. Buffers are meant to be
pre-allocated for the workload; an oversized frame is a config error, not a
hot-path allocation.

### shm: attach memory ordering

`ControlBlock::validate()` now does an Acquire load of `status` before reading the
non-atomic header, and rejects `UNINIT`. Already correct on x86-TSO; this makes the
publish/acquire handshake sound on weak-memory architectures (ARM/POWER, #420) and
rejects a zeroed-but-never-created mapping instead of trusting it.

### Tests plus CI-gated harness

- Transport gains unit tests where it previously had none, including a regression
  for #588 (a Heartbeat at a stale seqnum must disconnect with `SeqNumTooLow`).
- The adversarial behave harness is now a CI job (`verify-fix-harness`), so it can
  no longer merge red. That gap is how #590's dead scenario slipped in.
- Deletes that dead `SequenceReset` scenario: SequenceReset in Reset mode ignores
  `MsgSeqNum` by spec, so "duplicate seqnum closes the session" asserted wrong
  behavior.

### P2 polish

- Platform: the blocking OFD file-lock retries on `EINTR` instead of surfacing an
  interrupted wait as a failure.
- Codegen: a missing mandatory session tag now returns a typed
  `EmitError::MissingSessionTag` instead of `panic!`, so `build.rs` gets a clean
  error.
- Docs: `AppendOnlyJournalConfig` field docs (#508), codegen crate-level docs
  (#509), and the `Out` 2-admin-capacity invariant.

## Testing

- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Full suites green for the touched crates (fix-engine, fix-codec, fix-codegen,
  journal, platform, shm, net) plus the adversarial harness.

## Deferred (follow-ups)

- Session seqnum checkpoint redesign, folded into a broader journal rework (single
  write serving both resend and FIX-log visibility). The `NI=` inbound sentinels
  are untouched here.
- `AdminSink` refactor plus #568 (dictionary-driven admin encode and venue Logon
  auth), which unblocks logging onto a real venue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
