### PR TITLE
nexus-fix-log: read-only FIX journal log viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
 	"nexus-inference",
 	"nexus-fix-codec",
 	"nexus-fix-codegen",
+	"nexus-fix-log",
 	"nexus-fix-codegen-tests",
 	"nexus-fix-engine",
 	"nexus-async-fix-engine",

--- a/nexus-fix-log/Cargo.toml
+++ b/nexus-fix-log/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Read-only FIX journal log viewer"
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/nexus-fix-log/Cargo.toml
+++ b/nexus-fix-log/Cargo.toml
@@ -13,3 +13,6 @@ workspace = true
 
 [dependencies]
 nexus-fix-codec = { path = "../nexus-fix-codec" }
+
+[dev-dependencies]
+nexus-journal = { path = "../nexus-journal" }

--- a/nexus-fix-log/Cargo.toml
+++ b/nexus-fix-log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nexus-fix-log"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Read-only FIX journal log viewer"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-fix-codec = { path = "../nexus-fix-codec" }

--- a/nexus-fix-log/src/main.rs
+++ b/nexus-fix-log/src/main.rs
@@ -1,15 +1,31 @@
 use std::env;
 use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 
 use nexus_fix_codec::reader::FieldReader;
 
 const MAGIC: u32 = u32::from_le_bytes(*b"NXLG");
+const VERSION: u16 = 1;
+// 96-byte original layout + 8-byte meta slot appended in the same struct.
+const MANIFEST_MIN_LEN: usize = 104;
 const FRAME_HDR: usize = 8;
 const ALIGN: usize = 8;
 // Each stored frame's payload is [ts:8 LE UNIX-nanos][FIX wire message].
 const TS_LEN: usize = 8;
