### PR TITLE
FIX journal rework: two-journal both-sides archive, O(1) seqnum recovery

### DIFF
--- a/nexus-async-fix-engine/CHANGELOG.md
+++ b/nexus-async-fix-engine/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to nexus-async-fix-engine are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [Unreleased]
+
+### Added
+
+- Inbound message journaling: well-framed, comp-id-valid inbound frames are
+  archived to the session's inbound journal for visibility/audit, mirroring the
+  sync engine.
+- Outbound admin journaling: outbound admin frames (Logon, Heartbeat, Logout,
+  TestRequest, ResendRequest, SequenceReset, Reject) are now journaled to the
+  outbound journal, mirroring the sync engine's `store_admin`. Previously async
+  sessions journaled inbound + app but dropped their own admin, leaving the
+  both-sides archive incomplete.
+- `Error::Journal(WriteError)`: journal write-path failures now surface through
+  the connection error type. Both journaling sites use the existing transient
+  backpressure pattern (retry on `StandbyNotReady` via `tokio::task::yield_now`).
+
+### Changed
+
+- `AsyncFixConnection::encode_admin` returns `Result<(), Error>` (was `()`) so
+  outbound-admin journal writes can propagate; `flush_out` forwards the error.

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -20,11 +20,7 @@ use nexus_fix_engine::{
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout_at;
 
-/// Transient/misconfiguration errors from the FIX journal write path.
-///
-/// Re-exported so callers matching on [`Error::Journal`] can name its inner
-/// type without depending on `nexus-fix-engine` directly.
-pub use nexus_fix_engine::WriteError;
+use nexus_fix_engine::WriteError;
 
 const TS_LEN: usize = 21;
 
@@ -32,16 +28,14 @@ const TS_LEN: usize = 21;
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
-    FrameTooLarge(usize),
-    Journal(WriteError),
+    MessageTooLarge(usize),
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(e) => write!(f, "I/O: {e}"),
-            Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
-            Self::Journal(e) => write!(f, "journal: {e}"),
+            Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
         }
     }
 }
@@ -162,7 +156,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
         self.reader
             .read(&tmp[..n])
-            .map_err(|_| Error::FrameTooLarge(n))?;
+            .map_err(|_| Error::MessageTooLarge(n))?;
 
         let now = Instant::now();
         loop {
@@ -175,7 +169,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                 }
                 Ok(None) => break,
                 Err(FrameError::MessageTooLarge { size }) => {
-                    return Err(Error::FrameTooLarge(size));
+                    return Err(Error::MessageTooLarge(size));
                 }
                 Err(FrameError::Garbage { .. }) => {}
             }
@@ -194,7 +188,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         // for a later resend reframe. Size the buffer up front for larger
         // messages; see the sync `FixConnection::send_app`.
         if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
-            return Err(Error::FrameTooLarge(frame.len()));
+            return Err(Error::MessageTooLarge(frame.len()));
         }
         // Unbounded on purpose. StandbyNotReady is transient backpressure the
         // conductor clears in sub-ms; the only way this loops forever is a
@@ -206,7 +200,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             match self.journal.store(seq, frame) {
                 Ok(()) => break,
                 Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                Err(e) => return Err(Error::Journal(e)),
+                Err(_) => return Err(Error::MessageTooLarge(frame.len())),
             }
         }
         self.write_through(frame).await
@@ -244,7 +238,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             match self.journal.store_inbound(frame) {
                 Ok(()) => break,
                 Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                Err(e) => return Err(Error::Journal(e)),
+                Err(_) => return Err(Error::MessageTooLarge(frame.len())),
             }
         }
 
@@ -455,7 +449,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                 match self.journal.store(seq, frame) {
                     Ok(()) => break,
                     Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                    Err(e) => return Err(Error::Journal(e)),
+                    Err(_) => return Err(Error::MessageTooLarge(frame.len())),
                 }
             }
         }
@@ -481,7 +475,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         if self.writer.remaining() < frame.len() {
             // Exceeds the pre-allocated buffer even when empty; `send_app` caps
             // app frames below this, so this is an undersized-buffer config error.
-            return Err(Error::FrameTooLarge(frame.len()));
+            return Err(Error::MessageTooLarge(frame.len()));
         }
         let spare = self.writer.spare();
         spare[..frame.len()].copy_from_slice(frame);
@@ -537,7 +531,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
                     Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
                 };
                 retry.map_err(|()| {
-                    Error::FrameTooLarge(self.writer.remaining().saturating_add(1))
+                    Error::MessageTooLarge(self.writer.remaining().saturating_add(1))
                 })?;
             }
         }

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -20,6 +20,12 @@ use nexus_fix_engine::{
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout_at;
 
+/// Transient/misconfiguration errors from the FIX journal write path.
+///
+/// Re-exported so callers matching on [`Error::Journal`] can name its inner
+/// type without depending on `nexus-fix-engine` directly.
+pub use nexus_fix_engine::WriteError;
+
 const TS_LEN: usize = 21;
 
 /// Error from [`AsyncFixConnection`].
@@ -27,6 +33,7 @@ const TS_LEN: usize = 21;
 pub enum Error {
     Io(io::Error),
     FrameTooLarge(usize),
+    Journal(WriteError),
 }
 
 impl std::fmt::Display for Error {
@@ -34,6 +41,7 @@ impl std::fmt::Display for Error {
         match self {
             Self::Io(e) => write!(f, "I/O: {e}"),
             Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
+            Self::Journal(e) => write!(f, "journal: {e}"),
         }
     }
 }
@@ -188,9 +196,19 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
             return Err(Error::FrameTooLarge(frame.len()));
         }
-        self.journal
-            .store(seq, frame)
-            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        // Unbounded on purpose. StandbyNotReady is transient backpressure the
+        // conductor clears in sub-ms; the only way this loops forever is a
+        // full/failing disk, which must be caught by observability. Retrying
+        // beats the alternative of dropping a message from a resend/audit
+        // journal. We yield rather than spin so the tokio executor keeps
+        // driving the conductor and other tasks.
+        loop {
+            match self.journal.store(seq, frame) {
+                Ok(()) => break,
+                Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
+                Err(e) => return Err(Error::Journal(e)),
+            }
+        }
         self.write_through(frame).await
     }
 
@@ -217,6 +235,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
             let out = self.state.on_comp_id_mismatch(now);
             self.flush_out(out).await?;
             return Ok(Some(DisconnectReason::CompIdMismatch));
+        }
+
+        // Well-framed and comp-id-valid: archive the inbound message for
+        // visibility/audit. Garbage and foreign frames never reach here.
+        // Unbounded retry on transient standby backpressure; see `send_app`.
+        loop {
+            match self.journal.store_inbound(frame) {
+                Ok(()) => break,
+                Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
+                Err(e) => return Err(Error::Journal(e)),
+            }
         }
 
         let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
