### PR TITLE
Fix the temp-dir leak in the FIX and journal test suites

### DIFF
--- a/nexus-async-fix-engine/CHANGELOG.md
+++ b/nexus-async-fix-engine/CHANGELOG.md
@@ -10,6 +10,18 @@ contained.
 
 ## [Unreleased]
 
+### Internal
+
+- Test scratch directories are now removed on drop. The `tmp_dir` helpers in
+  `tests/async_conformance.rs`, `tests/journal_outbound_admin.rs`, and
+  `tests/frame_too_large.rs` return an RAII `TempDir` guard instead of a bare
+  `PathBuf`. Each test opens a `FixJournal`, which preallocates ~25M, and the
+  directories were never removed — a full run leaked into `$TMPDIR`, and the
+  PID in each name meant every run minted a fresh set rather than reusing the
+  last. The guard's `Drop` also runs while unwinding, so a *failing* test now
+  cleans up too. Mirrors the existing guard in
+  `nexus-journal/src/rotating/tests.rs`.
+
 ### Added
 
 - Inbound message journaling: well-framed, comp-id-valid inbound frames are

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -1,7 +1,7 @@
 #![cfg(unix)]
 
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -87,15 +87,43 @@ impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
 const BEGIN: &[u8] = b"FIX.4.4";
 const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
 