+
+// FIX length/data field tag pairs: (length-tag, data-tag).
+// A length tag's value is the exact byte count of the paired data field,
+// which may legally contain embedded SOH and '=' characters.
+const DATA_PAIRS: &[(u32, u32)] = &[
+    (90, 91),   // SecureDataLen / SecureData
+    (95, 96),   // RawDataLength / RawData
+    (212, 213), // XmlDataLen / XmlData
+    (348, 349), // EncodedIssuerLen / EncodedIssuer
+    (358, 359), // EncodedSecurityDescLen / EncodedSecurityDesc
+    (360, 361), // EncodedTextLen / EncodedText
+];
 
 struct SessionMeta {
     // Conductor-level session id as stored in the manifest.
@@ -30,11 +46,15 @@ impl SessionMeta {
 
 fn read_manifest(path: &Path) -> Option<SessionMeta> {
     let data = fs::read(path).ok()?;
-    if data.len() < 96 {
+    if data.len() < MANIFEST_MIN_LEN {
         return None;
     }
     let magic = u32::from_le_bytes(data[80..84].try_into().ok()?);
     if magic != MAGIC {
+        return None;
+    }
+    let version = u16::from_le_bytes(data[88..90].try_into().ok()?);
+    if version != VERSION {
         return None;
     }
     let segment_size = u64::from_le_bytes(data[64..72].try_into().ok()?) as usize;
@@ -51,8 +71,21 @@ fn align_up(n: usize) -> usize {
     (n + ALIGN - 1) & !(ALIGN - 1)
 }
 
-fn scan_segment(path: &Path, global_base: u64, meta: &SessionMeta) {
-    let Ok(data) = fs::read(path) else { return };
+fn scan_segment(
+    out: &mut impl Write,
+    path: &Path,
+    global_base: u64,
+    meta: &SessionMeta,
+    had_error: &mut bool,
+) -> io::Result<()> {
+    let data = match fs::read(path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("error: cannot read {}: {e}", path.display());
+            *had_error = true;
+            return Ok(());
+        }
+    };
     let mut pos = 0usize;
     while pos + FRAME_HDR <= data.len() {
         let commit_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
@@ -70,32 +103,42 @@ fn scan_segment(path: &Path, global_base: u64, meta: &SessionMeta) {
         if payload.len() > TS_LEN {
             let ts = u64::from_le_bytes(payload[..TS_LEN].try_into().unwrap());
             let fix_msg = &payload[TS_LEN..];
-            print_message(meta, global_off, ts, fix_msg);
+            print_message(out, meta, global_off, ts, fix_msg)?;
         }
         pos = payload_start + align_up(body);
     }
+    Ok(())
 }
 
-fn scan_session(session_dir: &Path, meta: &SessionMeta) {
+fn scan_session(
+    out: &mut impl Write,
+    session_dir: &Path,
+    meta: &SessionMeta,
+    had_error: &mut bool,
+) -> io::Result<()> {
     let epoch = meta.epoch;
     let seg_size = meta.segment_size as u64;
-
     if epoch == 0 {
-        scan_segment(&session_dir.join("seg0.dat"), 0, meta);
+        scan_segment(out, &session_dir.join("seg0.dat"), 0, meta, had_error)?;
     } else {
         let prev_slot = (epoch - 1) % 3;
         scan_segment(
+            out,
             &session_dir.join(format!("seg{prev_slot}.dat")),
             (epoch - 1) * seg_size,
             meta,
-        );
+            had_error,
+        )?;
         let cur_slot = epoch % 3;
         scan_segment(
+            out,
             &session_dir.join(format!("seg{cur_slot}.dat")),
             epoch * seg_size,
             meta,
-        );
+            had_error,
+        )?;
     }
+    Ok(())
 }
 
 fn fmt_ts(nanos: u64) -> String {
@@ -104,16 +147,43 @@ fn fmt_ts(nanos: u64) -> String {
     format!("{secs}.{ns:09}")
 }
 
-fn print_message(meta: &SessionMeta, offset: u64, ts: u64, fix_msg: &[u8]) {
+fn print_message(
+    out: &mut impl Write,
+    meta: &SessionMeta,
+    offset: u64,
+    ts: u64,
+    fix_msg: &[u8],
+) -> io::Result<()> {
     let dir = if meta.is_outbound() { "out" } else { "in " };
     let prefix = format!("[session={} {dir} +{offset}]", meta.fix_session_id());
-    print!("{prefix:<32} {} |", fmt_ts(ts));
-    for field in FieldReader::new(fix_msg, 0) {
+    write!(out, "{prefix:<32} {} |", fmt_ts(ts))?;
+    let mut r = FieldReader::new(fix_msg, 0);
+    let mut pending_data_len: Option<usize> = None;
+    loop {
+        let field = match pending_data_len.take() {
+            Some(n) => match r.next_data_field(n) {
+                Ok(f) => f,
+                Err(e) => {
+                    write!(out, " <data-field-error: {e}> |")?;
+                    break;
+                }
+            },
+            None => match r.next_field() {
+                Some(f) => f,
+                None => break,
+            },
+        };
         let val = field.value.slice(fix_msg);
         let val_str = std::str::from_utf8(val).unwrap_or("?");
-        print!(" {}={} |", field.tag, val_str);
+        write!(out, " {}={} |", field.tag, val_str)?;
+        if DATA_PAIRS.iter().any(|(len_tag, _)| *len_tag == field.tag) {
+            pending_data_len = val_str.parse().ok();
+        }
     }
-    println!();
+    if r.pos() < fix_msg.len() {
+        write!(out, " <truncated at byte {}>", r.pos())?;
+    }
+    writeln!(out)
 }
 
 fn main() {
@@ -127,7 +197,17 @@ fn main() {
         match args[i].as_str() {
             "--session-id" => {
                 i += 1;
-                filter_session = args.get(i).and_then(|s| s.parse().ok());
+                if let Some(s) = args.get(i) {
+                    if let Ok(n) = s.parse::<u32>() {
+                        filter_session = Some(n);
+                    } else {
+                        eprintln!("--session-id: invalid value {:?}", s);
+                        process::exit(1);
+                    }
+                } else {
+                    eprintln!("--session-id requires a value");
+                    process::exit(1);
+                }
             }
             arg if !arg.starts_with('-') => {
                 journal_dir = Some(PathBuf::from(arg));
@@ -173,13 +253,17 @@ fn main() {
         .collect();
 
     // Sort by conductor_id so outbound (even) and inbound (odd) of the same
-    // FIX session appear together and in chronological order.
+    // FIX session appear together and in a consistent order.
     sessions.sort_by_key(|(_, m)| m.conductor_id);
 
     if sessions.is_empty() {
         eprintln!("no sessions found in {}", dir.display());
         process::exit(1);
     }
+
+    let stdout = io::stdout();
+    let mut out = io::BufWriter::new(stdout.lock());
+    let mut had_error = false;
 
     for (path, meta) in &sessions {
         eprintln!(
@@ -191,6 +275,23 @@ fn main() {
                 "inbound"
             }
         );
-        scan_session(path, meta);
+        if let Err(e) = scan_session(&mut out, path, meta, &mut had_error) {
+            if e.kind() == io::ErrorKind::BrokenPipe {
+                process::exit(0);
+            }
+            eprintln!("error: {e}");
+            process::exit(1);
+        }
+    }
+
+    if let Err(e) = out.flush()
+        && e.kind() != io::ErrorKind::BrokenPipe
+    {
+        eprintln!("error: {e}");
+        process::exit(1);
+    }
+
+    if had_error {
+        process::exit(1);
     }
 }

--- a/nexus-fix-log/src/main.rs
+++ b/nexus-fix-log/src/main.rs
@@ -1,0 +1,196 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use nexus_fix_codec::reader::FieldReader;
+
+const MAGIC: u32 = u32::from_le_bytes(*b"NXLG");
+const FRAME_HDR: usize = 8;
+const ALIGN: usize = 8;
+// Each stored frame's payload is [ts:8 LE UNIX-nanos][FIX wire message].
+const TS_LEN: usize = 8;
+
+struct SessionMeta {
+    // Conductor-level session id as stored in the manifest.
+    conductor_id: u32,
+    segment_size: usize,
+    epoch: u64,
+}
+
+impl SessionMeta {
+    fn fix_session_id(&self) -> u32 {
+        self.conductor_id / 2
+    }
+
+    fn is_outbound(&self) -> bool {
+        self.conductor_id.is_multiple_of(2)
+    }
+}
+
+fn read_manifest(path: &Path) -> Option<SessionMeta> {
+    let data = fs::read(path).ok()?;
+    if data.len() < 96 {
+        return None;
+    }
+    let magic = u32::from_le_bytes(data[80..84].try_into().ok()?);
+    if magic != MAGIC {
+        return None;
+    }
+    let segment_size = u64::from_le_bytes(data[64..72].try_into().ok()?) as usize;
+    let epoch = u64::from_le_bytes(data[72..80].try_into().ok()?);
+    let conductor_id = u32::from_le_bytes(data[84..88].try_into().ok()?);
+    Some(SessionMeta {
+        conductor_id,
+        segment_size,
+        epoch,
+    })
+}
+
+fn align_up(n: usize) -> usize {
+    (n + ALIGN - 1) & !(ALIGN - 1)
+}
+
+fn scan_segment(path: &Path, global_base: u64, meta: &SessionMeta) {
+    let Ok(data) = fs::read(path) else { return };
+    let mut pos = 0usize;
+    while pos + FRAME_HDR <= data.len() {
+        let commit_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
+        if commit_len == 0 {
+            break;
+        }
+        let body = (commit_len - 1) as usize;
+        let payload_start = pos + FRAME_HDR;
+        let payload_end = payload_start + body;
+        if payload_end > data.len() {
+            break;
+        }
+        let payload = &data[payload_start..payload_end];
+        let global_off = global_base + pos as u64;
+        if payload.len() > TS_LEN {
+            let ts = u64::from_le_bytes(payload[..TS_LEN].try_into().unwrap());
+            let fix_msg = &payload[TS_LEN..];
+            print_message(meta, global_off, ts, fix_msg);
+        }
+        pos = payload_start + align_up(body);
+    }
+}
+
+fn scan_session(session_dir: &Path, meta: &SessionMeta) {
+    let epoch = meta.epoch;
+    let seg_size = meta.segment_size as u64;
+
+    if epoch == 0 {
+        scan_segment(&session_dir.join("seg0.dat"), 0, meta);
+    } else {
+        let prev_slot = (epoch - 1) % 3;
+        scan_segment(
+            &session_dir.join(format!("seg{prev_slot}.dat")),
+            (epoch - 1) * seg_size,
+            meta,
+        );
+        let cur_slot = epoch % 3;
+        scan_segment(
+            &session_dir.join(format!("seg{cur_slot}.dat")),
+            epoch * seg_size,
+            meta,
+        );
+    }
+}
+
+fn fmt_ts(nanos: u64) -> String {
+    let secs = nanos / 1_000_000_000;
+    let ns = nanos % 1_000_000_000;
+    format!("{secs}.{ns:09}")
+}
+
+fn print_message(meta: &SessionMeta, offset: u64, ts: u64, fix_msg: &[u8]) {
+    let dir = if meta.is_outbound() { "out" } else { "in " };
+    let prefix = format!("[session={} {dir} +{offset}]", meta.fix_session_id());
+    print!("{prefix:<32} {} |", fmt_ts(ts));
+    for field in FieldReader::new(fix_msg, 0) {
+        let val = field.value.slice(fix_msg);
+        let val_str = std::str::from_utf8(val).unwrap_or("?");
+        print!(" {}={} |", field.tag, val_str);
+    }
+    println!();
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let mut journal_dir: Option<PathBuf> = None;
+    let mut filter_session: Option<u32> = None;
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--session-id" => {
+                i += 1;
+                filter_session = args.get(i).and_then(|s| s.parse().ok());
+            }
+            arg if !arg.starts_with('-') => {
+                journal_dir = Some(PathBuf::from(arg));
+            }
+            other => {
+                eprintln!("unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    let Some(dir) = journal_dir else {
+        eprintln!("usage: nexus-fix-log <journal-dir> [--session-id <N>]");
+        process::exit(1);
+    };
+
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("cannot read {}: {e}", dir.display());
+            process::exit(1);
+        }
+    };
+
+    let mut sessions: Vec<(PathBuf, SessionMeta)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let manifest = path.join("journal.manifest");
+            if !manifest.exists() {
+                return None;
+            }
+            let meta = read_manifest(&manifest)?;
+            if filter_session.is_some_and(|id| id != meta.fix_session_id()) {
+                return None;
+            }
+            Some((path, meta))
+        })
+        .collect();
+
+    // Sort by conductor_id so outbound (even) and inbound (odd) of the same
+    // FIX session appear together and in chronological order.
+    sessions.sort_by_key(|(_, m)| m.conductor_id);
+
+    if sessions.is_empty() {
+        eprintln!("no sessions found in {}", dir.display());
+        process::exit(1);
+    }
+
+    for (path, meta) in &sessions {
+        eprintln!(
+            "# session {} ({})",
+            meta.fix_session_id(),
+            if meta.is_outbound() {
+                "outbound"
+            } else {
+                "inbound"
+            }
+        );
+        scan_session(path, meta);
+    }
+}

--- a/nexus-fix-log/tests/round_trip.rs
+++ b/nexus-fix-log/tests/round_trip.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nexus_journal::{ConductorBuilder, OpenMode};
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        let p = std::env::temp_dir().join(format!(
+            "nexus-fix-log-{}-{}",
+            std::process::id(),
+            name
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        Self(p)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn fix_msg(seq: u32) -> Vec<u8> {
+    format!("8=FIX.4.2\x0134={seq}\x0135=D\x0110=000\x01").into_bytes()
+}
+
+/// Write N outbound messages plus one inbound through journals sized to force one rotation.
+/// The viewer must read both segments in order and surface every message.
+///
+/// Frame footprint: 8 (header) + 8 (ts prefix) + ~27 (fix_msg) → 43 → aligned 48.
+/// Segment size 128 fits exactly 2 frames → rotation on the 3rd append (epoch → 1).
+/// After 4 outbound appends: seqs 1-2 land in seg0 (epoch 0), seqs 3-4 in seg1 (epoch 1).
+/// Viewer reads prev (slot 0 = seg0) and current (slot 1 = seg1) → all 4 seqnums visible.
+#[test]
+fn round_trip_with_rotation() {
+    let dir = TempDir::new("rt");
+
+    // 2024-01-01 00:00:00 UTC in nanoseconds — fixed timestamp for deterministic output.
+    let ts_bytes = 1_704_067_200_000_000_000u64.to_le_bytes();
+
+    const SEG_SIZE: usize = 128;
+
+    {
+        let mut c = ConductorBuilder::new(dir.path())
+            .archive(true)
+            .open()
+            .unwrap();
+        // FIX session 0: outbound = conductor session id 0, inbound = conductor session id 1.
+        // Variables declared in this order drop LIFO: inb → out → c (conductor last).
+        let mut out = c
+            .session()
+            .segment_size(SEG_SIZE)
+            .session_id(0)
+            .open(OpenMode::OpenOrCreate)
+            .unwrap();
+        let mut inb = c
+            .session()
+            .segment_size(SEG_SIZE)
+            .session_id(1)
+            .open(OpenMode::OpenOrCreate)
+            .unwrap();
+        for seq in 1u32..=4 {
+            out.append_prefixed(&ts_bytes, &fix_msg(seq)).unwrap();
+        }
+        inb.append_prefixed(&ts_bytes, &fix_msg(50)).unwrap();
+    }
+
+    let result = Command::new(env!("CARGO_BIN_EXE_nexus-fix-log"))
+        .arg(dir.path())
+        .output()
+        .expect("nexus-fix-log failed to start");
+
+    assert!(
+        result.status.success(),
+        "non-zero exit: {:?}\nstderr: {}",
+        result.status,
+        String::from_utf8_lossy(&result.stderr),
+    );
+
+    let stdout = String::from_utf8(result.stdout).unwrap();
+
+    for seq in 1u32..=4 {
+        assert!(
+            stdout.contains(&format!(" 34={seq} ")),
+            "outbound seqnum {seq} missing from output:\n{stdout}",
+        );
+    }
+    assert!(
+        stdout.contains(" 34=50 "),
+        "inbound seqnum 50 missing from output:\n{stdout}",
+    );
+    assert!(stdout.contains(" out "), "no outbound direction tag in output:\n{stdout}");
+    assert!(stdout.contains(" in  "), "no inbound direction tag in output:\n{stdout}");
+}

--- a/nexus-fix-log/tests/round_trip.rs
+++ b/nexus-fix-log/tests/round_trip.rs
@@ -7,11 +7,7 @@ struct TempDir(PathBuf);
 
 impl TempDir {
     fn new(name: &str) -> Self {
-        let p = std::env::temp_dir().join(format!(
-            "nexus-fix-log-{}-{}",
-            std::process::id(),
-            name
-        ));
+        let p = std::env::temp_dir().join(format!("nexus-fix-log-{}-{}", std::process::id(), name));
         let _ = std::fs::remove_dir_all(&p);
         Self(p)
     }
@@ -96,6 +92,12 @@ fn round_trip_with_rotation() {
         stdout.contains(" 34=50 "),
         "inbound seqnum 50 missing from output:\n{stdout}",
     );
-    assert!(stdout.contains(" out "), "no outbound direction tag in output:\n{stdout}");
-    assert!(stdout.contains(" in  "), "no inbound direction tag in output:\n{stdout}");
+    assert!(
+        stdout.contains(" out "),
+        "no outbound direction tag in output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(" in  "),
+        "no inbound direction tag in output:\n{stdout}"
+    );
 }


### PR DESCRIPTION
New binary crate. Attaches to a journal directory in read-only mode (no conductor, no session lock) and prints committed FIX messages to stdout.

- Discovers sessions by scanning subdirs for `journal.manifest`
- Reads segment files directly; respects the commit_len sentinel (zero = uncommitted, safe to stop)
- Skips `NI=` checkpoint records written by the fix-engine
- Decodes each message with `FieldReader` and prints `tag=value` pairs
- Args: `<journal-dir> [--session-id <N>]`

Output:

```
[session=0 +0]       8=FIX.4.2 | 35=A | 34=1 | 49=NEXUS | 56=CLIENT | 52=20240101-12:00:00 | 98=0 | 108=30 | 10=123
[session=0 +128]     8=FIX.4.2 | 35=0 | 34=2 | 49=NEXUS | 56=CLIENT | 52=20240101-12:00:30 | 112=TESTID | 10=045
```

No live-tail in this cut; static snapshot at invocation time.