### PR TITLE
msg_type() -> Result<MsgType, UnknownMsgType> — carry the offending value, printable

### DIFF
--- a/nexus-fix-codec/src/error.rs
+++ b/nexus-fix-codec/src/error.rs
@@ -43,6 +43,58 @@ impl std::error::Error for DecodeError {
     }
 }
 
+/// The `MsgType(35)` value of a received message whose type is not in the
+/// dictionary — the error returned by the generated `HeaderDecoder::msg_type`.
+///
+/// Carries the raw tag-35 bytes (empty if tag 35 was absent). `Display` and
+/// `Debug` render them readably — printable ASCII verbatim, other bytes escaped
+/// as `\xNN` — so a log shows the actual type, e.g. `unknown MsgType(35)=ZZ`,
+/// never a byte array, and stays safe on hostile input.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct UnknownMsgType<'buf>(&'buf [u8]);
+
+impl<'buf> UnknownMsgType<'buf> {
+    /// Wrap the raw `MsgType(35)` bytes.
+    pub fn new(bytes: &'buf [u8]) -> Self {
+        Self(bytes)
+    }
+
+    /// The raw `MsgType(35)` bytes (empty if tag 35 was absent).
+    pub fn bytes(&self) -> &'buf [u8] {
+        self.0
+    }
+}
+
+impl fmt::Display for UnknownMsgType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unknown MsgType(35)=")?;
+        write_ascii_escaped(f, self.0)
+    }
+}
+
+impl fmt::Debug for UnknownMsgType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("UnknownMsgType(\"")?;
+        write_ascii_escaped(f, self.0)?;
+        f.write_str("\")")
+    }
+}
+
+impl std::error::Error for UnknownMsgType<'_> {}
+
+/// Writes `bytes` as text — printable ASCII (and space) verbatim, every other
+/// byte as `\xNN`. No allocation; safe on non-ASCII / hostile input.
+fn write_ascii_escaped(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    for &b in bytes {
+        if b.is_ascii_graphic() || b == b' ' {
+            write!(f, "{}", b as char)?;
+        } else {
+            write!(f, "\\x{b:02x}")?;
+        }
+    }
+    Ok(())
+}
+
 impl From<ChecksumError> for DecodeError {
     fn from(e: ChecksumError) -> Self {
         Self::Checksum(e)
@@ -161,6 +213,21 @@ mod tests {
             computed: 42,
         };
         assert_eq!(e.to_string(), "expected 178, computed 042");
+    }
+
+    #[test]
+    fn unknown_msg_type_is_printable() {
+        let e = UnknownMsgType::new(b"ZZ");
+        assert_eq!(e.to_string(), "unknown MsgType(35)=ZZ");
+        assert_eq!(format!("{e:?}"), r#"UnknownMsgType("ZZ")"#);
+        assert_eq!(e.bytes(), b"ZZ");
+    }
+
+    #[test]
+    fn unknown_msg_type_escapes_non_printable() {
+        // A hostile 35 value with a control byte renders safely, never as raw bytes.
+        let e = UnknownMsgType::new(b"\x01Z");
+        assert_eq!(e.to_string(), "unknown MsgType(35)=\\x01Z");
     }
 
     #[test]

--- a/nexus-fix-codec/src/lib.rs
+++ b/nexus-fix-codec/src/lib.rs
@@ -44,7 +44,7 @@ pub use admin::{
 };
 pub use customizer::{AdminMsgOut, NoCustomizer, SessionCustomizer};
 pub use dict::{AdminHeader, FixAdminMsg, FixDictionary, FixHeader};
-pub use error::{ChecksumError, DecodeError, EncodeError, FixValueError};
+pub use error::{ChecksumError, DecodeError, EncodeError, FixValueError, UnknownMsgType};
 pub use field::{FieldView, FromFixValue};
 pub use nexus_ascii::{AsciiChar, AsciiText, AsciiTextStr};
 pub use reader::{FieldReader, RawField, checksum, find_tag, parse_tag, validate_checksum};

--- a/nexus-fix-codegen-tests/tests/roundtrip.rs
+++ b/nexus-fix-codegen-tests/tests/roundtrip.rs
@@ -271,7 +271,7 @@ fn alpha_header_fields_absent() {
     let msg = b"11=ORD1\x0155=X\x01";
     let m = venue_alpha::messages::NewOrderSingle::decode(msg).unwrap();
     assert!(m.header().begin_string().is_none());
-    assert!(m.header().msg_type().is_none());
+    assert!(m.header().msg_type().is_err());
     assert_eq!(m.cl_ord_id().unwrap().as_bytes(), &b"ORD1"[..]);
 }
 

--- a/nexus-fix-codegen/src/emit/header.rs
+++ b/nexus-fix-codegen/src/emit/header.rs
@@ -168,13 +168,18 @@ fn emit_fix_header_impl(s: &mut String, fields: &[&RField]) -> Result<(), EmitEr
 }
 
 fn emit_msg_type_accessor(s: &mut String) {
-    s.push_str("impl HeaderDecoder<'_> {\n");
-    s.push_str("    pub fn msg_type(&self) -> Option<super::MsgType> {\n");
-    s.push_str("        if self.msg_type.is_present() {\n");
-    s.push_str("            super::MsgType::from_bytes(self.msg_type.slice(self.reader.buf()))\n");
+    s.push_str("impl<'buf> HeaderDecoder<'buf> {\n");
+    s.push_str(
+        "    pub fn msg_type(&self) -> Result<super::MsgType, nexus_fix_codec::UnknownMsgType<'buf>> {\n",
+    );
+    s.push_str("        let bytes = if self.msg_type.is_present() {\n");
+    s.push_str("            self.msg_type.slice(self.reader.buf())\n");
     s.push_str("        } else {\n");
-    s.push_str("            None\n");
-    s.push_str("        }\n");
+    s.push_str("            &[]\n");
+    s.push_str("        };\n");
+    s.push_str(
+        "        super::MsgType::from_bytes(bytes).ok_or_else(|| nexus_fix_codec::UnknownMsgType::new(bytes))\n",
+    );
     s.push_str("    }\n");
     s.push_str("}\n\n");
 }

--- a/nexus-fix-codegen/src/tests.rs
+++ b/nexus-fix-codegen/src/tests.rs
@@ -74,7 +74,9 @@ fn emits_generated_header_decoder() {
     let h = file(&files, "header.rs");
     assert!(h.contains("pub struct HeaderDecoder<'buf>"));
     assert!(h.contains("pub fn decode(buf: &'buf [u8]) -> Self"));
-    assert!(h.contains("pub fn msg_type(&self) -> Option<super::MsgType>"));
+    assert!(h.contains(
+        "pub fn msg_type(&self) -> Result<super::MsgType, nexus_fix_codec::UnknownMsgType<'buf>>"
+    ));
     assert!(h.contains("impl<'buf> nexus_fix_codec::FixHeader<'buf> for HeaderDecoder<'buf>"));
     assert!(h.contains("fn raw_msg_type(&self)"));
     assert!(h.contains("fn msg_seq_num(&self)"));


### PR DESCRIPTION
## Summary

The generated `HeaderDecoder::msg_type()` returned `Option<MsgType>`, where `None` conflated *two* cases — tag 35 absent, and tag 35 present-but-not-in-the-dictionary — and lost the offending value. This changes it to `Result<MsgType, UnknownMsgType<'buf>>` so an unknown MsgType comes back **with its bytes, printable**.

## What changed

- **New `nexus_fix_codec::UnknownMsgType<'buf>`** — carries the raw tag-35 bytes, with a `Display` that renders them readably (`unknown MsgType(35)=ZZ`), a matching `Debug`, and `impl std::error::Error`. Non-printable / hostile bytes escape as `\xNN`, so it's log-safe and never shows up as a byte array. Two unit tests pin both the verbatim-ASCII and the escaping behavior.
- **Generated `HeaderDecoder::msg_type()`** now returns `Result<MsgType, UnknownMsgType<'buf>>` — `Ok(known)` or `Err` carrying the value. `MsgType::from_bytes` stays `Option` (the low-level parser); only the header method gains the richer error.

## Caller impact

Small. The seven `.msg_type().unwrap()` sites work unchanged on `Result`; only one `.is_none()` → `.is_err()`. The **engine is untouched** — it dispatches on `raw_msg_type()`, not `msg_type()`.

## Why

The app-facing path routes an unknown MsgType (`35=ZZ`) to the application (matching QuickFIX with `UseDataDictionary=N` — MsgType validation is the app's responsibility). With `Option`, the app's default arm knew only "unknown" and had to re-fetch `raw_msg_type()` to find out *which*. Now the `Err` hands it the value directly — ready to log, or to emit a `Reject(SessionRejectReason=11 "Invalid MsgType")` with the right `RefMsgType(372)`.

Surfaced during the #603 battle-test. Closes #605.