@@ -304,7 +333,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
     async fn flush_out(&mut self, out: Out) -> Result<(), Error> {
         for admin in out.admin_messages() {
-            self.encode_admin(admin);
+            self.encode_admin(admin).await?;
         }
         if !self.writer.is_empty() {
             self.flush_writer().await?;
@@ -312,7 +341,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
         Ok(())
     }
 
-    fn encode_admin(&mut self, admin: AdminMsg) {
+    async fn encode_admin(&mut self, admin: AdminMsg) -> Result<(), Error> {
         let ts = make_ts();
 
         let msg_type: &[u8] = match admin {
@@ -408,11 +437,29 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
 
             match fmt.finish() {
                 Ok(sl) => sl,
-                Err(_) => return,
+                Err(_) => return Ok(()),
             }
         };
 
+        // Journal the outbound admin frame, mirroring the sync `store_admin`:
+        // capture the frame slice from the writer after commit so it is
+        // contiguous and correctly sized. `self.journal` and `self.writer` are
+        // disjoint fields, so the mutable-journal / shared-writer borrows do not
+        // conflict. Unbounded retry on transient standby backpressure; see
+        // `send_app`. This keeps async sessions' outbound admin in the archive.
+        let before = self.writer.data().len();
         self.writer.commit(start, len);
+        let frame = &self.writer.data()[before..];
+        if !frame.is_empty() {
+            loop {
+                match self.journal.store(seq, frame) {
+                    Ok(()) => break,
+                    Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
+                    Err(e) => return Err(Error::Journal(e)),
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn flush_writer(&mut self) -> Result<(), Error> {

--- a/nexus-async-fix-engine/tests/journal_outbound_admin.rs
+++ b/nexus-async-fix-engine/tests/journal_outbound_admin.rs
@@ -1,0 +1,98 @@
+//! Outbound admin messages sent by an async session must land in the session's
+//! outbound journal, mirroring the sync engine's `store_admin` behavior. The
+//! both-sides archive is incomplete if async sessions journal inbound + app but
+//! drop their own Logon/Heartbeat/Logout/... admin frames.
+
+#![cfg(unix)]
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use nexus_async_fix_engine::AsyncFixConnection;
+use nexus_fix_engine::{CompId, FixJournal, SessionConfig, SessionState};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+const BEGIN: &[u8] = b"FIX.4.4";
+
+fn tmp_dir(suffix: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "nexus_async_fix_admin_{}_{}",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// In-memory stream: writes are accepted (and buffered), reads block forever.
+///
+/// `connect()` only exercises the write path — it encodes the opening Logon and
+/// flushes it — so the read side never needs data. A perpetually-pending read
+/// keeps `recv` from ever being reached in this test.
+#[derive(Default)]
+struct SinkStream {
+    written: Vec<u8>,
+}
+
+impl AsyncRead for SinkStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // Never completes: connect() does not read.
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for SinkStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.written.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn outbound_admin_is_journaled() {
+    let dir = tmp_dir("logon");
+
+    {
+        let mut conn = AsyncFixConnection::from_parts(
+            SinkStream::default(),
+            SessionState::new(Duration::from_secs(30)),
+            SessionConfig {
+                sender: CompId::new(b"ENGINE").unwrap(),
+                target: CompId::new(b"PEER").unwrap(),
+            },
+            FixJournal::open(&dir, 0, 256).unwrap(),
+            BEGIN,
+        );
+        // Sends the opening Logon at seq 1; the write is accepted by the sink.
+        conn.connect().await.unwrap();
+    }
+
+    // The Logon (seq 1) must be present in the outbound journal: recovering the
+    // outbound counter from the meta-slot yields 2 only if `store(1, ..)` ran.
+    // A journal that never stored anything recovers to 1.
+    let recovered = FixJournal::open(&dir, 0, 256).unwrap();
+    assert_eq!(
+        recovered.next_outbound(),
+        2,
+        "outbound Logon admin must be journaled"
+    );
+}

--- a/nexus-fix-engine/CHANGELOG.md
+++ b/nexus-fix-engine/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to nexus-fix-engine are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [Unreleased]
+
+### Changed
+
+- `FixJournal` reworked from an outbound-only resend log into a **two-journal**
+  (outbound + inbound) both-sides archive that serves resend *and* visibility.
+  Direction is implicit in which journal a frame lands in — no per-frame
+  direction flag. Each stored payload is prefixed with an 8-byte LE UNIX-nanos
+  timestamp (`[ts:8][wire msg]`); resend strips the prefix before replay.
+- Sequence-number recovery is now O(1) from a per-journal manifest meta-slot
+  (`next_outbound` in the outbound manifest, `next_inbound` in the inbound
+  manifest), replacing the O(n) tag-34 recovery scan and the `NI=` inbound
+  sentinel messages. Counters now survive even when the messages that carried
+  them age out of the hot window.
+- On recovery, the resend ring is rebuilt by scanning the bounded outbound hot
+  window, restoring cross-restart resend (previously a restart replayed
+  gap-fills for everything).
+
+### Added
+
+- `FixJournal::open_in`: primary constructor that opens the two per-session
+  journals through a shared `&mut Conductor` (folds in the shared-conductor
+  work). The convenience `open` / `open_existing` constructors own a
+  private archive-enabled conductor for single-session callers (harness, tests).
+  Conductor-outlives-journals is a documented drop-order invariant.
+- `FixJournal::store_inbound`: archive an inbound frame for visibility/audit.
+- `Error::Journal(WriteError)`: journal write-path failures now surface through
+  the transport error type; `WriteError` is re-exported for callers matching on it.

--- a/nexus-fix-engine/README.md
+++ b/nexus-fix-engine/README.md
@@ -48,6 +48,7 @@ interval sends a TestRequest; no answer within another interval
 disconnects.
 
 Inbound ResendRequests are answered with a gap-fill SequenceReset and
-surfaced as `Event::ResendRange`; store-backed retransmission arrives
-with the persistence layer (#411). TCP framing and checksum validation
+surfaced as `Event::ResendRange`; store-backed retransmission replays
+the original messages from `FixJournal`, a two-journal (outbound +
+inbound) both-sides archive. TCP framing and checksum validation
 happen before `handle_message` (#410).

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -22,6 +22,8 @@ pub use frame::{
 };
 pub use framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig, SessionError};
 #[cfg(unix)]
+pub use nexus_journal::{Conductor, ConductorBuilder, OpenError, OpenMode, WriteError};
+#[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem};
 pub use session::{AdminMsg, DisconnectReason, Event, Out, SessionState, State};
 #[cfg(unix)]

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -1,31 +1,56 @@
+//! Both-sides FIX session archive backing resend recovery and audit visibility.
+//!
+//! [`FixJournal`] wraps **two** [`RotatingJournal`]s — one outbound, one inbound
+//! — under a shared [`Conductor`]. Direction is implicit in which journal a
+//! message lands in; there is no per-frame direction flag. Each stored frame's
+//! payload is `[ts:8][wire msg]`: an 8-byte little-endian UNIX-nanoseconds
+//! timestamp prepended by [`FixJournal`] via
+//! [`RotatingJournal::append_prefixed`], followed by the untouched FIX wire
+//! message. The journal frame format itself is unchanged — the FIX layer owns
+//! the timestamp.
+//!
+//! # Roles
+//!
+//! - **Resend recovery** reads the *outbound* journal only, via an in-memory
+//!   offset table indexed by `MsgSeqNum` (tag 34). The table is repopulated on
+//!   recovery by a bounded scan of the outbound hot window.
+//! - **Visibility / audit** is served by both journals with `archive(true)`:
+//!   evicted segments are preserved rather than zeroed, so the full history is
+//!   readable beyond the active window.
+//!
+//! # Sequence-number recovery
+//!
+//! `next_outbound` lives in the outbound journal's manifest meta-slot,
+//! `next_inbound` in the inbound journal's. Each is written in place on every
+//! update ([`store`](FixJournal::store) / [`set_next_inbound`](FixJournal::set_next_inbound))
+//! and recovered in O(1) — no scan, robust against window aging (the counter
+//! survives even after the messages it counted have rotated out).
+//!
+//! # Conductor ownership
+//!
+//! [`open`](FixJournal::open) / [`open_existing`](FixJournal::open_existing)
+//! own their conductor (single-session convenience). [`open_in`](FixJournal::open_in)
+//! borrows a caller-owned [`Conductor`] so many sessions share one background
+//! cleanup thread. The conductor must outlive every [`FixJournal`] opened
+//! through it — a drop-order rule the owner controls, since the journals hold
+//! owned clones of the conductor's producer and Arcs rather than a borrow.
+
 use std::path::Path;
 
 use nexus_fix_codec::{find_tag, parse_fix_seqnum};
 use nexus_journal::{
-    Conductor, Frame, LogOffset, OpenError, OpenMode, RotatingJournal, WriteError,
+    Conductor, ConductorBuilder, Frame, LogOffset, OpenError, OpenMode, RotatingJournal, WriteError,
 };
 
-const INBOUND_MARKER: &[u8] = b"NI=";
+/// Width of the per-frame timestamp prefix: an 8-byte LE UNIX-nanos `u64`.
+const TS_LEN: usize = 8;
 
-fn encode_inbound_checkpoint(seq: u32, buf: &mut [u8; 13]) -> usize {
-    buf[0] = b'N';
-    buf[1] = b'I';
-    buf[2] = b'=';
-    if seq == 0 {
-        buf[3] = b'0';
-        return 4;
-    }
-    let mut tmp = [0u8; 10];
-    let mut len = 0;
-    let mut n = seq;
-    while n > 0 {
-        tmp[len] = b'0' + (n % 10) as u8;
-        len += 1;
-        n /= 10;
-    }
-    tmp[..len].reverse();
-    buf[3..3 + len].copy_from_slice(&tmp[..len]);
-    3 + len
+fn unix_nanos_now() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
 }
 
 enum ResendPlan<'a> {
@@ -38,13 +63,28 @@ pub enum ReplayItem<'a> {
     App(&'a [u8]),
 }
 
+/// Two-journal (outbound + inbound) FIX session archive.
+///
+/// See the [module docs](self) for the storage model, timestamp prefix, and
+/// recovery guarantees.
 pub struct FixJournal {
-    journal: RotatingJournal,
-    _conductor: Conductor,
+    outbound: RotatingJournal,
+    inbound: RotatingJournal,
     offsets: Box<[Option<LogOffset>]>,
     window: usize,
     next_outbound: u32,
     next_inbound: u32,
+    /// `Some` when this journal owns its conductor (via [`open`](Self::open) /
+    /// [`open_existing`](Self::open_existing)); `None` when the conductor is
+    /// caller-owned (via [`open_in`](Self::open_in)). Held only to drop after
+    /// the journals — never touched directly.
+    ///
+    /// Declared **last** so it drops after `outbound`/`inbound`: a
+    /// [`RotatingJournal`]'s `Drop` may spin waiting for the conductor thread to
+    /// finish an in-flight segment swap, so the [`Conductor`] (whose own `Drop`
+    /// joins that thread) must outlive the journals. Rust drops struct fields in
+    /// declaration order, so field order here is load-bearing.
+    _conductor: Option<Conductor>,
 }
 
 struct ResendIter<'a> {
@@ -79,12 +119,13 @@ impl<'a> Iterator for ResendIter<'a> {
             let is_gap = match self.journal.resend_one(seq) {
                 ResendPlan::GapFill => true,
                 ResendPlan::Replay(frame) => {
-                    let p = frame.payload();
-                    let msg_type = find_tag(p, 0, 35).map_or(b"" as &[u8], |s| s.slice(p));
+                    // Payload is `[ts:8][msg]`; replay the wire message only.
+                    let msg = &frame.payload()[TS_LEN..];
+                    let msg_type = find_tag(msg, 0, 35).map_or(b"" as &[u8], |s| s.slice(msg));
                     if is_admin_type(msg_type) {
                         true
                     } else {
-                        let app = ReplayItem::App(p);
+                        let app = ReplayItem::App(msg);
                         if let Some(gs) = self.gap_start.take() {
                             self.deferred = Some(app);
                             return Some(ReplayItem::GapFill {
@@ -104,32 +145,68 @@ impl<'a> Iterator for ResendIter<'a> {
 }
 
 impl FixJournal {
-    /// Open (or create) the journal for `session_id` under `dir`.
+    /// Open both journals for `session_id` through a caller-owned `conductor`.
     ///
-    /// If a manifest for `session_id` already exists under `dir`, the session
-    /// is recovered and `next_outbound` is restored from the stored messages.
-    /// If no manifest exists, a fresh session is created. Multiple sessions
-    /// can coexist under the same `dir` with distinct `session_id` values,
-    /// each with independent sequence number state.
+    /// This is the primary constructor: many sessions share one conductor (and
+    /// thus one background cleanup thread). The outbound journal uses conductor
+    /// session id `session_id * 2`, the inbound `session_id * 2 + 1`, so a FIX
+    /// `session_id` maps to a disjoint pair of conductor sessions.
     ///
     /// `window` is the resend horizon in messages (must be a power of two): the
     /// last `window` sequence numbers are replayable, older ones are gap-filled.
-    pub fn open(dir: impl AsRef<Path>, session_id: u32, window: usize) -> Result<Self, OpenError> {
-        assert!(window.is_power_of_two());
-        let mut conductor = Conductor::open(dir)?;
-        let journal: RotatingJournal = conductor
+    ///
+    /// The `conductor` must outlive the returned journal (see the [module
+    /// docs](self)). To get archival history for audit, build the conductor with
+    /// [`ConductorBuilder::archive(true)`](ConductorBuilder::archive) — the
+    /// convenience [`open`](Self::open) does this for you.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `window` is not a power of two, or if `session_id >= 2^31`
+    /// (the id is doubled to derive the two conductor session ids).
+    pub fn open_in(
+        conductor: &mut Conductor,
+        session_id: u32,
+        window: usize,
+        mode: OpenMode,
+    ) -> Result<Self, OpenError> {
+        assert!(window.is_power_of_two(), "window must be a power of two");
+        assert!(session_id < 1 << 31, "session_id must be < 2^31");
+        let outbound = conductor.session().session_id(session_id * 2).open(mode)?;
+        let inbound = conductor
             .session()
-            .session_id(session_id)
-            .open(OpenMode::OpenOrCreate)?;
+            .session_id(session_id * 2 + 1)
+            .open(mode)?;
         let mut this = Self {
-            journal,
-            _conductor: conductor,
+            _conductor: None,
+            outbound,
+            inbound,
             offsets: vec![None; window].into_boxed_slice(),
             window,
             next_outbound: 1,
             next_inbound: 1,
         };
-        this.recover_from_journal();
+        this.recover();
+        Ok(this)
+    }
+
+    /// Open (or create) the journal for `session_id` under `dir`, owning a
+    /// private conductor with archival enabled.
+    ///
+    /// Convenience for single-session callers. If a manifest for `session_id`
+    /// already exists under `dir`, the session is recovered (counters from the
+    /// meta-slots, resend ring from the outbound hot window); otherwise a fresh
+    /// session is created. Multiple sessions can coexist under the same `dir`
+    /// with distinct `session_id` values, each with independent state.
+    ///
+    /// `window` is the resend horizon in messages (must be a power of two).
+    ///
+    /// Multi-session applications should instead share one [`Conductor`] via
+    /// [`open_in`](Self::open_in).
+    pub fn open(dir: impl AsRef<Path>, session_id: u32, window: usize) -> Result<Self, OpenError> {
+        let mut conductor = ConductorBuilder::new(dir).archive(true).open()?;
+        let mut this = Self::open_in(&mut conductor, session_id, window, OpenMode::OpenOrCreate)?;
+        this._conductor = Some(conductor);
         Ok(this)
     }
 
@@ -138,56 +215,54 @@ impl FixJournal {
     ///
     /// Unlike [`open`](Self::open) this never creates a new session. Use for
     /// reconnect callers that must recover state — a wrong `session_id` is an
-    /// error rather than a silent fresh start.
+    /// error rather than a silent fresh start. Like [`open`](Self::open), the
+    /// owned conductor has archival enabled.
     pub fn open_existing(
         dir: impl AsRef<Path>,
         session_id: u32,
         window: usize,
     ) -> Result<Self, OpenError> {
-        assert!(window.is_power_of_two());
+        assert!(window.is_power_of_two(), "window must be a power of two");
+        assert!(session_id < 1 << 31, "session_id must be < 2^31");
         // No filesystem side-effects when the journal root does not exist: a
         // typo'd path must not materialize an empty conductor directory.
         if !dir.as_ref().exists() {
             return Err(OpenError::SessionNotFound { session_id });
         }
-        let mut conductor = Conductor::open(dir)?;
-        let journal: RotatingJournal = conductor
-            .session()
-            .session_id(session_id)
-            .open(OpenMode::OpenExisting)?;
-        let mut this = Self {
-            journal,
-            _conductor: conductor,
-            offsets: vec![None; window].into_boxed_slice(),
-            window,
-            next_outbound: 1,
-            next_inbound: 1,
-        };
-        this.recover_from_journal();
+        let mut conductor = ConductorBuilder::new(dir).archive(true).open()?;
+        let mut this = Self::open_in(&mut conductor, session_id, window, OpenMode::OpenExisting)?;
+        this._conductor = Some(conductor);
         Ok(this)
     }
 
-    fn recover_from_journal(&mut self) {
-        let mut pos = self.journal.read_start();
-        let mut last_seq: Option<u32> = None;
-        let mut last_inbound: Option<u32> = None;
-        while let Some(frame) = self.journal.read_next(&mut pos) {
+    /// Recover counters (O(1) from the manifest meta-slots) and rebuild the
+    /// resend ring by scanning the bounded outbound hot window.
+    fn recover(&mut self) {
+        // Counters: the meta-slot stores `next_*` directly; 0 means fresh → 1.
+        self.next_outbound = match self.outbound.meta() as u32 {
+            0 => 1,
+            n => n,
+        };
+        self.next_inbound = match self.inbound.meta() as u32 {
+            0 => 1,
+            n => n,
+        };
+        // Resend ring: repopulate `offsets` from the outbound hot window. Bounded
+        // by the readable segments (O(window) at most), so this survives across a
+        // restart — the whole point of persisting the offset table's inputs.
+        let mut pos = self.outbound.read_start();
+        while let Some(frame) = self.outbound.read_next(&mut pos) {
             let p = frame.payload();
-            if let Some(rest) = p.strip_prefix(INBOUND_MARKER) {
-                if let Some(n) = std::str::from_utf8(rest).ok().and_then(|s| s.parse().ok()) {
-                    last_inbound = Some(n);
-                }
-            } else if let Some(span) = find_tag(p, 0, 34)
-                && let Ok(seq) = parse_fix_seqnum(span.slice(p))
-            {
-                last_seq = Some(seq as u32);
+            if p.len() < TS_LEN {
+                continue;
             }
-        }
-        if let Some(seq) = last_seq {
-            self.next_outbound = seq.wrapping_add(1);
-        }
-        if let Some(n) = last_inbound {
-            self.next_inbound = n;
+            let msg = &p[TS_LEN..];
+            if let Some(span) = find_tag(msg, 0, 34)
+                && let Ok(seq) = parse_fix_seqnum(span.slice(msg))
+            {
+                let lo = self.outbound.log_offset_at(frame.offset());
+                self.offsets[seq as usize & (self.window - 1)] = Some(lo);
+            }
         }
     }
 
@@ -198,21 +273,40 @@ impl FixJournal {
     /// is passed in only to index the resend ring without re-parsing on the hot
     /// path; the cold paths ([`resend`](Self::resend), [`recover`](Self::recover))
     /// read the seqnum back out of the message via tag 34.
+    ///
+    /// The stored payload is `[ts:8][msg]` (an 8-byte LE UNIX-nanos timestamp
+    /// prepended in-frame). The outbound manifest's meta-slot is updated to
+    /// `seq + 1` so `next_outbound` recovers in O(1).
     pub fn store(&mut self, seq: u32, msg: &[u8]) -> Result<(), WriteError> {
-        let offset = self.journal.append(msg)?;
-        self.offsets[seq as usize & (self.window - 1)] = Some(offset);
+        let ts = unix_nanos_now().to_le_bytes();
+        let off = self.outbound.append_prefixed(&ts, msg)?;
+        self.offsets[seq as usize & (self.window - 1)] = Some(off);
         self.next_outbound = seq.wrapping_add(1);
+        self.outbound.set_meta(self.next_outbound as u64);
+        Ok(())
+    }
+
+    /// Archive an inbound message for visibility / audit.
+    ///
+    /// Purely archival: the inbound journal is never read by the resend path.
+    /// The inbound *counter* is maintained separately via
+    /// [`set_next_inbound`](Self::set_next_inbound). Stored payload is
+    /// `[ts:8][msg]`, matching the outbound side.
+    pub fn store_inbound(&mut self, msg: &[u8]) -> Result<(), WriteError> {
+        let ts = unix_nanos_now().to_le_bytes();
+        self.inbound.append_prefixed(&ts, msg)?;
         Ok(())
     }
 
     fn resend_one(&self, seq: u32) -> ResendPlan<'_> {
         let slot = seq as usize & (self.window - 1);
         if let Some(off) = self.offsets[slot]
-            && let Some(frame) = self.journal.read(off)
+            && let Some(frame) = self.outbound.read(off)
+            && frame.payload().len() >= TS_LEN
         {
-            let p = frame.payload();
-            if let Some(span) = find_tag(p, 0, 34)
-                && parse_fix_seqnum(span.slice(p)).ok().map(|s| s as u32) == Some(seq)
+            let msg = &frame.payload()[TS_LEN..];
+            if let Some(span) = find_tag(msg, 0, 34)
+                && parse_fix_seqnum(span.slice(msg)).ok().map(|s| s as u32) == Some(seq)
             {
                 return ResendPlan::Replay(frame);
             }
@@ -248,14 +342,17 @@ impl FixJournal {
         self.set_next_inbound(self.next_inbound.wrapping_add(1));
     }
 
+    /// Set the expected next inbound sequence number, persisting it to the
+    /// inbound journal's meta-slot for O(1) recovery.
+    ///
+    /// A no-op when `seq` is unchanged, so a hot-path caller can invoke it every
+    /// receive without a redundant manifest write.
     pub fn set_next_inbound(&mut self, seq: u32) {
         if seq == self.next_inbound {
             return;
         }
         self.next_inbound = seq;
-        let mut buf = [0u8; 13];
-        let len = encode_inbound_checkpoint(seq, &mut buf);
-        let _ = self.journal.append(&buf[..len]);
+        self.inbound.set_meta(seq as u64);
     }
 }
 
@@ -345,12 +442,13 @@ mod tests {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
 
-        match j.resend_one(3) {
-            ResendPlan::Replay(frame) => {
-                assert_eq!(frame.payload(), fix_msg(3).as_slice());
-            }
-            ResendPlan::GapFill => panic!("expected Replay"),
-        }
+        // resend strips the 8-byte ts prefix and returns the original wire bytes.
+        let items = collect_range(&j, 3, 3);
+        assert_eq!(items.len(), 1);
+        let ReplayItem::App(bytes) = items[0] else {
+            panic!("expected App");
+        };
+        assert_eq!(bytes, fix_msg(3).as_slice());
 
         cleanup(&dir);
     }
@@ -389,6 +487,58 @@ mod tests {
         let j = FixJournal::open(&dir, 0, 64).unwrap();
         assert_eq!(j.next_inbound(), 42);
         assert_eq!(j.next_outbound(), 2);
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn cross_restart_resend_replays() {
+        // The point of rebuilding the resend ring on recovery: after a restart,
+        // in-window seqnums replay the ACTUAL stored bytes, not a gap-fill.
+        let dir = tmp_dir("cross-restart");
+        cleanup(&dir);
+
+        let msgs: Vec<Vec<u8>> = (1..=5u32).map(fix_msg).collect();
+        {
+            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            for (i, m) in msgs.iter().enumerate() {
+                j.store(i as u32 + 1, m).unwrap();
+            }
+        }
+
+        // Reopen: offsets table is empty until `recover()` rebuilds it from the
+        // outbound hot window.
+        let j = FixJournal::open_existing(&dir, 0, 64).unwrap();
+        assert_eq!(j.next_outbound(), 6);
+
+        let items = collect_range(&j, 1, 5);
+        assert_eq!(items.len(), 5, "all five should replay, none gap-filled");
+        for (i, item) in items.iter().enumerate() {
+            let ReplayItem::App(bytes) = item else {
+                panic!("seq {} gap-filled after restart", i + 1);
+            };
+            assert_eq!(*bytes, msgs[i].as_slice(), "seq {} bytes mismatch", i + 1);
+        }
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn store_inbound_is_archival_only() {
+        // store_inbound must not touch the outbound resend path or counters.
+        let dir = tmp_dir("store-inbound");
+        cleanup(&dir);
+
+        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        j.store(1, &fix_msg(1)).unwrap();
+        j.store_inbound(&fix_msg(9)).unwrap();
+        j.store_inbound(&fix_msg(10)).unwrap();
+
+        // Outbound state untouched by inbound writes.
+        assert_eq!(j.next_outbound(), 2);
+        let items = collect_range(&j, 1, 1);
+        assert_eq!(items.len(), 1);
+        assert!(matches!(items[0], ReplayItem::App(_)));
 
         cleanup(&dir);
     }
@@ -597,8 +747,11 @@ mod tests {
         cleanup(&dir);
 
         {
-            let mut j0 = FixJournal::open(&dir, 0, 64).unwrap();
-            let mut j1 = FixJournal::open(&dir, 1, 64).unwrap();
+            let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+            let mut j0 =
+                FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenOrCreate).unwrap();
+            let mut j1 =
+                FixJournal::open_in(&mut conductor, 1, 64, OpenMode::OpenOrCreate).unwrap();
 
             for seq in 1..=3u32 {
                 j0.store(seq, &fix_msg(seq)).unwrap();
@@ -611,11 +764,34 @@ mod tests {
             assert_eq!(j1.next_outbound(), 6);
         }
 
-        // Reopen both and verify each recovers its own next_outbound independently.
-        let j0 = FixJournal::open(&dir, 0, 64).unwrap();
-        let j1 = FixJournal::open(&dir, 1, 64).unwrap();
+        // Reopen both through a fresh shared conductor and verify each recovers
+        // its own next_outbound independently.
+        let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+        let j0 = FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenExisting).unwrap();
+        let j1 = FixJournal::open_in(&mut conductor, 1, 64, OpenMode::OpenExisting).unwrap();
         assert_eq!(j0.next_outbound(), 4);
         assert_eq!(j1.next_outbound(), 6);
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn open_in_shares_one_conductor() {
+        // Two FIX sessions under one conductor use disjoint conductor session
+        // ids (2n / 2n+1) and stay independent.
+        let dir = tmp_dir("open-in-shared");
+        cleanup(&dir);
+
+        let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+        let mut a = FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenOrCreate).unwrap();
+        let mut b = FixJournal::open_in(&mut conductor, 7, 64, OpenMode::OpenOrCreate).unwrap();
+
+        a.store(1, &fix_msg(1)).unwrap();
+        a.store(2, &fix_msg(2)).unwrap();
+        b.store(1, &fix_msg(1)).unwrap();
+
+        assert_eq!(a.next_outbound(), 3);
+        assert_eq!(b.next_outbound(), 2);
 
         cleanup(&dir);
     }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -6,6 +6,7 @@ use nexus_fix_codec::{
     FieldReader, FixAdminMsg, FixDictionary, FixHeader, FrameFormatter, encode_fix_uint, find_tag,
     parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
 };
+use nexus_journal::WriteError;
 
 use crate::frame::{FrameError, FrameWriter};
 use crate::framework::{Message, MessageReader, MessageWriter, SessionConfig, SessionError};
@@ -18,6 +19,7 @@ pub enum Error {
     Io(io::Error),
     FrameTooLarge(usize),
     Protocol(SessionError),
+    Journal(WriteError),
 }
 
 impl std::fmt::Display for Error {
@@ -26,6 +28,7 @@ impl std::fmt::Display for Error {
             Self::Io(e) => write!(f, "I/O: {e}"),
             Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
             Self::Protocol(e) => write!(f, "protocol: {e}"),
+            Self::Journal(e) => write!(f, "journal: {e}"),
         }
     }
 }
@@ -252,9 +255,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
             return Err(Error::FrameTooLarge(frame.len()));
         }
-        self.journal
-            .store(seq, frame)
-            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        journal_write(|| self.journal.store(seq, frame))?;
         write_through(&mut self.stream, &mut self.writer.inner, frame)
     }
 
@@ -366,6 +367,11 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 reason: DisconnectReason::CompIdMismatch,
             }));
         }
+
+        // Well-framed and comp-id-valid: archive the inbound message for
+        // visibility/audit. Garbage and foreign (comp-id-mismatched) frames are
+        // not journaled — they never reach here.
+        journal_write(|| self.journal.store_inbound(frame))?;
 
         let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
             s.slice(frame)
@@ -613,6 +619,30 @@ fn do_resend<S: Write, D: FixDictionary>(
     writer.flush_to(stream).map_err(Error::Io)
 }
 
+/// Write to the journal, retrying on transient standby backpressure.
+///
+/// `store` is one of `FixJournal::store` / `store_inbound`. On
+/// [`WriteError::StandbyNotReady`] we spin and retry; any other error (a static
+/// [`WriteError::RecordTooLarge`] misconfiguration) is returned as
+/// [`Error::Journal`].
+///
+/// Unbounded on purpose. StandbyNotReady is transient backpressure the conductor
+/// clears in sub-ms; the only way this spins forever is a full/failing disk,
+/// which must be caught by observability. Spinning beats the alternative of
+/// dropping a message from a resend/audit journal. Spinning (rather than
+/// blocking) is fine here: the conductor makes progress on its own thread, and
+/// `recv` already blocks on the socket read.
+#[inline]
+fn journal_write(mut store: impl FnMut() -> Result<(), WriteError>) -> Result<(), Error> {
+    loop {
+        match store() {
+            Ok(()) => return Ok(()),
+            Err(WriteError::StandbyNotReady) => std::hint::spin_loop(),
+            Err(e) => return Err(Error::Journal(e)),
+        }
+    }
+}
+
 fn store_admin<D: FixDictionary>(
     admin: AdminMsg,
     writer: &mut MessageWriter<D>,
@@ -633,9 +663,7 @@ fn store_admin<D: FixDictionary>(
     writer.encode_admin(admin, config);
     let frame = &writer.inner.data()[before..];
     if !frame.is_empty() {
-        journal
-            .store(seq, frame)
-            .map_err(|e| Error::Io(io::Error::other(format!("{e:?}"))))?;
+        journal_write(|| journal.store(seq, frame))?;
     }
     Ok(())
 }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -17,18 +17,16 @@ use crate::timestamp::UTC_TIMESTAMP_LEN;
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
-    FrameTooLarge(usize),
+    MessageTooLarge(usize),
     Protocol(SessionError),
-    Journal(WriteError),
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(e) => write!(f, "I/O: {e}"),
-            Self::FrameTooLarge(n) => write!(f, "frame too large: {n} bytes"),
+            Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
             Self::Protocol(e) => write!(f, "protocol: {e}"),
-            Self::Journal(e) => write!(f, "journal: {e}"),
         }
     }
 }
@@ -253,9 +251,9 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         // for a later resend reframe. An application that sends larger messages
         // sizes the buffer up front via `writer_capacity(...)`.
         if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
-            return Err(Error::FrameTooLarge(frame.len()));
+            return Err(Error::MessageTooLarge(frame.len()));
         }
-        journal_write(|| self.journal.store(seq, frame))?;
+        journal_write(frame.len(), || self.journal.store(seq, frame))?;
         write_through(&mut self.stream, &mut self.writer.inner, frame)
     }
 
@@ -283,7 +281,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
 
             match self.reader.inner.next() {
                 Err(FrameError::MessageTooLarge { size }) => {
-                    return Err(Error::FrameTooLarge(size));
+                    return Err(Error::MessageTooLarge(size));
                 }
                 Err(FrameError::Garbage { .. }) => {
                     self.garbage_frames += 1;
@@ -371,7 +369,7 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
         // Well-framed and comp-id-valid: archive the inbound message for
         // visibility/audit. Garbage and foreign (comp-id-mismatched) frames are
         // not journaled — they never reach here.
-        journal_write(|| self.journal.store_inbound(frame))?;
+        journal_write(frame.len(), || self.journal.store_inbound(frame))?;
 
         let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
             s.slice(frame)
@@ -613,7 +611,8 @@ fn do_resend<S: Write, D: FixDictionary>(
             };
             // `send_app`'s headroom guarantees a reframe fits an empty buffer;
             // a failure here means the writer was sized too small.
-            retry.map_err(|()| Error::FrameTooLarge(writer.inner.remaining().saturating_add(1)))?;
+            retry
+                .map_err(|()| Error::MessageTooLarge(writer.inner.remaining().saturating_add(1)))?;
         }
     }
     writer.flush_to(stream).map_err(Error::Io)
@@ -621,10 +620,10 @@ fn do_resend<S: Write, D: FixDictionary>(
 
 /// Write to the journal, retrying on transient standby backpressure.
 ///
-/// `store` is one of `FixJournal::store` / `store_inbound`. On
-/// [`WriteError::StandbyNotReady`] we spin and retry; any other error (a static
-/// [`WriteError::RecordTooLarge`] misconfiguration) is returned as
-/// [`Error::Journal`].
+/// `store` is one of `FixJournal::store` / `store_inbound`, `size` its frame
+/// length. On [`WriteError::StandbyNotReady`] (transient backpressure) we spin
+/// and retry; a [`WriteError::RecordTooLarge`] misconfiguration surfaces as
+/// [`Error::MessageTooLarge`].
 ///
 /// Unbounded on purpose. StandbyNotReady is transient backpressure the conductor
 /// clears in sub-ms; the only way this spins forever is a full/failing disk,
@@ -633,12 +632,17 @@ fn do_resend<S: Write, D: FixDictionary>(
 /// blocking) is fine here: the conductor makes progress on its own thread, and
 /// `recv` already blocks on the socket read.
 #[inline]
-fn journal_write(mut store: impl FnMut() -> Result<(), WriteError>) -> Result<(), Error> {
+fn journal_write(
+    size: usize,
+    mut store: impl FnMut() -> Result<(), WriteError>,
+) -> Result<(), Error> {
     loop {
         match store() {
             Ok(()) => return Ok(()),
             Err(WriteError::StandbyNotReady) => std::hint::spin_loop(),
-            Err(e) => return Err(Error::Journal(e)),
+            // Only RecordTooLarge today; WriteError is non-exhaustive, so any
+            // other (non-backpressure) journal write error surfaces the same way.
+            Err(_) => return Err(Error::MessageTooLarge(size)),
         }
     }
 }
@@ -663,7 +667,7 @@ fn store_admin<D: FixDictionary>(
     writer.encode_admin(admin, config);
     let frame = &writer.inner.data()[before..];
     if !frame.is_empty() {
-        journal_write(|| journal.store(seq, frame))?;
+        journal_write(frame.len(), || journal.store(seq, frame))?;
     }
     Ok(())
 }
@@ -680,7 +684,7 @@ fn write_through<S: Write>(
         // The frame exceeds the pre-allocated buffer even when empty. `send_app`
         // caps app frames below this, so reaching here means the buffer is
         // undersized for the workload — a configuration error, not a fallback.
-        return Err(Error::FrameTooLarge(frame.len()));
+        return Err(Error::MessageTooLarge(frame.len()));
     }
     let spare = writer.spare();
     spare[..frame.len()].copy_from_slice(frame);

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -759,6 +759,6 @@ fn send_app_rejects_oversized_frame() {
     let oversized = vec![0u8; 64 * 1024];
     assert!(matches!(
         conn.send_app(1, &oversized),
-        Err(TransportError::FrameTooLarge(_))
+        Err(TransportError::MessageTooLarge(_))
     ));
 }

--- a/nexus-journal/CHANGELOG.md
+++ b/nexus-journal/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to nexus-journal are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/),
+with the project-specific allowance that a minor bump may carry small,
+narrowly-scoped breaking changes when external blast radius is
+contained.
+
+## [Unreleased]
+
+### Added
+
+- `RotatingJournal::meta` / `set_meta`: an opaque `u64` manifest meta-slot,
+  written in place and recovered on reopen (mirrors `epoch`/`set_epoch`). The
+  journal never interprets it; callers use it as a durable checkpoint (e.g. a
+  FIX sequence number).
+- `RotatingJournal::log_offset_at`: reconstruct a ring-usable `LogOffset` from a
+  frame's global offset (as returned by `Frame::offset()` during a `read_next`
+  scan), using the current `slot_gen`. Frames outside the readable window fail
+  the gen-check on `read()` and yield `None`.
+- `RotatingJournal::append_prefixed`: write a prefix and body contiguously into
+  one frame in a single copy. `append` is now `append_prefixed(&[], body)`.

--- a/nexus-journal/src/rotating/manifest.rs
+++ b/nexus-journal/src/rotating/manifest.rs
@@ -14,12 +14,14 @@ pub(crate) const SESSION_NAME_LEN: usize = 64;
 /// Fixed-size header at the start of `journal.manifest`.
 ///
 /// Mmap'd directly — reads and writes go through the page cache with no
-/// serialization layer. All fields except `epoch` are written once at
-/// creation and never change. `epoch` is atomically updated on each
+/// serialization layer. All fields except `epoch` and `meta` are written
+/// once at creation and never change. `epoch` is atomically updated on each
 /// segment rotation, which is how crash recovery knows which slot was
-/// active: `slot_index = epoch % 3`.
+/// active: `slot_index = epoch % 3`. `meta` is an opaque `u64` slot the
+/// journal never interprets; the owner (e.g. a FIX engine storing a seqnum
+/// checkpoint) reads and writes it in place.
 ///
-/// # Binary layout (96 bytes, 8-byte aligned)
+/// # Binary layout (104 bytes, 8-byte aligned)
 ///
 /// ```text
 ///  offset  size  field
@@ -32,7 +34,12 @@ pub(crate) const SESSION_NAME_LEN: usize = 64;
 ///   88       2   version          (format version, currently 1)
 ///   90       1   name_len         (valid bytes in name[])
 ///   91       5   _pad
+///   96       8   meta             (AtomicU64, opaque owner-defined slot)
 /// ```
+///
+/// `meta` is appended after the original 96-byte layout so existing offsets
+/// are unchanged; a manifest written by an earlier build (which zero-extends
+/// the 4 KiB file) reads `meta` back as `0`.
 #[repr(C)]
 struct ManifestHeader {
     name: [u8; SESSION_NAME_LEN],
@@ -43,10 +50,11 @@ struct ManifestHeader {
     version: u16,
     name_len: u8,
     _pad: [u8; 5],
+    meta: AtomicU64,
 }
 
 const _: () = {
-    assert!(size_of::<ManifestHeader>() == 96);
+    assert!(size_of::<ManifestHeader>() == 104);
     assert!(align_of::<ManifestHeader>() == 8);
 };
 
@@ -95,6 +103,7 @@ impl Manifest {
         hdr.version = VERSION;
         hdr.name_len = n as u8;
         hdr._pad = [0; 5];
+        *hdr.meta.get_mut() = 0;
 
         Ok(Self { mapping })
     }
@@ -138,13 +147,21 @@ impl Manifest {
         self.header().epoch.store(epoch, Ordering::Release);
     }
 
+    pub(crate) fn meta(&self) -> u64 {
+        self.header().meta.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_meta(&self, val: u64) {
+        self.header().meta.store(val, Ordering::Release);
+    }
+
     fn header(&self) -> &ManifestHeader {
         Self::header_of(&self.mapping)
     }
 
     fn header_of(mapping: &MappedFile) -> &ManifestHeader {
         // SAFETY: the mapping is at least MANIFEST_FILE_SIZE bytes and
-        // page-aligned. ManifestHeader is 96 bytes with 8-byte alignment.
+        // page-aligned. ManifestHeader is 104 bytes with 8-byte alignment.
         unsafe { &*mapping.as_ptr().cast::<ManifestHeader>() }
     }
 }

--- a/nexus-journal/src/rotating/mod.rs
+++ b/nexus-journal/src/rotating/mod.rs
@@ -319,6 +319,30 @@ impl RotatingJournal {
         std::str::from_utf8(bytes).unwrap_or("")
     }
 
+    /// Read the opaque metadata slot stored in the manifest.
+    ///
+    /// The journal never interprets this value — it is a reserved `u64` the
+    /// owner writes via [`set_meta`](Self::set_meta) and reads here. It
+    /// survives rotation and recovery (persisted in the manifest, like the
+    /// rotation epoch). A freshly created session, or one created by a build
+    /// predating this slot, reads back `0`.
+    ///
+    /// Typical use is a small application checkpoint (e.g. a FIX sequence
+    /// number) that must be recovered in O(1) without scanning the log.
+    pub fn meta(&self) -> u64 {
+        self.manifest.meta()
+    }
+
+    /// Write the opaque metadata slot in the manifest, in place.
+    ///
+    /// Persisted like the rotation epoch: an mmap store to the manifest page,
+    /// no syscall on the hot path, not fsynced (process-crash-safe, not
+    /// power-loss-safe — matching the journal's durability model). The value
+    /// is read back by [`meta`](Self::meta) after recovery.
+    pub fn set_meta(&self, val: u64) {
+        self.manifest.set_meta(val);
+    }
+
     /// Append `payload` to the active segment.
     ///
     /// The session ID is set by the conductor at open time and written into
@@ -331,9 +355,31 @@ impl RotatingJournal {
     ///
     /// Panics if the conductor cleanup thread has exited (indicates a bug).
     pub fn append(&mut self, payload: &[u8]) -> Result<LogOffset, WriteError> {
+        self.append_prefixed(&[], payload)
+    }
+
+    /// Append `prefix` immediately followed by `body` as a single frame.
+    ///
+    /// The two slices are written contiguously into one frame — the stored
+    /// payload is `[prefix][body]`, indistinguishable on read from a single
+    /// `append` of the concatenation. This costs exactly one copy of each
+    /// slice (the same total copy as `append`), letting a caller prepend a
+    /// small header (e.g. a timestamp) without staging the concatenation in a
+    /// temporary buffer first.
+    ///
+    /// The session ID is set by the conductor at open time and written into
+    /// every frame header automatically.
+    ///
+    /// Returns a [`LogOffset`] valid for reads until the slot is rotated out
+    /// (two rotations after this write).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the conductor cleanup thread has exited (indicates a bug).
+    pub fn append_prefixed(&mut self, prefix: &[u8], body: &[u8]) -> Result<LogOffset, WriteError> {
         self.try_flush_dirty();
-        let body = payload.len();
-        let foot = footprint(body);
+        let payload_len = prefix.len() + body.len();
+        let foot = footprint(payload_len);
         if foot > self.segment_size {
             return Err(WriteError::RecordTooLarge {
                 max: self.segment_size.saturating_sub(FRAME_HDR),
@@ -346,19 +392,23 @@ impl RotatingJournal {
         let data = self.slots[self.current].data;
         // SAFETY: `off + foot <= self.segment_size` (checked above or after rotate).
         // `data` points into a live mmap'd mapping that is at least `segment_size`
-        // bytes. Frame header fields are at 4-byte-aligned offsets.
+        // bytes. Frame header fields are at 4-byte-aligned offsets. `prefix` and
+        // `body` are written back-to-back starting at `ptr + FRAME_HDR`; their
+        // combined length is `payload_len`, which fits within `foot`.
         // Write order: payload, session_id, next sentinel, then commit_len.
         // commit_len encodes body length as `len + 1` so that zero means
         // "uncommitted", allowing zero-length payloads.
         unsafe {
             let ptr = data.add(off);
-            std::ptr::copy_nonoverlapping(payload.as_ptr(), ptr.add(FRAME_HDR), body);
+            let dst = ptr.add(FRAME_HDR);
+            std::ptr::copy_nonoverlapping(prefix.as_ptr(), dst, prefix.len());
+            std::ptr::copy_nonoverlapping(body.as_ptr(), dst.add(prefix.len()), body.len());
             *session_id_ptr(ptr) = self.session_id;
             let next = off + foot;
             if next + FRAME_HDR <= self.segment_size {
                 write_commit_len(data.add(next), 0);
             }
-            write_commit_len(ptr, (body as u32).wrapping_add(1));
+            write_commit_len(ptr, (payload_len as u32).wrapping_add(1));
         }
         self.cursor += foot;
         Ok(LogOffset::new(
@@ -398,6 +448,36 @@ impl RotatingJournal {
                 *session_id_ptr(ptr),
             ))
         }
+    }
+
+    /// Reconstruct a [`LogOffset`] for a frame at global offset `global`.
+    ///
+    /// [`Frame::offset`] yields a *global* byte position (spanning all
+    /// segments), but [`read`](Self::read) takes a slot-addressed
+    /// [`LogOffset`]. This bridges the two: given a global offset obtained
+    /// from a frame **currently in the readable window** (i.e. just returned
+    /// by [`read_next`](Self::read_next)), it returns a handle that
+    /// [`read`](Self::read) resolves to the same frame.
+    ///
+    /// The handle is tagged with the current generation of the slot the offset
+    /// lands in, so it behaves like one returned by [`append`](Self::append):
+    /// valid until that slot rotates out, after which [`read`](Self::read)
+    /// returns `None` (the generation check fails).
+    ///
+    /// # Contract
+    ///
+    /// `global` must reference a frame that is readable *now* — pass it
+    /// straight from a live scan. A global offset saved from a segment that
+    /// has since been reused by a newer one is not detectable here (the slot
+    /// index collides); the resulting handle would resolve against the new
+    /// segment's contents. This is the same staleness window as any
+    /// [`LogOffset`], surfaced through a different constructor.
+    pub fn log_offset_at(&self, global: u64) -> LogOffset {
+        let seg_size = self.segment_size as u64;
+        let seg = global / seg_size;
+        let local = (global % seg_size) as usize;
+        let slot = (seg % 3) as usize;
+        LogOffset::new(slot as u8, local, self.slot_gen[slot])
     }
 
     /// Monotonically increasing global offset at the current write position.

--- a/nexus-journal/src/rotating/tests.rs
+++ b/nexus-journal/src/rotating/tests.rs
@@ -1391,3 +1391,235 @@ fn overwrite_shrinks_reused_segment_files() {
         );
     }
 }
+
+// ---- meta slot (1a) ----
+
+#[test]
+fn meta_defaults_to_zero() {
+    let d = TempDir::new("meta-default");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log = open_id(&mut c, 1 << 16, 1);
+    assert_eq!(log.meta(), 0);
+}
+
+#[test]
+fn meta_roundtrips_in_memory() {
+    let d = TempDir::new("meta-mem");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log = open_id(&mut c, 1 << 16, 1);
+    log.set_meta(0xDEAD_BEEF_CAFE_F00D);
+    assert_eq!(log.meta(), 0xDEAD_BEEF_CAFE_F00D);
+    log.set_meta(42);
+    assert_eq!(log.meta(), 42);
+}
+
+#[test]
+fn meta_survives_recovery() {
+    let d = TempDir::new("meta-recover");
+
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let mut log = open_id(&mut c, 1 << 16, 1);
+        log.append(b"data").unwrap();
+        log.set_meta(0x0123_4567_89AB_CDEF);
+    }
+
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log = c
+        .session()
+        .session_id(1)
+        .open(OpenMode::OpenExisting)
+        .unwrap();
+    assert_eq!(log.meta(), 0x0123_4567_89AB_CDEF);
+}
+
+#[test]
+fn meta_independent_across_sessions() {
+    let d = TempDir::new("meta-multi");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log1 = open_id(&mut c, 1 << 16, 1);
+    let log2 = open_id(&mut c, 1 << 16, 2);
+    log1.set_meta(111);
+    log2.set_meta(222);
+    assert_eq!(log1.meta(), 111);
+    assert_eq!(log2.meta(), 222);
+}
+
+#[test]
+fn meta_survives_rotation() {
+    // The meta-slot lives in the manifest, not the segments, so a counter
+    // stored there must survive the segments rotating out from under it — the
+    // whole reason FixJournal recovers seqnums from it instead of scanning a
+    // window that ages out.
+    let d = TempDir::new("meta-rotation");
+    {
+        let mut c = Conductor::open(d.path()).unwrap();
+        let mut log = open_id(&mut c, 64, 1);
+        // Interleave set_meta with appends that force many rotations, mirroring
+        // FixJournal updating next_outbound on every store. Retry across rotation
+        // backpressure (StandbyNotReady until the conductor cleans the standby),
+        // as the engine does on the hot path; an 8-byte record can only fail that
+        // way here.
+        for i in 1..=20u64 {
+            while log.append(&[0u8; 8]).is_err() {
+                wait_conductor(&log);
+            }
+            log.set_meta(i);
+        }
+        wait_conductor(&log);
+        assert_eq!(log.meta(), 20, "meta corrupted by rotation");
+    }
+    // Recovers after all that rotation, with the counted records long aged out.
+    let mut c = Conductor::open(d.path()).unwrap();
+    let log = c
+        .session()
+        .session_id(1)
+        .open(OpenMode::OpenExisting)
+        .unwrap();
+    assert_eq!(log.meta(), 20);
+}
+
+// ---- log_offset_at (1b) ----
+
+#[test]
+fn log_offset_at_roundtrips_scanned_frames() {
+    let d = TempDir::new("logoff-rt");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 1 << 16);
+
+    let payloads: Vec<Vec<u8>> = (0u8..8).map(|i| vec![i; (i as usize) + 1]).collect();
+    for p in &payloads {
+        log.append(p).unwrap();
+    }
+
+    // Scan the readable window, capturing each frame's global offset.
+    let mut scanned: Vec<(u64, Vec<u8>)> = Vec::new();
+    let mut pos = log.read_start();
+    while let Some(frame) = log.read_next(&mut pos) {
+        scanned.push((frame.offset(), frame.payload().to_vec()));
+    }
+    assert_eq!(scanned.len(), payloads.len());
+
+    // Reconstruct a LogOffset from each global offset and read it back.
+    for (global, expected) in &scanned {
+        let lo = log.log_offset_at(*global);
+        let frame = log.read(lo).expect("reconstructed offset must read");
+        assert_eq!(frame.payload(), expected.as_slice());
+        assert_eq!(frame.offset(), *global);
+    }
+}
+
+#[test]
+fn log_offset_at_roundtrips_across_rotation() {
+    let d = TempDir::new("logoff-rot");
+    let mut c = Conductor::open(d.path()).unwrap();
+    // 4 records per 64-byte segment. Write into current + prev, both readable.
+    let mut log = open_id(&mut c, 64, 1);
+    for i in 0..6u8 {
+        log.append(&[i; 8]).unwrap();
+    }
+
+    let mut scanned: Vec<(u64, [u8; 8])> = Vec::new();
+    let mut pos = log.read_start();
+    while let Some(frame) = log.read_next(&mut pos) {
+        scanned.push((frame.offset(), frame.payload().try_into().unwrap()));
+    }
+    // prev (epoch 0) evicted-empty at init, so readable window is the 4 in
+    // prev slot (recs 2..6) plus current — verify each round-trips.
+    assert!(!scanned.is_empty());
+    for (global, expected) in &scanned {
+        let lo = log.log_offset_at(*global);
+        let frame = log.read(lo).expect("reconstructed offset must read");
+        assert_eq!(frame.payload(), expected);
+    }
+}
+
+#[test]
+fn log_offset_at_evicted_reads_none() {
+    let d = TempDir::new("logoff-evict");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open_id(&mut c, 64, 1);
+
+    // Capture a global offset in the first segment, then rotate it out.
+    log.append(&[7u8; 8]).unwrap();
+    let mut pos = log.read_start();
+    let stale_global = log.read_next(&mut pos).unwrap().offset();
+
+    for _ in 1..4 {
+        log.append(&[0u8; 8]).unwrap();
+    }
+    for _ in 0..4 {
+        log.append(&[0u8; 8]).unwrap();
+    }
+    wait_conductor(&log);
+    log.append(&[0u8; 8]).unwrap();
+
+    // The segment holding stale_global has been evicted; the reconstructed
+    // handle must fail the generation check rather than mis-read.
+    let lo = log.log_offset_at(stale_global);
+    assert!(log.read(lo).is_none());
+}
+
+// ---- append_prefixed (1c) ----
+
+#[test]
+fn append_prefixed_concatenates() {
+    let d = TempDir::new("prefix-cat");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 1 << 16);
+
+    let ts = 0x0102_0304_0506_0708u64.to_le_bytes();
+    let msg = b"8=FIX.4.4\x0135=D\x01";
+    let off = log.append_prefixed(&ts, msg).unwrap();
+
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&ts);
+    expected.extend_from_slice(msg);
+    assert_eq!(log.read(off).unwrap().payload(), expected.as_slice());
+}
+
+#[test]
+fn append_prefixed_empty_prefix_equals_append() {
+    let d = TempDir::new("prefix-empty-pfx");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 1 << 16);
+    let off = log.append_prefixed(&[], b"hello").unwrap();
+    assert_eq!(log.read(off).unwrap().payload(), b"hello");
+}
+
+#[test]
+fn append_prefixed_empty_body() {
+    let d = TempDir::new("prefix-empty-body");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 1 << 16);
+    let ts = 99u64.to_le_bytes();
+    let off = log.append_prefixed(&ts, &[]).unwrap();
+    assert_eq!(log.read(off).unwrap().payload(), &ts);
+}
+
+#[test]
+fn append_prefixed_scans_as_one_frame() {
+    let d = TempDir::new("prefix-scan");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 1 << 16);
+    log.append_prefixed(&[0xAAu8; 8], b"one").unwrap();
+    log.append_prefixed(&[0xBBu8; 8], b"two").unwrap();
+
+    let mut pos = log.read_start();
+    let f1 = log.read_next(&mut pos).unwrap();
+    assert_eq!(&f1.payload()[..8], &[0xAAu8; 8]);
+    assert_eq!(&f1.payload()[8..], b"one");
+    let f2 = log.read_next(&mut pos).unwrap();
+    assert_eq!(&f2.payload()[..8], &[0xBBu8; 8]);
+    assert_eq!(&f2.payload()[8..], b"two");
+    assert!(log.read_next(&mut pos).is_none());
+}
+
+#[test]
+fn append_prefixed_too_large_rejected() {
+    let d = TempDir::new("prefix-large");
+    let mut c = Conductor::open(d.path()).unwrap();
+    let mut log = open(&mut c, 64);
+    // prefix + body exceeds a single frame's capacity.
+    assert!(log.append_prefixed(&[0u8; 32], &[0u8; 64]).is_err());
+}


### PR DESCRIPTION
## Summary

Reworks `FixJournal` from an outbound-only resend log into a **two-journal (inbound + outbound) both-sides archive** under a shared conductor, serving both resend recovery and session audit/visibility, with O(1) sequence-number recovery that is robust against window aging.

Previously the journal recorded only outbound messages, derived `next_outbound` by scanning stored messages (which reset to 1 once they aged out of the window), and bolted `next_inbound` on as `NI=` sentinel records in the same log. This replaces all of that with a symmetric, self-describing design.

## What changed

### nexus-journal: three generic primitives
- **`meta` / `set_meta`**: an opaque `u64` slot in the manifest (alongside `epoch`), written in place, recovered in O(1) without scanning. The journal never interprets it.
- **`log_offset_at`**: reconstruct a `LogOffset` from a scanned frame's global offset, so a recovery scan can repopulate an offset table.
- **`append_prefixed`**: write `[prefix][body]` as a single frame in one copy, for prepending a small header without a staging buffer.

### nexus-fix-engine: two-journal FixJournal
- Two `RotatingJournal`s (inbound + outbound) under one shared `Conductor`, both with `archive(true)` so full history is preserved beyond the active window.
- Every frame stores `[ts:8][wire msg]`: an 8-byte little-endian UNIX-nanos timestamp prepended by the FIX layer. The journal frame format is untouched (the timestamp is FIX-layer only).
- `next_outbound` / `next_inbound` live in each journal's manifest meta-slot, recovered O(1). Deletes the tag-34 recovery scan, the `NI=` sentinels, and `encode_inbound_checkpoint`.
- The resend ring is rebuilt from the outbound hot window on recovery, so a `ResendRequest` after a restart replays the actual messages (matching Artio's Replay Index and QuickFIX's FileStore) rather than gap-filling everything.
- `open_in(&mut Conductor, ...)` shares one conductor (one archival thread) across all sessions; `open` / `open_existing` remain single-session convenience constructors that own their conductor.
- A journal write error surfaces as a distinct, typed engine error instead of being disguised as `Error::Io`. On transient `StandbyNotReady` backpressure the engine spins (unbounded `std::hint::spin_loop()`, `yield_now` on async); a record too large for a segment (a config error) surfaces immediately. Spinning is deliberate: the only way it spins forever is a full disk, which observability must catch, and it beats dropping a message from a resend/audit journal.

### nexus-async-fix-engine
- Now journals inbound messages and outbound admin (both previously unjournaled), so async sessions get the same both-sides archive. `encode_admin` returns `Result` and journals each admin frame with `yield_now`-based backpressure.

## Recovery semantics

| | before | after |
|---|---|---|
| `next_outbound` | scan stored messages (resets to 1 once aged out) | O(1) manifest meta-slot |
| `next_inbound` | `NI=` sentinel records in the outbound log | O(1) manifest meta-slot |
| inbound messages | not journaled | journaled (audit) |
| resend after restart | ring empty, gap-fill everything | ring rebuilt from hot window, replays real messages |

## Scope

- **Delivers #575** (single shared conductor across sessions).
- **Viewer deferred to #595** (`FixLogReader` + `nexus-fix-log` CLI + the archived-segment reader). This PR lands the complete both-sides journaling with timestamps so #595 is a pure additive reader, no second on-disk format change.

## Testing

- nexus-journal 87, nexus-fix-engine 120, nexus-async-fix-engine 6, all green.
- New coverage: cross-restart resend replays real bytes; the seqnum counter survives segment rotation/aging; two sessions independent through a shared conductor; outbound admin is journaled (async).
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean; harness builds.

## Follow-up

- Conductor disk-full observability (the backpressure spin leans on it, and the archive write is silently skipped on IO error). Not yet filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
