### PR TITLE
Unify the sync and async FIX engines under a sans-IO FixSession core

### DIFF
--- a/nexus-async-fix-engine/CHANGELOG.md
+++ b/nexus-async-fix-engine/CHANGELOG.md
@@ -26,5 +26,15 @@ contained.
 
 ### Changed
 
-- `AsyncFixConnection::encode_admin` returns `Result<(), Error>` (was `()`) so
-  outbound-admin journal writes can propagate; `flush_out` forwards the error.
+- `AsyncFixConnection<S>` renamed to `FixConnection<S, D>` (now generic over the
+  `FixDictionary` `D`) and rewritten as a thin tokio wrapper over the shared
+  sans-IO `FixSession<D>` core (the thin-adapter half of #544). The hand-rolled
+  inbound frame parsing, admin encoding, resend loop, and UNIX-nanos timestamp
+  code are deleted — all of that now lives in `FixSession`; the wrapper does only
+  the `.await`ed socket I/O.
+- `recv` is no longer callback-based. It is now
+  `recv(now) -> Result<Option<Message<'_, D>>, Error>`, returning the next typed
+  `Message` borrowed from the session buffer (was
+  `recv(on_app: &mut impl FnMut(&[u8])) -> Result<Option<DisconnectReason>, Error>`).
+  Outbound admin, journaling, and resend that the old `recv` drove by hand are
+  now handled inside the core.

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -239,6 +239,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin, D: FixDictionary> FixConnection<S, D> {
                 // Buffer already drained above; loop to continue the resend.
                 PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
+                    // An empty spare means the reader buffer is full with a single
+                    // incomplete frame that cannot grow (compaction reclaimed
+                    // nothing). Reading into a zero-length slice yields `Ok(0)`,
+                    // which the `Ok(Ok(0))` arm below would misread as EOF. Surface
+                    // it as the real cause: a frame larger than the reader buffer.
+                    // Identical to the sync wrapper's guard.
+                    if self.session.read_spare().is_empty() {
+                        return Err(Error::MessageTooLarge(
+                            self.session.reader_capacity().saturating_add(1),
+                        ));
+                    }
                     // No socket-level read timeout on an async stream, so bound
                     // the read with the session's next heartbeat/TestRequest
                     // deadline (60s fallback when the state machine has no timer).

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -6,11 +6,16 @@
 //! outbound buffer, both `.await`ed. All protocol logic (framing, the state
 //! machine, journaling, resend) lives in [`FixSession`]; this crate is the exact
 //! async analog of the blocking
-//! [`nexus_fix_engine::FixConnection`](nexus_fix_engine::FixConnection), differing
+//! [`nexus_fix_engine::FixConnection`], differing
 //! only in that socket I/O is `.await`ed and heartbeat/TestRequest deadlines use
 //! `tokio::time`.
 
 #![cfg(unix)]
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::redundant_explicit_links
+)]
 
 use std::io;
 use std::marker::PhantomData;
@@ -37,7 +42,7 @@ pub use nexus_fix_engine::TransportError as Error;
 /// Thin wrapper over [`FixSession`]: the socket calls are `.await`ed; everything
 /// else — framing, the [`SessionState`] machine, journaling, resend — is in the
 /// shared core. This is the async twin of
-/// [`nexus_fix_engine::FixConnection`](nexus_fix_engine::FixConnection).
+/// [`nexus_fix_engine::FixConnection`].
 pub struct FixConnection<S, D: FixDictionary> {
     stream: S,
     session: FixSession<D>,

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -1,697 +1,279 @@
-//! Tokio async adapter for the sans-IO FIX session layer.
+//! Tokio adapter for the sans-IO FIX session core.
 //!
-//! [`AsyncFixConnection`] drives [`SessionState`] over a tokio `AsyncRead +
-//! AsyncWrite` stream, mirroring [`FixConnection`](nexus_fix_engine::FixConnection)
-//! with `.await` on socket I/O and `tokio::time` for heartbeat/TestRequest timers.
+//! [`FixConnection`] is a thin wrapper over the sans-IO [`FixSession`] core: it
+//! owns a tokio `AsyncRead + AsyncWrite` stream and does *only* the I/O —
+//! `stream.read` into the session's inbound buffer, `stream.write` from its
+//! outbound buffer, both `.await`ed. All protocol logic (framing, the state
+//! machine, journaling, resend) lives in [`FixSession`]; this crate is the exact
+//! async analog of the blocking
+//! [`nexus_fix_engine::FixConnection`](nexus_fix_engine::FixConnection), differing
+//! only in that socket I/O is `.await`ed and heartbeat/TestRequest deadlines use
+//! `tokio::time`.
 
 #![cfg(unix)]
 
 use std::io;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::marker::PhantomData;
+use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{
-    FieldReader, FrameFormatter, encode_fix_uint, find_tag, parse_fix_bool, parse_fix_seqnum,
-    parse_fix_uint,
-};
+use nexus_fix_codec::FixDictionary;
 use nexus_fix_engine::{
-    AdminMsg, CompId, DisconnectReason, Event, FixJournal, FrameError, FrameReader, FrameWriter,
-    Out, REFRAME_HEADROOM, ReplayItem, SessionConfig, SessionError, SessionState, State,
+    DisconnectReason, FixJournal, FixSession, FrameReader, FrameWriter, Message, MessageReader,
+    MessageWriter, PollOutcome, SessionConfig, SessionError, SessionState, State,
 };
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout_at;
 
-use nexus_fix_engine::WriteError;
-
-const TS_LEN: usize = 21;
-
-/// Error from [`AsyncFixConnection`].
-#[derive(Debug)]
-pub enum Error {
-    Io(io::Error),
-    MessageTooLarge(usize),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "I/O: {e}"),
-            Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-/// Async FIX session transport over any `AsyncRead + AsyncWrite` stream.
+/// Per-message resend reserve; see [`nexus_fix_engine::REFRAME_HEADROOM`].
+pub use nexus_fix_engine::REFRAME_HEADROOM;
+/// Shared session-core error type, re-exported from `nexus-fix-engine`.
 ///
-/// Wraps [`SessionState`] with tokio I/O and timers. The session core is
-/// identical to [`FixConnection`](nexus_fix_engine::FixConnection); only the
-/// transport layer is async.
-pub struct AsyncFixConnection<S> {
+/// This is the same `Error` [`FixSession`] returns; the async wrapper adds only
+/// socket I/O errors via the existing `From<io::Error>` impl.
+pub use nexus_fix_engine::TransportError as Error;
+
+/// Async FIX session transport over any tokio `AsyncRead + AsyncWrite` stream.
+///
+/// Thin wrapper over [`FixSession`]: the socket calls are `.await`ed; everything
+/// else — framing, the [`SessionState`] machine, journaling, resend — is in the
+/// shared core. This is the async twin of
+/// [`nexus_fix_engine::FixConnection`](nexus_fix_engine::FixConnection).
+pub struct FixConnection<S, D: FixDictionary> {
     stream: S,
-    reader: FrameReader,
-    writer: FrameWriter,
-    state: SessionState,
-    journal: FixJournal,
-    config: SessionConfig,
-    begin_string: &'static [u8],
+    session: FixSession<D>,
 }
 
-impl<S: AsyncRead + AsyncWrite + Unpin> AsyncFixConnection<S> {
-    pub fn from_parts(
+/// Builder for [`FixConnection`], mirroring the sync
+/// [`FixConnectionBuilder`](nexus_fix_engine::FixConnectionBuilder).
+pub struct FixConnectionBuilder<D: FixDictionary> {
+    reader_cap: usize,
+    writer_cap: usize,
+    nodelay: bool,
+    _dict: PhantomData<fn() -> D>,
+}
+
+impl<D: FixDictionary> FixConnectionBuilder<D> {
+    pub fn reader_capacity(mut self, n: usize) -> Self {
+        self.reader_cap = n;
+        self
+    }
+
+    pub fn writer_capacity(mut self, n: usize) -> Self {
+        self.writer_cap = n;
+        self
+    }
+
+    pub fn nodelay(mut self, v: bool) -> Self {
+        self.nodelay = v;
+        self
+    }
+
+    fn build_session(
+        &self,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+    ) -> FixSession<D> {
+        FixSession::from_buffers(
+            MessageReader::with_frame_reader(
+                FrameReader::builder()
+                    .buffer_capacity(self.reader_cap)
+                    .build(),
+            ),
+            MessageWriter::with_frame_writer(
+                FrameWriter::builder()
+                    .buffer_capacity(self.writer_cap)
+                    .build(),
+            ),
+            state,
+            config,
+            journal,
+        )
+    }
+
+    /// Connects a TCP stream, applies `TCP_NODELAY`, and wraps it.
+    pub async fn connect(
+        self,
+        addr: std::net::SocketAddr,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+    ) -> io::Result<FixConnection<tokio::net::TcpStream, D>> {
+        let stream = tokio::net::TcpStream::connect(addr).await?;
+        stream.set_nodelay(self.nodelay)?;
+        let session = self.build_session(state, config, journal);
+        Ok(FixConnection { stream, session })
+    }
+
+    /// Wraps an already-connected stream (acceptor role or a pre-built stream).
+    pub fn accept<S: AsyncRead + AsyncWrite + Unpin>(
+        self,
         stream: S,
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
-        begin_string: &'static [u8],
-    ) -> Self {
-        Self {
-            stream,
-            reader: FrameReader::builder().build(),
-            writer: FrameWriter::builder().build(),
-            state,
-            journal,
-            config,
-            begin_string,
-        }
-    }
-
-    pub fn state(&self) -> &SessionState {
-        &self.state
-    }
-
-    pub fn state_mut(&mut self) -> &mut SessionState {
-        &mut self.state
-    }
-
-    pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
-        self.state.allocate_seq(Instant::now())
-    }
-
-    pub fn wants_read(&self) -> bool {
-        self.state.state() != State::Disconnected
-    }
-
-    pub fn wants_write(&self) -> bool {
-        !self.writer.is_empty()
-    }
-
-    /// Initiates a session: encodes and sends the opening Logon.
-    pub async fn connect(&mut self) -> Result<(), Error> {
-        let out = self.state.connect(Instant::now());
-        self.flush_out(out).await
-    }
-
-    /// Initiates a session with `ResetSeqNumFlag(141)=Y`.
-    pub async fn connect_reset(&mut self) -> Result<(), Error> {
-        let out = self
-            .state
-            .connect_reset(Instant::now())
-            .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
-        self.flush_out(out).await
-    }
-
-    /// Initiates an in-session sequence reset.
-    pub async fn reset_sequence(&mut self) -> Result<(), Error> {
-        let out = self
-            .state
-            .reset_sequence(Instant::now())
-            .map_err(|e| Error::Io(io::Error::other(e.to_string())))?;
-        self.flush_out(out).await
-    }
-
-    /// Receives one batch of bytes, dispatches all complete frames, and
-    /// fires any due timers. Returns `Some(reason)` when the session ends.
-    pub async fn recv<H>(&mut self, on_app: &mut H) -> Result<Option<DisconnectReason>, Error>
-    where
-        H: FnMut(&[u8]),
-    {
-        let deadline = self.state.next_timeout().map_or_else(
-            || tokio::time::Instant::now() + Duration::from_secs(60),
-            tokio::time::Instant::from_std,
-        );
-
-        let mut tmp = [0u8; 8192];
-        let n = match timeout_at(deadline, self.stream.read(&mut tmp)).await {
-            Ok(Ok(0)) => return Ok(Some(DisconnectReason::Logout)),
-            Ok(Ok(n)) => n,
-            Ok(Err(e)) => return Err(Error::Io(e)),
-            Err(_elapsed) => {
-                let now = Instant::now();
-                let out = self.state.on_timeout(now);
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    self.flush_out(out).await?;
-                    return Ok(Some(reason));
-                }
-                self.flush_out(out).await?;
-                return Ok(None);
-            }
-        };
-
-        self.reader
-            .read(&tmp[..n])
-            .map_err(|_| Error::MessageTooLarge(n))?;
-
-        let now = Instant::now();
-        loop {
-            match self.reader.next() {
-                Ok(Some(frame)) => {
-                    let frame = frame.to_vec();
-                    if let Some(reason) = self.dispatch(&frame, now, on_app).await? {
-                        return Ok(Some(reason));
-                    }
-                }
-                Ok(None) => break,
-                Err(FrameError::MessageTooLarge { size }) => {
-                    return Err(Error::MessageTooLarge(size));
-                }
-                Err(FrameError::Garbage { .. }) => {}
-            }
-        }
-
-        if self.reader.should_compact() {
-            self.reader.compact();
-        }
-
-        Ok(None)
-    }
-
-    /// Stores the frame in the journal and writes it to the stream.
-    pub async fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
-        // Every outbound frame must fit the pre-allocated writer, with headroom
-        // for a later resend reframe. Size the buffer up front for larger
-        // messages; see the sync `FixConnection::send_app`.
-        if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
-            return Err(Error::MessageTooLarge(frame.len()));
-        }
-        // Unbounded on purpose. StandbyNotReady is transient backpressure the
-        // conductor clears in sub-ms; the only way this loops forever is a
-        // full/failing disk, which must be caught by observability. Retrying
-        // beats the alternative of dropping a message from a resend/audit
-        // journal. We yield rather than spin so the tokio executor keeps
-        // driving the conductor and other tasks.
-        loop {
-            match self.journal.store(seq, frame) {
-                Ok(()) => break,
-                Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                Err(_) => return Err(Error::MessageTooLarge(frame.len())),
-            }
-        }
-        self.write_through(frame).await
-    }
-
-    /// Initiates a clean logout.
-    pub async fn logout(&mut self) -> Result<(), Error> {
-        let out = self.state.logout(Instant::now());
-        self.flush_out(out).await
-    }
-
-    async fn dispatch<H>(
-        &mut self,
-        frame: &[u8],
-        now: Instant,
-        on_app: &mut H,
-    ) -> Result<Option<DisconnectReason>, Error>
-    where
-        H: FnMut(&[u8]),
-    {
-        let sender_ok =
-            find_tag(frame, 0, 49).is_some_and(|s| s.slice(frame) == self.config.target.as_bytes());
-        let target_ok =
-            find_tag(frame, 0, 56).is_some_and(|s| s.slice(frame) == self.config.sender.as_bytes());
-        if !sender_ok || !target_ok {
-            let out = self.state.on_comp_id_mismatch(now);
-            self.flush_out(out).await?;
-            return Ok(Some(DisconnectReason::CompIdMismatch));
-        }
-
-        // Well-framed and comp-id-valid: archive the inbound message for
-        // visibility/audit. Garbage and foreign frames never reach here.
-        // Unbounded retry on transient standby backpressure; see `send_app`.
-        loop {
-            match self.journal.store_inbound(frame) {
-                Ok(()) => break,
-                Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                Err(_) => return Err(Error::MessageTooLarge(frame.len())),
-            }
-        }
-
-        let seq = match find_tag(frame, 0, 34).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok()) {
-            Some(s) => s as u32,
-            None => return Ok(None),
-        };
-
-        let poss_dup = find_tag(frame, 0, 43)
-            .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-            .unwrap_or(false);
-
-        let msg_type = match find_tag(frame, 0, 35) {
-            Some(s) => s.slice(frame),
-            None => return Ok(None),
-        };
-
-        let (out, is_app) = match msg_type {
-            b"A" => {
-                let hbi = find_tag(frame, 0, 108)
-                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
-                    .unwrap_or(30);
-                let reset = find_tag(frame, 0, 141)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
-                let was_logon_sent = self.state.state() == State::LogonSent;
-                (
-                    self.state.on_logon(seq, hbi, reset, !was_logon_sent, now),
-                    false,
-                )
-            }
-            b"5" => (self.state.on_logout(seq, poss_dup, now), false),
-            b"0" => {
-                let echo_id =
-                    find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
-                (self.state.on_heartbeat(seq, poss_dup, echo_id, now), false)
-            }
-            b"1" => {
-                let id = find_tag(frame, 0, 112).map_or(&b""[..], |s| s.slice(frame));
-                (self.state.on_test_request(seq, poss_dup, id, now), false)
-            }
-            b"2" => {
-                let begin = find_tag(frame, 0, 7)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                let end = find_tag(frame, 0, 16)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                (
-                    self.state.on_resend_request(seq, poss_dup, begin, end, now),
-                    false,
-                )
-            }
-            b"3" => {
-                let ref_seq = find_tag(frame, 0, 45)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                (self.state.on_reject(seq, poss_dup, ref_seq, now), false)
-            }
-            b"4" => {
-                let new_seq = find_tag(frame, 0, 36)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .unwrap_or(0) as u32;
-                let gap_fill = find_tag(frame, 0, 123)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
-                (
-                    self.state.on_sequence_reset(seq, new_seq, gap_fill, now),
-                    false,
-                )
-            }
-            _ => (self.state.on_app(seq, poss_dup, now), true),
-        };
-
-        self.flush_out(out).await?;
-
-        match out.event() {
-            Some(Event::Disconnected { reason }) => return Ok(Some(reason)),
-            Some(Event::ResendRange { begin, end }) => self.do_resend(begin, end).await?,
-            Some(Event::App { .. }) if is_app => on_app(frame),
-            _ => {}
-        }
-
-        Ok(None)
-    }
-
-    async fn flush_out(&mut self, out: Out) -> Result<(), Error> {
-        for admin in out.admin_messages() {
-            self.encode_admin(admin).await?;
-        }
-        if !self.writer.is_empty() {
-            self.flush_writer().await?;
-        }
-        Ok(())
-    }
-
-    async fn encode_admin(&mut self, admin: AdminMsg) -> Result<(), Error> {
-        let ts = make_ts();
-
-        let msg_type: &[u8] = match admin {
-            AdminMsg::Logon { .. } | AdminMsg::LogonReset { .. } => b"A",
-            AdminMsg::Logout { .. } => b"5",
-            AdminMsg::Heartbeat { .. } => b"0",
-            AdminMsg::TestRequest { .. } => b"1",
-            AdminMsg::ResendRequest { .. } => b"2",
-            AdminMsg::SequenceReset { .. } => b"4",
-            AdminMsg::Reject { .. } => b"3",
-        };
-
-        let seq = match admin {
-            AdminMsg::Logon { seq, .. }
-            | AdminMsg::LogonReset { seq, .. }
-            | AdminMsg::Logout { seq }
-            | AdminMsg::Heartbeat { seq, .. }
-            | AdminMsg::TestRequest { seq, .. }
-            | AdminMsg::ResendRequest { seq, .. }
-            | AdminMsg::SequenceReset { seq, .. }
-            | AdminMsg::Reject { seq, .. } => seq,
-        };
-
-        let begin_string = self.begin_string;
-        let sender = self.config.sender;
-        let target = self.config.target;
-
-        let mut seq_buf = [0u8; 10];
-        let seq_n = encode_fix_uint(seq, &mut seq_buf);
-
-        let (start, len) = {
-            let spare = self.writer.spare();
-            let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
-            fmt.field(34, &seq_buf[..seq_n]);
-            fmt.field(49, sender.as_bytes());
-            fmt.field(56, target.as_bytes());
-            fmt.field(52, &ts);
-
-            match admin {
-                AdminMsg::Logon { heart_bt_int_s, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
-                    fmt.field(108, &buf[..n]);
-                }
-                AdminMsg::LogonReset { heart_bt_int_s, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(heart_bt_int_s, &mut buf);
-                    fmt.field(108, &buf[..n]);
-                    fmt.field(141, b"Y");
-                }
-                AdminMsg::Logout { .. } | AdminMsg::Heartbeat { echo: None, .. } => {}
-                AdminMsg::Heartbeat {
-                    echo: Some((id, id_len)),
-                    ..
-                } => {
-                    fmt.field(112, &id[..id_len as usize]);
-                }
-                AdminMsg::TestRequest { id, .. } => {
-                    let mut buf = [0u8; 20];
-                    let n = encode_u64(id, &mut buf);
-                    fmt.field(112, &buf[..n]);
-                }
-                AdminMsg::ResendRequest { begin, .. } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(begin, &mut buf);
-                    fmt.field(7, &buf[..n]);
-                    fmt.field(16, b"0");
-                }
-                AdminMsg::SequenceReset { new_seq, .. } => {
-                    fmt.field(43, b"Y");
-                    fmt.field(123, b"Y");
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(new_seq, &mut buf);
-                    fmt.field(36, &buf[..n]);
-                }
-                AdminMsg::Reject {
-                    ref_seq_num,
-                    ref_tag_id,
-                    session_reject_reason,
-                    ..
-                } => {
-                    let mut buf = [0u8; 10];
-                    let n = encode_fix_uint(ref_seq_num, &mut buf);
-                    fmt.field(45, &buf[..n]);
-                    if let Some(tag) = ref_tag_id {
-                        let n = encode_fix_uint(tag, &mut buf);
-                        fmt.field(371, &buf[..n]);
-                    }
-                    let n = encode_fix_uint(session_reject_reason as u32, &mut buf);
-                    fmt.field(373, &buf[..n]);
-                }
-            }
-
-            match fmt.finish() {
-                Ok(sl) => sl,
-                Err(_) => return Ok(()),
-            }
-        };
-
-        // Journal the outbound admin frame, mirroring the sync `store_admin`:
-        // capture the frame slice from the writer after commit so it is
-        // contiguous and correctly sized. `self.journal` and `self.writer` are
-        // disjoint fields, so the mutable-journal / shared-writer borrows do not
-        // conflict. Unbounded retry on transient standby backpressure; see
-        // `send_app`. This keeps async sessions' outbound admin in the archive.
-        let before = self.writer.data().len();
-        self.writer.commit(start, len);
-        let frame = &self.writer.data()[before..];
-        if !frame.is_empty() {
-            loop {
-                match self.journal.store(seq, frame) {
-                    Ok(()) => break,
-                    Err(WriteError::StandbyNotReady) => tokio::task::yield_now().await,
-                    Err(_) => return Err(Error::MessageTooLarge(frame.len())),
-                }
-            }
-        }
-        Ok(())
-    }
-
-    async fn flush_writer(&mut self) -> Result<(), Error> {
-        while !self.writer.is_empty() {
-            let n = self.stream.write(self.writer.data()).await?;
-            if n == 0 {
-                return Err(Error::Io(io::Error::other("write returned 0")));
-            }
-            self.writer.advance(n);
-        }
-        self.stream.flush().await?;
-        Ok(())
-    }
-
-    async fn write_through(&mut self, frame: &[u8]) -> Result<(), Error> {
-        if self.writer.remaining() < frame.len() {
-            self.flush_writer().await?;
-        }
-        if self.writer.remaining() < frame.len() {
-            // Exceeds the pre-allocated buffer even when empty; `send_app` caps
-            // app frames below this, so this is an undersized-buffer config error.
-            return Err(Error::MessageTooLarge(frame.len()));
-        }
-        let spare = self.writer.spare();
-        spare[..frame.len()].copy_from_slice(frame);
-        self.writer.commit(0, frame.len());
-        self.flush_writer().await
-    }
-
-    async fn do_resend(&mut self, begin: u32, end: u32) -> Result<(), Error> {
-        enum Item {
-            Gap(u32, u32),
-            App(Vec<u8>),
-        }
-
-        let ts = make_ts();
-        let begin_string = self.begin_string;
-        let sender = self.config.sender;
-        let target = self.config.target;
-
-        let items: Vec<Item> = self
-            .journal
-            .resend(begin, end)
-            .map(|r| match r {
-                ReplayItem::GapFill { seq, new_seq } => Item::Gap(seq, new_seq),
-                ReplayItem::App(d) => Item::App(d.to_vec()),
-            })
-            .collect();
-
-        for item in items {
-            let ok = match &item {
-                Item::Gap(seq, new_seq) => encode_gap_fill(
-                    &mut self.writer,
-                    begin_string,
-                    sender,
-                    target,
-                    &ts,
-                    *seq,
-                    *new_seq,
-                ),
-                Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
-            };
-            if ok.is_err() {
-                self.flush_writer().await?;
-                let retry = match &item {
-                    Item::Gap(seq, new_seq) => encode_gap_fill(
-                        &mut self.writer,
-                        begin_string,
-                        sender,
-                        target,
-                        &ts,
-                        *seq,
-                        *new_seq,
-                    ),
-                    Item::App(data) => reframe_app(&mut self.writer, data, &ts, begin_string),
-                };
-                retry.map_err(|()| {
-                    Error::MessageTooLarge(self.writer.remaining().saturating_add(1))
-                })?;
-            }
-        }
-        self.flush_writer().await
+    ) -> FixConnection<S, D> {
+        let session = self.build_session(state, config, journal);
+        FixConnection { stream, session }
     }
 }
 
