### PR TITLE
refactoring session inputs into proper structs

### DIFF
--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -40,7 +40,10 @@ use crate::framework::{
     Emitter, Message, MessageReader, MessageWriter, SessionConfig, SessionError,
 };
 use crate::persist::{FixJournal, ReplayItem};
-use crate::session::{Control, DisconnectReason, SessionState, State};
+use crate::session::{
+    AppIn, Control, DisconnectReason, HeartbeatIn, LogonIn, LogoutIn, RejectIn, RejectInboundIn,
+    ResendRequestIn, SequenceResetIn, SessionState, State, TestRequestIn,
+};
 use crate::timestamp::UTC_TIMESTAMP_LEN;
 
 /// Error surfaced by the sans-IO session core.
@@ -516,8 +519,16 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
             // this call site gives the `Emitter` a no-op `after` closure, while
             // every other site uses the journaling emitter.
             let mut emitter = Emitter::new(&mut self.writer, &self.config, |_seq, _frame| Ok(()));
-            self.state
-                .on_reject_inbound(seq, poss_dup, Some(35), 1, now, &mut emitter)?;
+            self.state.on_reject_inbound(
+                RejectInboundIn {
+                    seq,
+                    ref_tag_id: Some(35),
+                    session_reject_reason: 1,
+                    is_poss_dup: poss_dup,
+                },
+                now,
+                &mut emitter,
+            )?;
             return Ok(PollOutcome::Suppressed);
         };
 
