### PR TITLE
Honor PossDupFlag on a below-expected SequenceReset-GapFill (discard, don't disconnect)

### DIFF
--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -447,7 +447,6 @@ async fn conformance_test_request_timeout() {
 // (the session survives), NOT treated as SeqNumTooLow. Asserts the CORRECT
 // behavior and fails today — kept `#[ignore]`'d until the engine fix lands.
 #[tokio::test]
-#[ignore = "battletest finding Q1: below-expected GapFill w/ PossDup must be discarded, not disconnect; see .claude/fix-battletest-findings.md"]
 async fn conformance_seq_reset_gap_fill_below_possdup() {
     let dir = tmp_dir("seq_reset_gap_fill_below_possdup");
     let (mut child, port) = spawn_peer("seq_reset_gap_fill_below_possdup");

--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -637,8 +637,14 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state
-                        .on_sequence_reset(seq, new_seq, gap_fill, now, &mut emitter)?
+                    self.state.on_sequence_reset(
+                        seq,
+                        poss_dup,
+                        new_seq,
+                        gap_fill,
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -600,6 +600,7 @@ impl SessionState {
     pub fn on_sequence_reset<E: Emit>(
         &mut self,
         seq: u32,
+        poss_dup: bool,
         new_seq: u32,
         gap_fill: bool,
         now: Instant,
@@ -614,7 +615,11 @@ impl SessionState {
         self.last_received = Some(now);
         self.test_request_sent = None;
         if gap_fill {
-            match self.validate_seq(seq, false, now, emitter)? {
+            // Honor the frame's PossDupFlag: a below-expected GapFill carrying
+            // PossDup=Y is a benign duplicate (the overlapping-ResendRequest
+            // race) — discarded, not a disconnect (FIX 4.4 / QuickFIX). Without
+            // PossDup it is a genuine too-low error.
+            match self.validate_seq(seq, poss_dup, now, emitter)? {
                 // In-sequence GapFill only: advance next_inbound to NewSeqNo. A
                 // gap/dup must not advance — it is a recovery event.
                 Control::Proceed => {
@@ -1176,7 +1181,7 @@ mod tests {
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
         let ctrl = s
-            .on_sequence_reset(100, 1, false, now, &mut recorder)
+            .on_sequence_reset(100, false, 1, false, now, &mut recorder)
             .unwrap();
         assert_eq!(ctrl, Control::SequenceReset);
         assert_eq!(recorder.len(), 1);
@@ -1365,7 +1370,9 @@ mod tests {
         establish(&mut s, now); // next_inbound = 2
         let mut recorder = RecordingEmitter::new();
         // GapFill (gap_fill = true) at seq 5 > 2: out of sequence.
-        let ctrl = s.on_sequence_reset(5, 9, true, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_sequence_reset(5, false, 9, true, now, &mut recorder)
+            .unwrap();
         assert_eq!(
             ctrl,
             Control::None,
@@ -1383,23 +1390,49 @@ mod tests {
     }
 
     #[test]
-    fn sequence_reset_gap_fill_duplicate_suppressed_no_advance() {
+    fn sequence_reset_gap_fill_below_expected_possdup_discarded() {
+        // A below-expected GapFill carrying PossDup=Y is a benign duplicate (the
+        // classic overlapping-ResendRequest race) — discarded, session survives,
+        // next_inbound unchanged. Matches FIX 4.4 / QuickFIX.
         let mut s = SessionState::new(Duration::from_secs(30));
         let now = Instant::now();
         establish(&mut s, now);
         consume_seq_2(&mut s, now); // next_inbound = 3
         let mut recorder = RecordingEmitter::new();
-        // Note: on_sequence_reset validates GapFill with poss_dup = false
-        // internally, so a below-expected GapFill is a too-low-without-PossDup
-        // case → Disconnected, NOT a silent duplicate. Assert that path here so
-        // the GapFill duplicate semantics are pinned. seq 2 < 3.
-        let ctrl = s.on_sequence_reset(2, 9, true, now, &mut recorder).unwrap();
+        // seq 2 < 3, PossDup = true.
+        let ctrl = s
+            .on_sequence_reset(2, true, 9, true, now, &mut recorder)
+            .unwrap();
+        assert_eq!(
+            ctrl,
+            Control::None,
+            "a below-expected GapFill with PossDup is discarded, not a disconnect"
+        );
+        assert_eq!(
+            s.next_inbound_seq(),
+            3,
+            "next_inbound must not advance on the discarded GapFill"
+        );
+    }
+
+    #[test]
+    fn sequence_reset_gap_fill_below_expected_no_possdup_disconnects() {
+        // Without PossDup, a below-expected GapFill is a genuine too-low error.
+        let mut s = SessionState::new(Duration::from_secs(30));
+        let now = Instant::now();
+        establish(&mut s, now);
+        consume_seq_2(&mut s, now); // next_inbound = 3
+        let mut recorder = RecordingEmitter::new();
+        // seq 2 < 3, PossDup = false.
+        let ctrl = s
+            .on_sequence_reset(2, false, 9, true, now, &mut recorder)
+            .unwrap();
         assert_eq!(
             ctrl,
             Control::Disconnected {
                 reason: DisconnectReason::SeqNumTooLow
             },
-            "a below-expected GapFill (validated with PossDup=false) disconnects"
+            "a below-expected GapFill without PossDup disconnects"
         );
         assert_eq!(
             s.next_inbound_seq(),
@@ -1415,7 +1448,9 @@ mod tests {
         establish(&mut s, now); // next_inbound = 2
         let mut recorder = RecordingEmitter::new();
         // In-sequence GapFill at seq 2 advancing to new_seq 7.
-        let ctrl = s.on_sequence_reset(2, 7, true, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_sequence_reset(2, false, 7, true, now, &mut recorder)
+            .unwrap();
         assert_eq!(ctrl, Control::SequenceReset);
         assert_eq!(s.next_inbound_seq(), 7, "in-sequence GapFill advances");
         assert_eq!(recorder.len(), 0);

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -483,7 +483,6 @@ fn conformance_test_request_timeout() {
 // disconnects because `on_sequence_reset` hard-codes `poss_dup=false`, so this
 // asserts the CORRECT behavior and fails today — kept `#[ignore]`'d until the fix.
 #[test]
-#[ignore = "battletest finding Q1: below-expected GapFill w/ PossDup must be discarded, not disconnect; see .claude/fix-battletest-findings.md"]
 fn conformance_seq_reset_gap_fill_below_possdup() {
     let dir = tmp_dir("seq_reset_gap_fill_below_possdup");
     let (mut child, port) = spawn_peer("seq_reset_gap_fill_below_possdup");

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -394,7 +394,9 @@ fn gap_fill_advances_past_admin_messages() {
     assert_eq!(s.state(), State::Resending);
 
     recorder.clear();
-    let ctrl = s.on_sequence_reset(2, 7, true, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_sequence_reset(2, false, 7, true, now, &mut recorder)
+        .unwrap();
     assert_eq!(s.next_inbound_seq(), 7);
     assert_eq!(s.state(), State::Active);
     assert_eq!(recorder.len(), 0);
@@ -408,7 +410,7 @@ fn sequence_reset_reset_mode_ignores_seq() {
     establish(&mut s, now);
 
     let ctrl = s
-        .on_sequence_reset(999, 50, false, now, &mut RecordingEmitter::new())
+        .on_sequence_reset(999, false, 50, false, now, &mut RecordingEmitter::new())
         .unwrap();
     assert_eq!(s.next_inbound_seq(), 50);
     assert_eq!(ctrl, Control::SequenceReset);


### PR DESCRIPTION
## Summary

Fixes the conformance bug the battle-test (#603) surfaced: a below-expected SequenceReset-GapFill carrying `PossDupFlag(43)=Y` is disconnected instead of **discarded**.

## The bug

`on_sequence_reset` validated its GapFill with `poss_dup` hard-coded to `false`, so a GapFill whose own `MsgSeqNum(34)` is below the expected inbound seqnum **and** carries `43=Y` took the too-low-without-PossDup path → Logout + `DisconnectReason::SeqNumTooLow`. Every other handler forwards the frame's real PossDupFlag; only this one dropped it (and the engine *emits* GapFills with `43=Y` but was ignoring it on receive).

FIX 4.4 says a below-expected GapFill "should be discarded" — the too-low → terminate rule applies only when PossDupFlag is **absent** — and QuickFIX (C++ `doTargetTooLow` and /J) honors PossDup on GapFills. The classic trigger is **overlapping ResendRequests**: the counterparty sends a second GapFill now below expected. QuickFIX discards it; we dropped the session — turning a recoverable, self-healing race into a dead session.

## The fix

Thread the frame's `PossDupFlag` into `on_sequence_reset`: add the `poss_dup` param, forward it from the dispatch (`fix_session.rs`), and pass it to `validate_seq` instead of the hard-coded `false`. `validate_seq` already returns `Control::None` (discard) for too-low + PossDup and `Disconnected { SeqNumTooLow }` for too-low without it, and the gap-fill branch already routes both outcomes — so threading the flag is the entire fix.

## Tests

- Un-ignores the `seq_reset_gap_fill_below_possdup` regression scenario added in #603 — now **passes** in both the sync and async conformance suites (17 each, 0 ignored).
- Replaces the unit test that pinned the buggy disconnect with two: below-expected GapFill **with** PossDup → `Control::None` (discarded, session survives, `next_inbound` unchanged); **without** PossDup → `SeqNumTooLow` disconnect.

Closes #604.