-fn tmp_dir(suffix: &str) -> std::path::PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "nexus_async_fix_conf_{}_{}",
-        std::process::id(),
-        suffix
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+/// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+/// into each of these, so they must not outlive the test that made them.
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// a manual `cleanup(&dir)` at the end of the body would not.
+///
+/// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+/// the directory is removed before the test can use it.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(suffix: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "nexus_async_fix_conf_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        // A previous run killed by a signal can leave the tree behind, and PIDs
+        // get recycled -- start from a clean slate.
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_dir(suffix: &str) -> TempDir {
+    TempDir::new(suffix)
 }
 
 fn spawn_peer(scenario: &str) -> (std::process::Child, u16) {
@@ -153,7 +181,7 @@ fn new_order(seq: u32) -> Vec<u8> {
 async fn conformance_logon_logout() {
     let dir = tmp_dir("logon_logout");
     let (mut child, port) = spawn_peer("logon_logout");
-    let mut conn = connect(port, &dir).await;
+    let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -163,7 +191,7 @@ async fn conformance_logon_logout() {
 async fn conformance_heartbeat() {
     let dir = tmp_dir("heartbeat");
     let (mut child, port) = spawn_peer("heartbeat");
-    let mut conn = connect(port, &dir).await;
+    let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -173,7 +201,7 @@ async fn conformance_heartbeat() {
 async fn conformance_resend() {
     let dir = tmp_dir("resend");
     let (mut child, port) = spawn_peer("resend");
-    let mut conn = connect(port, &dir).await;
+    let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
 
     loop {
@@ -196,7 +224,7 @@ async fn conformance_resend() {
 async fn conformance_gap_fill() {
     let dir = tmp_dir("gap_fill");
     let (mut child, port) = spawn_peer("gap_fill");
-    let mut conn = connect(port, &dir).await;
+    let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -206,7 +234,7 @@ async fn conformance_gap_fill() {
 async fn conformance_seq_reset() {
     let dir = tmp_dir("seq_reset");
     let (mut child, port) = spawn_peer("seq_reset");
-    let mut conn = connect(port, &dir).await;
+    let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());

--- a/nexus-async-fix-engine/tests/frame_too_large.rs
+++ b/nexus-async-fix-engine/tests/frame_too_large.rs
@@ -97,15 +97,43 @@ fn target() -> CompId {
     CompId::new(b"ACCEPTOR").unwrap()
 }
 
-fn tmp_dir(suffix: &str) -> std::path::PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "nexus_async_fix_toolarge_{}_{}",
-        std::process::id(),
-        suffix
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+/// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+/// into each of these, so they must not outlive the test that made them.
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// a manual `cleanup(&dir)` at the end of the body would not.
+///
+/// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+/// the directory is removed before the test can use it.
+struct TempDir(std::path::PathBuf);
+
+impl TempDir {
+    fn new(suffix: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "nexus_async_fix_toolarge_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        // A previous run killed by a signal can leave the tree behind, and PIDs
+        // get recycled -- start from a clean slate.
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_dir(suffix: &str) -> TempDir {
+    TempDir::new(suffix)
 }
 
 /// Async stream that hands out queued inbound bytes (never more than the
@@ -188,7 +216,7 @@ async fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
                 sender: target(),
                 target: sender(),
             },
-            FixJournal::open(&dir, 0, 256).unwrap(),
+            FixJournal::open(dir.path(), 0, 256).unwrap(),
         );
 
     match conn.recv(Instant::now()).await {

--- a/nexus-async-fix-engine/tests/journal_outbound_admin.rs
+++ b/nexus-async-fix-engine/tests/journal_outbound_admin.rs
@@ -84,15 +84,43 @@ impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-fn tmp_dir(suffix: &str) -> std::path::PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "nexus_async_fix_admin_{}_{}",
-        std::process::id(),
-        suffix
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+/// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+/// into each of these, so they must not outlive the test that made them.
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// a manual `cleanup(&dir)` at the end of the body would not.
+///
+/// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+/// the directory is removed before the test can use it.
+struct TempDir(std::path::PathBuf);
+
+impl TempDir {
+    fn new(suffix: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "nexus_async_fix_admin_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        // A previous run killed by a signal can leave the tree behind, and PIDs
+        // get recycled -- start from a clean slate.
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_dir(suffix: &str) -> TempDir {
+    TempDir::new(suffix)
 }
 
 /// In-memory stream: writes are accepted (and buffered), reads block forever.
@@ -147,7 +175,7 @@ async fn outbound_admin_is_journaled() {
                 sender: CompId::new(b"ENGINE").unwrap(),
                 target: CompId::new(b"PEER").unwrap(),
             },
-            FixJournal::open(&dir, 0, 256).unwrap(),
+            FixJournal::open(dir.path(), 0, 256).unwrap(),
         );
         // Sends the opening Logon at seq 1; the write is accepted by the sink.
         conn.connect(Instant::now()).await.unwrap();
@@ -156,7 +184,7 @@ async fn outbound_admin_is_journaled() {
     // The Logon (seq 1) must be present in the outbound journal: recovering the
     // outbound counter from the meta-slot yields 2 only if `store(1, ..)` ran.
     // A journal that never stored anything recovers to 1.
-    let recovered = FixJournal::open(&dir, 0, 256).unwrap();
+    let recovered = FixJournal::open(dir.path(), 0, 256).unwrap();
     assert_eq!(
         recovered.next_outbound(),
         2,

--- a/nexus-fix-engine/CHANGELOG.md
+++ b/nexus-fix-engine/CHANGELOG.md
@@ -10,6 +10,19 @@ contained.
 
 ## [Unreleased]
 
+### Internal
+
+- Test scratch directories are now removed on drop. The `tmp_dir` helpers in
+  `tests/transport.rs`, `tests/fix_conformance.rs`, `src/fix_session.rs`, and
+  `src/persist.rs` return an RAII `TempDir` guard instead of a bare `PathBuf`.
+  Each test opens a `FixJournal`, which preallocates ~25M, and the directories
+  were never removed — a full run leaked hundreds of megabytes into `$TMPDIR`,
+  and the PID in each name meant every run minted a fresh set rather than
+  reusing the last. The guard's `Drop` also runs while unwinding, so a
+  *failing* test now cleans up too; the manual `cleanup(&dir)` calls it
+  replaces did not. Mirrors the existing guard in
+  `nexus-journal/src/rotating/tests.rs`.
+
 ### Changed
 
 - `SessionState` handler API reworked: the `Out` and `Event` types are

--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -875,7 +875,7 @@ fn reframe_app_into(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::{Duration, Instant};
 
     use nexus_fix_codec::{
@@ -980,16 +980,43 @@ mod tests {
         CompId::new(b"ACCEPTOR").unwrap()
     }
 
-    fn tmp_dir(suffix: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "nexus_fix_session_{}_{}",
-            std::process::id(),
-            suffix
-        ));
-        let _ = std::fs::remove_dir_all(&p);
-        std::fs::create_dir_all(&p).unwrap();
-        p
+    /// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+    /// into each of these, so they must not outlive the test that made them.
+    /// `Drop` also runs while unwinding, so a *failing* test cleans up too —
+    /// which a manual `remove_dir_all` at the end of the body would not.
+    ///
+    /// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+    /// the directory is removed before the test can use it.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(suffix: &str) -> Self {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "nexus_fix_session_{}_{}",
+                std::process::id(),
+                suffix
+            ));
+            // A previous run killed by a signal can leave the tree behind, and
+            // PIDs get recycled -- start from a clean slate.
+            let _ = std::fs::remove_dir_all(&p);
+            std::fs::create_dir_all(&p).unwrap();
+            Self(p)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn tmp_dir(suffix: &str) -> TempDir {
+        TempDir::new(suffix)
     }
 
     /// Build a stored app frame at `seq` with a filler `58=Text` field whose
@@ -1047,7 +1074,7 @@ mod tests {
     /// `writer_cap` sizes only the outbound writer — the shared journal content
     /// is byte-identical across runs, so the two resends differ only in the
     /// resend `SendingTime` (normalized away by the oracle).
-    fn build_session(dir: &PathBuf, writer_cap: usize) -> FixSession<MockDict> {
+    fn build_session(dir: &Path, writer_cap: usize) -> FixSession<MockDict> {
         let reader = MessageReader::with_frame_reader(FrameReader::builder().build());
         let writer = MessageWriter::with_frame_writer(
             FrameWriter::builder().buffer_capacity(writer_cap).build(),
@@ -1185,7 +1212,7 @@ mod tests {
         let dir_small = tmp_dir("resume_small");
 
         // Large writer: whole resend fits in one pass.
-        let mut big = build_session(&dir_big, 64 * 1024);
+        let mut big = build_session(dir_big.path(), 64 * 1024);
         let (big_stream, big_pending) = drive_resend_stream(&mut big);
         assert_eq!(big_pending, 0, "large-writer resend must be a single pass");
 
@@ -1193,7 +1220,7 @@ mod tests {
         // 200 bytes holds one reframed item (< ~180) but never two (>= ~250),
         // and comfortably exceeds the largest single frame so the empty-buffer
         // MessageTooLarge guard never fires.
-        let mut small = build_session(&dir_small, 200);
+        let mut small = build_session(dir_small.path(), 200);
         let (small_stream, small_pending) = drive_resend_stream(&mut small);
 
         // The path was actually exercised, not trivially skipped.
@@ -1286,9 +1313,6 @@ mod tests {
             let tags: Vec<u32> = FieldReader::new(f, 0).map(|fld| fld.tag).collect();
             assert!(tags.contains(&8) && tags.contains(&34) && tags.contains(&52));
         }
-
-        let _ = std::fs::remove_dir_all(&dir_big);
-        let _ = std::fs::remove_dir_all(&dir_small);
     }
 
     #[test]
@@ -1404,7 +1428,7 @@ mod tests {
         // expects the peer's Logon at inbound seq 1.
         state.connect(now, &mut drop_emit).unwrap();
 
-        let journal = FixJournal::open(&dir, 0, 256).unwrap();
+        let journal = FixJournal::open(dir.path(), 0, 256).unwrap();
         let mut session: FixSession<StrictDict> = FixSession::from_buffers(
             reader,
             writer,
@@ -1429,7 +1453,7 @@ mod tests {
             );
             let mut state = SessionState::new(Duration::from_secs(30));
             state.connect(now, &mut drop_emit).unwrap();
-            let journal = FixJournal::open(&dir_ok, 0, 256).unwrap();
+            let journal = FixJournal::open(dir_ok.path(), 0, 256).unwrap();
             let mut ok_session: FixSession<StrictDict> = FixSession::from_buffers(
                 reader,
                 writer,
@@ -1453,7 +1477,6 @@ mod tests {
                 PollOutcome::Message,
                 "a well-formed Logon (with tag 108) must surface as a Message"
             );
-            let _ = std::fs::remove_dir_all(&dir_ok);
         }
 
         // The malformed Logon: missing HeartBtInt(108) → typed decode fails.
@@ -1478,8 +1501,6 @@ mod tests {
                 panic!("malformed admin must return Protocol(MalformedMessage), got {other:?}")
             }
         }
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── Fix B part 1: compaction when the buffer is full below the threshold ──
@@ -1504,7 +1525,7 @@ mod tests {
 
     /// Build an Active session (post-logon, `next_inbound == 2`) with the given
     /// reader capacity, ready to receive inbound app frames.
-    fn active_session(dir: &PathBuf, reader_cap: usize) -> FixSession<MockDict> {
+    fn active_session(dir: &Path, reader_cap: usize) -> FixSession<MockDict> {
         let reader = MessageReader::with_frame_reader(
             FrameReader::builder().buffer_capacity(reader_cap).build(),
         );
@@ -1541,7 +1562,7 @@ mod tests {
 
         // Reader cap 512 → compact threshold at 256 bytes consumed.
         const READER_CAP: usize = 512;
-        let mut session = active_session(&dir, READER_CAP);
+        let mut session = active_session(dir.path(), READER_CAP);
 
         // Small app (seq 2): once consumed it leaves < 256 bytes behind, so the
         // buffer will be "full but below the compaction threshold" after we top
@@ -1630,7 +1651,5 @@ mod tests {
             matches!(msg, Message::Application { .. }),
             "delivered message must be the reassembled application frame"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -402,6 +402,39 @@ mod tests {
         }
     }
 
+    /// Cleanup must survive a panic. `Drop` running during unwind is the whole
+    /// reason this is RAII rather than a `cleanup(&dir)` call at the end of each
+    /// test: a panicking test never reaches such a call, which is exactly how
+    /// the previous convention leaked. If a refactor drops the `Drop` impl or
+    /// reverts to manual cleanup, this fails.
+    #[test]
+    fn temp_dir_cleans_up_while_unwinding() {
+        let captured: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let dir = TempDir::new("panic_cleanup");
+            std::fs::create_dir_all(dir.path()).unwrap();
+            *captured.lock().unwrap() = Some(dir.path().to_path_buf());
+            assert!(dir.path().exists());
+            // Deliberate: this message is expected in an otherwise-passing run.
+            // The global panic hook is left alone on purpose; overriding it would
+            // race with other tests panicking in parallel and swallow their output.
+            panic!("deliberate panic: exercising TempDir cleanup during unwind");
+        }));
+        assert!(res.is_err(), "the closure must have panicked");
+
+        let p = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("path captured before the panic");
+        assert!(
+            !p.exists(),
+            "TempDir must remove its directory while unwinding: {}",
+            p.display()
+        );
+    }
+
     fn tmp_dir(name: &str) -> TempDir {
         TempDir::new(name)
     }

--- a/nexus-fix-engine/src/persist.rs
+++ b/nexus-fix-engine/src/persist.rs
@@ -363,14 +363,47 @@ fn is_admin_type(msg_type: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    fn tmp_dir(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!("nexus-fix-journal-{}-{}", std::process::id(), name))
+    /// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+    /// into each of these, so they must not outlive the test that made them.
+    /// `Drop` also runs while unwinding, so a *failing* test cleans up too —
+    /// which the old manual `cleanup(&dir)` at the end of the body did not.
+    ///
+    /// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+    /// the directory is removed before the test can use it.
+    ///
+    /// Deliberately does not create the directory: the journal creates it on
+    /// `open`, and the `open_existing`-on-missing-dir tests depend on it being
+    /// absent.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let p = std::env::temp_dir().join(format!(
+                "nexus-fix-journal-{}-{}",
+                std::process::id(),
+                name
+            ));
+            // A previous run killed by a signal can leave the tree behind, and
+            // PIDs get recycled -- start from a clean slate.
+            let _ = std::fs::remove_dir_all(&p);
+            Self(p)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
     }
 
-    fn cleanup(dir: &PathBuf) {
-        let _ = std::fs::remove_dir_all(dir);
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn tmp_dir(name: &str) -> TempDir {
+        TempDir::new(name)
     }
 
     fn fix_msg(seq: u32) -> Vec<u8> {
@@ -392,52 +425,45 @@ mod tests {
     #[test]
     fn open_existing_missing_returns_not_found() {
         let dir = tmp_dir("oe-missing");
-        cleanup(&dir);
-        let result = FixJournal::open_existing(&dir, 0, 64);
+        let result = FixJournal::open_existing(dir.path(), 0, 64);
         assert!(
             matches!(result, Err(OpenError::SessionNotFound { .. })),
             "expected SessionNotFound"
         );
-        cleanup(&dir);
     }
 
     #[test]
     fn open_existing_wrong_id_returns_not_found() {
         let dir = tmp_dir("oe-wrongid");
-        cleanup(&dir);
         {
-            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
             j.store(1, &fix_msg(1)).unwrap();
         }
-        let result = FixJournal::open_existing(&dir, 1, 64);
+        let result = FixJournal::open_existing(dir.path(), 1, 64);
         assert!(
             matches!(result, Err(OpenError::SessionNotFound { .. })),
             "expected SessionNotFound for wrong id"
         );
-        cleanup(&dir);
     }
 
     #[test]
     fn open_existing_recovers_correct_session() {
         let dir = tmp_dir("oe-recover");
-        cleanup(&dir);
         {
-            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
             for seq in 1..=3u32 {
                 j.store(seq, &fix_msg(seq)).unwrap();
             }
         }
-        let j = FixJournal::open_existing(&dir, 0, 64).unwrap();
+        let j = FixJournal::open_existing(dir.path(), 0, 64).unwrap();
         assert_eq!(j.next_outbound(), 4);
-        cleanup(&dir);
     }
 
     #[test]
     fn store_and_resend_roundtrip() {
         let dir = tmp_dir("store-resend");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         for seq in 1..=5u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -449,46 +475,38 @@ mod tests {
             panic!("expected App");
         };
         assert_eq!(bytes, fix_msg(3).as_slice());
-
-        cleanup(&dir);
     }
 
     #[test]
     fn open_recovers_next_outbound() {
         let dir = tmp_dir("recover");
-        cleanup(&dir);
 
         {
-            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
             for seq in 1..=7u32 {
                 j.store(seq, &fix_msg(seq)).unwrap();
             }
         }
 
-        let j = FixJournal::open(&dir, 0, 64).unwrap();
+        let j = FixJournal::open(dir.path(), 0, 64).unwrap();
         assert_eq!(j.next_outbound(), 8);
-
-        cleanup(&dir);
     }
 
     #[test]
     fn open_recovers_next_inbound() {
         let dir = tmp_dir("recover-inbound");
-        cleanup(&dir);
 
         {
-            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
             j.store(1, &fix_msg(1)).unwrap();
             j.advance_inbound();
             j.advance_inbound();
             j.set_next_inbound(42);
         }
 
-        let j = FixJournal::open(&dir, 0, 64).unwrap();
+        let j = FixJournal::open(dir.path(), 0, 64).unwrap();
         assert_eq!(j.next_inbound(), 42);
         assert_eq!(j.next_outbound(), 2);
-
-        cleanup(&dir);
     }
 
     #[test]
@@ -496,11 +514,10 @@ mod tests {
         // The point of rebuilding the resend ring on recovery: after a restart,
         // in-window seqnums replay the ACTUAL stored bytes, not a gap-fill.
         let dir = tmp_dir("cross-restart");
-        cleanup(&dir);
 
         let msgs: Vec<Vec<u8>> = (1..=5u32).map(fix_msg).collect();
         {
-            let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+            let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
             for (i, m) in msgs.iter().enumerate() {
                 j.store(i as u32 + 1, m).unwrap();
             }
@@ -508,7 +525,7 @@ mod tests {
 
         // Reopen: offsets table is empty until `recover()` rebuilds it from the
         // outbound hot window.
-        let j = FixJournal::open_existing(&dir, 0, 64).unwrap();
+        let j = FixJournal::open_existing(dir.path(), 0, 64).unwrap();
         assert_eq!(j.next_outbound(), 6);
 
         let items = collect_range(&j, 1, 5);
@@ -519,17 +536,14 @@ mod tests {
             };
             assert_eq!(*bytes, msgs[i].as_slice(), "seq {} bytes mismatch", i + 1);
         }
-
-        cleanup(&dir);
     }
 
     #[test]
     fn store_inbound_is_archival_only() {
         // store_inbound must not touch the outbound resend path or counters.
         let dir = tmp_dir("store-inbound");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
         j.store_inbound(&fix_msg(9)).unwrap();
         j.store_inbound(&fix_msg(10)).unwrap();
@@ -539,32 +553,26 @@ mod tests {
         let items = collect_range(&j, 1, 1);
         assert_eq!(items.len(), 1);
         assert!(matches!(items[0], ReplayItem::App(_)));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn gapfill_for_unstored_seq() {
         let dir = tmp_dir("gapfill");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
 
         match j.resend_one(2) {
             ResendPlan::GapFill => {}
             ResendPlan::Replay(_) => panic!("expected GapFill"),
         }
-
-        cleanup(&dir);
     }
 
     #[test]
     fn straddle_mixed_replay_and_gapfill() {
         let dir = tmp_dir("straddle");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         for seq in [1u32, 3, 5] {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -573,32 +581,26 @@ mod tests {
             .map(|seq| matches!(j.resend_one(seq), ResendPlan::Replay(_)))
             .collect();
         assert_eq!(results, vec![true, false, true, false, true]);
-
-        cleanup(&dir);
     }
 
     #[test]
     fn inbound_counter() {
         let dir = tmp_dir("inbound");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         assert_eq!(j.next_inbound(), 1);
         j.advance_inbound();
         j.advance_inbound();
         assert_eq!(j.next_inbound(), 3);
         j.set_next_inbound(10);
         assert_eq!(j.next_inbound(), 10);
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_admin_skip() {
         let dir = tmp_dir("rr-admin-skip");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         j.store(1, &fix_admin(1, "A")).unwrap();
         j.store(2, &fix_admin(2, "0")).unwrap();
         j.store(3, &fix_admin(3, "5")).unwrap();
@@ -609,16 +611,13 @@ mod tests {
             items[0],
             ReplayItem::GapFill { seq: 1, new_seq: 4 }
         ));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_interior_holes() {
         let dir = tmp_dir("rr-holes");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         for seq in [1u32, 3, 5] {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -636,16 +635,13 @@ mod tests {
             ReplayItem::GapFill { seq: 4, new_seq: 5 }
         ));
         assert!(matches!(items[4], ReplayItem::App(_)));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_straddle_window() {
         let dir = tmp_dir("rr-straddle");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 4).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 4).unwrap();
         for seq in 1..=8u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -660,16 +656,13 @@ mod tests {
         assert!(matches!(items[2], ReplayItem::App(_)));
         assert!(matches!(items[3], ReplayItem::App(_)));
         assert!(matches!(items[4], ReplayItem::App(_)));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_yields_original_bytes() {
         let dir = tmp_dir("rr-original");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         let msg = fix_msg_with_time(1, "20240101-12:00:00");
         j.store(1, &msg).unwrap();
 
@@ -679,16 +672,13 @@ mod tests {
             panic!("expected App");
         };
         assert_eq!(bytes, msg.as_slice());
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_coalesced_gapfill() {
         let dir = tmp_dir("rr-coalesced");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         j.store(1, &fix_msg(1)).unwrap();
         j.store(5, &fix_msg(5)).unwrap();
 
@@ -700,16 +690,13 @@ mod tests {
             ReplayItem::GapFill { seq: 2, new_seq: 5 }
         ));
         assert!(matches!(items[2], ReplayItem::App(_)));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_all_gapfill() {
         let dir = tmp_dir("rr-allgap");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         j.store(1, &fix_admin(1, "A")).unwrap();
         j.store(2, &fix_admin(2, "1")).unwrap();
         j.store(3, &fix_admin(3, "2")).unwrap();
@@ -720,16 +707,13 @@ mod tests {
             items[0],
             ReplayItem::GapFill { seq: 1, new_seq: 4 }
         ));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn resend_range_end_zero_means_all() {
         let dir = tmp_dir("rr-endzero");
-        cleanup(&dir);
 
-        let mut j = FixJournal::open(&dir, 0, 64).unwrap();
+        let mut j = FixJournal::open(dir.path(), 0, 64).unwrap();
         for seq in 1..=3u32 {
             j.store(seq, &fix_msg(seq)).unwrap();
         }
@@ -737,17 +721,17 @@ mod tests {
         let items = collect_range(&j, 1, 0);
         assert_eq!(items.len(), 3);
         assert!(items.iter().all(|i| matches!(i, ReplayItem::App(_))));
-
-        cleanup(&dir);
     }
 
     #[test]
     fn two_sessions_in_one_directory_are_independent() {
         let dir = tmp_dir("two-sessions");
-        cleanup(&dir);
 
         {
-            let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+            let mut conductor = ConductorBuilder::new(dir.path())
+                .archive(true)
+                .open()
+                .unwrap();
             let mut j0 =
                 FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenOrCreate).unwrap();
             let mut j1 =
@@ -766,13 +750,14 @@ mod tests {
 
         // Reopen both through a fresh shared conductor and verify each recovers
         // its own next_outbound independently.
-        let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+        let mut conductor = ConductorBuilder::new(dir.path())
+            .archive(true)
+            .open()
+            .unwrap();
         let j0 = FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenExisting).unwrap();
         let j1 = FixJournal::open_in(&mut conductor, 1, 64, OpenMode::OpenExisting).unwrap();
         assert_eq!(j0.next_outbound(), 4);
         assert_eq!(j1.next_outbound(), 6);
-
-        cleanup(&dir);
     }
 
     #[test]
@@ -780,9 +765,11 @@ mod tests {
         // Two FIX sessions under one conductor use disjoint conductor session
         // ids (2n / 2n+1) and stay independent.
         let dir = tmp_dir("open-in-shared");
-        cleanup(&dir);
 
-        let mut conductor = ConductorBuilder::new(&dir).archive(true).open().unwrap();
+        let mut conductor = ConductorBuilder::new(dir.path())
+            .archive(true)
+            .open()
+            .unwrap();
         let mut a = FixJournal::open_in(&mut conductor, 0, 64, OpenMode::OpenOrCreate).unwrap();
         let mut b = FixJournal::open_in(&mut conductor, 7, 64, OpenMode::OpenOrCreate).unwrap();
 
@@ -792,7 +779,5 @@ mod tests {
 
         assert_eq!(a.next_outbound(), 3);
         assert_eq!(b.next_outbound(), 2);
-
-        cleanup(&dir);
     }
 }

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -3,7 +3,7 @@
 use std::io::BufRead;
 use std::io::BufReader;
 use std::net::TcpStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -87,11 +87,39 @@ impl<'buf> FixHeader<'buf> for MockHeader<'buf> {
 
 const PEER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/fix_peer.py");
 
-fn tmp_dir(suffix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!("nexus_fix_conf_{}_{}", std::process::id(), suffix));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+/// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+/// into each of these, so they must not outlive the test that made them.
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// a manual `cleanup(&dir)` at the end of the body would not.
+///
+/// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+/// the directory is removed before the test can use it.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(suffix: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!("nexus_fix_conf_{}_{}", std::process::id(), suffix));
+        // A previous run killed by a signal can leave the tree behind, and PIDs
+        // get recycled -- start from a clean slate.
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_dir(suffix: &str) -> TempDir {
+    TempDir::new(suffix)
 }
 
 struct ChildGuard(std::process::Child);
@@ -122,7 +150,7 @@ fn spawn_peer(scenario: &str) -> (ChildGuard, u16) {
     (ChildGuard(child), port)
 }
 
-fn connect(port: u16, dir: &PathBuf) -> FixConnection<TcpStream, MockDict> {
+fn connect(port: u16, dir: &Path) -> FixConnection<TcpStream, MockDict> {
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(10)))
@@ -166,7 +194,7 @@ fn new_order(seq: u32) -> Vec<u8> {
 fn conformance_logon_logout() {
     let dir = tmp_dir("logon_logout");
     let (mut child, port) = spawn_peer("logon_logout");
-    let mut conn = connect(port, &dir);
+    let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     assert_eq!(drive(&mut conn), DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -176,7 +204,7 @@ fn conformance_logon_logout() {
 fn conformance_heartbeat() {
     let dir = tmp_dir("heartbeat");
     let (mut child, port) = spawn_peer("heartbeat");
-    let mut conn = connect(port, &dir);
+    let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     assert_eq!(drive(&mut conn), DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -186,7 +214,7 @@ fn conformance_heartbeat() {
 fn conformance_resend() {
     let dir = tmp_dir("resend");
     let (mut child, port) = spawn_peer("resend");
-    let mut conn = connect(port, &dir);
+    let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
 
     loop {
@@ -209,7 +237,7 @@ fn conformance_resend() {
 fn conformance_gap_fill() {
     let dir = tmp_dir("gap_fill");
     let (mut child, port) = spawn_peer("gap_fill");
-    let mut conn = connect(port, &dir);
+    let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     assert_eq!(drive(&mut conn), DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());
@@ -219,7 +247,7 @@ fn conformance_gap_fill() {
 fn conformance_seq_reset() {
     let dir = tmp_dir("seq_reset");
     let (mut child, port) = spawn_peer("seq_reset");
-    let mut conn = connect(port, &dir);
+    let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     assert_eq!(drive(&mut conn), DisconnectReason::Logout);
     assert!(child.wait().unwrap().success());

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use nexus_fix_codec::{
@@ -94,7 +94,7 @@ fn session_cfg(sender: CompId, target: CompId) -> SessionConfig {
     SessionConfig { sender, target }
 }
 
-fn journal(dir: &PathBuf) -> FixJournal {
+fn journal(dir: &Path) -> FixJournal {
     FixJournal::open(dir, 0, 256).unwrap()
 }
 
@@ -106,15 +106,43 @@ fn loopback_pair() -> (TcpStream, TcpStream) {
     (client, server)
 }
 
-fn tmp_dir(suffix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "nexus_fix_transport_{}_{}",
-        std::process::id(),
-        suffix
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+/// RAII scratch directory. `FixJournal::open` preallocates tens of megabytes
+/// into each of these, so they must not outlive the test that made them.
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// a manual `cleanup(&dir)` at the end of the body would not.
+///
+/// Bind it to a live local (`let dir = tmp_dir(..)`), never `let _ = ..`, or
+/// the directory is removed before the test can use it.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(suffix: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "nexus_fix_transport_{}_{}",
+            std::process::id(),
+            suffix
+        ));
+        // A previous run killed by a signal can leave the tree behind, and PIDs
+        // get recycled -- start from a clean slate.
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        Self(p)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_dir(suffix: &str) -> TempDir {
+    TempDir::new(suffix)
 }
 
 fn drive(
@@ -324,7 +352,7 @@ fn initiator_logon_and_logout() {
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(t_sender, t_target),
-        journal(&dir),
+        journal(dir.path()),
     );
     conn.connect(Instant::now()).unwrap();
 
@@ -358,7 +386,7 @@ fn acceptor_receives_app_message() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir2),
+        journal(dir2.path()),
     );
 
     let reason = loop {
@@ -403,7 +431,7 @@ fn heartbeat_stale_seqnum_disconnects() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     let reason = loop {
@@ -456,7 +484,7 @@ fn resend_request_triggers_gap_fill() {
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(sender(), target()),
-        journal(&dir_cli),
+        journal(dir_cli.path()),
     );
     conn.connect(Instant::now()).unwrap();
 
@@ -490,7 +518,7 @@ fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir_cli),
+        journal(dir_cli.path()),
     );
 
     let mut saw_app = false;
@@ -554,7 +582,7 @@ fn out_of_sequence_admin_suppressed_and_resends() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     let mut saw_admin = false;
@@ -606,7 +634,7 @@ fn duplicate_admin_suppressed_no_resend() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     let mut saw_dup_admin = false;
@@ -672,7 +700,7 @@ fn resend_request_huge_end_seq_clamped() {
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(sender(), target()),
-        journal(&dir),
+        journal(dir.path()),
     );
     conn.connect(Instant::now()).unwrap();
     let reason = drive(&mut conn).unwrap();
@@ -703,7 +731,7 @@ fn corrupt_checksum_frame_counted_as_garbage() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     loop {
@@ -743,7 +771,7 @@ fn garbage_bytes_increment_counter() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     loop {
@@ -783,7 +811,7 @@ fn sequence_reset_backward_ignored() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     loop {
@@ -835,7 +863,7 @@ fn overflowed_tag_34_yields_missing_seq_num() {
         server_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(target(), sender()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     let result = conn.recv(Instant::now());
@@ -871,7 +899,7 @@ fn journal_recovers_admin_seqnums() {
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(sender(), target()),
-        journal(&dir),
+        journal(dir.path()),
     );
     conn.connect(Instant::now()).unwrap();
     let reason = drive(&mut conn).unwrap();
@@ -880,7 +908,7 @@ fn journal_recovers_admin_seqnums() {
     drop(conn);
 
     // seq=1 logon + seq=2 logout-ack → next_outbound must be 3 after recovery
-    let recovered = FixJournal::open(&dir, 0, 256).unwrap();
+    let recovered = FixJournal::open(dir.path(), 0, 256).unwrap();
     assert_eq!(
         recovered.next_outbound(),
         3,
@@ -899,7 +927,7 @@ fn send_app_rejects_oversized_frame() {
         client_sock,
         SessionState::new(Duration::from_secs(30)),
         session_cfg(sender(), target()),
-        journal(&dir),
+        journal(dir.path()),
     );
 
     // The default writer is 64 KiB; a 64 KiB frame exceeds cap - headroom.
@@ -980,7 +1008,7 @@ fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
             stream,
             SessionState::new(Duration::from_secs(30)),
             session_cfg(target(), sender()),
-            journal(&dir),
+            journal(dir.path()),
         );
 
     match conn.recv(Instant::now()) {

--- a/nexus-journal/CHANGELOG.md
+++ b/nexus-journal/CHANGELOG.md
@@ -10,6 +10,15 @@ contained.
 
 ## [Unreleased]
 
+### Internal
+
+- `src/append/tests.rs` scratch segments are now removed on drop. `base_path`
+  returns an RAII `TempBase` guard that deletes the numbered segment files
+  (`base.0`, `base.1`, …) via the existing `segment_path` helper, replacing the
+  manual `cleanup(&base)` calls. `Drop` also runs while unwinding, so a
+  *failing* test now cleans up too — the manual calls did not. Mirrors the
+  existing guard in `src/rotating/tests.rs`.
+
 ### Added
 
 - `RotatingJournal::meta` / `set_meta`: an opaque `u64` manifest meta-slot,

--- a/nexus-journal/src/append/tests.rs
+++ b/nexus-journal/src/append/tests.rs
@@ -45,6 +45,39 @@ impl Drop for TempBase {
     }
 }
 
+/// Cleanup must survive a panic. `Drop` running during unwind is the whole
+/// reason this is RAII rather than the `cleanup(base)` call this replaced: a
+/// panicking test never reaches such a call, which is exactly how the previous
+/// convention leaked segments. If a refactor drops the `Drop` impl or reverts to
+/// manual cleanup, this fails.
+#[test]
+fn temp_base_cleans_up_while_unwinding() {
+    let captured: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let base = TempBase::new("panic_cleanup");
+        std::fs::write(super::segment_path(base.path(), 0), b"x").unwrap();
+        *captured.lock().unwrap() = Some(base.path().to_path_buf());
+        assert!(super::segment_path(base.path(), 0).exists());
+        // Deliberate: this message is expected in an otherwise-passing run. The
+        // global panic hook is left alone on purpose; overriding it would race
+        // with other tests panicking in parallel and swallow their output.
+        panic!("deliberate panic: exercising TempBase cleanup during unwind");
+    }));
+    assert!(res.is_err(), "the closure must have panicked");
+
+    let p = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("path captured before the panic");
+    assert!(
+        !super::segment_path(&p, 0).exists(),
+        "TempBase must remove its segments while unwinding: {}",
+        p.display()
+    );
+}
+
 fn base_path(name: &str) -> TempBase {
     TempBase::new(name)
 }

--- a/nexus-journal/src/append/tests.rs
+++ b/nexus-journal/src/append/tests.rs
@@ -4,16 +4,49 @@ use nexus_platform::MapHints;
 
 use super::{AppendOnlyJournal, AppendOnlyJournalConfig, AppendOnlyJournalError, FixHeader};
 
-fn base_path(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("nexus-journal-{}-{}", std::process::id(), name))
+/// RAII scratch path *prefix*. Unlike the other journals, an
+/// [`AppendOnlyJournal`] does not own a directory: it writes sibling segment
+/// files `base.0`, `base.1`, ... So this guard removes the numbered segments
+/// rather than a tree.
+///
+/// `Drop` also runs while unwinding, so a *failing* test cleans up too — which
+/// the old manual `cleanup(&base)` at the end of the body did not.
+///
+/// Bind it to a live local (`let base = base_path(..)`), never `let _ = ..`, or
+/// the segments are removed before the test can use them.
+struct TempBase(PathBuf);
+
+impl TempBase {
+    fn new(name: &str) -> Self {
+        let p = std::env::temp_dir().join(format!("nexus-journal-{}-{}", std::process::id(), name));
+        let this = Self(p);
+        // A previous run killed by a signal can leave segments behind, and PIDs
+        // get recycled -- start from a clean slate.
+        this.remove_segments();
+        this
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Remove every segment this base could have produced. The tests here never
+    /// roll past a handful of segments; 32 covers them all with room to spare.
+    fn remove_segments(&self) {
+        for i in 0..32u64 {
+            let _ = std::fs::remove_file(super::segment_path(&self.0, i));
+        }
+    }
 }
 
-fn cleanup(base: &Path) {
-    for i in 0..32u64 {
-        let mut p = base.as_os_str().to_owned();
-        p.push(format!(".{i}"));
-        let _ = std::fs::remove_file(PathBuf::from(p));
+impl Drop for TempBase {
+    fn drop(&mut self) {
+        self.remove_segments();
     }
+}
+
+fn base_path(name: &str) -> TempBase {
+    TempBase::new(name)
 }
 
 fn fix(seq: u64) -> FixHeader {
@@ -33,9 +66,8 @@ fn cfg(segment_size: usize) -> AppendOnlyJournalConfig {
 #[test]
 fn roundtrip_fix() {
     let base = base_path("roundtrip");
-    cleanup(&base);
 
-    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(1 << 16)).unwrap();
     for seq in 1..=3u64 {
         let payload = vec![seq as u8; seq as usize * 4];
         let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
@@ -51,15 +83,13 @@ fn roundtrip_fix() {
     assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
-    cleanup(&base);
 }
 
 #[test]
 fn unit_header_zero_overhead() {
     let base = base_path("unit");
-    cleanup(&base);
 
-    let (mut w, mut r) = AppendOnlyJournal::<()>::open(&base, cfg(1 << 16)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<()>::open(base.path(), cfg(1 << 16)).unwrap();
     let mut claim = w.try_claim((), 5).unwrap();
     claim.as_mut_slice().copy_from_slice(b"hello");
     claim.commit();
@@ -69,45 +99,39 @@ fn unit_header_zero_overhead() {
     assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
-    cleanup(&base);
 }
 
 #[test]
 fn empty_unit_record_rejected() {
     let base = base_path("empty");
-    cleanup(&base);
 
-    let (mut w, _r) = AppendOnlyJournal::<()>::open(&base, cfg(1 << 16)).unwrap();
+    let (mut w, _r) = AppendOnlyJournal::<()>::open(base.path(), cfg(1 << 16)).unwrap();
     assert!(matches!(
         w.try_claim((), 0),
         Err(AppendOnlyJournalError::EmptyRecord)
     ));
 
     drop(w);
-    cleanup(&base);
 }
 
 #[test]
 fn record_too_large_rejected() {
     let base = base_path("toolarge");
-    cleanup(&base);
 
-    let (mut w, _r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(256)).unwrap();
+    let (mut w, _r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(256)).unwrap();
     assert!(matches!(
         w.try_claim(fix(1), 4096),
         Err(AppendOnlyJournalError::RecordTooLarge { .. })
     ));
 
     drop(w);
-    cleanup(&base);
 }
 
 #[test]
 fn multi_segment_roll() {
     let base = base_path("roll");
-    cleanup(&base);
 
-    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(128)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(128)).unwrap();
     for seq in 1..=20u64 {
         let payload = (seq as u32).to_le_bytes();
         let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
@@ -124,18 +148,16 @@ fn multi_segment_roll() {
     }
     assert_eq!(seen, 20);
     assert!(r.next_record().unwrap().is_none());
-    assert!(super::segment_path(&base, 1).exists());
+    assert!(super::segment_path(base.path(), 1).exists());
 
     drop((w, r));
-    cleanup(&base);
 }
 
 #[test]
 fn pad_at_frame_header_boundary() {
     let base = base_path("pad-boundary");
-    cleanup(&base);
 
-    let (mut w, mut r) = AppendOnlyJournal::<()>::open(&base, cfg(64)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<()>::open(base.path(), cfg(64)).unwrap();
     let lens = [8usize, 8, 16, 8, 8];
     for (i, &len) in lens.iter().enumerate() {
         let payload = vec![i as u8 + 1; len];
@@ -143,7 +165,7 @@ fn pad_at_frame_header_boundary() {
         claim.as_mut_slice().copy_from_slice(&payload);
         claim.commit();
     }
-    assert!(super::segment_path(&base, 1).exists());
+    assert!(super::segment_path(base.path(), 1).exists());
 
     for (i, &len) in lens.iter().enumerate() {
         let rec = r.next_record().unwrap().unwrap();
@@ -152,16 +174,14 @@ fn pad_at_frame_header_boundary() {
     assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
-    cleanup(&base);
 }
 
 #[test]
 fn recovery_stops_at_uncommitted_tail() {
     let base = base_path("recovery");
-    cleanup(&base);
 
     {
-        let (mut w, _r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+        let (mut w, _r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(1 << 16)).unwrap();
         for seq in 1..=2u64 {
             let payload = (seq as u32).to_le_bytes();
             let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
@@ -175,7 +195,7 @@ fn recovery_stops_at_uncommitted_tail() {
         drop(w);
     }
 
-    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(1 << 16)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(1 << 16)).unwrap();
     let payload = 99u32.to_le_bytes();
     let mut claim = w.try_claim(fix(3), payload.len()).unwrap();
     claim.as_mut_slice().copy_from_slice(&payload);
@@ -189,15 +209,13 @@ fn recovery_stops_at_uncommitted_tail() {
     assert!(r.next_record().unwrap().is_none());
 
     drop((w, r));
-    cleanup(&base);
 }
 
 #[test]
 fn read_range_by_seq() {
     let base = base_path("range");
-    cleanup(&base);
 
-    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(&base, cfg(128)).unwrap();
+    let (mut w, mut r) = AppendOnlyJournal::<FixHeader>::open(base.path(), cfg(128)).unwrap();
     for seq in 1..=10u64 {
         let payload = (seq as u32).to_le_bytes();
         let mut claim = w.try_claim(fix(seq), payload.len()).unwrap();
@@ -220,5 +238,4 @@ fn read_range_by_seq() {
     assert_eq!(got, vec![8, 9, 10]);
 
     drop((w, r));
-    cleanup(&base);
 }


### PR DESCRIPTION
## Summary

The FIX test helpers created a journal directory per test under `$TMPDIR` and **never removed it**. `FixJournal::open` preallocates ~25M into each, and `$TMPDIR` is tmpfs on most Linux setups, so every `cargo test` run leaked a few hundred MB.

This was not theoretical. It had accumulated **1,354 directories and roughly 25G**, filled the 32G tmpfs, and started breaking unrelated tooling that writes there. That is how it was found.

> Found while working on #598: this leak filled the tmpfs and started breaking tooling that writes to `/tmp`, which is how it surfaced. Rebased onto `main` now that #598 has merged.

## Root cause

Eight copies of the same helper. For example `nexus-fix-engine/tests/transport.rs`:

```rust
fn tmp_dir(suffix: &str) -> PathBuf {
    let mut p = std::env::temp_dir();
    p.push(format!("nexus_fix_transport_{}_{}", std::process::id(), suffix));
    std::fs::create_dir_all(&p).unwrap();
    p                      // <-- nothing ever removes this
}
```

The PID in the name is what makes it *compound*: every run mints a fresh set instead of reusing the last one's, so the litter accumulates rather than being overwritten.

A few sites had a manual `cleanup(dir)` call at the end of the test instead. That does not survive a panicking test, because unwind never reaches it.

## The fix

Adopt the RAII guard that `nexus-journal/src/rotating/tests.rs` **already uses**, rather than inventing a pattern or adding a `tempfile` dev-dependency (which is nowhere in the workspace and would be ~12 lines of savings):

```rust
struct TempDir(PathBuf);
impl Drop for TempDir {
    fn drop(&mut self) { let _ = std::fs::remove_dir_all(&self.0); }
}
```

`Drop` runs during unwind, so a panicking test still cleans up. That is precisely why the manual-cleanup prefixes leaked while `nexus-seglog-*` (the RAII one) did not — so the manual convention is **deleted rather than copied**: 5 stale `remove_dir_all` calls in `fix_session.rs` and 40 `cleanup(&dir)` calls in `persist.rs` are gone.

Each site keeps its existing prefix and PID, so concurrent runs still don't collide. `new()` also pre-cleans, since a SIGKILL'd run leaves a tree behind and PIDs get recycled.

**Sites fixed (8):** `tests/transport.rs`, `tests/fix_conformance.rs`, the `fix_session.rs` and `persist.rs` test rigs, the three `nexus-async-fix-engine` test files, and `nexus-journal`'s `append/tests.rs`. `rotating/tests.rs` is left alone: it's the reference.

`append/tests.rs` is file-based rather than dir-based (`AppendOnlyJournal` writes sibling `base.0`, `base.1`, … segments, not a directory), so its guard removes the numbered segments and reuses the crate's existing `segment_path` helper instead of re-deriving the `.{i}` suffix.

**Out of scope:** examples, benches, and the harness — they're manual-run or reuse a single directory, so they don't compound in CI.

## Verification

A full run of all three crates:

| | Leftover dirs | `/tmp` |
|---|---|---|
| Before the fix | 58 | 1.33 GB leaked per run |
| After | **0** | unchanged (131M / 1%) |

Panic safety was **proven, not assumed**: a temporary `#[should_panic]` test created a directory, recorded its path, and panicked; the directory was gone after unwind. (Scratch test removed. The workspace has no `panic = "abort"`, so unwinding — and therefore `Drop` — is guaranteed.)

All 13 suites green, clippy `--all-features --all-targets -D warnings` clean, `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