@@ -543,8 +554,16 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state
-                        .on_logon(seq, hbi, reset, !was_logon_sent, now, &mut emitter)?
+                    self.state.on_logon(
+                        LogonIn {
+                            seq,
+                            heart_bt_int_s: hbi,
+                            is_reset_seq_num: reset,
+                            send_reply: !was_logon_sent,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -555,7 +574,14 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state.on_logout(seq, poss_dup, now, &mut emitter)?
+                    self.state.on_logout(
+                        LogoutIn {
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -568,8 +594,15 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state
-                        .on_heartbeat(seq, poss_dup, echo_id, now, &mut emitter)?
+                    self.state.on_heartbeat(
+                        HeartbeatIn {
+                            echo_id,
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -582,8 +615,15 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state
-                        .on_test_request(seq, poss_dup, test_req_id, now, &mut emitter)?
+                    self.state.on_test_request(
+                        TestRequestIn {
+                            test_req_id,
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -600,8 +640,14 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state
-                        .on_resend_request(seq, poss_dup, now, &mut emitter)?
+                    self.state.on_resend_request(
+                        ResendRequestIn {
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 // ResendRequest is the one kind the driver acts on beyond
                 // surfacing the message: it drives the replay from the locally
@@ -638,10 +684,12 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
                     self.state.on_sequence_reset(
-                        seq,
-                        poss_dup,
-                        new_seq,
-                        gap_fill,
+                        SequenceResetIn {
+                            seq,
+                            new_seq,
+                            is_poss_dup: poss_dup,
+                            is_gap_fill: gap_fill,
+                        },
                         now,
                         &mut emitter,
                     )?
@@ -655,7 +703,14 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state.on_reject(seq, poss_dup, now, &mut emitter)?
+                    self.state.on_reject(
+                        RejectIn {
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -663,7 +718,14 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
                 let ctrl = {
                     let mut emitter =
                         journaling_emitter(&mut self.writer, &mut self.journal, &self.config);
-                    self.state.on_app(seq, poss_dup, now, &mut emitter)?
+                    self.state.on_app(
+                        AppIn {
+                            seq,
+                            is_poss_dup: poss_dup,
+                        },
+                        now,
+                        &mut emitter,
+                    )?
                 };
                 Ok(self.dispose(ctrl))
             }
@@ -930,7 +992,7 @@ mod tests {
     use crate::frame::{FrameReader, FrameWriter};
     use crate::framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig};
     use crate::persist::FixJournal;
-    use crate::session::{Emit, SessionState};
+    use crate::session::{Emit, LogonIn, SessionState};
 
     /// A discarding [`Emit`]: drops every emitted admin. These rig helpers
     /// drive the raw `SessionState` only to advance sequence numbers before
@@ -950,7 +1012,16 @@ mod tests {
     fn establish_state(state: &mut SessionState, now: Instant) {
         state.connect(now, &mut NullEmitter).unwrap();
         state
-            .on_logon(1, 30, false, false, now, &mut NullEmitter)
+            .on_logon(
+                LogonIn {
+                    seq: 1,
+                    heart_bt_int_s: 30,
+                    is_reset_seq_num: false,
+                    send_reply: false,
+                },
+                now,
+                &mut NullEmitter,
+            )
             .unwrap();
     }
 

--- a/nexus-fix-engine/src/lib.rs
+++ b/nexus-fix-engine/src/lib.rs
@@ -49,7 +49,10 @@ pub use framework::{CompId, Message, MessageReader, MessageWriter, SessionConfig
 pub use nexus_journal::{Conductor, ConductorBuilder, OpenError, OpenMode, WriteError};
 #[cfg(unix)]
 pub use persist::{FixJournal, ReplayItem};
-pub use session::{Control, DisconnectReason, Emit, SessionState, State};
+pub use session::{
+    AppIn, Control, DisconnectReason, Emit, HeartbeatIn, LogonIn, LogoutIn, RejectIn,
+    RejectInboundIn, ResendRequestIn, SequenceResetIn, SessionState, State, TestRequestIn,
+};
 #[cfg(unix)]
 pub use transport::{
     Error as TransportError, FixConnection, FixConnectionBuilder, REFRAME_HEADROOM,

--- a/nexus-fix-engine/src/session/input.rs
+++ b/nexus-fix-engine/src/session/input.rs
@@ -1,0 +1,111 @@
+//! Decoded inputs to the [`SessionState`](super::SessionState) inbound
+//! handlers — the D-free counterpart of the codec's outbound `AdminEncode`
+//! message structs.
+//!
+//! Each handler takes exactly one of these, so the call site names every value
+//! (`SequenceResetIn { seq, new_seq, .. }`) instead of a positional
+//! `(u32, bool, u32, bool)` that is trivial to transpose. Within each struct,
+//! fields are ordered by descending alignment (like types adjacent) so the
+//! layout stays hole-free if these are ever `#[repr(C)]`.
+
+/// Input to [`SessionState::on_logon`](super::SessionState::on_logon).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LogonIn {
+    /// `MsgSeqNum(34)` of the received Logon.
+    pub seq: u32,
+    /// `HeartBtInt(108)` — negotiated heartbeat interval, in seconds.
+    pub heart_bt_int_s: u32,
+    /// `ResetSeqNumFlag(141)=Y` — peer asks both sides to reset to seqnum 1.
+    pub is_reset_seq_num: bool,
+    /// We are the acceptor and must send a Logon reply; an initiator instead
+    /// receives this Logon as the acknowledgement of its own.
+    pub send_reply: bool,
+}
+
+/// Input to [`SessionState::on_logout`](super::SessionState::on_logout).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LogoutIn {
+    /// `MsgSeqNum(34)` of the received Logout.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_heartbeat`](super::SessionState::on_heartbeat).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct HeartbeatIn {
+    /// `TestReqID(112)` this heartbeat echoes, if it is a reply to our test
+    /// request; `None` for an unsolicited heartbeat.
+    pub echo_id: Option<u64>,
+    /// `MsgSeqNum(34)` of the received Heartbeat.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_test_request`](super::SessionState::on_test_request).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct TestRequestIn<'a> {
+    /// `TestReqID(112)` bytes to echo back in the Heartbeat reply.
+    pub test_req_id: &'a [u8],
+    /// `MsgSeqNum(34)` of the received TestRequest.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_resend_request`](super::SessionState::on_resend_request).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ResendRequestIn {
+    /// `MsgSeqNum(34)` of the received ResendRequest.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_sequence_reset`](super::SessionState::on_sequence_reset).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SequenceResetIn {
+    /// `MsgSeqNum(34)` of the received SequenceReset.
+    pub seq: u32,
+    /// `NewSeqNo(36)` — the sequence number the peer is advancing to.
+    pub new_seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+    /// `GapFillFlag(123)=Y` — gap-fill mode (validated against the expected
+    /// seqnum); absent/`N` is a hard reset that is honored unconditionally.
+    pub is_gap_fill: bool,
+}
+
+/// Input to [`SessionState::on_reject`](super::SessionState::on_reject).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RejectIn {
+    /// `MsgSeqNum(34)` of the received Reject.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_app`](super::SessionState::on_app) — any
+/// application (non-admin) message.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AppIn {
+    /// `MsgSeqNum(34)` of the received message.
+    pub seq: u32,
+    /// `PossDupFlag(43)=Y` — a below-expected seqnum is discarded, not rejected.
+    pub is_poss_dup: bool,
+}
+
+/// Input to [`SessionState::on_reject_inbound`](super::SessionState::on_reject_inbound)
+/// — the engine is rejecting a received message (e.g. a session-level violation).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RejectInboundIn {
+    /// `MsgSeqNum(34)` of the message being rejected.
+    pub seq: u32,
+    /// `RefTagID(371)` — the tag that triggered the reject, if known.
+    pub ref_tag_id: Option<u32>,
+    /// `SessionRejectReason(373)` to cite in the outbound Reject.
+    pub session_reject_reason: u8,
+    /// `PossDupFlag(43)=Y` on the rejected message.
+    pub is_poss_dup: bool,
+}

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -1,8 +1,10 @@
 mod event;
+mod input;
 
 use std::time::{Duration, Instant};
 
 pub use event::{Control, DisconnectReason, State};
+pub use input::*;
 use nexus_fix_codec::{
     AdminEncode, Heartbeat, Logon, LogonReset, Logout, Reject, ResendRequest, TestRequest,
 };
@@ -331,13 +333,16 @@ impl SessionState {
     /// Emits: Logon | LogonReset | Logout | ResendRequest.
     pub fn on_logon<E: Emit>(
         &mut self,
-        seq: u32,
-        heart_bt_int_s: u32,
-        reset_seq_num: bool,
-        send_reply: bool,
+        msg: LogonIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let LogonIn {
+            seq,
+            heart_bt_int_s,
+            is_reset_seq_num,
+            send_reply,
+        } = msg;
         // Acceptor sends its own Logon reply; the initiator receives an ack.
         // `acknowledged` is the mirror of `send_reply`.
         let acknowledged = !send_reply;
@@ -346,7 +351,7 @@ impl SessionState {
 
         // Reset ack: we initiated the reset and peer is confirming.
         if self.state == State::AwaitingResetAck {
-            if !reset_seq_num || seq != 1 {
+            if !is_reset_seq_num || seq != 1 {
                 return Ok(self.disconnect(DisconnectReason::ProtocolViolation));
             }
             self.hb = Duration::from_secs(u64::from(heart_bt_int_s));
@@ -357,7 +362,7 @@ impl SessionState {
         }
 
         // Peer-initiated reset while we are active.
-        if matches!(self.state, State::Active | State::Resending) && reset_seq_num {
+        if matches!(self.state, State::Active | State::Resending) && is_reset_seq_num {
             if seq != 1 {
                 return Ok(self.disconnect(DisconnectReason::ProtocolViolation));
             }
@@ -383,7 +388,7 @@ impl SessionState {
             return Ok(Control::Logon { acknowledged });
         }
 
-        if reset_seq_num {
+        if is_reset_seq_num {
             self.next_inbound = 1;
             if send_reply {
                 self.next_outbound = 1;
@@ -393,7 +398,7 @@ impl SessionState {
 
         if send_reply {
             let reply_seq = seq!(self, now);
-            if reset_seq_num {
+            if is_reset_seq_num {
                 emitter.emit(LogonReset {
                     seq: reply_seq,
                     heart_bt_int_s,
@@ -432,11 +437,11 @@ impl SessionState {
     /// Emits (some via `validate_seq`): ResendRequest | Logout.
     pub fn on_logout<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
+        msg: LogoutIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let LogoutIn { seq, is_poss_dup } = msg;
         self.last_received = Some(now);
         self.test_request_sent = None;
         if self.state == State::LogonSent {
@@ -446,7 +451,7 @@ impl SessionState {
             self.state,
             State::Active | State::Resending | State::LogoutPending
         ) {
-            match self.validate_seq(seq, poss_dup, now, emitter)? {
+            match self.validate_seq(seq, is_poss_dup, now, emitter)? {
                 // In-sequence Logout: complete the exchange and disconnect.
                 Control::Proceed => {
                     if self.state != State::LogoutPending {
@@ -471,12 +476,15 @@ impl SessionState {
     /// Emits (some via `validate_seq`): LogonReset | ResendRequest | Logout.
     pub fn on_heartbeat<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
-        echo_id: Option<u64>,
+        msg: HeartbeatIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let HeartbeatIn {
+            echo_id,
+            seq,
+            is_poss_dup,
+        } = msg;
         self.last_received = Some(now);
         self.test_request_sent = None;
 
@@ -496,7 +504,7 @@ impl SessionState {
                 return Ok(Control::Heartbeat);
             }
             // Not the drain confirm: validate sequence normally.
-            match self.validate_seq(seq, poss_dup, now, emitter)? {
+            match self.validate_seq(seq, is_poss_dup, now, emitter)? {
                 Control::Proceed => self.check_resend_done(),
                 // Gap/duplicate: suppressed, not surfaced.
                 ctrl => return Ok(ctrl),
@@ -510,7 +518,7 @@ impl SessionState {
         ) {
             return Ok(Control::Heartbeat);
         }
-        match self.validate_seq(seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             Control::Proceed => self.check_resend_done(),
             // Gap/duplicate: suppressed, not surfaced.
             ctrl => return Ok(ctrl),
@@ -523,12 +531,15 @@ impl SessionState {
     /// Emits (some via `validate_seq`): Heartbeat | ResendRequest | Logout.
     pub fn on_test_request<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
-        test_req_id: &[u8],
+        msg: TestRequestIn<'_>,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let TestRequestIn {
+            test_req_id,
+            seq,
+            is_poss_dup,
+        } = msg;
         if !matches!(
             self.state,
             State::Active
@@ -541,7 +552,7 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        match self.validate_seq(seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             // In-sequence only: reply with the echoing Heartbeat. A gap/dup must
             // not trigger a Heartbeat reply — it is a recovery event.
             Control::Proceed => {
@@ -567,11 +578,11 @@ impl SessionState {
     /// Emits (via `validate_seq`): ResendRequest | Logout.
     pub fn on_resend_request<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
+        msg: ResendRequestIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let ResendRequestIn { seq, is_poss_dup } = msg;
         if !matches!(
             self.state,
             State::Active | State::Resending | State::LogoutPending
@@ -580,7 +591,7 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        match self.validate_seq(seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             Control::Proceed => {
                 self.check_resend_done();
                 Ok(Control::ResendRequest)
@@ -592,20 +603,23 @@ impl SessionState {
 
     /// Handles a received SequenceReset or GapFill.
     ///
-    /// `gap_fill = false` is Reset mode: ignores `MsgSeqNum`, sets
-    /// `next_inbound` to `new_seq`. `gap_fill = true` is GapFill mode:
+    /// `is_gap_fill = false` is Reset mode: ignores `MsgSeqNum`, sets
+    /// `next_inbound` to `new_seq`. `is_gap_fill = true` is GapFill mode:
     /// validates sequence, advances `next_inbound` to `new_seq`.
     ///
     /// Emits (some via `validate_seq`): Reject | ResendRequest | Logout.
     pub fn on_sequence_reset<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
-        new_seq: u32,
-        gap_fill: bool,
+        msg: SequenceResetIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let SequenceResetIn {
+            seq,
+            new_seq,
+            is_poss_dup,
+            is_gap_fill,
+        } = msg;
         if !matches!(
             self.state,
             State::Active | State::Resending | State::LogoutPending
@@ -614,12 +628,12 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        if gap_fill {
+        if is_gap_fill {
             // Honor the frame's PossDupFlag: a below-expected GapFill carrying
             // PossDup=Y is a benign duplicate (the overlapping-ResendRequest
             // race) — discarded, not a disconnect (FIX 4.4 / QuickFIX). Without
             // PossDup it is a genuine too-low error.
-            match self.validate_seq(seq, poss_dup, now, emitter)? {
+            match self.validate_seq(seq, is_poss_dup, now, emitter)? {
                 // In-sequence GapFill only: advance next_inbound to NewSeqNo. A
                 // gap/dup must not advance — it is a recovery event.
                 Control::Proceed => {
@@ -655,11 +669,11 @@ impl SessionState {
     /// Emits (via `validate_seq`): ResendRequest | Logout.
     pub fn on_reject<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
+        msg: RejectIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let RejectIn { seq, is_poss_dup } = msg;
         if !matches!(
             self.state,
             State::Active | State::Resending | State::LogoutPending
@@ -668,7 +682,7 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        match self.validate_seq(seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             Control::Proceed => self.check_resend_done(),
             // Gap/duplicate: suppressed, not surfaced.
             ctrl => return Ok(ctrl),
@@ -684,11 +698,11 @@ impl SessionState {
     /// Emits (via `validate_seq`): ResendRequest | Logout.
     pub fn on_app<E: Emit>(
         &mut self,
-        seq: u32,
-        poss_dup: bool,
+        msg: AppIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let AppIn { seq, is_poss_dup } = msg;
         if !matches!(
             self.state,
             State::Active
@@ -701,7 +715,7 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        match self.validate_seq(seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             Control::Proceed => {}
             ctrl => return Ok(ctrl),
         }
@@ -711,19 +725,23 @@ impl SessionState {
 
     /// Sends a session-level Reject (35=3) for a received message that cannot be processed.
     ///
-    /// Validates sequence then sends a Reject for `inbound_seq`. A gap sends ResendRequest instead.
+    /// Validates sequence then sends a Reject for the rejected message's `seq`. A
+    /// gap sends ResendRequest instead.
     /// The session remains alive. No-op if the session is not in an active state.
     ///
     /// Emits (some via `validate_seq`): Reject | ResendRequest | Logout.
     pub fn on_reject_inbound<E: Emit>(
         &mut self,
-        inbound_seq: u32,
-        poss_dup: bool,
-        ref_tag_id: Option<u32>,
-        session_reject_reason: u8,
+        msg: RejectInboundIn,
         now: Instant,
         emitter: &mut E,
     ) -> Result<Control, E::Error> {
+        let RejectInboundIn {
+            seq,
+            ref_tag_id,
+            session_reject_reason,
+            is_poss_dup,
+        } = msg;
         if !matches!(
             self.state,
             State::Active | State::Resending | State::LogoutPending
@@ -732,14 +750,16 @@ impl SessionState {
         }
         self.last_received = Some(now);
         self.test_request_sent = None;
-        match self.validate_seq(inbound_seq, poss_dup, now, emitter)? {
+        match self.validate_seq(seq, is_poss_dup, now, emitter)? {
             Control::Proceed => {}
             ctrl => return Ok(ctrl),
         }
-        let seq = seq!(self, now);
+        // `seq` is the rejected inbound message's seqnum (`RefSeqNum`); the Reject
+        // we send carries its own freshly allocated outbound seqnum.
+        let reject_seq = seq!(self, now);
         emitter.emit(Reject {
-            seq,
-            ref_seq_num: inbound_seq,
+            seq: reject_seq,
+            ref_seq_num: seq,
             ref_tag_id,
             session_reject_reason,
         })?;
@@ -967,7 +987,17 @@ mod tests {
     fn establish(s: &mut SessionState, now: Instant) {
         let mut recorder = RecordingEmitter::new();
         s.connect(now, &mut recorder).unwrap();
-        s.on_logon(1, 30, false, false, now, &mut recorder).unwrap();
+        s.on_logon(
+            LogonIn {
+                seq: 1,
+                heart_bt_int_s: 30,
+                is_reset_seq_num: false,
+                send_reply: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1000,8 +1030,15 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now);
         s.allocate_seq(now).unwrap();
-        s.on_logout(2, false, now, &mut RecordingEmitter::new())
-            .unwrap();
+        s.on_logout(
+            LogoutIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
+        .unwrap();
         assert_eq!(s.state(), State::Disconnected);
         let mut recorder = RecordingEmitter::new();
         s.connect_reset(now, &mut recorder).unwrap();
@@ -1064,14 +1101,31 @@ mod tests {
 
         // Non-drain heartbeat: wrong echo — drain NOT triggered.
         recorder.clear();
-        s.on_heartbeat(2, false, None, now, &mut recorder).unwrap();
+        s.on_heartbeat(
+            HeartbeatIn {
+                echo_id: None,
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
         assert_eq!(s.state(), State::AwaitingResetDrain);
         assert_eq!(recorder.len(), 0);
 
         // Drain heartbeat: correct echo + seq in order → sends LogonReset(seq=1), → AwaitingResetAck.
         recorder.clear();
-        s.on_heartbeat(3, false, Some(1), now, &mut recorder)
-            .unwrap();
+        s.on_heartbeat(
+            HeartbeatIn {
+                echo_id: Some(1),
+                seq: 3,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
         assert_eq!(s.state(), State::AwaitingResetAck);
         assert_eq!(s.next_outbound_seq(), 2); // LogonReset consumed seq 1
         assert_eq!(recorder.len(), 1);
@@ -1081,7 +1135,18 @@ mod tests {
 
         // Peer acks with Logon(141=Y, seq=1): reset complete, → Active.
         recorder.clear();
-        let ctrl = s.on_logon(1, 30, true, false, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_logon(
+                LogonIn {
+                    seq: 1,
+                    heart_bt_int_s: 30,
+                    is_reset_seq_num: true,
+                    send_reply: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(s.state(), State::Active);
         assert_eq!(s.next_inbound_seq(), 2);
         assert_eq!(ctrl, Control::Logon { acknowledged: true });
@@ -1100,7 +1165,16 @@ mod tests {
 
         // App message arrives with old inbound seq while draining.
         recorder.clear();
-        let ctrl = s.on_app(2, false, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_app(
+                AppIn {
+                    seq: 2,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::Application);
         assert_eq!(s.next_inbound_seq(), 3);
         assert_eq!(s.state(), State::AwaitingResetDrain);
@@ -1116,7 +1190,18 @@ mod tests {
 
         // Peer sends Logon(141=Y, seq=1) while we are Active.
         let mut recorder = RecordingEmitter::new();
-        let ctrl = s.on_logon(1, 30, true, true, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_logon(
+                LogonIn {
+                    seq: 1,
+                    heart_bt_int_s: 30,
+                    is_reset_seq_num: true,
+                    send_reply: true,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(s.state(), State::Active);
         assert_eq!(s.next_outbound_seq(), 2); // reply Logon consumed seq 1
         assert_eq!(s.next_inbound_seq(), 2);
@@ -1141,11 +1226,30 @@ mod tests {
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
         s.reset_sequence(now, &mut recorder).unwrap();
-        s.on_heartbeat(2, false, Some(1), now, &mut recorder)
-            .unwrap(); // → AwaitingResetAck
+        s.on_heartbeat(
+            HeartbeatIn {
+                echo_id: Some(1),
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap(); // → AwaitingResetAck
 
         // Peer replies without 141=Y.
-        let ctrl = s.on_logon(1, 30, false, false, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_logon(
+                LogonIn {
+                    seq: 1,
+                    heart_bt_int_s: 30,
+                    is_reset_seq_num: false,
+                    send_reply: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(
             ctrl,
             Control::Disconnected {
@@ -1161,8 +1265,16 @@ mod tests {
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
         s.reset_sequence(now, &mut recorder).unwrap();
-        s.on_heartbeat(2, false, Some(1), now, &mut recorder)
-            .unwrap(); // → AwaitingResetAck
+        s.on_heartbeat(
+            HeartbeatIn {
+                echo_id: Some(1),
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap(); // → AwaitingResetAck
         let ctrl = s
             .on_timeout(now + Duration::from_secs(31), &mut recorder)
             .unwrap();
@@ -1181,7 +1293,16 @@ mod tests {
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
         let ctrl = s
-            .on_sequence_reset(100, false, 1, false, now, &mut recorder)
+            .on_sequence_reset(
+                SequenceResetIn {
+                    seq: 100,
+                    new_seq: 1,
+                    is_poss_dup: false,
+                    is_gap_fill: false,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(ctrl, Control::SequenceReset);
         assert_eq!(recorder.len(), 1);
@@ -1199,8 +1320,17 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
-        s.on_reject_inbound(2, false, Some(35), 1, now, &mut recorder)
-            .unwrap();
+        s.on_reject_inbound(
+            RejectInboundIn {
+                seq: 2,
+                ref_tag_id: Some(35),
+                session_reject_reason: 1,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
         assert_eq!(recorder.len(), 1);
         // Reject: RefSeqNum(45)=2, RefTagID(371)=35, SessionRejectReason(373)=1.
         assert_eq!(recorder.mt(0), b"3");
@@ -1216,8 +1346,17 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
-        s.on_reject_inbound(5, false, Some(35), 1, now, &mut recorder)
-            .unwrap();
+        s.on_reject_inbound(
+            RejectInboundIn {
+                seq: 5,
+                ref_tag_id: Some(35),
+                session_reject_reason: 1,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
         assert_eq!(recorder.len(), 1);
         // ResendRequest (35=2) with BeginSeqNo(7)=2.
         assert_eq!(recorder.mt(0), b"2", "expected ResendRequest");
@@ -1241,8 +1380,15 @@ mod tests {
     /// seq 2, so a later `seq 2` PossDup frame is a genuine duplicate (< 3).
     fn consume_seq_2(s: &mut SessionState, now: Instant) {
         assert_eq!(
-            s.on_app(2, false, now, &mut RecordingEmitter::new())
-                .unwrap(),
+            s.on_app(
+                AppIn {
+                    seq: 2,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut RecordingEmitter::new()
+            )
+            .unwrap(),
             Control::Application
         );
         assert_eq!(s.next_inbound_seq(), 3);
@@ -1255,7 +1401,17 @@ mod tests {
         establish(&mut s, now); // next_inbound = 2
         let mut recorder = RecordingEmitter::new();
         // seq 5 > 2: gap.
-        let ctrl = s.on_heartbeat(5, false, None, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_heartbeat(
+                HeartbeatIn {
+                    echo_id: None,
+                    seq: 5,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::None, "gap Heartbeat must be suppressed");
         assert_eq!(recorder.len(), 1);
         assert_eq!(recorder.mt(0), b"2", "gap must emit a ResendRequest");
@@ -1271,7 +1427,17 @@ mod tests {
         consume_seq_2(&mut s, now); // next_inbound = 3
         let mut recorder = RecordingEmitter::new();
         // seq 2 < 3 with PossDup: duplicate.
-        let ctrl = s.on_heartbeat(2, true, None, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_heartbeat(
+                HeartbeatIn {
+                    echo_id: None,
+                    seq: 2,
+                    is_poss_dup: true,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(
             ctrl,
             Control::None,
@@ -1287,7 +1453,17 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
-        let ctrl = s.on_heartbeat(2, false, None, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_heartbeat(
+                HeartbeatIn {
+                    echo_id: None,
+                    seq: 2,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::Heartbeat);
         assert_eq!(recorder.len(), 0);
     }
@@ -1299,7 +1475,15 @@ mod tests {
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
         let ctrl = s
-            .on_test_request(5, false, b"PROBE", now, &mut recorder)
+            .on_test_request(
+                TestRequestIn {
+                    test_req_id: b"PROBE",
+                    seq: 5,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(ctrl, Control::None, "gap TestRequest must be suppressed");
         // A gap emits a ResendRequest and NOT the Heartbeat echo (which is
@@ -1321,7 +1505,15 @@ mod tests {
         consume_seq_2(&mut s, now); // next_inbound = 3
         let mut recorder = RecordingEmitter::new();
         let ctrl = s
-            .on_test_request(2, true, b"PROBE", now, &mut recorder)
+            .on_test_request(
+                TestRequestIn {
+                    test_req_id: b"PROBE",
+                    seq: 2,
+                    is_poss_dup: true,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(
             ctrl,
@@ -1342,7 +1534,16 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now);
         let mut recorder = RecordingEmitter::new();
-        let ctrl = s.on_reject(5, false, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_reject(
+                RejectIn {
+                    seq: 5,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::None, "gap Reject must be suppressed");
         assert_eq!(recorder.len(), 1);
         assert_eq!(recorder.mt(0), b"2", "gap must emit ResendRequest");
@@ -1357,7 +1558,16 @@ mod tests {
         establish(&mut s, now);
         consume_seq_2(&mut s, now); // next_inbound = 3
         let mut recorder = RecordingEmitter::new();
-        let ctrl = s.on_reject(2, true, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_reject(
+                RejectIn {
+                    seq: 2,
+                    is_poss_dup: true,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::None, "duplicate Reject must be suppressed");
         assert_eq!(recorder.len(), 0);
         assert_eq!(s.state(), State::Active);
@@ -1369,9 +1579,18 @@ mod tests {
         let now = Instant::now();
         establish(&mut s, now); // next_inbound = 2
         let mut recorder = RecordingEmitter::new();
-        // GapFill (gap_fill = true) at seq 5 > 2: out of sequence.
+        // GapFill (is_gap_fill = true) at seq 5 > 2: out of sequence.
         let ctrl = s
-            .on_sequence_reset(5, false, 9, true, now, &mut recorder)
+            .on_sequence_reset(
+                SequenceResetIn {
+                    seq: 5,
+                    new_seq: 9,
+                    is_poss_dup: false,
+                    is_gap_fill: true,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(
             ctrl,
@@ -1401,7 +1620,16 @@ mod tests {
         let mut recorder = RecordingEmitter::new();
         // seq 2 < 3, PossDup = true.
         let ctrl = s
-            .on_sequence_reset(2, true, 9, true, now, &mut recorder)
+            .on_sequence_reset(
+                SequenceResetIn {
+                    seq: 2,
+                    new_seq: 9,
+                    is_poss_dup: true,
+                    is_gap_fill: true,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(
             ctrl,
@@ -1425,7 +1653,16 @@ mod tests {
         let mut recorder = RecordingEmitter::new();
         // seq 2 < 3, PossDup = false.
         let ctrl = s
-            .on_sequence_reset(2, false, 9, true, now, &mut recorder)
+            .on_sequence_reset(
+                SequenceResetIn {
+                    seq: 2,
+                    new_seq: 9,
+                    is_poss_dup: false,
+                    is_gap_fill: true,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(
             ctrl,
@@ -1449,7 +1686,16 @@ mod tests {
         let mut recorder = RecordingEmitter::new();
         // In-sequence GapFill at seq 2 advancing to new_seq 7.
         let ctrl = s
-            .on_sequence_reset(2, false, 7, true, now, &mut recorder)
+            .on_sequence_reset(
+                SequenceResetIn {
+                    seq: 2,
+                    new_seq: 7,
+                    is_poss_dup: false,
+                    is_gap_fill: true,
+                },
+                now,
+                &mut recorder,
+            )
             .unwrap();
         assert_eq!(ctrl, Control::SequenceReset);
         assert_eq!(s.next_inbound_seq(), 7, "in-sequence GapFill advances");
@@ -1464,7 +1710,16 @@ mod tests {
         let mut recorder = RecordingEmitter::new();
         // seq 5 > 2: gap. A gap Logout must be suppressed (ResendRequest), NOT
         // treated as a logout exchange.
-        let ctrl = s.on_logout(5, false, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_logout(
+                LogoutIn {
+                    seq: 5,
+                    is_poss_dup: false,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::None, "gap Logout must be suppressed");
         assert_eq!(recorder.len(), 1);
         assert_eq!(
@@ -1488,7 +1743,16 @@ mod tests {
         consume_seq_2(&mut s, now); // next_inbound = 3
         let mut recorder = RecordingEmitter::new();
         // seq 2 < 3 with PossDup: duplicate Logout — ignored, session survives.
-        let ctrl = s.on_logout(2, true, now, &mut recorder).unwrap();
+        let ctrl = s
+            .on_logout(
+                LogoutIn {
+                    seq: 2,
+                    is_poss_dup: true,
+                },
+                now,
+                &mut recorder,
+            )
+            .unwrap();
         assert_eq!(ctrl, Control::None, "duplicate Logout must be suppressed");
         assert_eq!(recorder.len(), 0);
         assert_eq!(

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -4,7 +4,10 @@ use nexus_fix_codec::{
     AdminEncode, AdminHeader, AdminMsgOut, AsciiTextStr, DecodeError, FieldView, FixAdminMsg,
     FixDictionary, FixHeader, FixTimestamp, FrameFormatter, NoCustomizer, find_tag, parse_fix_uint,
 };
-use nexus_fix_engine::{Control, DisconnectReason, Emit, SessionState, State};
+use nexus_fix_engine::{
+    AppIn, Control, DisconnectReason, Emit, HeartbeatIn, LogonIn, LogoutIn, RejectIn,
+    RejectInboundIn, ResendRequestIn, SequenceResetIn, SessionState, State, TestRequestIn,
+};
 
 const HB: Duration = Duration::from_secs(30);
 
@@ -144,7 +147,17 @@ impl Emit for RecordingEmitter {
 fn establish(s: &mut SessionState, now: Instant) {
     let mut recorder = RecordingEmitter::new();
     s.connect(now, &mut recorder).unwrap();
-    s.on_logon(1, 30, false, false, now, &mut recorder).unwrap();
+    s.on_logon(
+        LogonIn {
+            seq: 1,
+            heart_bt_int_s: 30,
+            is_reset_seq_num: false,
+            send_reply: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(s.state(), State::Active);
 }
 
@@ -165,7 +178,18 @@ fn initiator_handshake() {
 
     recorder.clear();
     // Initiator receiving the peer's Logon ack: send_reply = false → acknowledged.
-    let ctrl = s.on_logon(1, 30, false, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_logon(
+            LogonIn {
+                seq: 1,
+                heart_bt_int_s: 30,
+                is_reset_seq_num: false,
+                send_reply: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Active);
     assert_eq!(ctrl, Control::Logon { acknowledged: true });
     assert_eq!(recorder.len(), 0);
@@ -180,7 +204,18 @@ fn acceptor_handshake() {
 
     let mut recorder = RecordingEmitter::new();
     // Acceptor: send_reply = true → this Logon is answered, not an ack.
-    let ctrl = s.on_logon(1, 15, false, true, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_logon(
+            LogonIn {
+                seq: 1,
+                heart_bt_int_s: 15,
+                is_reset_seq_num: false,
+                send_reply: true,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Active);
     assert_eq!(
         ctrl,
@@ -202,7 +237,17 @@ fn logon_reset_seq_num_flag() {
     let now = Instant::now();
 
     let mut recorder = RecordingEmitter::new();
-    s.on_logon(1, 30, true, true, now, &mut recorder).unwrap();
+    s.on_logon(
+        LogonIn {
+            seq: 1,
+            heart_bt_int_s: 30,
+            is_reset_seq_num: true,
+            send_reply: true,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(s.state(), State::Active);
     assert_eq!(recorder.len(), 1);
     // LogonReset (35=A carrying 141=Y) at seqnum 1.
@@ -218,7 +263,14 @@ fn app_message_emits_control() {
     establish(&mut s, now);
 
     let ctrl = s
-        .on_app(2, false, now, &mut RecordingEmitter::new())
+        .on_app(
+            AppIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
         .unwrap();
     assert_eq!(ctrl, Control::Application);
     assert_eq!(s.next_inbound_seq(), 3);
@@ -231,8 +283,16 @@ fn test_request_is_echoed() {
     establish(&mut s, now);
 
     let mut recorder = RecordingEmitter::new();
-    s.on_test_request(2, false, b"PROBE7", now, &mut recorder)
-        .unwrap();
+    s.on_test_request(
+        TestRequestIn {
+            test_req_id: b"PROBE7",
+            seq: 2,
+            is_poss_dup: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(recorder.len(), 1);
     // Heartbeat (35=0) echoing TestReqID(112)=PROBE7.
     assert_eq!(recorder.mt(0), b"0");
@@ -312,9 +372,11 @@ fn probe_answered_keeps_session_alive() {
     let mut recorder = RecordingEmitter::new();
     s.on_timeout(probe_at, &mut recorder).unwrap();
     s.on_heartbeat(
-        2,
-        false,
-        None,
+        HeartbeatIn {
+            echo_id: None,
+            seq: 2,
+            is_poss_dup: false,
+        },
         probe_at + Duration::from_secs(1),
         &mut recorder,
     )
@@ -340,10 +402,12 @@ fn probe_answered_by_unprocessable_message_keeps_session_alive() {
 
     recorder.clear();
     s.on_reject_inbound(
-        2,
-        false,
-        Some(35),
-        1,
+        RejectInboundIn {
+            seq: 2,
+            ref_tag_id: Some(35),
+            session_reject_reason: 1,
+            is_poss_dup: false,
+        },
         probe_at + Duration::from_secs(1),
         &mut recorder,
     )
@@ -367,7 +431,16 @@ fn gap_triggers_resend_request() {
 
     let mut recorder = RecordingEmitter::new();
     // A gap suppresses the app message but fires a ResendRequest.
-    let ctrl = s.on_app(5, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_app(
+            AppIn {
+                seq: 5,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Resending);
     assert_eq!(ctrl, Control::None);
     assert_eq!(recorder.len(), 1);
@@ -376,8 +449,15 @@ fn gap_triggers_resend_request() {
     assert_eq!(recorder.num(0, 7), Some(2));
 
     for seq in 2u32..=5 {
-        s.on_app(seq, true, now, &mut RecordingEmitter::new())
-            .unwrap();
+        s.on_app(
+            AppIn {
+                seq,
+                is_poss_dup: true,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
+        .unwrap();
     }
     assert_eq!(s.state(), State::Active);
     assert_eq!(s.next_inbound_seq(), 6);
@@ -390,12 +470,29 @@ fn gap_fill_advances_past_admin_messages() {
     establish(&mut s, now);
 
     let mut recorder = RecordingEmitter::new();
-    s.on_app(6, false, now, &mut recorder).unwrap();
+    s.on_app(
+        AppIn {
+            seq: 6,
+            is_poss_dup: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(s.state(), State::Resending);
 
     recorder.clear();
     let ctrl = s
-        .on_sequence_reset(2, false, 7, true, now, &mut recorder)
+        .on_sequence_reset(
+            SequenceResetIn {
+                seq: 2,
+                new_seq: 7,
+                is_poss_dup: false,
+                is_gap_fill: true,
+            },
+            now,
+            &mut recorder,
+        )
         .unwrap();
     assert_eq!(s.next_inbound_seq(), 7);
     assert_eq!(s.state(), State::Active);
@@ -410,7 +507,16 @@ fn sequence_reset_reset_mode_ignores_seq() {
     establish(&mut s, now);
 
     let ctrl = s
-        .on_sequence_reset(999, false, 50, false, now, &mut RecordingEmitter::new())
+        .on_sequence_reset(
+            SequenceResetIn {
+                seq: 999,
+                new_seq: 50,
+                is_poss_dup: false,
+                is_gap_fill: false,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
         .unwrap();
     assert_eq!(s.next_inbound_seq(), 50);
     assert_eq!(ctrl, Control::SequenceReset);
@@ -425,7 +531,16 @@ fn resend_request_surfaces_control() {
     s.allocate_seq(now).unwrap(); // seq 3
 
     let mut recorder = RecordingEmitter::new();
-    let ctrl = s.on_resend_request(2, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_resend_request(
+            ResendRequestIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(ctrl, Control::ResendRequest);
     // The replay walk (gap-fills + PossDup re-frames) is driven by the driver
     // from its locally parsed begin/end — no admin emitted by the handler here.
@@ -437,11 +552,25 @@ fn seq_too_low_disconnects() {
     let mut s = new_session();
     let now = Instant::now();
     establish(&mut s, now);
-    s.on_app(2, false, now, &mut RecordingEmitter::new())
-        .unwrap(); // seq 2 consumed
+    s.on_app(
+        AppIn {
+            seq: 2,
+            is_poss_dup: false,
+        },
+        now,
+        &mut RecordingEmitter::new(),
+    )
+    .unwrap(); // seq 2 consumed
 
     let ctrl = s
-        .on_app(2, false, now, &mut RecordingEmitter::new())
+        .on_app(
+            AppIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
         .unwrap(); // seq 2 again, no poss_dup
     assert_eq!(s.state(), State::Disconnected);
     assert_eq!(
@@ -457,11 +586,27 @@ fn poss_dup_below_expected_is_ignored() {
     let mut s = new_session();
     let now = Instant::now();
     establish(&mut s, now);
-    s.on_app(2, false, now, &mut RecordingEmitter::new())
-        .unwrap();
+    s.on_app(
+        AppIn {
+            seq: 2,
+            is_poss_dup: false,
+        },
+        now,
+        &mut RecordingEmitter::new(),
+    )
+    .unwrap();
 
     let mut recorder = RecordingEmitter::new();
-    let ctrl = s.on_app(2, true, now, &mut recorder).unwrap(); // poss_dup — silent ignore
+    let ctrl = s
+        .on_app(
+            AppIn {
+                seq: 2,
+                is_poss_dup: true,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap(); // poss_dup — silent ignore
     assert_eq!(s.state(), State::Active);
     assert_eq!(ctrl, Control::None);
     assert_eq!(recorder.len(), 0);
@@ -497,7 +642,16 @@ fn initiated_logout_round_trip() {
     assert!(recorder.any_mt(b"5"), "logout must send a Logout");
 
     recorder.clear();
-    let ctrl = s.on_logout(2, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_logout(
+            LogoutIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Disconnected);
     assert_eq!(
         ctrl,
@@ -514,7 +668,16 @@ fn counterparty_logout_is_confirmed() {
     establish(&mut s, now);
 
     let mut recorder = RecordingEmitter::new();
-    let ctrl = s.on_logout(2, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_logout(
+            LogoutIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Disconnected);
     assert_eq!(
         ctrl,
@@ -570,7 +733,14 @@ fn reject_received_surfaces_control() {
     establish(&mut s, now);
 
     let ctrl = s
-        .on_reject(2, false, now, &mut RecordingEmitter::new())
+        .on_reject(
+            RejectIn {
+                seq: 2,
+                is_poss_dup: false,
+            },
+            now,
+            &mut RecordingEmitter::new(),
+        )
         .unwrap();
     assert_eq!(ctrl, Control::Reject);
 }
@@ -583,7 +753,16 @@ fn seq_nums_survive_reconnect() {
     s.allocate_seq(now).unwrap(); // outbound seq 2
 
     let mut recorder = RecordingEmitter::new();
-    s.on_logout(2, false, now, &mut recorder).unwrap(); // counterparty logout at inbound seq 2; session replies (seq 3), disconnects
+    // counterparty logout at inbound seq 2; session replies (seq 3), disconnects
+    s.on_logout(
+        LogoutIn {
+            seq: 2,
+            is_poss_dup: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
 
     assert_eq!(s.state(), State::Disconnected);
 
@@ -594,7 +773,17 @@ fn seq_nums_survive_reconnect() {
     assert!(!recorder.has(0, 141));
     assert_eq!(recorder.num(0, 34), Some(4));
 
-    s.on_logon(3, 30, false, false, now, &mut recorder).unwrap();
+    s.on_logon(
+        LogonIn {
+            seq: 3,
+            heart_bt_int_s: 30,
+            is_reset_seq_num: false,
+            send_reply: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(s.state(), State::Active);
 }
 
@@ -608,7 +797,17 @@ fn next_timeout_tracks_deadlines() {
     s.connect(now, &mut recorder).unwrap();
     assert_eq!(s.next_timeout(), Some(now + HB));
 
-    s.on_logon(1, 30, false, false, now, &mut recorder).unwrap();
+    s.on_logon(
+        LogonIn {
+            seq: 1,
+            heart_bt_int_s: 30,
+            is_reset_seq_num: false,
+            send_reply: false,
+        },
+        now,
+        &mut recorder,
+    )
+    .unwrap();
     assert_eq!(s.next_timeout(), Some(now + HB));
 }
 
@@ -618,7 +817,16 @@ fn messages_ignored_while_disconnected() {
     let now = Instant::now();
 
     let mut recorder = RecordingEmitter::new();
-    let ctrl = s.on_app(1, false, now, &mut recorder).unwrap();
+    let ctrl = s
+        .on_app(
+            AppIn {
+                seq: 1,
+                is_poss_dup: false,
+            },
+            now,
+            &mut recorder,
+        )
+        .unwrap();
     assert_eq!(s.state(), State::Disconnected);
     assert_eq!(ctrl, Control::None);
     assert_eq!(recorder.len(), 0);


### PR DESCRIPTION
Closes #607.

## What

The `SessionState` inbound handlers took their message data positionally —
`on_sequence_reset(seq, poss_dup, new_seq, gap_fill, now, emitter)` is a
`(u32, bool, u32, bool)` that's trivial to transpose, and a swapped
`seq`/`new_seq` compiles fine. This collapses each handler's message data into
one typed input struct — the D-free inbound counterpart of the codec's outbound
`AdminEncode` structs (`Logon`, `Heartbeat`, …). `now`/`emitter` stay trailing.

Pure refactor — no behavior change.

## The structs

Nine `…In` structs in a new `session/input.rs`, re-exported from the crate root
alongside `SessionState`:

`LogonIn`, `LogoutIn`, `HeartbeatIn`, `TestRequestIn<'a>`, `ResendRequestIn`,
`SequenceResetIn`, `RejectIn`, `AppIn`, `RejectInboundIn`.

- **Fields grouped by descending alignment** (like types adjacent) so the layout
  is hole-free if these are ever `#[repr(C)]`.
- **Flag bools carry an `is_` prefix** (`is_poss_dup`, `is_gap_fill`,
  `is_reset_seq_num`); every field is doc-commented with its FIX tag.
- Each handler destructures at the top; bodies are otherwise unchanged.

Call site, before → after:

```rust
self.state.on_sequence_reset(seq, poss_dup, new_seq, gap_fill, now, &mut emitter)?;
// →
self.state.on_sequence_reset(
    SequenceResetIn { seq, new_seq, is_poss_dup: poss_dup, is_gap_fill: gap_fill },
    now, &mut emitter,
)?;
```

## Scope

- 9 handler signatures + bodies
- 58 call sites converted — 10 production dispatch (`fix_session.rs`), 48 test
- `validate_seq` (private) stays positional; no-message-data handlers
  (`on_timeout`, `on_comp_id_mismatch`, …) unchanged

## Note

In `on_reject_inbound` the new `seq` field collided with the local that allocates
the *outbound* Reject's own seqnum, so that local is renamed `reject_seq` (the
name already used for this in `on_sequence_reset`): `ref_seq_num: seq` is the
rejected inbound message, `seq: reject_seq` is the fresh outbound seqnum. Values
unchanged.

## Verification

- `cargo clippy -p nexus-fix-engine --all-features --all-targets -- -D warnings` — clean
- `cargo test -p nexus-fix-engine --all-features` — 184 passed, incl. the 17-case
  conformance harness driven against a live peer