-impl AsyncFixConnection<tokio::net::TcpStream> {
-    /// Connects a TCP stream, enables `TCP_NODELAY`, and wraps it.
+impl<D: FixDictionary> FixConnection<tokio::net::TcpStream, D> {
+    pub fn builder() -> FixConnectionBuilder<D> {
+        FixConnectionBuilder {
+            reader_cap: 64 * 1024,
+            writer_cap: 64 * 1024,
+            nodelay: true,
+            _dict: PhantomData,
+        }
+    }
+
+    /// Connects a TCP stream, enables `TCP_NODELAY`, and wraps it with default
+    /// buffer sizes.
     pub async fn tcp_connect(
         addr: std::net::SocketAddr,
         state: SessionState,
         config: SessionConfig,
         journal: FixJournal,
-        begin_string: &'static [u8],
     ) -> io::Result<Self> {
-        let stream = tokio::net::TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        Ok(Self::from_parts(
+        Self::builder().connect(addr, state, config, journal).await
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin, D: FixDictionary> FixConnection<S, D> {
+    pub fn from_parts(
+        stream: S,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+    ) -> Self {
+        Self {
             stream,
-            state,
-            config,
-            journal,
-            begin_string,
-        ))
+            session: FixSession::new(state, config, journal),
+        }
     }
-}
 
-fn make_ts() -> [u8; TS_LEN] {
-    let unix_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as i128;
-    let mut ts = [0u8; TS_LEN];
-    format_utc_timestamp(unix_nanos, &mut ts);
-    ts
-}
-
-fn format_utc_timestamp(unix_nanos: i128, out: &mut [u8; TS_LEN]) {
-    let secs = unix_nanos.div_euclid(1_000_000_000) as i64;
-    let millis = (unix_nanos.rem_euclid(1_000_000_000) / 1_000_000) as u32;
-    let days = secs.div_euclid(86_400);
-    let sod = secs.rem_euclid(86_400) as u32;
-    let (y, m, d) = civil_from_days(days);
-
-    write_digits(&mut out[0..4], y.max(0) as u32);
-    write_digits(&mut out[4..6], m);
-    write_digits(&mut out[6..8], d);
-    out[8] = b'-';
-    write_digits(&mut out[9..11], sod / 3600);
-    out[11] = b':';
-    write_digits(&mut out[12..14], sod / 60 % 60);
-    out[14] = b':';
-    write_digits(&mut out[15..17], sod % 60);
-    out[17] = b'.';
-    write_digits(&mut out[18..21], millis);
-}
-
-fn civil_from_days(z: i64) -> (i64, u32, u32) {
-    let z = z + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
-    (y + i64::from(m <= 2), m, d)
-}
-
-fn write_digits(out: &mut [u8], mut v: u32) {
-    for slot in out.iter_mut().rev() {
-        *slot = b'0' + (v % 10) as u8;
-        v /= 10;
+    pub fn state(&self) -> &SessionState {
+        self.session.state()
     }
-}
 
-fn encode_u64(v: u64, out: &mut [u8; 20]) -> usize {
-    if v == 0 {
-        out[0] = b'0';
-        return 1;
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        self.session.state_mut()
     }
-    let mut tmp = [0u8; 20];
-    let mut n = 0;
-    let mut x = v;
-    while x > 0 {
-        tmp[n] = b'0' + (x % 10) as u8;
-        x /= 10;
-        n += 1;
+
+    pub fn garbage_frame_count(&self) -> u64 {
+        self.session.garbage_frame_count()
     }
-    for i in 0..n {
-        out[i] = tmp[n - 1 - i];
+
+    pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
+        self.session.allocate_seq()
     }
-    n
-}
 
-fn encode_gap_fill(
-    writer: &mut FrameWriter,
-    begin_string: &'static [u8],
-    sender: CompId,
-    target: CompId,
-    ts: &[u8],
-    seq: u32,
-    new_seq: u32,
-) -> Result<(), ()> {
-    let spare = writer.spare();
-    let mut seq_buf = [0u8; 10];
-    let seq_n = encode_fix_uint(seq, &mut seq_buf);
-    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
-    fmt.field(34, &seq_buf[..seq_n]);
-    fmt.field(49, sender.as_bytes());
-    fmt.field(56, target.as_bytes());
-    fmt.field(52, ts);
-    fmt.field(43, b"Y");
-    fmt.field(123, b"Y");
-    let mut nsq_buf = [0u8; 10];
-    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
-    fmt.field(36, &nsq_buf[..nsq_n]);
-    let (start, len) = fmt.finish().map_err(|_| ())?;
-    writer.commit(start, len);
-    Ok(())
-}
+    pub fn wants_read(&self) -> bool {
+        self.session.state().state() != State::Disconnected
+    }
 
-fn reframe_app(
-    writer: &mut FrameWriter,
-    orig: &[u8],
-    ts: &[u8],
-    begin_string: &'static [u8],
-) -> Result<(), ()> {
-    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
-    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
+    pub fn wants_write(&self) -> bool {
+        self.session.has_outbound()
+    }
 
-    let spare = writer.spare();
-    let mut fmt = FrameFormatter::new(spare, begin_string, msg_type);
-    let mut poss_dup_done = false;
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.drain_outbound().await
+    }
 
-    for field in FieldReader::new(orig, 0) {
-        match field.tag {
-            8 | 9 | 10 | 35 | 43 | 122 => {}
-            52 => {
-                fmt.field(52, ts);
-                fmt.field(43, b"Y");
-                if let Some(t) = orig_time {
-                    fmt.field(122, t);
+    /// Initiates a session: enqueues and sends the opening Logon.
+    pub async fn connect(&mut self, now: Instant) -> Result<(), Error> {
+        self.session.connect(now)?;
+        self.drain_outbound().await
+    }
+
+    /// Initiates a session with `ResetSeqNumFlag(141)=Y`.
+    pub async fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
+        self.session.connect_reset(now)?;
+        self.drain_outbound().await
+    }
+
+    /// Initiates an in-session sequence reset.
+    pub async fn reset_sequence(&mut self, now: Instant) -> Result<(), Error> {
+        self.session.reset_sequence(now)?;
+        self.drain_outbound().await
+    }
+
+    /// Journals then sends an application frame at sequence `seq`.
+    pub async fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        self.session.send_app(seq, frame)?;
+        self.drain_outbound().await
+    }
+
+    /// Initiates a clean logout.
+    pub async fn logout(&mut self, now: Instant) -> Result<(), Error> {
+        self.session.logout(now)?;
+        self.drain_outbound().await
+    }
+
+    /// Processes buffered inbound frames, reading more bytes when needed and
+    /// firing heartbeat/TestRequest timers on read idle. Returns the next typed
+    /// [`Message`], or `None` when a step produced nothing to surface (an
+    /// out-of-sequence app, a session reject, or a fired timer that did not
+    /// disconnect). Mirrors the sync
+    /// [`FixConnection::recv`](nexus_fix_engine::FixConnection::recv) loop with
+    /// `.await` on the socket read and a `tokio::time` deadline in place of the
+    /// blocking socket read-timeout.
+    pub async fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        loop {
+            let outcome = self.session.poll(now)?;
+            // Drain any admin/resend the core enqueued for this step (matches the
+            // sync wrapper, which flushes after every protocol handler).
+            self.drain_outbound().await?;
+
+            match outcome {
+                PollOutcome::Message | PollOutcome::Disconnected(_) => {
+                    return Ok(Some(self.session.message()));
                 }
-                poss_dup_done = true;
+                PollOutcome::Suppressed => return Ok(None),
+                // Buffer already drained above; loop to continue the resend.
+                PollOutcome::ResendPending => {}
+                PollOutcome::NeedMoreBytes => {
+                    // No socket-level read timeout on an async stream, so bound
+                    // the read with the session's next heartbeat/TestRequest
+                    // deadline (60s fallback when the state machine has no timer).
+                    let deadline = self.session.state().next_timeout().map_or_else(
+                        || tokio::time::Instant::now() + Duration::from_secs(60),
+                        tokio::time::Instant::from_std,
+                    );
+                    let spare = self.session.read_spare();
+                    match timeout_at(deadline, self.stream.read(spare)).await {
+                        Ok(Ok(0)) => {
+                            return Ok(Some(Message::Disconnected {
+                                reason: DisconnectReason::Logout,
+                            }));
+                        }
+                        Ok(Ok(n)) => self.session.read_filled(n),
+                        Ok(Err(e)) => return Err(Error::Io(e)),
+                        Err(_elapsed) => {
+                            if let Some(reason) = self.session.on_timeout(now)? {
+                                self.drain_outbound().await?;
+                                return Ok(Some(Message::Disconnected { reason }));
+                            }
+                            self.drain_outbound().await?;
+                            return Ok(None);
+                        }
+                    }
+                }
             }
-            _ => fmt.field(field.tag, field.value.slice(orig)),
         }
     }
 
-    if !poss_dup_done {
-        fmt.field(43, b"Y");
-        if let Some(t) = orig_time {
-            fmt.field(122, t);
+    /// Writes all buffered outbound bytes to the socket and flushes.
+    async fn drain_outbound(&mut self) -> Result<(), Error> {
+        while self.session.has_outbound() {
+            let n = self.stream.write(self.session.outbound()).await?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
+            }
+            self.session.advance_outbound(n);
         }
+        self.stream.flush().await?;
+        Ok(())
     }
-
-    let (start, len) = fmt.finish().map_err(|_| ())?;
-    writer.commit(start, len);
-    Ok(())
 }

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -3,12 +3,86 @@
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use nexus_async_fix_engine::AsyncFixConnection;
-use nexus_fix_codec::{FrameFormatter, encode_fix_uint};
-use nexus_fix_engine::{CompId, DisconnectReason, FixJournal, SessionConfig, SessionState, State};
+use nexus_async_fix_engine::FixConnection;
+use nexus_fix_codec::{
+    FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
+    encode_fix_uint, find_tag,
+};
+use nexus_fix_engine::{
+    CompId, DisconnectReason, FixJournal, Message, SessionConfig, SessionState, State,
+};
 use tokio::net::TcpStream;
+
+// ── mock dictionary (mirrors the sync engine's tests) ────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+struct AdminDecoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 const BEGIN: &[u8] = b"FIX.4.4";
 const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
@@ -38,9 +112,9 @@ fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
     (child, port)
 }
 
-async fn connect(port: u16, dir: &Path) -> AsyncFixConnection<TcpStream> {
+async fn connect(port: u16, dir: &Path) -> FixConnection<TcpStream, MockDict> {
     let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-    AsyncFixConnection::from_parts(
+    FixConnection::from_parts(
         stream,
         SessionState::new(Duration::from_secs(30)),
         SessionConfig {
@@ -48,14 +122,13 @@ async fn connect(port: u16, dir: &Path) -> AsyncFixConnection<TcpStream> {
             target: CompId::new(b"PEER").unwrap(),
         },
         FixJournal::open(dir, 0, 256).unwrap(),
-        BEGIN,
     )
 }
 
-async fn drive(conn: &mut AsyncFixConnection<TcpStream>) -> DisconnectReason {
+async fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> DisconnectReason {
     loop {
-        if let Some(r) = conn.recv(&mut |_| {}).await.unwrap() {
-            return r;
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).await.unwrap() {
+            return reason;
         }
     }
 }
@@ -74,12 +147,14 @@ fn new_order(seq: u32) -> Vec<u8> {
     buf[start..start + len].to_vec()
 }
 
+// ── tests ────────────────────────────────────────────────────────────────────
+
 #[tokio::test]
 async fn conformance_logon_logout() {
     let dir = tmp_dir("logon_logout");
     let (mut child, port) = spawn_peer("logon_logout");
     let mut conn = connect(port, &dir).await;
-    conn.connect().await.unwrap();
+    conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
 }
@@ -89,7 +164,7 @@ async fn conformance_heartbeat() {
     let dir = tmp_dir("heartbeat");
     let (mut child, port) = spawn_peer("heartbeat");
     let mut conn = connect(port, &dir).await;
-    conn.connect().await.unwrap();
+    conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
 }
@@ -99,13 +174,14 @@ async fn conformance_resend() {
     let dir = tmp_dir("resend");
     let (mut child, port) = spawn_peer("resend");
     let mut conn = connect(port, &dir).await;
-    conn.connect().await.unwrap();
+    conn.connect(Instant::now()).await.unwrap();
 
     loop {
-        match conn.recv(&mut |_| {}).await.unwrap() {
-            Some(r) => panic!("disconnected before active: {r:?}"),
-            None if conn.state().state() == State::Active => break,
-            None => {}
+        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).await.unwrap() {
+            panic!("disconnected before active: {reason:?}");
+        }
+        if conn.state().state() == State::Active {
+            break;
         }
     }
 
@@ -121,7 +197,7 @@ async fn conformance_gap_fill() {
     let dir = tmp_dir("gap_fill");
     let (mut child, port) = spawn_peer("gap_fill");
     let mut conn = connect(port, &dir).await;
-    conn.connect().await.unwrap();
+    conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
 }
@@ -131,7 +207,7 @@ async fn conformance_seq_reset() {
     let dir = tmp_dir("seq_reset");
     let (mut child, port) = spawn_peer("seq_reset");
     let mut conn = connect(port, &dir).await;
-    conn.connect().await.unwrap();
+    conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
 }

--- a/nexus-async-fix-engine/tests/frame_too_large.rs
+++ b/nexus-async-fix-engine/tests/frame_too_large.rs
@@ -1,0 +1,204 @@
+//! Fix B (async): a single inbound frame larger than the reader buffer must
+//! surface as `MessageTooLarge`, not a false disconnect. The async wrapper's
+//! `NeedMoreBytes` guard must behave identically to the sync wrapper's: when
+//! `read_spare()` is empty (the buffer is full with one incomplete frame that
+//! cannot grow), return `MessageTooLarge` instead of reading into a zero-length
+//! slice and misreading `Ok(0)` as EOF.
+
+#![cfg(unix)]
+
+use std::collections::VecDeque;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use nexus_async_fix_engine::{Error as TransportError, FixConnection};
+use nexus_fix_codec::{
+    FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
+    encode_fix_uint, find_tag,
+};
+use nexus_fix_engine::{CompId, FixJournal, Message, SessionConfig, SessionState};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+// ── mock dictionary (mirrors the sync engine's tests) ────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+struct AdminDecoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn sender() -> CompId {
+    CompId::new(b"INITIATOR").unwrap()
+}
+fn target() -> CompId {
+    CompId::new(b"ACCEPTOR").unwrap()
+}
+
+fn tmp_dir(suffix: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "nexus_async_fix_toolarge_{}_{}",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Async stream that hands out queued inbound bytes (never more than the
+/// caller's `ReadBuf` room) and swallows writes. The mirror of the sync
+/// `ChunkStream` in `nexus-fix-engine/tests/transport.rs`.
+struct ChunkStream {
+    inbound: VecDeque<u8>,
+}
+
+impl ChunkStream {
+    fn new(bytes: &[u8]) -> Self {
+        Self {
+            inbound: bytes.iter().copied().collect(),
+        }
+    }
+}
+
+impl AsyncRead for ChunkStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let n = buf.remaining().min(self.inbound.len());
+        for _ in 0..n {
+            buf.put_slice(&[self.inbound.pop_front().unwrap()]);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for ChunkStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
+    let dir = tmp_dir("reader_buf_too_large");
+
+    // One valid, self-delimiting FIX frame larger than a tiny reader buffer but
+    // well under the 1 MiB frame-reader max.
+    const READER_CAP: usize = 256;
+    let mut buf = vec![0u8; 4096];
+    let big_filler = vec![b'x'; 512]; // frame ~570 bytes > READER_CAP
+    let frame = {
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
+        let mut seq_buf = [0u8; 10];
+        let seq_n = encode_fix_uint(1, &mut seq_buf);
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, sender().as_bytes());
+        fmt.field(56, target().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(58, &big_filler);
+        let (start, len) = fmt.finish().unwrap();
+        buf[start..start + len].to_vec()
+    };
+    assert!(
+        frame.len() > READER_CAP,
+        "frame must exceed the reader buffer to trip the guard"
+    );
+
+    let stream = ChunkStream::new(&frame);
+    let mut conn: FixConnection<ChunkStream, MockDict> =
+        FixConnection::builder().reader_capacity(READER_CAP).accept(
+            stream,
+            SessionState::new(Duration::from_secs(30)),
+            SessionConfig {
+                sender: target(),
+                target: sender(),
+            },
+            FixJournal::open(&dir, 0, 256).unwrap(),
+        );
+
+    match conn.recv(Instant::now()).await {
+        Err(TransportError::MessageTooLarge(_)) => {}
+        Err(other) => panic!(
+            "an inbound frame exceeding the reader buffer must be MessageTooLarge, got {other:?}"
+        ),
+        Ok(Some(Message::Disconnected { reason })) => {
+            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
+        }
+        Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
+    }
+}

--- a/nexus-async-fix-engine/tests/journal_outbound_admin.rs
+++ b/nexus-async-fix-engine/tests/journal_outbound_admin.rs
@@ -8,13 +8,81 @@
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use nexus_async_fix_engine::AsyncFixConnection;
+use nexus_async_fix_engine::FixConnection;
+use nexus_fix_codec::{FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, find_tag};
 use nexus_fix_engine::{CompId, FixJournal, SessionConfig, SessionState};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-const BEGIN: &[u8] = b"FIX.4.4";
+// ── mock dictionary (mirrors the sync engine's tests) ────────────────────────
+
+struct MockDict;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MockMsgType {}
+
+struct AdminDecoder<'buf> {
+    _buf: &'buf [u8],
+}
+
+impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+    fn decode(buf: &'buf [u8]) -> Result<Self, nexus_fix_codec::DecodeError> {
+        Ok(Self { _buf: buf })
+    }
+}
+
+impl FixDictionary for MockDict {
+    type MsgType = MockMsgType;
+    type Header<'buf> = MockHeader<'buf>;
+    type Logon<'buf> = AdminDecoder<'buf>;
+    type Logout<'buf> = AdminDecoder<'buf>;
+    type Heartbeat<'buf> = AdminDecoder<'buf>;
+    type TestRequest<'buf> = AdminDecoder<'buf>;
+    type ResendRequest<'buf> = AdminDecoder<'buf>;
+    type SequenceReset<'buf> = AdminDecoder<'buf>;
+    type Reject<'buf> = AdminDecoder<'buf>;
+    const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+    fn is_admin(_: MockMsgType) -> bool {
+        false
+    }
+}
+
+struct MockHeader<'buf> {
+    buf: &'buf [u8],
+}
+
+impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+    fn decode(buf: &'buf [u8]) -> Self {
+        Self { buf }
+    }
+
+    fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+        find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+        find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf nexus_fix_codec::AsciiTextStr>> {
+        find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+        find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+    }
+
+    fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+        None
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 fn tmp_dir(suffix: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -72,7 +140,7 @@ async fn outbound_admin_is_journaled() {
     let dir = tmp_dir("logon");
 
     {
-        let mut conn = AsyncFixConnection::from_parts(
+        let mut conn: FixConnection<SinkStream, MockDict> = FixConnection::from_parts(
             SinkStream::default(),
             SessionState::new(Duration::from_secs(30)),
             SessionConfig {
@@ -80,10 +148,9 @@ async fn outbound_admin_is_journaled() {
                 target: CompId::new(b"PEER").unwrap(),
             },
             FixJournal::open(&dir, 0, 256).unwrap(),
-            BEGIN,
         );
         // Sends the opening Logon at seq 1; the write is accepted by the sink.
-        conn.connect().await.unwrap();
+        conn.connect(Instant::now()).await.unwrap();
     }
 
     // The Logon (seq 1) must be present in the outbound journal: recovering the

--- a/nexus-fix-codec/src/dict.rs
+++ b/nexus-fix-codec/src/dict.rs
@@ -6,7 +6,7 @@ use nexus_ascii::AsciiTextStr;
 ///
 /// Implemented by every generated admin message type in `admin::*`.
 /// The session framework calls `decode` to construct the decoder and hands it
-/// to the caller via [`Message`](crate::Message); the caller then uses the
+/// to the caller via the engine's `Message` type; the caller then uses the
 /// typed accessor methods to read fields.
 pub trait FixAdminMsg<'buf>: Sized {
     /// Construct the decoder from a raw FIX message buffer.

--- a/nexus-fix-codec/src/lib.rs
+++ b/nexus-fix-codec/src/lib.rs
@@ -16,6 +16,12 @@
 //!
 //! Generated FIX codecs (from `nexus-fix-codegen`) depend on these primitives.
 
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::redundant_explicit_links
+)]
+
 pub mod dict;
 mod error;
 mod field;

--- a/nexus-fix-codec/src/writer.rs
+++ b/nexus-fix-codec/src/writer.rs
@@ -89,7 +89,7 @@ impl<'a> FieldWriter<'a> {
 /// trades that for a caller-chosen prefix size and shifts only if undersized.
 ///
 /// On overflow the writer is poisoned (further writes are dropped) and
-/// [`finish`](Self::finish) returns [`EncodeError::BufferFull`](crate::EncodeError::BufferFull)
+/// [`finish`](Self::finish) returns [`EncodeError::BufferFull`]
 /// — encoding never panics on a too-small buffer.
 ///
 /// # Example
@@ -168,7 +168,7 @@ impl<'buf> FrameFormatter<'buf> {
     }
 
     /// Whether a write has overflowed the buffer (so [`finish`](Self::finish)
-    /// will return [`EncodeError::BufferFull`](crate::EncodeError::BufferFull)).
+    /// will return [`EncodeError::BufferFull`]).
     #[inline]
     pub fn is_full(&self) -> bool {
         self.full
@@ -180,7 +180,7 @@ impl<'buf> FrameFormatter<'buf> {
     /// message within the buffer. The message is at `buf[start..start + len]`.
     ///
     /// # Errors
-    /// [`EncodeError::BufferFull`](crate::EncodeError::BufferFull) if any field,
+    /// [`EncodeError::BufferFull`] if any field,
     /// the prefix, or the checksum did not fit.
     pub fn finish(mut self) -> Result<(usize, usize), EncodeError> {
         if self.full {

--- a/nexus-fix-engine/CHANGELOG.md
+++ b/nexus-fix-engine/CHANGELOG.md
@@ -12,6 +12,13 @@ contained.
 
 ### Changed
 
+- `FixConnection<S, D>` is now a thin socket wrapper over a new sans-IO
+  `FixSession<D>` core (the thin-adapter half of #544). All protocol logic —
+  frame decode, the `SessionState` machine, journaling, encode, and resend —
+  lives in `FixSession`; the connection does only the blocking socket I/O.
+  Resend is resumable: `FixSession::poll` surfaces `PollOutcome::ResendPending`
+  so a partial retransmission resumes across reads instead of restarting. The
+  public `FixConnection` API is unchanged.
 - `FixJournal` reworked from an outbound-only resend log into a **two-journal**
   (outbound + inbound) both-sides archive that serves resend *and* visibility.
   Direction is implicit in which journal a frame lands in — no per-frame

--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -1,0 +1,1285 @@
+//! Sans-IO FIX session core.
+//!
+//! [`FixSession`] owns everything a FIX session needs *except the socket*: the
+//! frame reader/writer, the [`SessionState`] machine, the [`FixJournal`], and the
+//! [`SessionConfig`]. It never performs I/O. A wrapper (e.g.
+//! [`crate::transport::FixConnection`]) drives it by filling the inbound buffer
+//! from a socket and draining the outbound buffer to a socket.
+//!
+//! # Byte-buffer seam
+//!
+//! Inbound: the wrapper reads socket bytes into [`read_spare`](FixSession::read_spare),
+//! commits the count with [`read_filled`](FixSession::read_filled), then calls
+//! [`poll`](FixSession::poll) to process the next buffered frame.
+//!
+//! Outbound: protocol handling enqueues bytes into the writer buffer; the wrapper
+//! drains them via [`outbound`](FixSession::outbound) / [`advance_outbound`](FixSession::advance_outbound).
+//!
+//! # The poll/message split
+//!
+//! Returning a borrowed [`Message`] directly from a loop that also reads more
+//! bytes hits the borrow checker (the classic NLL conditional-borrow wall). So
+//! [`poll`](FixSession::poll) returns a *non-borrowing* [`PollOutcome`] after
+//! processing one frame into a stable buffer (`reader.frame`), and
+//! [`message`](FixSession::message) borrows that stable buffer to reconstruct the
+//! typed [`Message`]. The wrapper loops on `poll`, servicing
+//! [`PollOutcome::NeedMoreBytes`] (read the socket) and
+//! [`PollOutcome::ResendPending`] (drain outbound), and calls `message()` once
+//! [`PollOutcome::Message`] is returned.
+
+use std::time::Instant;
+
+use nexus_fix_codec::{
+    FieldReader, FixAdminMsg, FixDictionary, FixHeader, FrameFormatter, encode_fix_uint, find_tag,
+    parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
+};
+use nexus_journal::WriteError;
+
+use crate::frame::{FrameError, FrameWriter};
+use crate::framework::{Message, MessageReader, MessageWriter, SessionConfig, SessionError};
+use crate::persist::{FixJournal, ReplayItem};
+use crate::session::{AdminMsg, DisconnectReason, Event, SessionState, State};
+use crate::timestamp::UTC_TIMESTAMP_LEN;
+
+/// Error surfaced by the sans-IO session core.
+///
+/// Note: unlike the wrapper, the core never performs I/O, so it never produces
+/// [`Error::Io`] on its own. The `Io` variant exists so the wrapper's `From<io::Error>`
+/// can live on this shared type (the wrapper adds the socket errors).
+#[derive(Debug)]
+pub enum Error {
+    Io(std::io::Error),
+    MessageTooLarge(usize),
+    Protocol(SessionError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O: {e}"),
+            Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
+            Self::Protocol(e) => write!(f, "protocol: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Bytes reserved per app message for a later resend reframe.
+///
+/// A reframe adds `PossDupFlag` (`43=Y`), `OrigSendingTime` (`122=<UTC
+/// timestamp>`), and a little `BodyLength` digit growth. [`FixSession::send_app`]
+/// keeps app frames this far below the writer capacity so a stored message always
+/// reframes back into the pre-allocated buffer — no runtime allocation on the
+/// resend path.
+///
+/// Exposed so callers sizing a writer via `writer_capacity(...)` know the
+/// per-message reserve: the largest app frame they can send is
+/// `writer_capacity - REFRAME_HEADROOM`.
+pub const REFRAME_HEADROOM: usize = 64;
+
+/// Non-borrowing result of [`FixSession::poll`].
+///
+/// A separate [`FixSession::message`] borrows the stable frame buffer to build
+/// the typed [`Message`] once [`PollOutcome::Message`] is returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollOutcome {
+    /// A typed message is ready. Call [`FixSession::message`] to borrow it.
+    Message,
+    /// No complete frame is buffered. The wrapper must read more bytes into
+    /// [`read_spare`](FixSession::read_spare) and commit with
+    /// [`read_filled`](FixSession::read_filled), then poll again.
+    NeedMoreBytes,
+    /// A resend is in progress and the outbound buffer filled. The wrapper must
+    /// drain [`outbound`](FixSession::outbound) and poll again to continue it.
+    ResendPending,
+    /// The frame was processed but there is nothing to surface to the application
+    /// (an out-of-sequence app suppressed pending resend, or a session-level
+    /// reject was emitted). The wrapper should surface this as `Ok(None)`.
+    Suppressed,
+    /// The session disconnected. The wrapper surfaces
+    /// `Message::Disconnected { reason }`.
+    Disconnected(DisconnectReason),
+}
+
+/// Which typed [`Message`] [`FixSession::message`] should reconstruct from the
+/// stable frame buffer. All arms decode from `reader.frame`, so this carries only
+/// the per-arm flags the borrowed message needs.
+#[derive(Debug, Clone, Copy)]
+enum PendingKind {
+    None,
+    Logon { acknowledged: bool },
+    Logout { acknowledged: bool },
+    Heartbeat,
+    TestRequest,
+    ResendRequest,
+    SequenceReset,
+    Reject,
+    Application,
+    Disconnected { reason: DisconnectReason },
+}
+
+/// Resumable resend state. A resend can enqueue more bytes than the outbound
+/// buffer holds; on overflow the wrapper drains the buffer and re-polls, which
+/// resumes here. `drained` counts fully-encoded [`ReplayItem`]s so re-deriving
+/// `journal.resend(begin, end).skip(drained)` yields the remaining items with
+/// identical wire output (`resend` is deterministic for a fixed journal state).
+#[derive(Debug, Clone, Copy)]
+struct ResendState {
+    begin: u32,
+    end: u32,
+    drained: usize,
+    ts: [u8; UTC_TIMESTAMP_LEN],
+}
+
+/// Sans-IO FIX session: state machine + framing + journal, no socket.
+///
+/// See the [module docs](self) for the byte-buffer seam and the poll/message
+/// split.
+pub struct FixSession<D: FixDictionary> {
+    reader: MessageReader<D>,
+    writer: MessageWriter<D>,
+    state: SessionState,
+    journal: FixJournal,
+    config: SessionConfig,
+    garbage_frames: u64,
+    /// In-progress resend, if any (see [`ResendState`]).
+    resend: Option<ResendState>,
+    /// What [`message`](Self::message) reconstructs after a [`PollOutcome::Message`].
+    pending: PendingKind,
+}
+
+impl<D: FixDictionary> FixSession<D> {
+    /// Builds a session with default (empty) frame buffers. Prefer
+    /// [`from_buffers`](Self::from_buffers) to size the reader/writer up front.
+    pub fn new(state: SessionState, config: SessionConfig, journal: FixJournal) -> Self {
+        Self {
+            reader: MessageReader::new(),
+            writer: MessageWriter::new(),
+            state,
+            journal,
+            config,
+            garbage_frames: 0,
+            resend: None,
+            pending: PendingKind::None,
+        }
+    }
+
+    /// Builds a session from pre-sized reader and writer buffers.
+    pub fn from_buffers(
+        reader: MessageReader<D>,
+        writer: MessageWriter<D>,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+    ) -> Self {
+        Self {
+            reader,
+            writer,
+            state,
+            journal,
+            config,
+            garbage_frames: 0,
+            resend: None,
+            pending: PendingKind::None,
+        }
+    }
+
+    // ── introspection ────────────────────────────────────────────────────────
+
+    pub fn state(&self) -> &SessionState {
+        &self.state
+    }
+
+    pub fn state_mut(&mut self) -> &mut SessionState {
+        &mut self.state
+    }
+
+    pub fn garbage_frame_count(&self) -> u64 {
+        self.garbage_frames
+    }
+
+    /// Whether the session should still be read from (not disconnected).
+    pub fn wants_read(&self) -> bool {
+        self.state.state() != State::Disconnected
+    }
+
+    /// Whether the outbound buffer has bytes waiting to be written.
+    pub fn wants_write(&self) -> bool {
+        !self.writer.is_empty()
+    }
+
+    pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
+        self.state.allocate_seq(Instant::now())
+    }
+
+    /// Writer capacity in bytes (fixed at construction).
+    pub fn writer_capacity(&self) -> usize {
+        self.writer.capacity()
+    }
+
+    // ── inbound byte-buffer seam ─────────────────────────────────────────────
+
+    /// Spare region of the inbound buffer for the wrapper to read socket bytes
+    /// into. Commit the number actually read with [`read_filled`](Self::read_filled).
+    pub fn read_spare(&mut self) -> &mut [u8] {
+        if self.reader.inner.should_compact() {
+            self.reader.inner.compact();
+        }
+        self.reader.inner.spare()
+    }
+
+    /// Commit `n` bytes read into [`read_spare`](Self::read_spare).
+    pub fn read_filled(&mut self, n: usize) {
+        self.reader.inner.filled(n);
+    }
+
+    // ── outbound byte-buffer seam ────────────────────────────────────────────
+
+    pub fn has_outbound(&self) -> bool {
+        !self.writer.is_empty()
+    }
+
+    pub fn outbound(&self) -> &[u8] {
+        self.writer.data()
+    }
+
+    pub fn advance_outbound(&mut self, n: usize) {
+        self.writer.advance(n);
+    }
+
+    // ── protocol actions (enqueue only, no I/O) ──────────────────────────────
+
+    /// Enqueues a Logon (initiate the session). Outbound bytes land in the writer
+    /// buffer; the wrapper drains them.
+    pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.connect(now);
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        Ok(())
+    }
+
+    /// Enqueues a Logon with `ResetSeqNumFlag=Y`.
+    pub fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.connect_reset(now).map_err(Error::Protocol)?;
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        Ok(())
+    }
+
+    /// Enqueues an in-session sequence reset handshake.
+    pub fn reset_sequence(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.reset_sequence(now).map_err(Error::Protocol)?;
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        Ok(())
+    }
+
+    /// Enqueues a Logout.
+    pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
+        let out = self.state.logout(now);
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        Ok(())
+    }
+
+    /// Journals then enqueues an application frame at sequence `seq`.
+    ///
+    /// The frame must fit the pre-allocated writer with [`REFRAME_HEADROOM`] to
+    /// spare (so a later resend reframe fits). Larger frames return
+    /// [`Error::MessageTooLarge`] before any journal or buffer write; size the
+    /// writer up front for the workload.
+    pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
+        if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
+            return Err(Error::MessageTooLarge(frame.len()));
+        }
+        journal_write(frame.len(), || self.journal.store(seq, frame))?;
+        buffer_frame(&mut self.writer.inner, frame)
+    }
+
+    /// Advances heartbeat/test-request timers; enqueues any resulting admin
+    /// messages. Returns `Some(reason)` if the timeout drove a disconnect.
+    pub fn on_timeout(&mut self, now: Instant) -> Result<Option<DisconnectReason>, Error> {
+        let out = self.state.on_timeout(now);
+        for admin in out.admin_messages() {
+            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+        }
+        if let Some(Event::Disconnected { reason }) = out.event() {
+            return Ok(Some(reason));
+        }
+        Ok(None)
+    }
+
+    // ── inbound processing ───────────────────────────────────────────────────
+
+    /// Processes the next buffered inbound frame, driving the state machine,
+    /// journaling, and enqueuing any outbound admin. Returns a non-borrowing
+    /// [`PollOutcome`]; call [`message`](Self::message) after
+    /// [`PollOutcome::Message`].
+    ///
+    /// See the [module docs](self) for the wrapper's poll loop.
+    pub fn poll(&mut self, now: Instant) -> Result<PollOutcome, Error> {
+        // Resume an in-progress resend before touching new inbound.
+        if self.resend.is_some() {
+            if self.drive_resend()? {
+                return Ok(PollOutcome::ResendPending);
+            }
+            // Resend finished: surface the ResendRequest that triggered it.
+            self.pending = PendingKind::ResendRequest;
+            return Ok(PollOutcome::Message);
+        }
+
+        // Keep the journal's inbound cursor aligned with the state machine.
+        let n = self.state.next_inbound_seq();
+        if n != self.journal.next_inbound() {
+            self.journal.set_next_inbound(n);
+        }
+
+        // Pull the next complete frame into the stable buffer.
+        loop {
+            if self.reader.inner.should_compact() {
+                self.reader.inner.compact();
+            }
+            match self.reader.inner.next() {
+                Err(FrameError::MessageTooLarge { size }) => {
+                    return Err(Error::MessageTooLarge(size));
+                }
+                Err(FrameError::Garbage { .. }) => {
+                    self.garbage_frames += 1;
+                }
+                Ok(None) => return Ok(PollOutcome::NeedMoreBytes),
+                Ok(Some(raw)) => {
+                    self.reader.frame.clear();
+                    self.reader.frame.extend_from_slice(raw);
+                    break;
+                }
+            }
+        }
+
+        self.process_frame(now)
+    }
+
+    /// Reconstructs the typed [`Message`] for the frame just processed by
+    /// [`poll`](Self::poll). Only valid immediately after a [`PollOutcome::Message`]
+    /// (or a [`PollOutcome::Disconnected`], which also maps to
+    /// `Message::Disconnected`); the borrow is over the stable frame buffer.
+    pub fn message(&self) -> Message<'_, D> {
+        let frame = &self.reader.frame[..];
+        match self.pending {
+            PendingKind::Logon { acknowledged } => {
+                let msg = D::Logon::decode(frame).expect("frame decoded in poll");
+                if acknowledged {
+                    Message::LogonAcknowledged { msg }
+                } else {
+                    Message::LogonRequest { msg }
+                }
+            }
+            PendingKind::Logout { acknowledged } => {
+                let msg = D::Logout::decode(frame).expect("frame decoded in poll");
+                if acknowledged {
+                    Message::LogoutAcknowledged { msg }
+                } else {
+                    Message::LogoutRequest { msg }
+                }
+            }
+            PendingKind::Heartbeat => {
+                let msg = D::Heartbeat::decode(frame).expect("frame decoded in poll");
+                Message::Heartbeat { msg }
+            }
+            PendingKind::TestRequest => {
+                let msg = D::TestRequest::decode(frame).expect("frame decoded in poll");
+                Message::TestRequest { msg }
+            }
+            PendingKind::ResendRequest => {
+                let msg = D::ResendRequest::decode(frame).expect("frame decoded in poll");
+                Message::ResendRequest { msg }
+            }
+            PendingKind::SequenceReset => {
+                let msg = D::SequenceReset::decode(frame).expect("frame decoded in poll");
+                Message::SequenceReset { msg }
+            }
+            PendingKind::Reject => {
+                let msg = D::Reject::decode(frame).expect("frame decoded in poll");
+                Message::Reject { msg }
+            }
+            PendingKind::Application => Message::Application {
+                header: D::Header::decode(frame),
+            },
+            PendingKind::Disconnected { reason } => Message::Disconnected { reason },
+            PendingKind::None => unreachable!("message() called without a pending message"),
+        }
+    }
+
+    /// Full protocol handling for the frame in `reader.frame`. Mirrors the
+    /// original `recv` body: comp-id validation, inbound journaling, per-type
+    /// state driving, and outbound admin/resend enqueue.
+    fn process_frame(&mut self, now: Instant) -> Result<PollOutcome, Error> {
+        let frame = &self.reader.frame[..];
+
+        let (sender_ok, target_ok, seq, poss_dup) = {
+            let hdr = D::Header::decode(frame);
+            let sender_ok = hdr
+                .sender_comp_id()
+                .is_some_and(|fv| fv.as_bytes() == self.config.target.as_bytes());
+            let target_ok = hdr
+                .target_comp_id()
+                .is_some_and(|fv| fv.as_bytes() == self.config.sender.as_bytes());
+            let seq = match hdr.msg_seq_num() {
+                Some(fv) => match fv.checked() {
+                    Ok(num) => num as u32,
+                    Err(_) => {
+                        return Err(Error::Protocol(SessionError::MalformedField { tag: 34 }));
+                    }
+                },
+                None => return Err(Error::Protocol(SessionError::MissingMsgSeqNum)),
+            };
+            let poss_dup = hdr
+                .poss_dup_flag()
+                .and_then(|fv| fv.checked().ok())
+                .unwrap_or(false);
+            (sender_ok, target_ok, seq, poss_dup)
+        };
+
+        if !sender_ok || !target_ok {
+            let out = self.state.on_comp_id_mismatch(now);
+            for admin in out.admin_messages() {
+                store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+            }
+            return Ok(self.disconnected(DisconnectReason::CompIdMismatch));
+        }
+
+        // Well-framed and comp-id-valid: archive the inbound message for
+        // visibility/audit. Garbage and foreign (comp-id-mismatched) frames are
+        // not journaled — they never reach here.
+        journal_write(frame.len(), || self.journal.store_inbound(frame))?;
+
+        let frame = &self.reader.frame[..];
+        let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
+            s.slice(frame)
+        } else {
+            let out = self
+                .state
+                .on_reject_inbound(seq, poss_dup, Some(35), 1, now);
+            for admin in out.admin_messages() {
+                // Matches the original: this reject is NOT journaled.
+                self.writer.encode_admin(admin, &self.config);
+            }
+            return Ok(PollOutcome::Suppressed);
+        };
+
+        match raw_type {
+            b"A" => {
+                let hbi = find_tag(frame, 0, 108)
+                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
+                    .unwrap_or(30);
+                let reset = find_tag(frame, 0, 141)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let was_logon_sent = self.state.state() == State::LogonSent;
+                let out = self.state.on_logon(seq, hbi, reset, !was_logon_sent, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::Logon {
+                    acknowledged: was_logon_sent,
+                };
+                Ok(PollOutcome::Message)
+            }
+            b"5" => {
+                let was_logout_pending = self.state.state() == State::LogoutPending;
+                let out = self.state.on_logout(seq, poss_dup, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::Logout {
+                    acknowledged: was_logout_pending,
+                };
+                Ok(PollOutcome::Message)
+            }
+            b"0" => {
+                let echo_id =
+                    find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
+                let out = self.state.on_heartbeat(seq, poss_dup, echo_id, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::Heartbeat;
+                Ok(PollOutcome::Message)
+            }
+            b"1" => {
+                let test_req_id =
+                    find_tag(frame, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(frame));
+                let out = self.state.on_test_request(seq, poss_dup, test_req_id, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::TestRequest;
+                Ok(PollOutcome::Message)
+            }
+            b"2" => {
+                let begin = find_tag(frame, 0, 7)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let end = find_tag(frame, 0, 16)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let out = self.state.on_resend_request(seq, poss_dup, begin, end, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                if let Some(Event::ResendRange { begin: rb, end: re }) = out.event() {
+                    let re = if re == 0 {
+                        self.state.next_outbound_seq().saturating_sub(1)
+                    } else {
+                        re.min(self.state.next_outbound_seq().saturating_sub(1))
+                    };
+                    self.begin_resend(rb, re);
+                    if self.drive_resend()? {
+                        // Buffer filled mid-resend: wrapper drains, re-polls.
+                        return Ok(PollOutcome::ResendPending);
+                    }
+                }
+                self.pending = PendingKind::ResendRequest;
+                Ok(PollOutcome::Message)
+            }
+            b"4" => {
+                let new_seq = find_tag(frame, 0, 36)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let gap_fill = find_tag(frame, 0, 123)
+                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
+                    .unwrap_or(false);
+                let out = self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::SequenceReset;
+                Ok(PollOutcome::Message)
+            }
+            b"3" => {
+                let ref_seq = find_tag(frame, 0, 45)
+                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
+                    .map_or(0, |v| v as u32);
+                let out = self.state.on_reject(seq, poss_dup, ref_seq, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                self.pending = PendingKind::Reject;
+                Ok(PollOutcome::Message)
+            }
+            _ => {
+                let out = self.state.on_app(seq, poss_dup, now);
+                for admin in out.admin_messages() {
+                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+                }
+                if let Some(Event::Disconnected { reason }) = out.event() {
+                    return Ok(self.disconnected(reason));
+                }
+                if matches!(out.event(), Some(Event::App { .. })) {
+                    self.pending = PendingKind::Application;
+                    return Ok(PollOutcome::Message);
+                }
+                // gap: ResendRequest queued, nothing to surface
+                Ok(PollOutcome::Suppressed)
+            }
+        }
+    }
+
+    /// Records a disconnect for [`message`](Self::message) and returns the outcome.
+    fn disconnected(&mut self, reason: DisconnectReason) -> PollOutcome {
+        self.pending = PendingKind::Disconnected { reason };
+        PollOutcome::Disconnected(reason)
+    }
+
+    // ── resend ───────────────────────────────────────────────────────────────
+
+    /// Starts a resend of `[begin, end]`, capturing the timestamp once (matching
+    /// the original `do_resend`, which formats one `SendingTime` for the batch).
+    fn begin_resend(&mut self, begin: u32, end: u32) {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unix_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i128;
+        let mut ts = [0u8; UTC_TIMESTAMP_LEN];
+        crate::timestamp::format_utc_timestamp(unix_nanos, &mut ts);
+        self.resend = Some(ResendState {
+            begin,
+            end,
+            drained: 0,
+            ts,
+        });
+    }
+
+    /// Encodes as many pending resend items as fit the outbound buffer.
+    ///
+    /// Returns `Ok(true)` if the buffer filled and the resend is not yet complete
+    /// (wrapper must drain and re-poll); `Ok(false)` when the resend finished (the
+    /// state is cleared).
+    ///
+    /// Item-granular resume: `drained` counts fully-encoded items, and
+    /// `resend(begin, end)` is re-derived each call. The original flushed the
+    /// buffer and retried the *same whole item* into an empty buffer on overflow;
+    /// resuming at item granularity reproduces that exact wire output without
+    /// splitting an item.
+    fn drive_resend(&mut self) -> Result<bool, Error> {
+        let rs = self
+            .resend
+            .expect("drive_resend with no resend in progress");
+        let mut encoded = rs.drained;
+        for item in self.journal.resend(rs.begin, rs.end).skip(rs.drained) {
+            let ok = encode_resend_item(
+                &mut self.writer.inner,
+                &item,
+                &self.config,
+                &rs.ts,
+                D::BEGIN_STRING,
+            );
+            if ok.is_err() {
+                // Buffer full: leave the item for the next poll (after a drain).
+                // `send_app`'s headroom guarantees the item fits an *empty*
+                // buffer; if the buffer is already empty and it still fails, the
+                // writer is sized too small — a configuration error.
+                if self.writer.is_empty() {
+                    self.resend = None;
+                    return Err(Error::MessageTooLarge(
+                        self.writer.inner.remaining().saturating_add(1),
+                    ));
+                }
+                self.resend = Some(ResendState {
+                    drained: encoded,
+                    ..rs
+                });
+                return Ok(true);
+            }
+            encoded += 1;
+        }
+        self.resend = None;
+        Ok(false)
+    }
+}
+
+/// Write to the journal, retrying on transient standby backpressure.
+///
+/// `store` is one of `FixJournal::store` / `store_inbound`, `size` its frame
+/// length. On [`WriteError::StandbyNotReady`] (transient backpressure) we spin
+/// and retry; a [`WriteError::RecordTooLarge`] misconfiguration surfaces as
+/// [`Error::MessageTooLarge`].
+///
+/// Unbounded on purpose. StandbyNotReady is transient backpressure the conductor
+/// clears in sub-ms; the only way this spins forever is a full/failing disk,
+/// which must be caught by observability. Spinning beats the alternative of
+/// dropping a message from a resend/audit journal.
+#[inline]
+fn journal_write(
+    size: usize,
+    mut store: impl FnMut() -> Result<(), WriteError>,
+) -> Result<(), Error> {
+    loop {
+        match store() {
+            Ok(()) => return Ok(()),
+            Err(WriteError::StandbyNotReady) => std::hint::spin_loop(),
+            // Only RecordTooLarge today; WriteError is non-exhaustive, so any
+            // other (non-backpressure) journal write error surfaces the same way.
+            Err(_) => return Err(Error::MessageTooLarge(size)),
+        }
+    }
+}
+
+/// Encodes an admin message into the writer and journals it under its seqnum.
+fn store_admin<D: FixDictionary>(
+    admin: AdminMsg,
+    writer: &mut MessageWriter<D>,
+    journal: &mut FixJournal,
+    config: &SessionConfig,
+) -> Result<(), Error> {
+    let seq = match admin {
+        AdminMsg::Logon { seq, .. }
+        | AdminMsg::LogonReset { seq, .. }
+        | AdminMsg::Logout { seq }
+        | AdminMsg::Heartbeat { seq, .. }
+        | AdminMsg::TestRequest { seq, .. }
+        | AdminMsg::ResendRequest { seq, .. }
+        | AdminMsg::SequenceReset { seq, .. }
+        | AdminMsg::Reject { seq, .. } => seq,
+    };
+    let before = writer.inner.data().len();
+    writer.encode_admin(admin, config);
+    let frame = &writer.inner.data()[before..];
+    if !frame.is_empty() {
+        journal_write(frame.len(), || journal.store(seq, frame))?;
+    }
+    Ok(())
+}
+
+/// Copies a pre-built frame into the writer buffer for the wrapper to drain.
+///
+/// Unlike the original `write_through` this performs no I/O: it only stages bytes.
+/// The frame must fit the *empty* buffer capacity — [`FixSession::send_app`] caps
+/// app frames below it, so an overflow here is an undersized writer, not a
+/// fallback. Because the sans-IO core cannot flush to make room, the buffer must
+/// hold the frame as-is.
+fn buffer_frame(writer: &mut FrameWriter, frame: &[u8]) -> Result<(), Error> {
+    if writer.remaining() < frame.len() {
+        return Err(Error::MessageTooLarge(frame.len()));
+    }
+    let spare = writer.spare();
+    spare[..frame.len()].copy_from_slice(frame);
+    writer.commit(0, frame.len());
+    Ok(())
+}
+
+/// Encodes one resend [`ReplayItem`] into the writer. Returns `Err(())` if it
+/// does not fit the remaining buffer.
+fn encode_resend_item(
+    writer: &mut FrameWriter,
+    item: &ReplayItem<'_>,
+    config: &SessionConfig,
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Result<(), ()> {
+    match item {
+        ReplayItem::GapFill { seq, new_seq } => {
+            encode_gap_fill(writer, begin_string, config, ts, *seq, *new_seq)
+        }
+        ReplayItem::App(orig) => reframe_app(writer, orig, ts, begin_string),
+    }
+}
+
+fn encode_gap_fill(
+    writer: &mut FrameWriter,
+    begin_string: &'static [u8],
+    config: &SessionConfig,
+    ts: &[u8],
+    seq: u32,
+    new_seq: u32,
+) -> Result<(), ()> {
+    let spare = writer.spare();
+    let mut seq_buf = [0u8; 10];
+    let seq_n = encode_fix_uint(seq, &mut seq_buf);
+    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
+    fmt.field(34, &seq_buf[..seq_n]);
+    fmt.field(49, config.sender.as_bytes());
+    fmt.field(56, config.target.as_bytes());
+    fmt.field(52, ts);
+    fmt.field(43, b"Y");
+    fmt.field(123, b"Y");
+    let mut nsq_buf = [0u8; 10];
+    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
+    fmt.field(36, &nsq_buf[..nsq_n]);
+    let (start, len) = fmt.finish().map_err(|_| ())?;
+    writer.commit(start, len);
+    Ok(())
+}
+
+fn reframe_app(
+    writer: &mut FrameWriter,
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Result<(), ()> {
+    let spare = writer.spare();
+    let (start, len) = reframe_app_into(spare, orig, ts, begin_string).ok_or(())?;
+    writer.commit(start, len);
+    Ok(())
+}
+
+fn reframe_app_into(
+    buf: &mut [u8],
+    orig: &[u8],
+    ts: &[u8],
+    begin_string: &'static [u8],
+) -> Option<(usize, usize)> {
+    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
+    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
+
+    let mut fmt = FrameFormatter::new(buf, begin_string, msg_type);
+    let mut poss_dup_done = false;
+
+    for field in FieldReader::new(orig, 0) {
+        match field.tag {
+            8 | 9 | 10 | 35 | 43 | 122 => {}
+            52 => {
+                fmt.field(52, ts);
+                fmt.field(43, b"Y");
+                if let Some(t) = orig_time {
+                    fmt.field(122, t);
+                }
+                poss_dup_done = true;
+            }
+            _ => fmt.field(field.tag, field.value.slice(orig)),
+        }
+    }
+
+    if !poss_dup_done {
+        fmt.field(43, b"Y");
+        if let Some(t) = orig_time {
+            fmt.field(122, t);
+        }
+    }
+
+    fmt.finish().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    use nexus_fix_codec::{
+        AsciiTextStr, DecodeError, FieldReader, FieldView, FixAdminMsg, FixDictionary, FixHeader,
+        FixTimestamp, FrameFormatter, checksum, find_tag, format_checksum,
+    };
+
+    use super::{FixSession, PollOutcome};
+    use crate::frame::{FrameReader, FrameWriter};
+    use crate::framework::{CompId, MessageReader, MessageWriter, SessionConfig};
+    use crate::persist::FixJournal;
+    use crate::session::SessionState;
+
+    // ── minimal mock dictionary (mirrors tests/transport.rs) ─────────────────
+
+    struct MockDict;
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    enum MockMsgType {}
+
+    struct AdminDecoder<'buf> {
+        _buf: &'buf [u8],
+    }
+
+    impl<'buf> FixAdminMsg<'buf> for AdminDecoder<'buf> {
+        fn decode(buf: &'buf [u8]) -> Result<Self, DecodeError> {
+            Ok(Self { _buf: buf })
+        }
+    }
+
+    impl FixDictionary for MockDict {
+        type MsgType = MockMsgType;
+        type Header<'buf> = MockHeader<'buf>;
+        type Logon<'buf> = AdminDecoder<'buf>;
+        type Logout<'buf> = AdminDecoder<'buf>;
+        type Heartbeat<'buf> = AdminDecoder<'buf>;
+        type TestRequest<'buf> = AdminDecoder<'buf>;
+        type ResendRequest<'buf> = AdminDecoder<'buf>;
+        type SequenceReset<'buf> = AdminDecoder<'buf>;
+        type Reject<'buf> = AdminDecoder<'buf>;
+        const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+        fn is_admin(_: MockMsgType) -> bool {
+            false
+        }
+    }
+
+    struct MockHeader<'buf> {
+        buf: &'buf [u8],
+    }
+
+    impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
+        fn decode(buf: &'buf [u8]) -> Self {
+            Self { buf }
+        }
+        fn raw_msg_type(&self) -> Option<FieldView<'buf, &'buf [u8]>> {
+            find_tag(self.buf, 0, 35).and_then(|s| FieldView::new(s, self.buf))
+        }
+        fn msg_seq_num(&self) -> Option<FieldView<'buf, u64>> {
+            find_tag(self.buf, 0, 34).and_then(|s| FieldView::new(s, self.buf))
+        }
+        fn sender_comp_id(&self) -> Option<FieldView<'buf, &'buf AsciiTextStr>> {
+            find_tag(self.buf, 0, 49).and_then(|s| FieldView::new(s, self.buf))
+        }
+        fn target_comp_id(&self) -> Option<FieldView<'buf, &'buf AsciiTextStr>> {
+            find_tag(self.buf, 0, 56).and_then(|s| FieldView::new(s, self.buf))
+        }
+        fn poss_dup_flag(&self) -> Option<FieldView<'buf, bool>> {
+            find_tag(self.buf, 0, 43).and_then(|s| FieldView::new(s, self.buf))
+        }
+        fn sending_time(&self) -> Option<FieldView<'buf, FixTimestamp>> {
+            None
+        }
+    }
+
+    // ── test rig ─────────────────────────────────────────────────────────────
+
+    // Engine plays initiator: our SenderCompID is INITIATOR, the peer is ACCEPTOR.
+    // Inbound frames therefore carry 49=ACCEPTOR (peer's sender) and 56=INITIATOR.
+    fn our_id() -> CompId {
+        CompId::new(b"INITIATOR").unwrap()
+    }
+    fn peer_id() -> CompId {
+        CompId::new(b"ACCEPTOR").unwrap()
+    }
+
+    fn tmp_dir(suffix: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "nexus_fix_session_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// Build a stored app frame at `seq` with a filler `58=Text` field whose
+    /// length is derived from `seq` so frame sizes vary across the range. The
+    /// original `SendingTime` (52) is a fixed literal (comes from stored bytes,
+    /// not the resend clock), so it survives into `OrigSendingTime` (122)
+    /// identically in both runs.
+    fn app_frame(seq: u32, buf: &mut [u8]) -> usize {
+        let mut seq_buf = [0u8; 10];
+        let seq_n = nexus_fix_codec::encode_fix_uint(seq, &mut seq_buf);
+        // Filler 6..=26 bytes: varies the reframed size around the tiny-buffer
+        // boundary without ever exceeding `tiny_cap - REFRAME_HEADROOM`.
+        let fill_len = 6 + (seq as usize % 21);
+        let filler = vec![b'x'; fill_len];
+        let mut fmt = FrameFormatter::new(buf, b"FIX.4.4", b"D");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, our_id().as_bytes()); // engine is the SENDER of stored msgs
+        fmt.field(56, peer_id().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(58, &filler);
+        let (start, len) = fmt.finish().unwrap();
+        buf.copy_within(start..start + len, 0);
+        len
+    }
+
+    /// Encode an inbound ResendRequest (35=2) from the peer covering `[begin,end]`
+    /// at MsgSeqNum `seq`.
+    fn resend_request_frame(seq: u32, begin: u32, end: u32, buf: &mut [u8]) -> usize {
+        let mut nb = [0u8; 10];
+        let mut bb = [0u8; 10];
+        let mut eb = [0u8; 10];
+        let n = nexus_fix_codec::encode_fix_uint(seq, &mut nb);
+        let bn = nexus_fix_codec::encode_fix_uint(begin, &mut bb);
+        let en = nexus_fix_codec::encode_fix_uint(end, &mut eb);
+        let mut fmt = FrameFormatter::new(buf, b"FIX.4.4", b"2");
+        fmt.field(34, &nb[..n]);
+        fmt.field(49, peer_id().as_bytes()); // peer is the SENDER of the request
+        fmt.field(56, our_id().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(7, &bb[..bn]);
+        fmt.field(16, &eb[..en]);
+        let (start, len) = fmt.finish().unwrap();
+        buf.copy_within(start..start + len, 0);
+        len
+    }
+
+    /// Number of stored app messages and the two interior holes (gap-fills).
+    const N: u32 = 30;
+    const HOLE_A: u32 = 10;
+    const HOLE_B: u32 = 20;
+
+    /// Build an `Active` session whose outbound journal holds app frames for
+    /// seqs `1..=N` except `HOLE_A`/`HOLE_B`, ready to receive a ResendRequest.
+    ///
+    /// `writer_cap` sizes only the outbound writer — the shared journal content
+    /// is byte-identical across runs, so the two resends differ only in the
+    /// resend `SendingTime` (normalized away by the oracle).
+    fn build_session(dir: &PathBuf, writer_cap: usize) -> FixSession<MockDict> {
+        let reader = MessageReader::with_frame_reader(FrameReader::builder().build());
+        let writer = MessageWriter::with_frame_writer(
+            FrameWriter::builder().buffer_capacity(writer_cap).build(),
+        );
+        let mut state = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        // Establish (initiator): Logon consumes outbound seq 1, peer's Logon at
+        // seq 1 advances next_inbound to 2 and moves to Active.
+        state.connect(now);
+        state.on_logon(1, 30, false, false, now);
+        // Align outbound with the journal we are about to fill (next = N + 1) so
+        // the resend `end` clamp (`re.min(next_outbound - 1)`) does not chop the
+        // range. Keep next_inbound at 2 for the incoming ResendRequest.
+        state.reset_seq_nums(N + 1, 2);
+
+        let journal = FixJournal::open(dir, 0, 256).unwrap();
+        let mut session = FixSession::from_buffers(
+            reader,
+            writer,
+            state,
+            SessionConfig {
+                sender: our_id(),
+                target: peer_id(),
+            },
+            journal,
+        );
+
+        // Store the app messages. `send_app` also stages the frame in the writer;
+        // drain it so only the later resend output is captured.
+        let mut buf = vec![0u8; 512];
+        for seq in 1..=N {
+            if seq == HOLE_A || seq == HOLE_B {
+                continue; // interior hole → gap-fill on resend
+            }
+            let len = app_frame(seq, &mut buf);
+            session.send_app(seq, &buf[..len]).unwrap();
+            let n = session.outbound().len();
+            session.advance_outbound(n);
+        }
+        assert!(
+            !session.has_outbound(),
+            "writer must be drained before resend"
+        );
+        session
+    }
+
+    /// Drive a ResendRequest for `[1, N]` to completion, concatenating every
+    /// outbound byte. Returns `(stream, resend_pending_count)`.
+    ///
+    /// The loop fully drains the writer after each `poll`, so every resumed
+    /// `drive_resend` sees a freshly auto-reset (full-capacity) buffer — exactly
+    /// the "flush the buffer, retry the item into an empty buffer" contract the
+    /// resumable path replaced.
+    fn drive_resend_stream(session: &mut FixSession<MockDict>) -> (Vec<u8>, usize) {
+        let now = Instant::now();
+        let mut req = vec![0u8; 256];
+        let len = resend_request_frame(2, 1, N, &mut req);
+        let spare = session.read_spare();
+        spare[..len].copy_from_slice(&req[..len]);
+        session.read_filled(len);
+
+        let mut stream = Vec::new();
+        let mut pending = 0usize;
+        loop {
+            let outcome = session.poll(now).expect("poll");
+            // Drain everything currently staged, then decide.
+            while session.has_outbound() {
+                let data = session.outbound();
+                stream.extend_from_slice(data);
+                let n = data.len();
+                session.advance_outbound(n);
+            }
+            match outcome {
+                PollOutcome::ResendPending => pending += 1,
+                PollOutcome::Message => break, // ResendRequest surfaced: resend done
+                other => panic!("unexpected outcome during resend: {other:?}"),
+            }
+        }
+        (stream, pending)
+    }
+
+    /// Split a concatenated stream into frames using the production frame reader
+    /// (self-delimiting via BodyLength, checksum-validated).
+    fn split_frames(stream: &[u8]) -> Vec<Vec<u8>> {
+        let mut reader = FrameReader::builder().build();
+        reader.read(stream).expect("stream fits reader");
+        let mut frames = Vec::new();
+        loop {
+            match reader.next() {
+                Ok(Some(frame)) => frames.push(frame.to_vec()),
+                Ok(None) => break,
+                Err(e) => panic!("frame split error: {e:?}"),
+            }
+        }
+        frames
+    }
+
+    /// Canonicalize the resend `SendingTime` (52) to a fixed value and recompute
+    /// the checksum (10), reusing the codec's own `checksum`/`format_checksum` so
+    /// the normalization can never drift from the encoder. Every resend `52` is
+    /// exactly `UTC_TIMESTAMP_LEN` bytes, so the overwrite is length-preserving —
+    /// BodyLength (9) is untouched. `OrigSendingTime` (122) is left intact, so a
+    /// bug that mangled it would still surface.
+    fn normalize_sending_time(mut frame: Vec<u8>) -> Vec<u8> {
+        const CANON: &[u8; 21] = b"11111111-11:11:11.111";
+        if let Some(span) = find_tag(&frame, 0, 52) {
+            let (o, l) = (span.offset as usize, span.len as usize);
+            assert_eq!(l, CANON.len(), "resend SendingTime must be fixed width");
+            frame[o..o + l].copy_from_slice(CANON);
+            // Recompute checksum: sum bytes from `8=` up to (not including) the
+            // trailing `10=DDD\x01` (last 7 bytes), matching the codec.
+            let body_end = frame.len() - 7;
+            let sum = checksum(&frame[..body_end]);
+            let digits = format_checksum(sum);
+            let dstart = frame.len() - 4; // three digits then SOH
+            frame[dstart..dstart + 3].copy_from_slice(&digits);
+        }
+        frame
+    }
+
+    fn normalize_stream(stream: &[u8]) -> Vec<Vec<u8>> {
+        split_frames(stream)
+            .into_iter()
+            .map(normalize_sending_time)
+            .collect()
+    }
+
+    /// Oracle: a resend that overflows a tiny writer many times (drain → resume)
+    /// must produce byte-for-byte the same output as the same resend into a
+    /// writer large enough to complete in a single pass. Divergence would mean
+    /// the resumable path skipped, duplicated, split, reordered, or mis-reframed
+    /// an item across a resume boundary.
+    #[test]
+    fn resumable_resend_matches_single_pass() {
+        let dir_big = tmp_dir("resume_big");
+        let dir_small = tmp_dir("resume_small");
+
+        // Large writer: whole resend fits in one pass.
+        let mut big = build_session(&dir_big, 64 * 1024);
+        let (big_stream, big_pending) = drive_resend_stream(&mut big);
+        assert_eq!(big_pending, 0, "large-writer resend must be a single pass");
+
+        // Tiny writer: ~1 reframed item per cycle → many drain/resume boundaries.
+        // 200 bytes holds one reframed item (< ~180) but never two (>= ~250),
+        // and comfortably exceeds the largest single frame so the empty-buffer
+        // MessageTooLarge guard never fires.
+        let mut small = build_session(&dir_small, 200);
+        let (small_stream, small_pending) = drive_resend_stream(&mut small);
+
+        // The path was actually exercised, not trivially skipped.
+        assert!(
+            small_pending >= 5,
+            "tiny-writer resend must hit ResendPending repeatedly (got {small_pending})"
+        );
+
+        // Strong oracle: identical after normalizing the resend SendingTime.
+        let big_frames = normalize_stream(&big_stream);
+        let small_frames = normalize_stream(&small_stream);
+        assert_eq!(
+            big_frames.len(),
+            small_frames.len(),
+            "frame count diverged: single-pass {} vs resumable {}",
+            big_frames.len(),
+            small_frames.len()
+        );
+        for (i, (b, s)) in big_frames.iter().zip(small_frames.iter()).enumerate() {
+            assert_eq!(
+                b,
+                s,
+                "frame {i} diverged between single-pass and resumable resend\n \
+                 single-pass: {}\n resumable:   {}",
+                String::from_utf8_lossy(b),
+                String::from_utf8_lossy(s),
+            );
+        }
+
+        // Structural spot-checks on the (canonical) single-pass stream.
+        // Range [1,30] with holes at 10 and 20:
+        //   App(1..9), GapFill(10→11), App(11..19), GapFill(20→21), App(21..30).
+        // 28 app reframes + 2 coalesced gap-fills = 30 frames.
+        assert_eq!(big_frames.len(), 30, "expected 28 apps + 2 gap-fills");
+
+        let mut app_seqs = Vec::new();
+        let mut gapfills = Vec::new();
+        for f in &big_frames {
+            let msg_type = find_tag(f, 0, 35).map(|s| s.slice(f)).unwrap();
+            // Every reframed item and every gap-fill carries PossDupFlag=Y.
+            let poss_dup = find_tag(f, 0, 43).map(|s| s.slice(f));
+            assert_eq!(poss_dup, Some(b"Y".as_ref()), "resend frame must set 43=Y");
+            let seq: u32 = find_tag(f, 0, 34)
+                .and_then(|s| FieldView::new(s, f.as_slice()))
+                .unwrap()
+                .get();
+            match msg_type {
+                b"4" => {
+                    // GapFill carries NewSeqNo(36) and GapFillFlag(123)=Y.
+                    let gf = find_tag(f, 0, 123).map(|s| s.slice(f));
+                    assert_eq!(gf, Some(b"Y".as_ref()), "gap-fill must set 123=Y");
+                    let new_seq: u32 = find_tag(f, 0, 36)
+                        .and_then(|s| FieldView::new(s, f.as_slice()))
+                        .unwrap()
+                        .get();
+                    gapfills.push((seq, new_seq));
+                }
+                b"D" => {
+                    // Reframed app preserves OrigSendingTime(122) from the store.
+                    let orig = find_tag(f, 0, 122).map(|s| s.slice(f));
+                    assert_eq!(
+                        orig,
+                        Some(b"20260615-12:00:00.000".as_ref()),
+                        "reframed app must carry 122=<original 52>"
+                    );
+                    // Field 58 filler must survive the reframe.
+                    assert!(find_tag(f, 0, 58).is_some(), "reframed app dropped tag 58");
+                    app_seqs.push(seq);
+                }
+                other => panic!("unexpected resend msg type {:?}", other),
+            }
+        }
+
+        // Exactly the app seqnums we stored, in order.
+        let expected_apps: Vec<u32> = (1..=N).filter(|s| *s != HOLE_A && *s != HOLE_B).collect();
+        assert_eq!(
+            app_seqs, expected_apps,
+            "app reframe seqnums or order wrong"
+        );
+        // Gap-fills coalesce each hole up to the next stored seqnum.
+        assert_eq!(
+            gapfills,
+            vec![(HOLE_A, HOLE_A + 1), (HOLE_B, HOLE_B + 1)],
+            "gap-fill (seq,new_seq) wrong"
+        );
+
+        // Wire count must include a FieldReader-visible field parse for sanity:
+        // every frame has tags 8/34/52 present.
+        for f in &big_frames {
+            let tags: Vec<u32> = FieldReader::new(f, 0).map(|fld| fld.tag).collect();
+            assert!(tags.contains(&8) && tags.contains(&34) && tags.contains(&52));
+        }
+
+        let _ = std::fs::remove_dir_all(&dir_big);
+        let _ = std::fs::remove_dir_all(&dir_small);
+    }
+
+    #[test]
+    fn reframe_stays_within_headroom() {
+        // A resend reframe adds PossDupFlag (43=Y), OrigSendingTime (122=...),
+        // and a little BodyLength growth. It must never grow a message by more
+        // than REFRAME_HEADROOM, so a stored app frame always reframes back into
+        // the pre-allocated writer buffer without a runtime allocation.
+        let mut orig_buf = [0u8; 512];
+        let (s, l) = {
+            let mut fmt = FrameFormatter::new(&mut orig_buf, b"FIX.4.4", b"D");
+            fmt.field(34, b"5");
+            fmt.field(49, b"SENDER");
+            fmt.field(56, b"TARGET");
+            fmt.field(52, b"20260101-00:00:00.000");
+            fmt.field(11, b"ORDER-1");
+            fmt.finish().unwrap()
+        };
+        let orig = &orig_buf[s..s + l];
+
+        let ts = b"20260102-12:34:56.789";
+        let mut out = [0u8; 1024];
+        let (_start, len) = super::reframe_app_into(&mut out, orig, ts, b"FIX.4.4").unwrap();
+
+        assert!(
+            len <= orig.len() + super::REFRAME_HEADROOM,
+            "reframe grew message by {} bytes, exceeding REFRAME_HEADROOM ({})",
+            len - orig.len(),
+            super::REFRAME_HEADROOM
+        );
+    }
+}

--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -224,12 +224,32 @@ impl<D: FixDictionary> FixSession<D> {
         self.writer.capacity()
     }
 
+    /// Inbound reader buffer capacity in bytes (fixed at construction).
+    ///
+    /// The largest single frame the reader can buffer. A wrapper reports this as
+    /// the size in [`Error::MessageTooLarge`] when [`read_spare`](Self::read_spare)
+    /// returns an empty slice — the buffer is full with one incomplete frame that
+    /// cannot grow.
+    pub fn reader_capacity(&self) -> usize {
+        self.reader.inner.capacity()
+    }
+
     // ── inbound byte-buffer seam ─────────────────────────────────────────────
 
     /// Spare region of the inbound buffer for the wrapper to read socket bytes
     /// into. Commit the number actually read with [`read_filled`](Self::read_filled).
+    ///
+    /// Compacts on the usual `should_compact()` threshold, but *also* whenever the
+    /// buffer is full (`remaining() == 0`) even below that threshold. Without the
+    /// full-buffer case a buffer that is full but <50% consumed would return an
+    /// empty spare slice; the wrapper's `stream.read(&mut [])` then returns
+    /// `Ok(0)` and is misread as EOF/disconnect. Compacting reclaims all consumed
+    /// space, so the spare is non-empty whenever there is anything to reclaim. If
+    /// nothing is reclaimable (a single incomplete frame already fills the whole
+    /// buffer) the spare stays empty, and the wrapper turns that into
+    /// [`Error::MessageTooLarge`] rather than reading into a zero-length slice.
     pub fn read_spare(&mut self) -> &mut [u8] {
-        if self.reader.inner.should_compact() {
+        if self.reader.inner.should_compact() || self.reader.inner.remaining() == 0 {
             self.reader.inner.compact();
         }
         self.reader.inner.spare()
@@ -479,6 +499,15 @@ impl<D: FixDictionary> FixSession<D> {
 
         match raw_type {
             b"A" => {
+                // Validate the typed decode before any side effect: a malformed
+                // admin (e.g. a Logon missing a required field) must error with
+                // MalformedMessage, not drive the state machine and then panic in
+                // `message()`'s `.expect("frame decoded in poll")`. `process_frame`
+                // sets `PendingKind` from tag 35 alone, so this decode is the only
+                // place the typed parse runs — it makes that `.expect()` genuinely
+                // safe. Discard the value; this is validation only.
+                D::Logon::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let hbi = find_tag(frame, 0, 108)
                     .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
                     .unwrap_or(30);
@@ -499,6 +528,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"5" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::Logout::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let was_logout_pending = self.state.state() == State::LogoutPending;
                 let out = self.state.on_logout(seq, poss_dup, now);
                 for admin in out.admin_messages() {
@@ -513,6 +545,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"0" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::Heartbeat::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let echo_id =
                     find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
                 let out = self.state.on_heartbeat(seq, poss_dup, echo_id, now);
@@ -526,6 +561,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"1" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::TestRequest::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let test_req_id =
                     find_tag(frame, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(frame));
                 let out = self.state.on_test_request(seq, poss_dup, test_req_id, now);
@@ -539,6 +577,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"2" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::ResendRequest::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let begin = find_tag(frame, 0, 7)
                     .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
                     .map_or(0, |v| v as u32);
@@ -568,6 +609,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"4" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::SequenceReset::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let new_seq = find_tag(frame, 0, 36)
                     .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
                     .map_or(0, |v| v as u32);
@@ -585,6 +629,9 @@ impl<D: FixDictionary> FixSession<D> {
                 Ok(PollOutcome::Message)
             }
             b"3" => {
+                // Validate the typed decode before any side effect (see `b"A"`).
+                D::Reject::decode(frame)
+                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
                 let ref_seq = find_tag(frame, 0, 45)
                     .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
                     .map_or(0, |v| v as u32);
@@ -865,7 +912,7 @@ mod tests {
 
     use super::{FixSession, PollOutcome};
     use crate::frame::{FrameReader, FrameWriter};
-    use crate::framework::{CompId, MessageReader, MessageWriter, SessionConfig};
+    use crate::framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig};
     use crate::persist::FixJournal;
     use crate::session::SessionState;
 
@@ -1281,5 +1328,319 @@ mod tests {
             len - orig.len(),
             super::REFRAME_HEADROOM
         );
+    }
+
+    // ── strict dictionary: admin decode fails on a missing required field ─────
+
+    /// A dictionary whose admin decode rejects a Logon that lacks HeartBtInt
+    /// (tag 108). Real generated dictionaries fail the typed decode when a
+    /// required field is absent; `MockDict`'s always-`Ok` decoder cannot model
+    /// that, so this second dictionary exercises the malformed-admin path.
+    struct StrictDict;
+
+    struct StrictAdmin<'buf> {
+        _buf: &'buf [u8],
+    }
+
+    impl<'buf> FixAdminMsg<'buf> for StrictAdmin<'buf> {
+        fn decode(buf: &'buf [u8]) -> Result<Self, DecodeError> {
+            // Require HeartBtInt(108) — a well-formed Logon carries it. Its
+            // absence stands in for any required-field violation the typed
+            // decoder would reject.
+            if find_tag(buf, 0, 108).is_some() {
+                Ok(Self { _buf: buf })
+            } else {
+                Err(DecodeError::Truncated)
+            }
+        }
+    }
+
+    impl FixDictionary for StrictDict {
+        type MsgType = MockMsgType;
+        type Header<'buf> = MockHeader<'buf>;
+        type Logon<'buf> = StrictAdmin<'buf>;
+        type Logout<'buf> = StrictAdmin<'buf>;
+        type Heartbeat<'buf> = StrictAdmin<'buf>;
+        type TestRequest<'buf> = StrictAdmin<'buf>;
+        type ResendRequest<'buf> = StrictAdmin<'buf>;
+        type SequenceReset<'buf> = StrictAdmin<'buf>;
+        type Reject<'buf> = StrictAdmin<'buf>;
+        const BEGIN_STRING: &'static [u8] = b"FIX.4.4";
+        fn is_admin(_: MockMsgType) -> bool {
+            false
+        }
+    }
+
+    /// Build a well-framed Logon (35=A) from the peer at `seq`, optionally
+    /// omitting HeartBtInt(108). Comp IDs are peer→engine (49=ACCEPTOR,
+    /// 56=INITIATOR) so the frame passes comp-id validation.
+    fn peer_logon_frame(seq: u32, with_hbi: bool, buf: &mut [u8]) -> usize {
+        let mut seq_buf = [0u8; 10];
+        let seq_n = nexus_fix_codec::encode_fix_uint(seq, &mut seq_buf);
+        let mut fmt = FrameFormatter::new(buf, b"FIX.4.4", b"A");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, peer_id().as_bytes()); // peer is the SENDER of the Logon
+        fmt.field(56, our_id().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        if with_hbi {
+            fmt.field(108, b"30");
+        }
+        let (start, len) = fmt.finish().unwrap();
+        buf.copy_within(start..start + len, 0);
+        len
+    }
+
+    /// A well-framed, comp-id-valid, valid-seqnum admin message (Logon) whose
+    /// *typed* decode fails (missing a required field) must surface as
+    /// `Error::Protocol(MalformedMessage)` — never panic. Before the fix,
+    /// `process_frame` set `PendingKind` from tag 35 alone and never ran the
+    /// typed decode, so `message()`'s `.expect("frame decoded in poll")` panicked
+    /// the process on a malformed admin. Regression for the sans-IO refactor
+    /// (this is what the pre-refactor transport returned via its per-arm
+    /// decode-then-`map_err`).
+    #[test]
+    fn malformed_admin_errors_not_panics() {
+        use crate::framework::SessionError;
+
+        let dir = tmp_dir("malformed_admin");
+        let now = Instant::now();
+
+        let reader = MessageReader::with_frame_reader(FrameReader::builder().build());
+        let writer =
+            MessageWriter::with_frame_writer(FrameWriter::builder().buffer_capacity(4096).build());
+        let mut state = SessionState::new(Duration::from_secs(30));
+        // Initiate: engine sends Logon (outbound seq 1), moves to LogonSent, and
+        // expects the peer's Logon at inbound seq 1.
+        state.connect(now);
+
+        let journal = FixJournal::open(&dir, 0, 256).unwrap();
+        let mut session: FixSession<StrictDict> = FixSession::from_buffers(
+            reader,
+            writer,
+            state,
+            SessionConfig {
+                sender: our_id(),
+                target: peer_id(),
+            },
+            journal,
+        );
+        // Drain the opening Logon the engine staged so only inbound is exercised.
+        let n = session.outbound().len();
+        session.advance_outbound(n);
+
+        // Sanity: the *same* frame WITH tag 108 decodes and surfaces as a Message
+        // (guards against the frame being rejected for an unrelated reason).
+        {
+            let dir_ok = tmp_dir("malformed_admin_ok");
+            let reader = MessageReader::with_frame_reader(FrameReader::builder().build());
+            let writer = MessageWriter::with_frame_writer(
+                FrameWriter::builder().buffer_capacity(4096).build(),
+            );
+            let mut state = SessionState::new(Duration::from_secs(30));
+            state.connect(now);
+            let journal = FixJournal::open(&dir_ok, 0, 256).unwrap();
+            let mut ok_session: FixSession<StrictDict> = FixSession::from_buffers(
+                reader,
+                writer,
+                state,
+                SessionConfig {
+                    sender: our_id(),
+                    target: peer_id(),
+                },
+                journal,
+            );
+            let n = ok_session.outbound().len();
+            ok_session.advance_outbound(n);
+
+            let mut buf = vec![0u8; 256];
+            let len = peer_logon_frame(1, true, &mut buf);
+            let spare = ok_session.read_spare();
+            spare[..len].copy_from_slice(&buf[..len]);
+            ok_session.read_filled(len);
+            assert_eq!(
+                ok_session.poll(now).expect("valid Logon must not error"),
+                PollOutcome::Message,
+                "a well-formed Logon (with tag 108) must surface as a Message"
+            );
+            let _ = std::fs::remove_dir_all(&dir_ok);
+        }
+
+        // The malformed Logon: missing HeartBtInt(108) → typed decode fails.
+        let mut buf = vec![0u8; 256];
+        let len = peer_logon_frame(1, false, &mut buf);
+        let spare = session.read_spare();
+        spare[..len].copy_from_slice(&buf[..len]);
+        session.read_filled(len);
+
+        // Drive poll → message exactly as the wrapper's `recv` does. WITH the fix,
+        // `poll` returns the error before ever yielding `Message`, so `message()`
+        // is never reached. WITHOUT the fix, `poll` yields `Message` and the
+        // `message()` call below panics on `.expect("frame decoded in poll")` —
+        // this call is what makes the regression observable end-to-end.
+        match session.poll(now) {
+            Err(super::Error::Protocol(SessionError::MalformedMessage)) => {}
+            Ok(PollOutcome::Message) => {
+                let _ = session.message(); // panics without the fix
+                panic!("malformed admin surfaced as a Message instead of an error");
+            }
+            other => {
+                panic!("malformed admin must return Protocol(MalformedMessage), got {other:?}")
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── Fix B part 1: compaction when the buffer is full below the threshold ──
+
+    /// Build an inbound app frame (35=D) from the peer at `seq` with a `58=Text`
+    /// filler of `fill` bytes. Comp IDs are peer→engine (49=ACCEPTOR,56=INITIATOR)
+    /// so it passes comp-id validation on an Active session.
+    fn inbound_app_frame(seq: u32, fill: usize, buf: &mut [u8]) -> usize {
+        let mut seq_buf = [0u8; 10];
+        let seq_n = nexus_fix_codec::encode_fix_uint(seq, &mut seq_buf);
+        let filler = vec![b'y'; fill];
+        let mut fmt = FrameFormatter::new(buf, b"FIX.4.4", b"D");
+        fmt.field(34, &seq_buf[..seq_n]);
+        fmt.field(49, peer_id().as_bytes());
+        fmt.field(56, our_id().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(58, &filler);
+        let (start, len) = fmt.finish().unwrap();
+        buf.copy_within(start..start + len, 0);
+        len
+    }
+
+    /// Build an Active session (post-logon, `next_inbound == 2`) with the given
+    /// reader capacity, ready to receive inbound app frames.
+    fn active_session(dir: &PathBuf, reader_cap: usize) -> FixSession<MockDict> {
+        let reader = MessageReader::with_frame_reader(
+            FrameReader::builder().buffer_capacity(reader_cap).build(),
+        );
+        let writer =
+            MessageWriter::with_frame_writer(FrameWriter::builder().buffer_capacity(4096).build());
+        let mut state = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        state.connect(now);
+        state.on_logon(1, 30, false, false, now); // peer Logon at seq 1 → Active, next_inbound = 2
+        let journal = FixJournal::open(dir, 0, 256).unwrap();
+        let mut session = FixSession::from_buffers(
+            reader,
+            writer,
+            state,
+            SessionConfig {
+                sender: our_id(),
+                target: peer_id(),
+            },
+            journal,
+        );
+        let n = session.outbound().len();
+        session.advance_outbound(n); // drain the engine's opening Logon
+        session
+    }
+
+    /// Fix B: when the reader buffer is full but consumed below the compaction
+    /// threshold (`remaining() == 0 && !should_compact()`), `read_spare` must
+    /// still compact so the spare is non-empty — otherwise the wrapper reads into
+    /// a zero-length slice and false-EOFs. A large frame that needs compaction
+    /// mid-stream must be buffered and delivered, not dropped.
+    #[test]
+    fn full_buffer_below_threshold_compacts_and_delivers() {
+        let dir = tmp_dir("compact_below_threshold");
+        let now = Instant::now();
+
+        // Reader cap 512 → compact threshold at 256 bytes consumed.
+        const READER_CAP: usize = 512;
+        let mut session = active_session(&dir, READER_CAP);
+
+        // Small app (seq 2): once consumed it leaves < 256 bytes behind, so the
+        // buffer will be "full but below the compaction threshold" after we top
+        // it up — exactly the state Fix B fixes.
+        let mut small = vec![0u8; 256];
+        let small_len = inbound_app_frame(2, 6, &mut small);
+        assert!(
+            small_len < 128,
+            "small frame ({small_len}) must stay well under the compact threshold"
+        );
+
+        // A large app (seq 3) that FITS the buffer on its own but NOT beside the
+        // small frame's consumed residue — so completing it requires a compaction
+        // that reclaims the small frame's space. (Distinct from scenario (a),
+        // where the frame exceeds the buffer outright.)
+        let mut large = vec![0u8; 1024];
+        let large_len = inbound_app_frame(3, 400, &mut large);
+        assert!(
+            large_len <= READER_CAP,
+            "large frame ({large_len}) must fit the reader buffer ({READER_CAP}) on its own"
+        );
+        assert!(
+            large_len > READER_CAP - small_len,
+            "large frame ({large_len}) must not fit beside the small frame's residue \
+             ({small_len}) — that is what forces the mid-stream compaction"
+        );
+
+        // 1) Deliver the small frame.
+        let spare = session.read_spare();
+        spare[..small_len].copy_from_slice(&small[..small_len]);
+        session.read_filled(small_len);
+        assert_eq!(
+            session.poll(now).expect("poll small"),
+            PollOutcome::Message,
+            "small app must surface"
+        );
+
+        // 2) Fill the rest of the buffer with the head of the large frame. The
+        //    small frame's bytes are now consumed (< threshold) and the buffer is
+        //    full: should_compact() is false, remaining() is 0.
+        let head = READER_CAP - small_len;
+        let spare = session.read_spare();
+        let take = head.min(spare.len());
+        spare[..take].copy_from_slice(&large[..take]);
+        session.read_filled(take);
+
+        // The frame is still incomplete → NeedMoreBytes.
+        assert_eq!(
+            session.poll(now).expect("poll large head"),
+            PollOutcome::NeedMoreBytes,
+            "partial large frame must ask for more"
+        );
+
+        // 3) The fix: read_spare must be NON-EMPTY here (it compacts because the
+        //    buffer is full even though should_compact() is false). Without the
+        //    fix this slice is empty and the wrapper false-EOFs.
+        let spare = session.read_spare();
+        assert!(
+            !spare.is_empty(),
+            "read_spare must compact a full-but-below-threshold buffer to a \
+             non-empty spare (Fix B); empty spare would false-EOF the wrapper"
+        );
+
+        // 4) Feed the remainder and confirm the large frame is delivered intact.
+        let rest = &large[take..large_len];
+        let mut fed = 0;
+        while fed < rest.len() {
+            let spare = session.read_spare();
+            assert!(
+                !spare.is_empty(),
+                "spare must stay non-empty while draining"
+            );
+            let n = (rest.len() - fed).min(spare.len());
+            spare[..n].copy_from_slice(&rest[fed..fed + n]);
+            session.read_filled(n);
+            fed += n;
+        }
+        assert_eq!(
+            session.poll(now).expect("poll large complete"),
+            PollOutcome::Message,
+            "large app must be delivered after compaction — no false disconnect"
+        );
+        // The delivered frame is the seq-3 app we sent (byte-for-byte).
+        let msg = session.message();
+        assert!(
+            matches!(msg, Message::Application { .. }),
+            "delivered message must be the reassembled application frame"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/nexus-fix-engine/src/frame.rs
+++ b/nexus-fix-engine/src/frame.rs
@@ -195,6 +195,12 @@ impl FrameReader {
         self.buf.remaining()
     }
 
+    /// Total buffer capacity in bytes (fixed at construction).
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.capacity()
+    }
+
     /// Parse the next complete FIX message.
     ///
     /// Returns the full message bytes (`8=…` through `10=XXX\x01`) or

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -6,6 +6,24 @@
 //! fields and returns an [`Out`] containing any outbound admin messages and a
 //! session event. The framework layer above encodes those messages and drives
 //! the transport.
+//!
+//! # Layering
+//!
+//! - [`SessionState`] — the pure protocol state machine (above).
+//! - [`FixSession`] — the sans-IO core that wraps [`SessionState`] with frame
+//!   decode, journaling, encode, and resumable resend, exposing a
+//!   [`poll`](FixSession::poll) / [`recv`](FixConnection::recv)-shaped API that
+//!   owns everything *except* the socket. This is the reusable core an
+//!   integrator drives from their own I/O loop.
+//! - [`FixConnection`] — a thin blocking wrapper that adds only the socket I/O
+//!   over [`FixSession`]. The async twin, `nexus_async_fix_engine::FixConnection`,
+//!   wraps the same [`FixSession`] with `.await`ed I/O.
+
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::redundant_explicit_links
+)]
 
 #[cfg(unix)]
 pub mod fix_session;

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -7,6 +7,8 @@
 //! session event. The framework layer above encodes those messages and drives
 //! the transport.
 
+#[cfg(unix)]
+pub mod fix_session;
 mod frame;
 mod framework;
 #[cfg(unix)]
@@ -17,6 +19,8 @@ mod timestamp;
 #[cfg(unix)]
 pub mod transport;
 
+#[cfg(unix)]
+pub use fix_session::{FixSession, PollOutcome};
 pub use frame::{
     FrameError, FrameReader, FrameReaderBuilder, FrameWriter, FrameWriterBuilder, ReadError,
 };

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -271,7 +271,7 @@ impl FixJournal {
     /// `msg` is the already-formatted wire message; `seq` must equal its
     /// `MsgSeqNum` (tag 34). The send path satisfies this by construction — `seq`
     /// is passed in only to index the resend ring without re-parsing on the hot
-    /// path; the cold paths ([`resend`](Self::resend), [`recover`](Self::recover))
+    /// path; the cold paths ([`resend`](Self::resend), recovery on open)
     /// read the seqnum back out of the message via tag 34.
     ///
     /// The stored payload is `[ts:8][msg]` (an 8-byte LE UNIX-nanos timestamp

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -587,7 +587,7 @@ impl SessionState {
     }
 
     /// Handles a received ResendRequest. Surfaces `Event::ResendRange` so the
-    /// persistence layer can drive the replay walk via [`FixJournal::resend_range`].
+    /// persistence layer can drive the replay walk via `FixJournal::resend`.
     pub fn on_resend_request(
         &mut self,
         seq: u32,

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -1,65 +1,28 @@
+//! Blocking, socket-owning FIX connection.
+//!
+//! [`FixConnection`] is a thin wrapper over the sans-IO [`FixSession`] core
+//! ([`crate::fix_session`]): it owns the socket and does *only* the I/O —
+//! `stream.read` into the session's inbound buffer, `stream.write` from its
+//! outbound buffer. All protocol logic (framing, the state machine, journaling,
+//! resend) lives in [`FixSession`].
+
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
 
-use nexus_fix_codec::{
-    FieldReader, FixAdminMsg, FixDictionary, FixHeader, FrameFormatter, encode_fix_uint, find_tag,
-    parse_fix_bool, parse_fix_seqnum, parse_fix_uint,
-};
-use nexus_journal::WriteError;
+use nexus_fix_codec::FixDictionary;
 
-use crate::frame::{FrameError, FrameWriter};
+use crate::fix_session::{FixSession, PollOutcome};
+use crate::frame::FrameWriter;
 use crate::framework::{Message, MessageReader, MessageWriter, SessionConfig, SessionError};
-use crate::persist::{FixJournal, ReplayItem};
-use crate::session::{AdminMsg, DisconnectReason, Event, SessionState, State};
-use crate::timestamp::UTC_TIMESTAMP_LEN;
+use crate::persist::FixJournal;
+use crate::session::{DisconnectReason, SessionState, State};
 
-#[derive(Debug)]
-pub enum Error {
-    Io(io::Error),
-    MessageTooLarge(usize),
-    Protocol(SessionError),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "I/O: {e}"),
-            Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
-            Self::Protocol(e) => write!(f, "protocol: {e}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-/// Bytes reserved per app message for a later resend reframe.
-///
-/// A reframe adds `PossDupFlag` (`43=Y`), `OrigSendingTime` (`122=<UTC
-/// timestamp>`), and a little `BodyLength` digit growth. `send_app` keeps app
-/// frames this far below the writer capacity so a stored message always
-/// reframes back into the pre-allocated buffer — no runtime allocation on the
-/// resend path.
-///
-/// Exposed so callers sizing a writer via `writer_capacity(...)` know the
-/// per-message reserve: the largest app frame they can send is
-/// `writer_capacity - REFRAME_HEADROOM`.
-pub const REFRAME_HEADROOM: usize = 64;
+pub use crate::fix_session::{Error, REFRAME_HEADROOM};
 
 pub struct FixConnection<S, D: FixDictionary> {
     stream: S,
-    reader: MessageReader<D>,
-    writer: MessageWriter<D>,
-    state: SessionState,
-    journal: FixJournal,
-    config: SessionConfig,
-    garbage_frames: u64,
+    session: FixSession<D>,
 }
 
 pub struct FixConnectionBuilder<D: FixDictionary> {
@@ -91,6 +54,29 @@ impl<D: FixDictionary> FixConnectionBuilder<D> {
         self
     }
 
+    fn build_session(
+        &self,
+        state: SessionState,
+        config: SessionConfig,
+        journal: FixJournal,
+    ) -> FixSession<D> {
+        FixSession::from_buffers(
+            MessageReader::with_frame_reader(
+                crate::frame::FrameReader::builder()
+                    .buffer_capacity(self.reader_cap)
+                    .build(),
+            ),
+            MessageWriter::with_frame_writer(
+                FrameWriter::builder()
+                    .buffer_capacity(self.writer_cap)
+                    .build(),
+            ),
+            state,
+            config,
+            journal,
+        )
+    }
+
     pub fn connect<A: ToSocketAddrs>(
         self,
         addr: A,
@@ -109,23 +95,8 @@ impl<D: FixDictionary> FixConnectionBuilder<D> {
             None => TcpStream::connect(addr)?,
         };
         stream.set_nodelay(self.nodelay)?;
-        Ok(FixConnection {
-            stream,
-            reader: MessageReader::with_frame_reader(
-                crate::frame::FrameReader::builder()
-                    .buffer_capacity(self.reader_cap)
-                    .build(),
-            ),
-            writer: MessageWriter::with_frame_writer(
-                FrameWriter::builder()
-                    .buffer_capacity(self.writer_cap)
-                    .build(),
-            ),
-            state,
-            journal,
-            config,
-            garbage_frames: 0,
-        })
+        let session = self.build_session(state, config, journal);
+        Ok(FixConnection { stream, session })
     }
 
     pub fn accept<S: Read + Write>(
@@ -135,23 +106,8 @@ impl<D: FixDictionary> FixConnectionBuilder<D> {
         config: SessionConfig,
         journal: FixJournal,
     ) -> FixConnection<S, D> {
-        FixConnection {
-            stream,
-            reader: MessageReader::with_frame_reader(
-                crate::frame::FrameReader::builder()
-                    .buffer_capacity(self.reader_cap)
-                    .build(),
-            ),
-            writer: MessageWriter::with_frame_writer(
-                FrameWriter::builder()
-                    .buffer_capacity(self.writer_cap)
-                    .build(),
-            ),
-            state,
-            journal,
-            config,
-            garbage_frames: 0,
-        }
+        let session = self.build_session(state, config, journal);
+        FixConnection { stream, session }
     }
 }
 
@@ -176,607 +132,115 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
     ) -> Self {
         Self {
             stream,
-            reader: MessageReader::new(),
-            writer: MessageWriter::new(),
-            state,
-            journal,
-            config,
-            garbage_frames: 0,
+            session: FixSession::new(state, config, journal),
         }
     }
 
     pub fn state(&self) -> &SessionState {
-        &self.state
+        self.session.state()
     }
 
     pub fn state_mut(&mut self) -> &mut SessionState {
-        &mut self.state
+        self.session.state_mut()
     }
 
     pub fn garbage_frame_count(&self) -> u64 {
-        self.garbage_frames
+        self.session.garbage_frame_count()
     }
 
     pub fn allocate_seq(&mut self) -> Result<u32, SessionError> {
-        self.state.allocate_seq(Instant::now())
+        self.session.allocate_seq()
     }
 
     pub fn wants_read(&self) -> bool {
-        self.state.state() != State::Disconnected
+        self.session.state().state() != State::Disconnected
     }
 
     pub fn wants_write(&self) -> bool {
-        !self.writer.is_empty()
+        self.session.has_outbound()
     }
 
     pub fn flush(&mut self) -> Result<(), Error> {
-        self.writer.flush_to(&mut self.stream).map_err(Error::Io)
+        self.drain_outbound()
     }
 
     pub fn connect(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.connect(now);
-        for admin in out.admin_messages() {
-            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-        }
-        if !self.writer.is_empty() {
-            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-        }
-        Ok(())
+        self.session.connect(now)?;
+        self.drain_outbound()
     }
 
     pub fn connect_reset(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.connect_reset(now).map_err(Error::Protocol)?;
-        for admin in out.admin_messages() {
-            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-        }
-        if !self.writer.is_empty() {
-            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-        }
-        Ok(())
+        self.session.connect_reset(now)?;
+        self.drain_outbound()
     }
 
     pub fn reset_sequence(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.reset_sequence(now).map_err(Error::Protocol)?;
-        for admin in out.admin_messages() {
-            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-        }
-        if !self.writer.is_empty() {
-            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-        }
-        Ok(())
+        self.session.reset_sequence(now)?;
+        self.drain_outbound()
     }
 
     pub fn send_app(&mut self, seq: u32, frame: &[u8]) -> Result<(), Error> {
-        // Every outbound frame must fit the pre-allocated writer, with headroom
-        // for a later resend reframe. An application that sends larger messages
-        // sizes the buffer up front via `writer_capacity(...)`.
-        if frame.len() > self.writer.capacity().saturating_sub(REFRAME_HEADROOM) {
-            return Err(Error::MessageTooLarge(frame.len()));
-        }
-        journal_write(frame.len(), || self.journal.store(seq, frame))?;
-        write_through(&mut self.stream, &mut self.writer.inner, frame)
+        self.session.send_app(seq, frame)?;
+        self.drain_outbound()
     }
 
     pub fn logout(&mut self, now: Instant) -> Result<(), Error> {
-        let out = self.state.logout(now);
-        for admin in out.admin_messages() {
-            store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-        }
-        if !self.writer.is_empty() {
-            self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-        }
-        Ok(())
+        self.session.logout(now)?;
+        self.drain_outbound()
     }
 
     pub fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
-        let n = self.state.next_inbound_seq();
-        if n != self.journal.next_inbound() {
-            self.journal.set_next_inbound(n);
-        }
-
         loop {
-            if self.reader.inner.should_compact() {
-                self.reader.inner.compact();
-            }
+            let outcome = self.session.poll(now)?;
+            // Drain any admin/resend the core enqueued for this step (matches the
+            // original, which flushed after every protocol handler).
+            self.drain_outbound()?;
 
-            match self.reader.inner.next() {
-                Err(FrameError::MessageTooLarge { size }) => {
-                    return Err(Error::MessageTooLarge(size));
+            match outcome {
+                PollOutcome::Message | PollOutcome::Disconnected(_) => {
+                    return Ok(Some(self.session.message()));
                 }
-                Err(FrameError::Garbage { .. }) => {
-                    self.garbage_frames += 1;
-                }
-                Ok(None) => {
-                    let n = {
-                        let spare = self.reader.inner.spare();
-                        match self.stream.read(spare) {
-                            Ok(n) => n,
-                            Err(e) if is_timeout(&e) => {
-                                let out = self.state.on_timeout(now);
-                                for admin in out.admin_messages() {
-                                    store_admin(
-                                        admin,
-                                        &mut self.writer,
-                                        &mut self.journal,
-                                        &self.config,
-                                    )?;
-                                }
-                                if !self.writer.is_empty() {
-                                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                                }
-                                if let Some(Event::Disconnected { reason }) = out.event() {
-                                    return Ok(Some(Message::Disconnected { reason }));
-                                }
-                                return Ok(None);
-                            }
-                            Err(e) => return Err(Error::Io(e)),
+                PollOutcome::Suppressed => return Ok(None),
+                // Buffer already drained above; loop to continue the resend.
+                PollOutcome::ResendPending => {}
+                PollOutcome::NeedMoreBytes => {
+                    let spare = self.session.read_spare();
+                    match self.stream.read(spare) {
+                        Ok(0) => {
+                            return Ok(Some(Message::Disconnected {
+                                reason: DisconnectReason::Logout,
+                            }));
                         }
-                    };
-                    if n == 0 {
-                        return Ok(Some(Message::Disconnected {
-                            reason: DisconnectReason::Logout,
-                        }));
+                        Ok(n) => self.session.read_filled(n),
+                        Err(e) if is_timeout(&e) => {
+                            if let Some(reason) = self.session.on_timeout(now)? {
+                                self.drain_outbound()?;
+                                return Ok(Some(Message::Disconnected { reason }));
+                            }
+                            self.drain_outbound()?;
+                            return Ok(None);
+                        }
+                        Err(e) => return Err(Error::Io(e)),
                     }
-                    self.reader.inner.filled(n);
-                }
-                Ok(Some(raw)) => {
-                    self.reader.frame.clear();
-                    self.reader.frame.extend_from_slice(raw);
-                    break;
                 }
             }
         }
+    }
 
-        let frame = &self.reader.frame[..];
-
-        let (sender_ok, target_ok, seq, poss_dup) = {
-            let hdr = D::Header::decode(frame);
-            let sender_ok = hdr
-                .sender_comp_id()
-                .is_some_and(|fv| fv.as_bytes() == self.config.target.as_bytes());
-            let target_ok = hdr
-                .target_comp_id()
-                .is_some_and(|fv| fv.as_bytes() == self.config.sender.as_bytes());
-            let seq = match hdr.msg_seq_num() {
-                Some(fv) => match fv.checked() {
-                    Ok(num) => num as u32,
-                    Err(_) => {
-                        return Err(Error::Protocol(SessionError::MalformedField { tag: 34 }));
-                    }
-                },
-                None => return Err(Error::Protocol(SessionError::MissingMsgSeqNum)),
-            };
-            let poss_dup = hdr
-                .poss_dup_flag()
-                .and_then(|fv| fv.checked().ok())
-                .unwrap_or(false);
-            (sender_ok, target_ok, seq, poss_dup)
-        };
-
-        if !sender_ok || !target_ok {
-            let out = self.state.on_comp_id_mismatch(now);
-            for admin in out.admin_messages() {
-                store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
+    /// Writes all buffered outbound bytes to the socket and flushes.
+    fn drain_outbound(&mut self) -> Result<(), Error> {
+        while self.session.has_outbound() {
+            let n = self
+                .stream
+                .write(self.session.outbound())
+                .map_err(Error::Io)?;
+            if n == 0 {
+                return Err(Error::Io(io::Error::other("write returned 0")));
             }
-            if !self.writer.is_empty() {
-                self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-            }
-            return Ok(Some(Message::Disconnected {
-                reason: DisconnectReason::CompIdMismatch,
-            }));
+            self.session.advance_outbound(n);
         }
-
-        // Well-framed and comp-id-valid: archive the inbound message for
-        // visibility/audit. Garbage and foreign (comp-id-mismatched) frames are
-        // not journaled — they never reach here.
-        journal_write(frame.len(), || self.journal.store_inbound(frame))?;
-
-        let raw_type = if let Some(s) = find_tag(frame, 0, 35) {
-            s.slice(frame)
-        } else {
-            let out = self
-                .state
-                .on_reject_inbound(seq, poss_dup, Some(35), 1, now);
-            for admin in out.admin_messages() {
-                self.writer.encode_admin(admin, &self.config);
-            }
-            if !self.writer.is_empty() {
-                self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-            }
-            return Ok(None);
-        };
-
-        match raw_type {
-            b"A" => {
-                let hbi = find_tag(frame, 0, 108)
-                    .and_then(|s| parse_fix_uint(s.slice(frame)).ok())
-                    .unwrap_or(30);
-                let reset = find_tag(frame, 0, 141)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
-                let was_logon_sent = self.state.state() == State::LogonSent;
-                let out = self.state.on_logon(seq, hbi, reset, !was_logon_sent, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::Logon::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(if was_logon_sent {
-                    Message::LogonAcknowledged { msg }
-                } else {
-                    Message::LogonRequest { msg }
-                }))
-            }
-            b"5" => {
-                let was_logout_pending = self.state.state() == State::LogoutPending;
-                let out = self.state.on_logout(seq, poss_dup, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::Logout::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(if was_logout_pending {
-                    Message::LogoutAcknowledged { msg }
-                } else {
-                    Message::LogoutRequest { msg }
-                }))
-            }
-            b"0" => {
-                let echo_id =
-                    find_tag(frame, 0, 112).and_then(|s| parse_fix_seqnum(s.slice(frame)).ok());
-                let out = self.state.on_heartbeat(seq, poss_dup, echo_id, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::Heartbeat::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(Message::Heartbeat { msg }))
-            }
-            b"1" => {
-                let test_req_id =
-                    find_tag(frame, 0, 112).map_or_else(|| b"".as_ref(), |s| s.slice(frame));
-                let out = self.state.on_test_request(seq, poss_dup, test_req_id, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::TestRequest::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(Message::TestRequest { msg }))
-            }
-            b"2" => {
-                let begin = find_tag(frame, 0, 7)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map_or(0, |v| v as u32);
-                let end = find_tag(frame, 0, 16)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map_or(0, |v| v as u32);
-                let out = self.state.on_resend_request(seq, poss_dup, begin, end, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                if let Some(Event::ResendRange { begin: rb, end: re }) = out.event() {
-                    let re = if re == 0 {
-                        self.state.next_outbound_seq().saturating_sub(1)
-                    } else {
-                        re.min(self.state.next_outbound_seq().saturating_sub(1))
-                    };
-                    do_resend::<S, D>(
-                        rb,
-                        re,
-                        &self.journal,
-                        &mut self.writer,
-                        &mut self.stream,
-                        &self.config,
-                    )?;
-                }
-                let msg = D::ResendRequest::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(Message::ResendRequest { msg }))
-            }
-            b"4" => {
-                let new_seq = find_tag(frame, 0, 36)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map_or(0, |v| v as u32);
-                let gap_fill = find_tag(frame, 0, 123)
-                    .and_then(|s| parse_fix_bool(s.slice(frame)).ok())
-                    .unwrap_or(false);
-                let out = self.state.on_sequence_reset(seq, new_seq, gap_fill, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::SequenceReset::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(Message::SequenceReset { msg }))
-            }
-            b"3" => {
-                let ref_seq = find_tag(frame, 0, 45)
-                    .and_then(|s| parse_fix_seqnum(s.slice(frame)).ok())
-                    .map_or(0, |v| v as u32);
-                let out = self.state.on_reject(seq, poss_dup, ref_seq, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                let msg = D::Reject::decode(frame)
-                    .map_err(|_| Error::Protocol(SessionError::MalformedMessage))?;
-                Ok(Some(Message::Reject { msg }))
-            }
-            _ => {
-                let out = self.state.on_app(seq, poss_dup, now);
-                for admin in out.admin_messages() {
-                    store_admin(admin, &mut self.writer, &mut self.journal, &self.config)?;
-                }
-                if !self.writer.is_empty() {
-                    self.writer.flush_to(&mut self.stream).map_err(Error::Io)?;
-                }
-                if let Some(Event::Disconnected { reason }) = out.event() {
-                    return Ok(Some(Message::Disconnected { reason }));
-                }
-                if matches!(out.event(), Some(Event::App { .. })) {
-                    return Ok(Some(Message::Application {
-                        header: D::Header::decode(frame),
-                    }));
-                }
-                Ok(None) // gap: ResendRequest queued, nothing to surface
-            }
-        }
+        self.stream.flush().map_err(Error::Io)
     }
-}
-
-fn do_resend<S: Write, D: FixDictionary>(
-    begin: u32,
-    end: u32,
-    journal: &FixJournal,
-    writer: &mut MessageWriter<D>,
-    stream: &mut S,
-    config: &SessionConfig,
-) -> Result<(), Error> {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let unix_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as i128;
-    let mut ts = [0u8; UTC_TIMESTAMP_LEN];
-    crate::timestamp::format_utc_timestamp(unix_nanos, &mut ts);
-
-    let iter = journal.resend(begin, end);
-
-    for item in iter {
-        let ok = match &item {
-            ReplayItem::GapFill { seq, new_seq } => encode_gap_fill(
-                &mut writer.inner,
-                D::BEGIN_STRING,
-                config,
-                &ts,
-                *seq,
-                *new_seq,
-            ),
-            ReplayItem::App(orig) => reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING),
-        };
-        if ok.is_err() {
-            // Flush what is buffered, then retry into the now-empty buffer.
-            writer.flush_to(stream).map_err(Error::Io)?;
-            let retry = match &item {
-                ReplayItem::GapFill { seq, new_seq } => encode_gap_fill(
-                    &mut writer.inner,
-                    D::BEGIN_STRING,
-                    config,
-                    &ts,
-                    *seq,
-                    *new_seq,
-                ),
-                ReplayItem::App(orig) => reframe_app(&mut writer.inner, orig, &ts, D::BEGIN_STRING),
-            };
-            // `send_app`'s headroom guarantees a reframe fits an empty buffer;
-            // a failure here means the writer was sized too small.
-            retry
-                .map_err(|()| Error::MessageTooLarge(writer.inner.remaining().saturating_add(1)))?;
-        }
-    }
-    writer.flush_to(stream).map_err(Error::Io)
-}
-
-/// Write to the journal, retrying on transient standby backpressure.
-///
-/// `store` is one of `FixJournal::store` / `store_inbound`, `size` its frame
-/// length. On [`WriteError::StandbyNotReady`] (transient backpressure) we spin
-/// and retry; a [`WriteError::RecordTooLarge`] misconfiguration surfaces as
-/// [`Error::MessageTooLarge`].
-///
-/// Unbounded on purpose. StandbyNotReady is transient backpressure the conductor
-/// clears in sub-ms; the only way this spins forever is a full/failing disk,
-/// which must be caught by observability. Spinning beats the alternative of
-/// dropping a message from a resend/audit journal. Spinning (rather than
-/// blocking) is fine here: the conductor makes progress on its own thread, and
-/// `recv` already blocks on the socket read.
-#[inline]
-fn journal_write(
-    size: usize,
-    mut store: impl FnMut() -> Result<(), WriteError>,
-) -> Result<(), Error> {
-    loop {
-        match store() {
-            Ok(()) => return Ok(()),
-            Err(WriteError::StandbyNotReady) => std::hint::spin_loop(),
-            // Only RecordTooLarge today; WriteError is non-exhaustive, so any
-            // other (non-backpressure) journal write error surfaces the same way.
-            Err(_) => return Err(Error::MessageTooLarge(size)),
-        }
-    }
-}
-
-fn store_admin<D: FixDictionary>(
-    admin: AdminMsg,
-    writer: &mut MessageWriter<D>,
-    journal: &mut FixJournal,
-    config: &SessionConfig,
-) -> Result<(), Error> {
-    let seq = match admin {
-        AdminMsg::Logon { seq, .. }
-        | AdminMsg::LogonReset { seq, .. }
-        | AdminMsg::Logout { seq }
-        | AdminMsg::Heartbeat { seq, .. }
-        | AdminMsg::TestRequest { seq, .. }
-        | AdminMsg::ResendRequest { seq, .. }
-        | AdminMsg::SequenceReset { seq, .. }
-        | AdminMsg::Reject { seq, .. } => seq,
-    };
-    let before = writer.inner.data().len();
-    writer.encode_admin(admin, config);
-    let frame = &writer.inner.data()[before..];
-    if !frame.is_empty() {
-        journal_write(frame.len(), || journal.store(seq, frame))?;
-    }
-    Ok(())
-}
-
-fn write_through<S: Write>(
-    stream: &mut S,
-    writer: &mut FrameWriter,
-    frame: &[u8],
-) -> Result<(), Error> {
-    if writer.remaining() < frame.len() {
-        flush_to(stream, writer)?;
-    }
-    if writer.remaining() < frame.len() {
-        // The frame exceeds the pre-allocated buffer even when empty. `send_app`
-        // caps app frames below this, so reaching here means the buffer is
-        // undersized for the workload — a configuration error, not a fallback.
-        return Err(Error::MessageTooLarge(frame.len()));
-    }
-    let spare = writer.spare();
-    spare[..frame.len()].copy_from_slice(frame);
-    writer.commit(0, frame.len());
-    flush_to(stream, writer)
-}
-
-fn flush_to<S: Write>(stream: &mut S, writer: &mut FrameWriter) -> Result<(), Error> {
-    while !writer.is_empty() {
-        let n = stream.write(writer.data())?;
-        if n == 0 {
-            return Err(Error::Io(io::Error::other("write returned 0")));
-        }
-        writer.advance(n);
-    }
-    stream.flush()?;
-    Ok(())
-}
-
-fn encode_gap_fill(
-    writer: &mut FrameWriter,
-    begin_string: &'static [u8],
-    config: &SessionConfig,
-    ts: &[u8],
-    seq: u32,
-    new_seq: u32,
-) -> Result<(), ()> {
-    let spare = writer.spare();
-    let mut seq_buf = [0u8; 10];
-    let seq_n = encode_fix_uint(seq, &mut seq_buf);
-    let mut fmt = FrameFormatter::new(spare, begin_string, b"4");
-    fmt.field(34, &seq_buf[..seq_n]);
-    fmt.field(49, config.sender.as_bytes());
-    fmt.field(56, config.target.as_bytes());
-    fmt.field(52, ts);
-    fmt.field(43, b"Y");
-    fmt.field(123, b"Y");
-    let mut nsq_buf = [0u8; 10];
-    let nsq_n = encode_fix_uint(new_seq, &mut nsq_buf);
-    fmt.field(36, &nsq_buf[..nsq_n]);
-    let (start, len) = fmt.finish().map_err(|_| ())?;
-    writer.commit(start, len);
-    Ok(())
-}
-
-fn reframe_app(
-    writer: &mut FrameWriter,
-    orig: &[u8],
-    ts: &[u8],
-    begin_string: &'static [u8],
-) -> Result<(), ()> {
-    let spare = writer.spare();
-    let (start, len) = reframe_app_into(spare, orig, ts, begin_string).ok_or(())?;
-    writer.commit(start, len);
-    Ok(())
-}
-
-fn reframe_app_into(
-    buf: &mut [u8],
-    orig: &[u8],
-    ts: &[u8],
-    begin_string: &'static [u8],
-) -> Option<(usize, usize)> {
-    let msg_type = find_tag(orig, 0, 35).map_or(b"D" as &[u8], |s| s.slice(orig));
-    let orig_time = find_tag(orig, 0, 52).map(|s| s.slice(orig));
-
-    let mut fmt = FrameFormatter::new(buf, begin_string, msg_type);
-    let mut poss_dup_done = false;
-
-    for field in FieldReader::new(orig, 0) {
-        match field.tag {
-            8 | 9 | 10 | 35 | 43 | 122 => {}
-            52 => {
-                fmt.field(52, ts);
-                fmt.field(43, b"Y");
-                if let Some(t) = orig_time {
-                    fmt.field(122, t);
-                }
-                poss_dup_done = true;
-            }
-            _ => fmt.field(field.tag, field.value.slice(orig)),
-        }
-    }
-
-    if !poss_dup_done {
-        fmt.field(43, b"Y");
-        if let Some(t) = orig_time {
-            fmt.field(122, t);
-        }
-    }
-
-    fmt.finish().ok()
 }
 
 fn is_timeout(e: &io::Error) -> bool {
@@ -784,39 +248,4 @@ fn is_timeout(e: &io::Error) -> bool {
         e.kind(),
         io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use nexus_fix_codec::FrameFormatter;
-
-    #[test]
-    fn reframe_stays_within_headroom() {
-        // A resend reframe adds PossDupFlag (43=Y), OrigSendingTime (122=...),
-        // and a little BodyLength growth. It must never grow a message by more
-        // than REFRAME_HEADROOM, so a stored app frame always reframes back into
-        // the pre-allocated writer buffer without a runtime allocation.
-        let mut orig_buf = [0u8; 512];
-        let (s, l) = {
-            let mut fmt = FrameFormatter::new(&mut orig_buf, b"FIX.4.4", b"D");
-            fmt.field(34, b"5");
-            fmt.field(49, b"SENDER");
-            fmt.field(56, b"TARGET");
-            fmt.field(52, b"20260101-00:00:00.000");
-            fmt.field(11, b"ORDER-1");
-            fmt.finish().unwrap()
-        };
-        let orig = &orig_buf[s..s + l];
-
-        let ts = b"20260102-12:34:56.789";
-        let mut out = [0u8; 1024];
-        let (_start, len) = super::reframe_app_into(&mut out, orig, ts, b"FIX.4.4").unwrap();
-
-        assert!(
-            len <= orig.len() + super::REFRAME_HEADROOM,
-            "reframe grew message by {} bytes, exceeding REFRAME_HEADROOM ({})",
-            len - orig.len(),
-            super::REFRAME_HEADROOM
-        );
-    }
 }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -204,6 +204,16 @@ impl<S: Read + Write, D: FixDictionary> FixConnection<S, D> {
                 // Buffer already drained above; loop to continue the resend.
                 PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
+                    // An empty spare means the reader buffer is full with a single
+                    // incomplete frame that cannot grow (compaction reclaimed
+                    // nothing). Reading into a zero-length slice yields `Ok(0)`,
+                    // which the `Ok(0)` arm below would misread as EOF. Surface it
+                    // as the real cause: a frame larger than the reader buffer.
+                    if self.session.read_spare().is_empty() {
+                        return Err(Error::MessageTooLarge(
+                            self.session.reader_capacity().saturating_add(1),
+                        ));
+                    }
                     let spare = self.session.read_spare();
                     match self.stream.read(spare) {
                         Ok(0) => {

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -762,3 +762,88 @@ fn send_app_rejects_oversized_frame() {
         Err(TransportError::MessageTooLarge(_))
     ));
 }
+
+/// In-memory stream that hands out queued bytes on `read` (never more than the
+/// caller's spare) and swallows writes. Lets a test feed a single oversized frame
+/// through the wrapper without a socket.
+struct ChunkStream {
+    inbound: std::collections::VecDeque<u8>,
+}
+
+impl ChunkStream {
+    fn new(bytes: &[u8]) -> Self {
+        Self {
+            inbound: bytes.iter().copied().collect(),
+        }
+    }
+}
+
+impl Read for ChunkStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = buf.len().min(self.inbound.len());
+        for slot in buf.iter_mut().take(n) {
+            *slot = self.inbound.pop_front().unwrap();
+        }
+        Ok(n)
+    }
+}
+
+impl Write for ChunkStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
+    // Fix B: a single inbound frame larger than the reader buffer fills the
+    // buffer with one incomplete frame. `read_spare` then returns an empty slice
+    // (nothing to compact — the whole buffer is one partial frame). The wrapper
+    // must surface this as MessageTooLarge, NOT read into a zero-length slice and
+    // misread the resulting `Ok(0)` as EOF/Disconnected.
+    let dir = tmp_dir("reader_buf_too_large");
+
+    // Build one valid, self-delimiting FIX frame bigger than a tiny reader
+    // buffer but well under the 1 MiB frame-reader max (so the too-large trips
+    // at the buffer, not at max_message_size).
+    const READER_CAP: usize = 256;
+    let mut buf = vec![0u8; 4096];
+    let big_filler = vec![b'x'; 512]; // frame will be ~570 bytes > READER_CAP
+    let frame = {
+        let mut fmt = FrameFormatter::new(&mut buf, b"FIX.4.4", b"D");
+        fmt.field(34, b"1");
+        fmt.field(49, sender().as_bytes());
+        fmt.field(56, target().as_bytes());
+        fmt.field(52, b"20260615-12:00:00.000");
+        fmt.field(58, &big_filler);
+        let (start, len) = fmt.finish().unwrap();
+        buf[start..start + len].to_vec()
+    };
+    assert!(
+        frame.len() > READER_CAP,
+        "frame must exceed the reader buffer to trip the guard"
+    );
+
+    let stream = ChunkStream::new(&frame);
+    let mut conn: FixConnection<ChunkStream, MockDict> =
+        FixConnection::builder().reader_capacity(READER_CAP).accept(
+            stream,
+            SessionState::new(Duration::from_secs(30)),
+            session_cfg(target(), sender()),
+            journal(&dir),
+        );
+
+    match conn.recv(Instant::now()) {
+        Err(TransportError::MessageTooLarge(_)) => {}
+        Err(other) => panic!(
+            "an inbound frame exceeding the reader buffer must be MessageTooLarge, got {other:?}"
+        ),
+        Ok(Some(Message::Disconnected { reason })) => {
+            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
+        }
+        Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
+    }
+}


### PR DESCRIPTION
## Summary

Unifies the sync and async FIX engines under a single sans-IO `FixSession<D>` core, so both become thin I/O wrappers over shared protocol logic instead of two separate implementations. Mirrors how `nexus-async-web` wraps sans-IO `nexus-web`, and delivers the **thin-adapter half of #544**.

Before this, `nexus-async-fix-engine` was a full reimplementation: not generic over the dictionary `D`, hand-rolling all admin encoding, and parsing inbound with raw tag lookups, duplicating everything `nexus-fix-engine` did through the dictionary. That duplication is gone.

## What changed

### Sans-IO core: `FixSession<D>` (nexus-fix-engine)

A new `FixSession<D>` owns all protocol logic with no socket: frame decode (`D::Header`), the `SessionState` machine, journaling, admin/response encoding (`D::encode_*`), and resend. It exposes a byte-buffer seam:
- inbound: `read_spare` / `read_filled` (the wrapper fills the buffer), then `poll(now) -> PollOutcome` and `message()`
- outbound: `has_outbound` / `outbound` / `advance_outbound` (the wrapper drains)

The recv read-loop inverts to push-based: the core never touches a socket. `poll()` returns a non-borrowing `PollOutcome` (`Message`, `NeedMoreBytes`, `ResendPending`, `Suppressed`, `Disconnected`); `message()` borrows the decoded message only when returning it, which sidesteps the borrow-checker wall.

**Resumable resend:** a sans-IO core cannot flush mid-operation, so a resend that overflows the writer buffer returns `ResendPending`; the wrapper drains and re-polls, and the core resumes at item granularity (re-deriving `journal.resend(begin, end).skip(drained)`, deterministic for fixed journal state). Proven byte-identical to a single-pass resend by a fault-injection-validated oracle test.

### Thin wrappers

- `nexus_fix_engine::FixConnection<S, D>` (sync, transport.rs 769 to 251 lines) and `nexus_async_fix_engine::FixConnection<S, D>` (async, 698 to 275 lines) are now near-identical modulo `.await`: fill the read buffer, `poll` plus drain, return the message.
- The async engine is now generic over `D` and dictionary-driven; roughly 480 lines of hand-rolled parsing / encoding / timestamp code deleted.

### Naming: drop the `Async` prefix

`AsyncFixConnection<S>` becomes `nexus_async_fix_engine::FixConnection<S, D>`, disambiguated from the sync `FixConnection` by crate, matching the web crates (`WsStream`, `HttpConnection` carry no `Async` prefix). The `recv` API aligns too: `recv(now) -> Option<Message<'_, D>>`, replacing the old callback form. This is a breaking change for async callers (noted in the CHANGELOG).

### Review fixes

Two issues found in review, fixed with fault-injection-validated regression tests:
- A malformed admin message used to return `Error::Protocol(MalformedMessage)` in the old transport; the refactor briefly panicked via `message()`'s `expect`. `process_frame` now validates the typed decode, restoring the error path.
- `read_spare` could return an empty slice on a full but below-compaction-threshold buffer, which the wrapper misread as EOF. It now compacts on a full buffer, and both wrappers return `MessageTooLarge` for a frame exceeding the reader buffer rather than false-disconnecting.

The FIX crates are also now rustdoc-clean (broken / private / redundant intra-doc links), with `#![deny(...)]` on the crate roots to keep them that way.

## Behavior and testing

Behavior-preserving refactor: all pre-existing sync tests are unchanged and green. New coverage: the resumable-resend oracle, the malformed-admin regression, and oversized-frame handling (sync and async). Full suites green; clippy `--all-features --all-targets` and fmt clean.

## Scope / follow-ups

- **#544**: the `nexus-net` wire seam and TLS (`MaybeTls`), plus restoring the async engine's cooperative yield on journal backpressure (it currently inherits the core's `spin_loop`; near-nil practical impact, tracked there). This PR delivers #544's thin-adapter half.
- **#568**: venue `Config` (dictionary-driven Logon auth), now straightforward on the aligned core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
