### PR TITLE
improvements to unexpected logout reporting as errors

### DIFF
--- a/nexus-async-fix-engine/CHANGELOG.md
+++ b/nexus-async-fix-engine/CHANGELOG.md
@@ -36,6 +36,13 @@ contained.
   matching the sync engine (`is_fatal()` is `false`; the session resyncs and
   continues). (#583)
 
+- `recv()` splits session end by outcome, matching the sync engine: a clean logout
+  is `Ok(Some(Message::LoggedOut { msg }))`; an abnormal disconnect (including a
+  socket EOF, now `DisconnectReason::PeerClosed`) is
+  `Err(TransportError::UnexpectedDisconnect { reason })`; and a `recv()` after a
+  terminal outcome is `Err(TransportError::Closed)`. `Message::Disconnected` is
+  removed. (#612)
+
 ### Internal
 
 - Test scratch directories are now removed on drop. The `tmp_dir` helpers in

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -1,7 +1,7 @@
 //! Tokio adapter for the sans-IO FIX session core.
 //!
 //! [`FixConnection`] is a thin wrapper over the sans-IO [`FixSession`] core: it
-//! owns a [`WireStream`](nexus_net::WireStream) transport and does *only* the
+//! owns a [`WireStream`] transport and does *only* the
 //! I/O — `poll_fill_into` fills the session's inbound buffer copy-free,
 //! `poll_write`/`poll_flush` drain its outbound buffer, all `.await`ed. All
 //! protocol logic (framing, the state machine, journaling, resend) lives in
@@ -11,7 +11,7 @@
 //!
 //! # Transports
 //!
-//! Any [`WireStream`](nexus_net::WireStream) works. Two are provided out of the
+//! Any [`WireStream`] works. Two are provided out of the
 //! box:
 //!
 //! - [`MaybeTls`] — plaintext or transparent TLS, built by
@@ -56,7 +56,7 @@ pub use nexus_net::WireStream;
 /// `nexus-net-tokio` directly.
 pub use nexus_net_tokio::{AsyncReadAdapter, MaybeTls};
 
-/// Async FIX session transport over any [`WireStream`](nexus_net::WireStream).
+/// Async FIX session transport over any [`WireStream`].
 ///
 /// Thin wrapper over [`FixSession`]: the socket calls are `.await`ed; everything
 /// else — framing, the [`SessionState`] machine, journaling, resend — is in the
@@ -70,6 +70,9 @@ pub use nexus_net_tokio::{AsyncReadAdapter, MaybeTls};
 pub struct FixConnection<S, D: FixDictionary, C = NoCustomizer> {
     stream: S,
     session: FixSession<D, C>,
+    /// Set once a terminal outcome (a `LoggedOut` message or a fatal error) has
+    /// been surfaced; a subsequent `recv` returns `Err(Error::Closed)`.
+    terminated: bool,
 }
 
 /// Builder for [`FixConnection`], mirroring the sync
@@ -154,6 +157,7 @@ impl<D: FixDictionary, C: SessionCustomizer> FixConnectionBuilder<D, C> {
         Ok(FixConnection {
             stream: MaybeTls::Plain(tcp),
             session,
+            terminated: false,
         })
     }
 
@@ -185,10 +189,11 @@ impl<D: FixDictionary, C: SessionCustomizer> FixConnectionBuilder<D, C> {
         Ok(FixConnection {
             stream: MaybeTls::Tls(Box::new(tls_stream)),
             session,
+            terminated: false,
         })
     }
 
-    /// Wraps an already-connected [`WireStream`](nexus_net::WireStream) (acceptor
+    /// Wraps an already-connected [`WireStream`] (acceptor
     /// role or a pre-built stream). Wrap a raw tokio stream in
     /// [`AsyncReadAdapter`] first.
     pub fn accept<S: WireStream + Unpin>(
@@ -199,7 +204,11 @@ impl<D: FixDictionary, C: SessionCustomizer> FixConnectionBuilder<D, C> {
         journal: FixJournal,
     ) -> FixConnection<S, D, C> {
         let session = self.build_session(state, config, journal);
-        FixConnection { stream, session }
+        FixConnection {
+            stream,
+            session,
+            terminated: false,
+        }
     }
 }
 
@@ -250,6 +259,7 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
         Self {
             stream,
             session: FixSession::new_with_customizer(state, config, journal, customizer),
+            terminated: false,
         }
     }
 
@@ -320,6 +330,9 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
     /// `.await` on the socket read and a `tokio::time` deadline in place of the
     /// blocking socket read-timeout.
     pub async fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
         loop {
             let outcome = self.session.poll(now)?;
             // Drain any admin/resend the core enqueued for this step (matches the
@@ -327,8 +340,16 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
             self.drain_outbound().await?;
 
             match outcome {
-                PollOutcome::Message | PollOutcome::Disconnected(_) => {
+                PollOutcome::Message => return Ok(Some(self.session.message())),
+                // Clean, negotiated logout: the graceful terminal event.
+                PollOutcome::LoggedOut => {
+                    self.terminated = true;
                     return Ok(Some(self.session.message()));
+                }
+                // Abnormal drop: a fault, surfaced as an error, not a message.
+                PollOutcome::Disconnected(reason) => {
+                    self.terminated = true;
+                    return Err(Error::UnexpectedDisconnect { reason });
                 }
                 PollOutcome::Suppressed => return Ok(None),
                 // Buffer already drained above; loop to continue the resend.
@@ -366,9 +387,11 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
                     .await
                     {
                         Ok(Ok(0)) => {
-                            return Ok(Some(Message::Disconnected {
-                                reason: DisconnectReason::Logout,
-                            }));
+                            // Peer closed the transport (FIN) without a FIX Logout.
+                            self.terminated = true;
+                            return Err(Error::UnexpectedDisconnect {
+                                reason: DisconnectReason::PeerClosed,
+                            });
                         }
                         // Bytes already committed to the session by `poll_fill_into`;
                         // loop to parse them.
@@ -377,7 +400,8 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
                         Err(_elapsed) => {
                             if let Some(reason) = self.session.on_timeout(now)? {
                                 self.drain_outbound().await?;
-                                return Ok(Some(Message::Disconnected { reason }));
+                                self.terminated = true;
+                                return Err(Error::UnexpectedDisconnect { reason });
                             }
                             self.drain_outbound().await?;
                             return Ok(None);

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -56,6 +56,19 @@ pub use nexus_net::WireStream;
 /// `nexus-net-tokio` directly.
 pub use nexus_net_tokio::{AsyncReadAdapter, MaybeTls};
 
+/// Owned outcome of one [`FixConnection::recv`] step. Returned by the internal
+/// `recv_step` so `recv` can arm the terminated guard — on any fatal error or a
+/// clean logout — before borrowing `self` to reconstruct the borrowed message.
+enum RecvStep {
+    /// A typed message is ready; call `message()`.
+    Message,
+    /// A clean, negotiated logout ended the session.
+    LoggedOut,
+    /// Nothing to surface this step (a suppressed frame, or a read deadline with no
+    /// timer elapsed); the wrapper returns `Ok(None)`.
+    Nothing,
+}
+
 /// Async FIX session transport over any [`WireStream`].
 ///
 /// Thin wrapper over [`FixSession`]: the socket calls are `.await`ed; everything
@@ -333,6 +346,29 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
         if self.terminated {
             return Err(Error::Closed);
         }
+        match self.recv_step(now).await {
+            Ok(RecvStep::Message) => Ok(Some(self.session.message())),
+            // Clean, negotiated logout: the graceful terminal event.
+            Ok(RecvStep::LoggedOut) => {
+                self.terminated = true;
+                Ok(Some(self.session.message()))
+            }
+            Ok(RecvStep::Nothing) => Ok(None),
+            // Any fatal error ends the session, so the next `recv` is `Closed`; a
+            // recoverable error (`Malformed`) leaves the session live.
+            Err(e) => {
+                if e.is_fatal() {
+                    self.terminated = true;
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Advances the session one step, returning an *owned* outcome. Splitting this
+    /// from [`recv`](Self::recv) lets `recv` arm the terminated guard (on any fatal
+    /// error or a clean logout) before borrowing `self` to build the message.
+    async fn recv_step(&mut self, now: Instant) -> Result<RecvStep, Error> {
         loop {
             let outcome = self.session.poll(now)?;
             // Drain any admin/resend the core enqueued for this step (matches the
@@ -340,18 +376,13 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
             self.drain_outbound().await?;
 
             match outcome {
-                PollOutcome::Message => return Ok(Some(self.session.message())),
-                // Clean, negotiated logout: the graceful terminal event.
-                PollOutcome::LoggedOut => {
-                    self.terminated = true;
-                    return Ok(Some(self.session.message()));
-                }
+                PollOutcome::Message => return Ok(RecvStep::Message),
+                PollOutcome::LoggedOut => return Ok(RecvStep::LoggedOut),
                 // Abnormal drop: a fault, surfaced as an error, not a message.
                 PollOutcome::Disconnected(reason) => {
-                    self.terminated = true;
                     return Err(Error::UnexpectedDisconnect { reason });
                 }
-                PollOutcome::Suppressed => return Ok(None),
+                PollOutcome::Suppressed => return Ok(RecvStep::Nothing),
                 // Buffer already drained above; loop to continue the resend.
                 PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
@@ -386,9 +417,8 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
                     )
                     .await
                     {
+                        // Peer closed the transport (FIN) without a FIX Logout.
                         Ok(Ok(0)) => {
-                            // Peer closed the transport (FIN) without a FIX Logout.
-                            self.terminated = true;
                             return Err(Error::UnexpectedDisconnect {
                                 reason: DisconnectReason::PeerClosed,
                             });
@@ -400,11 +430,10 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
                         Err(_elapsed) => {
                             if let Some(reason) = self.session.on_timeout(now)? {
                                 self.drain_outbound().await?;
-                                self.terminated = true;
                                 return Err(Error::UnexpectedDisconnect { reason });
                             }
                             self.drain_outbound().await?;
-                            return Ok(None);
+                            return Ok(RecvStep::Nothing);
                         }
                     }
                 }

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -12,6 +12,7 @@ use nexus_fix_codec::{
 };
 use nexus_fix_engine::{
     CompId, DisconnectReason, FixJournal, Message, SessionConfig, SessionState, State,
+    TransportError,
 };
 use tokio::net::TcpStream;
 
@@ -153,12 +154,15 @@ async fn connect(port: u16, dir: &Path) -> FixConnection<AsyncReadAdapter<TcpStr
     )
 }
 
-async fn drive(
-    conn: &mut FixConnection<AsyncReadAdapter<TcpStream>, MockDict>,
-) -> DisconnectReason {
+/// Drive `recv` until the session completes a clean, negotiated logout
+/// (`Message::LoggedOut`). Every scenario here ends in a peer-sent Logout, so any
+/// error is a failure and panics.
+async fn drive(conn: &mut FixConnection<AsyncReadAdapter<TcpStream>, MockDict>) {
     loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).await.unwrap() {
-            return reason;
+        match conn.recv(Instant::now()).await {
+            Ok(Some(Message::LoggedOut { .. })) => return,
+            Ok(_) => {}
+            Err(e) => panic!("recv errored before clean logout: {e:?}"),
         }
     }
 }
@@ -185,7 +189,7 @@ async fn conformance_logon_logout() {
     let (mut child, port) = spawn_peer("logon_logout");
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
-    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    drive(&mut conn).await;
     assert!(child.wait().unwrap().success());
 }
 
@@ -195,7 +199,7 @@ async fn conformance_heartbeat() {
     let (mut child, port) = spawn_peer("heartbeat");
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
-    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    drive(&mut conn).await;
     assert!(child.wait().unwrap().success());
 }
 
@@ -206,19 +210,12 @@ async fn conformance_resend() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
 
-    loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).await.unwrap() {
-            panic!("disconnected before active: {reason:?}");
-        }
-        if conn.state().state() == State::Active {
-            break;
-        }
-    }
+    drive_to_active(&mut conn).await;
 
     let seq = conn.allocate_seq().unwrap();
     conn.send_app(seq, &new_order(seq)).await.unwrap();
 
-    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    drive(&mut conn).await;
     assert!(child.wait().unwrap().success());
 }
 
@@ -228,7 +225,7 @@ async fn conformance_gap_fill() {
     let (mut child, port) = spawn_peer("gap_fill");
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
-    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    drive(&mut conn).await;
     assert!(child.wait().unwrap().success());
 }
 
@@ -238,7 +235,7 @@ async fn conformance_seq_reset() {
     let (mut child, port) = spawn_peer("seq_reset");
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
-    assert_eq!(drive(&mut conn).await, DisconnectReason::Logout);
+    drive(&mut conn).await;
     assert!(child.wait().unwrap().success());
 }
 
@@ -252,17 +249,23 @@ async fn conformance_seq_reset() {
 
 type Conn = FixConnection<AsyncReadAdapter<TcpStream>, MockDict>;
 
-/// Drive `recv` to a disconnect, recording whether `Resending` was entered and
-/// whether an `Application` surfaced. A `recv` error mid-scenario is a
-/// survivability failure, so it panics (surfacing a finding as a test failure).
-async fn drive_observe(conn: &mut Conn) -> (DisconnectReason, bool, bool) {
+/// Drive `recv` to a terminal outcome, recording whether `Resending` was entered
+/// and whether an `Application` surfaced. Returns the disconnect reason: `None`
+/// for a clean, negotiated logout (`Message::LoggedOut`), or `Some(reason)` for
+/// an abnormal end (`TransportError::UnexpectedDisconnect`). Any other `recv`
+/// error mid-scenario is a survivability failure, so it panics (surfacing a
+/// finding as a test failure).
+async fn drive_observe(conn: &mut Conn) -> (Option<DisconnectReason>, bool, bool) {
     let mut saw_resending = false;
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()).await {
-            Ok(Some(Message::Disconnected { reason })) => return (reason, saw_resending, saw_app),
+            Ok(Some(Message::LoggedOut { .. })) => return (None, saw_resending, saw_app),
             Ok(Some(Message::Application { .. })) => saw_app = true,
             Ok(Some(_) | None) => {}
+            Err(TransportError::UnexpectedDisconnect { reason }) => {
+                return (Some(reason), saw_resending, saw_app);
+            }
             Err(e) => panic!("recv errored mid-scenario: {e:?}"),
         }
         if conn.state().state() == State::Resending {
@@ -275,10 +278,8 @@ async fn drive_observe(conn: &mut Conn) -> (DisconnectReason, bool, bool) {
 async fn drive_to_active(conn: &mut Conn) {
     loop {
         match conn.recv(Instant::now()).await {
-            Ok(Some(Message::Disconnected { reason })) => {
-                panic!("disconnected before active: {reason:?}")
-            }
-            Err(e) => panic!("recv errored before active: {e:?}"),
+            Ok(Some(Message::LoggedOut { .. })) => panic!("logged out before active"),
+            Err(e) => panic!("disconnected before active: {e:?}"),
             _ => {}
         }
         if conn.state().state() == State::Active {
@@ -314,7 +315,7 @@ async fn conformance_app_seq_too_low() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::SeqNumTooLow);
+    assert_eq!(reason, Some(DisconnectReason::SeqNumTooLow));
     assert!(child.wait().unwrap().success());
 }
 
@@ -325,7 +326,7 @@ async fn conformance_seq_too_low_poss_dup() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -340,7 +341,7 @@ async fn conformance_app_in_order() {
         saw_app,
         "an in-order app must surface as Message::Application"
     );
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -354,7 +355,7 @@ async fn conformance_resend_open_ended() {
     let seq = conn.allocate_seq().unwrap();
     conn.send_app(seq, &new_order(seq)).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -370,7 +371,7 @@ async fn conformance_resend_admin_and_app() {
         conn.send_app(seq, &new_order(seq)).await.unwrap();
     }
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -395,7 +396,7 @@ async fn conformance_seq_reset_backward() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -427,7 +428,7 @@ async fn conformance_test_request_long_id() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -438,7 +439,7 @@ async fn conformance_test_request_timeout() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::TestRequestTimeout);
+    assert_eq!(reason, Some(DisconnectReason::TestRequestTimeout));
     assert!(child.wait().unwrap().success());
 }
 
@@ -453,6 +454,6 @@ async fn conformance_seq_reset_gap_fill_below_possdup() {
     let mut conn = connect(port, dir.path()).await;
     conn.connect(Instant::now()).await.unwrap();
     let (reason, _, _) = drive_observe(&mut conn).await;
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }

--- a/nexus-async-fix-engine/tests/frame_too_large.rs
+++ b/nexus-async-fix-engine/tests/frame_too_large.rs
@@ -18,7 +18,7 @@ use nexus_fix_codec::{
     FieldView, FixAdminMsg, FixDictionary, FixHeader, FixTimestamp, FrameFormatter,
     encode_fix_uint, find_tag,
 };
-use nexus_fix_engine::{CompId, FixJournal, Message, SessionConfig, SessionState};
+use nexus_fix_engine::{CompId, DisconnectReason, FixJournal, SessionConfig, SessionState};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 // ── mock dictionary (mirrors the sync engine's tests) ────────────────────────
@@ -221,12 +221,47 @@ async fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
 
     match conn.recv(Instant::now()).await {
         Err(TransportError::MessageTooLarge(_)) => {}
+        Err(TransportError::UnexpectedDisconnect { reason }) => {
+            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
+        }
         Err(other) => panic!(
             "an inbound frame exceeding the reader buffer must be MessageTooLarge, got {other:?}"
         ),
-        Ok(Some(Message::Disconnected { reason })) => {
-            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
-        }
         Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
     }
+}
+
+#[tokio::test]
+async fn peer_eof_is_peer_closed_then_recv_is_closed() {
+    // Async parity with the sync engine: a peer EOF (empty stream, no Logout) is
+    // an abnormal `UnexpectedDisconnect { PeerClosed }`, not a fake clean logout,
+    // and every recv after that terminal is `Closed`.
+    let dir = tmp_dir("async_peer_eof");
+    let mut conn: FixConnection<AsyncReadAdapter<ChunkStream>, MockDict> = FixConnection::builder()
+        .accept(
+            AsyncReadAdapter::new(ChunkStream::new(b"")),
+            SessionState::new(Duration::from_secs(30)),
+            SessionConfig {
+                sender: target(),
+                target: sender(),
+            },
+            FixJournal::open(dir.path(), 0, 256).unwrap(),
+        );
+
+    let Err(err) = conn.recv(Instant::now()).await else {
+        panic!("expected an error on peer EOF");
+    };
+    assert!(err.is_fatal());
+    assert!(matches!(
+        err,
+        TransportError::UnexpectedDisconnect {
+            reason: DisconnectReason::PeerClosed
+        }
+    ));
+
+    // Session terminated → every subsequent recv is Closed.
+    let Err(err2) = conn.recv(Instant::now()).await else {
+        panic!("expected Closed on a terminated session");
+    };
+    assert!(matches!(err2, TransportError::Closed));
 }

--- a/nexus-async-fix-engine/tests/frame_too_large.rs
+++ b/nexus-async-fix-engine/tests/frame_too_large.rs
@@ -229,6 +229,14 @@ async fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
         ),
         Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
     }
+
+    // MessageTooLarge is a *fatal* error (not a disconnect), so it terminates the
+    // session — the next recv must be Closed. Regression guard: the terminated flag
+    // must arm on any fatal error, not just LoggedOut / UnexpectedDisconnect.
+    assert!(matches!(
+        conn.recv(Instant::now()).await,
+        Err(TransportError::Closed)
+    ));
 }
 
 #[tokio::test]

--- a/nexus-fix-engine/CHANGELOG.md
+++ b/nexus-fix-engine/CHANGELOG.md
@@ -80,6 +80,21 @@ contained.
 
 ### Changed
 
+- Session end is split by outcome. A clean, negotiated logout surfaces as
+  `Message::LoggedOut { msg }` (`Ok`, carrying the peer's Logout 35=5 so the caller
+  can read `Text(58)`); an abnormal disconnect surfaces as
+  `Err(TransportError::UnexpectedDisconnect { reason })`, never a message. The old
+  `Message::Disconnected { reason }` is removed. So `recv()?` now propagates a fault
+  disconnect toward reconnect/alert logic, while a graceful shutdown is a distinct
+  terminal event on the `Ok` side.
+  - `DisconnectReason` drops `Logout` (now represented by `Message::LoggedOut`) and
+    adds `PeerClosed` — a socket EOF with no FIX Logout, previously misreported as a
+    clean `Logout`. It is now purely the fault set.
+  - `TransportError` gains `UnexpectedDisconnect { reason }` and `Closed`. Calling
+    `recv()` after any terminal outcome returns `Closed` (mirrors tungstenite's
+    `AlreadyClosed`), tracked per connection. Both are fatal (`is_fatal()` is `true`;
+    only `Malformed` is recoverable). (#612)
+
 - `FrameError::Garbage { skipped }` is renamed to
   `FrameError::Malformed { skipped, reason }`, carrying a `MalformedReason`. The
   old name implied random bytes, but the reader also reports a bad

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -117,8 +117,8 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
     let mut n = 0usize;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { reason })) => {
-                println!("acceptor: {reason:?}, {n} app message(s) received");
+            Ok(Some(Message::LoggedOut { .. })) => {
+                println!("acceptor: logged out cleanly, {n} app message(s) received");
                 break;
             }
             Ok(Some(Message::Application { .. })) => n += 1,
@@ -148,8 +148,8 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { reason })) => {
-                eprintln!("initiator: disconnected before active ({reason:?})");
+            Ok(Some(Message::LoggedOut { .. })) => {
+                eprintln!("initiator: logged out before active");
                 return;
             }
             Err(e) => {

--- a/nexus-fix-engine/src/fix_session.rs
+++ b/nexus-fix-engine/src/fix_session.rs
@@ -67,6 +67,14 @@ pub enum Error {
         count: u64,
         reason: MalformedReason,
     },
+    /// The session was dropped abnormally (see `reason`) — a fault, distinct from
+    /// a clean logout (which surfaces as [`Message::LoggedOut`] on the `Ok` side).
+    /// Terminal.
+    UnexpectedDisconnect { reason: DisconnectReason },
+    /// `recv` was called after the session already ended — a prior call already
+    /// returned `Message::LoggedOut` or a terminal error. A caller bug: the
+    /// session is gone. Terminal.
+    Closed,
     /// A socket-level I/O failure. Terminal.
     Io(std::io::Error),
     /// An inbound frame exceeded the reader buffer or the configured maximum — a
@@ -91,6 +99,10 @@ impl std::fmt::Display for Error {
             Self::Malformed {
                 skipped, reason, ..
             } => write!(f, "malformed frame: discarded {skipped} bytes ({reason})"),
+            Self::UnexpectedDisconnect { reason } => {
+                write!(f, "unexpected disconnect: {reason:?}")
+            }
+            Self::Closed => f.write_str("recv on a closed session"),
             Self::Io(e) => write!(f, "I/O: {e}"),
             Self::MessageTooLarge(n) => write!(f, "message too large: {n} bytes"),
             Self::Protocol(e) => write!(f, "protocol: {e}"),
@@ -144,8 +156,11 @@ pub enum PollOutcome {
     /// (an out-of-sequence app suppressed pending resend, or a session-level
     /// reject was emitted). The wrapper should surface this as `Ok(None)`.
     Suppressed,
-    /// The session disconnected. The wrapper surfaces
-    /// `Message::Disconnected { reason }`.
+    /// A clean, negotiated logout ended the session. The wrapper surfaces
+    /// `Message::LoggedOut`.
+    LoggedOut,
+    /// The session was dropped abnormally. The wrapper surfaces
+    /// `Err(TransportError::UnexpectedDisconnect { reason })`.
     Disconnected(DisconnectReason),
 }
 
@@ -451,8 +466,9 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
 
     /// Reconstructs the typed [`Message`] for the frame just processed by
     /// [`poll`](Self::poll). Only valid immediately after a [`PollOutcome::Message`]
-    /// (or a [`PollOutcome::Disconnected`], which also maps to
-    /// `Message::Disconnected`); the borrow is over the stable frame buffer.
+    /// or a [`PollOutcome::LoggedOut`] (which maps to `Message::LoggedOut`); an
+    /// abnormal [`PollOutcome::Disconnected`] is surfaced as an `Err`, never here.
+    /// The borrow is over the stable frame buffer.
     pub fn message(&self) -> Message<'_, D> {
         let frame = &self.reader.frame[..];
         match self.pending {
@@ -491,7 +507,13 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
             Control::Application => Message::Application {
                 header: D::Header::decode(frame),
             },
-            Control::Disconnected { reason } => Message::Disconnected { reason },
+            Control::LoggedOut => {
+                let msg = D::Logout::decode(frame).expect("frame decoded in poll");
+                Message::LoggedOut { msg }
+            }
+            Control::Disconnected { .. } => {
+                unreachable!("abnormal disconnect is surfaced as an Err, never message()")
+            }
             Control::None | Control::Proceed => {
                 unreachable!("message() called without a pending message")
             }
@@ -774,6 +796,7 @@ impl<D: FixDictionary, C: SessionCustomizer> FixSession<D, C> {
         self.pending = ctrl;
         match ctrl {
             Control::None => PollOutcome::Suppressed,
+            Control::LoggedOut => PollOutcome::LoggedOut,
             Control::Disconnected { reason } => PollOutcome::Disconnected(reason),
             Control::Proceed => unreachable!("Proceed is transient; handlers never return it"),
             _ => PollOutcome::Message,

--- a/nexus-fix-engine/src/framework.rs
+++ b/nexus-fix-engine/src/framework.rs
@@ -99,8 +99,7 @@ pub enum Message<'buf, D: FixDictionary> {
     LogonAcknowledged { msg: D::Logon<'buf> },
     /// A Logout (35=5) that did not end the session, which only happens
     /// out-of-state (e.g. mid-reset). The engine answers and closes an
-    /// in-sequence logout itself; that surfaces as
-    /// [`Message::Disconnected`] with [`DisconnectReason::Logout`](crate::DisconnectReason::Logout).
+    /// in-sequence logout itself; that surfaces as [`Message::LoggedOut`].
     LogoutRequest { msg: D::Logout<'buf> },
     /// Heartbeat (35=0). No reply required unless it carries a TestReqID.
     Heartbeat { msg: D::Heartbeat<'buf> },
@@ -114,8 +113,11 @@ pub enum Message<'buf, D: FixDictionary> {
     Reject { msg: D::Reject<'buf> },
     /// Business message. Route by `header.raw_msg_type()` and decode the body.
     Application { header: D::Header<'buf> },
-    /// Session disconnected (CompID mismatch, timeout, or protocol violation).
-    Disconnected { reason: crate::DisconnectReason },
+    /// A clean, negotiated logout completed and the session ended — the graceful
+    /// terminal event. Carries the peer's Logout (35=5), so the caller can read
+    /// `Text(58)`. An *abnormal* end never appears here: it surfaces as
+    /// `Err(TransportError::UnexpectedDisconnect { reason })`.
+    LoggedOut { msg: D::Logout<'buf> },
 }
 
 /// Zero-copy FIX frame reader, dictionary-aware via `D::Header`.

--- a/nexus-fix-engine/src/session/event.rs
+++ b/nexus-fix-engine/src/session/event.rs
@@ -17,11 +17,14 @@ pub enum State {
     AwaitingResetAck,
 }
 
-/// Why the session disconnected.
+/// Why the session was dropped **abnormally**.
+///
+/// A clean, negotiated logout is not here — it surfaces as
+/// [`Message::LoggedOut`](crate::Message::LoggedOut) on the `Ok` side. Every
+/// reason in this enum is a fault, carried by
+/// [`TransportError::UnexpectedDisconnect`](crate::TransportError).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DisconnectReason {
-    /// Clean logout exchange completed.
-    Logout,
     /// No Logon reply within the logon timeout.
     LogonTimeout,
     /// No Logout confirm within the logout timeout.
@@ -38,6 +41,10 @@ pub enum DisconnectReason {
     SeqNumExhausted,
     /// Counterparty did not complete the reset handshake within the timeout.
     ResetTimeout,
+    /// The peer closed the transport (socket EOF) without a FIX Logout. Distinct
+    /// from a connection reset, which surfaces as
+    /// [`TransportError::Io`](crate::TransportError).
+    PeerClosed,
 }
 
 /// The owned verdict a [`SessionState`](super::SessionState) handler returns.
@@ -73,7 +80,7 @@ pub enum Control {
     },
     /// A Logout (35=5) was processed without ending the session. This only
     /// happens out-of-state (e.g. mid-reset); an in-sequence Logout completes
-    /// the exchange and surfaces as [`Control::Disconnected`] instead.
+    /// the exchange and surfaces as [`Control::LoggedOut`] instead.
     Logout,
     /// A Heartbeat (35=0) was processed.
     Heartbeat,
@@ -88,7 +95,12 @@ pub enum Control {
     Reject,
     /// An in-sequence application message was processed.
     Application,
-    /// The session left the connected states.
+    /// A clean, negotiated logout completed and the session ended. Surfaces as
+    /// [`Message::LoggedOut`](crate::Message::LoggedOut) — the graceful terminal
+    /// event on the `Ok` side, distinct from an abnormal [`Disconnected`](Self::Disconnected).
+    LoggedOut,
+    /// The session was dropped abnormally. Surfaces as
+    /// [`TransportError::UnexpectedDisconnect`](crate::TransportError), never a `Message`.
     Disconnected {
         /// Why the session ended.
         reason: DisconnectReason,

--- a/nexus-fix-engine/src/session/mod.rs
+++ b/nexus-fix-engine/src/session/mod.rs
@@ -39,10 +39,12 @@ pub trait Emit {
 /// disconnect if it is exhausted.
 ///
 /// [`SessionState::bump_outbound`] returns `Option<u32>` (`None` on exhaustion),
-/// but the exhaustion path returns a *success* value (`Ok(Control::Disconnected)`,
-/// surfaced as `Message::Disconnected`) rather than an `Err`, so it cannot ride
-/// `?`. This macro packages the `match` + early `return` so the ~8 handler sites
-/// that consume an outbound seqnum share one definition of disconnect-on-exhaustion.
+/// but the exhaustion path returns a *success* value at the handler level
+/// (`Ok(Control::Disconnected { reason: SeqNumExhausted })`, which the driver then
+/// surfaces as `Err(TransportError::UnexpectedDisconnect)`) rather than the handler
+/// itself producing an `Err`, so it cannot ride `?`. This macro packages the
+/// `match` + early `return` so the ~8 handler sites that consume an outbound
+/// seqnum share one definition of disconnect-on-exhaustion.
 macro_rules! seq {
     ($self:ident, $now:ident) => {
         match $self.bump_outbound($now) {
@@ -445,7 +447,7 @@ impl SessionState {
         self.last_received = Some(now);
         self.test_request_sent = None;
         if self.state == State::LogonSent {
-            return Ok(self.disconnect(DisconnectReason::Logout));
+            return Ok(self.logged_out());
         }
         if matches!(
             self.state,
@@ -458,7 +460,7 @@ impl SessionState {
                         let logout_seq = seq!(self, now);
                         emitter.emit(Logout { seq: logout_seq })?;
                     }
-                    return Ok(self.disconnect(DisconnectReason::Logout));
+                    return Ok(self.logged_out());
                 }
                 // Gap/duplicate: suppressed (ResendRequest already emitted, or a
                 // PossDup-too-low frame ignored). Too-low without PossDup:
@@ -834,6 +836,16 @@ impl SessionState {
         self.test_request_sent = None;
         self.state_entered = None;
         Control::Disconnected { reason }
+    }
+
+    /// Clean, negotiated logout: the same terminal state transition as
+    /// [`disconnect`](Self::disconnect), but the graceful `Control::LoggedOut`
+    /// verdict — surfaced as `Message::LoggedOut`, not an error.
+    fn logged_out(&mut self) -> Control {
+        self.state = State::Disconnected;
+        self.test_request_sent = None;
+        self.state_entered = None;
+        Control::LoggedOut
     }
 
     fn check_resend_done(&mut self) {

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -29,6 +29,9 @@ pub use crate::fix_session::{Error, REFRAME_HEADROOM};
 pub struct FixConnection<S, D: FixDictionary, C = NoCustomizer> {
     stream: S,
     session: FixSession<D, C>,
+    /// Set once a terminal outcome (a `LoggedOut` message or a fatal error) has
+    /// been surfaced; a subsequent `recv` returns `Err(Error::Closed)`.
+    terminated: bool,
 }
 
 pub struct FixConnectionBuilder<D: FixDictionary, C = NoCustomizer> {
@@ -122,7 +125,11 @@ impl<D: FixDictionary, C: SessionCustomizer> FixConnectionBuilder<D, C> {
         };
         stream.set_nodelay(self.nodelay)?;
         let session = self.build_session(state, config, journal);
-        Ok(FixConnection { stream, session })
+        Ok(FixConnection {
+            stream,
+            session,
+            terminated: false,
+        })
     }
 
     pub fn accept<S: Read + Write>(
@@ -133,7 +140,11 @@ impl<D: FixDictionary, C: SessionCustomizer> FixConnectionBuilder<D, C> {
         journal: FixJournal,
     ) -> FixConnection<S, D, C> {
         let session = self.build_session(state, config, journal);
-        FixConnection { stream, session }
+        FixConnection {
+            stream,
+            session,
+            terminated: false,
+        }
     }
 }
 
@@ -174,6 +185,7 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
         Self {
             stream,
             session: FixSession::new_with_customizer(state, config, journal, customizer),
+            terminated: false,
         }
     }
 
@@ -231,6 +243,9 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
     }
 
     pub fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
         loop {
             let outcome = self.session.poll(now)?;
             // Drain any admin/resend the core enqueued for this step (matches the
@@ -238,8 +253,16 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
             self.drain_outbound()?;
 
             match outcome {
-                PollOutcome::Message | PollOutcome::Disconnected(_) => {
+                PollOutcome::Message => return Ok(Some(self.session.message())),
+                // Clean, negotiated logout: the graceful terminal event.
+                PollOutcome::LoggedOut => {
+                    self.terminated = true;
                     return Ok(Some(self.session.message()));
+                }
+                // Abnormal drop: a fault, surfaced as an error, not a message.
+                PollOutcome::Disconnected(reason) => {
+                    self.terminated = true;
+                    return Err(Error::UnexpectedDisconnect { reason });
                 }
                 PollOutcome::Suppressed => return Ok(None),
                 // Buffer already drained above; loop to continue the resend.
@@ -258,15 +281,18 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
                     let spare = self.session.read_spare();
                     match self.stream.read(spare) {
                         Ok(0) => {
-                            return Ok(Some(Message::Disconnected {
-                                reason: DisconnectReason::Logout,
-                            }));
+                            // Peer closed the transport (FIN) without a FIX Logout.
+                            self.terminated = true;
+                            return Err(Error::UnexpectedDisconnect {
+                                reason: DisconnectReason::PeerClosed,
+                            });
                         }
                         Ok(n) => self.session.read_filled(n),
                         Err(e) if is_timeout(&e) => {
                             if let Some(reason) = self.session.on_timeout(now)? {
                                 self.drain_outbound()?;
-                                return Ok(Some(Message::Disconnected { reason }));
+                                self.terminated = true;
+                                return Err(Error::UnexpectedDisconnect { reason });
                             }
                             self.drain_outbound()?;
                             return Ok(None);

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -20,6 +20,19 @@ use crate::session::{DisconnectReason, SessionState, State};
 
 pub use crate::fix_session::{Error, REFRAME_HEADROOM};
 
+/// Owned outcome of one [`FixConnection::recv`] step. Returned by the internal
+/// `recv_step` so `recv` can arm the terminated guard — on any fatal error or a
+/// clean logout — before borrowing `self` to reconstruct the borrowed message.
+enum RecvStep {
+    /// A typed message is ready; call `message()`.
+    Message,
+    /// A clean, negotiated logout ended the session.
+    LoggedOut,
+    /// Nothing to surface this step (a suppressed frame, or a read timeout with no
+    /// deadline elapsed); the wrapper returns `Ok(None)`.
+    Nothing,
+}
+
 /// Blocking FIX session transport.
 ///
 /// `C` is the per-venue [`SessionCustomizer`] applied to outbound admin
@@ -246,6 +259,29 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
         if self.terminated {
             return Err(Error::Closed);
         }
+        match self.recv_step(now) {
+            Ok(RecvStep::Message) => Ok(Some(self.session.message())),
+            // Clean, negotiated logout: the graceful terminal event.
+            Ok(RecvStep::LoggedOut) => {
+                self.terminated = true;
+                Ok(Some(self.session.message()))
+            }
+            Ok(RecvStep::Nothing) => Ok(None),
+            // Any fatal error ends the session, so the next `recv` is `Closed`; a
+            // recoverable error (`Malformed`) leaves the session live.
+            Err(e) => {
+                if e.is_fatal() {
+                    self.terminated = true;
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Advances the session one step, returning an *owned* outcome. Splitting this
+    /// from [`recv`](Self::recv) lets `recv` arm the terminated guard (on any fatal
+    /// error or a clean logout) before borrowing `self` to build the message.
+    fn recv_step(&mut self, now: Instant) -> Result<RecvStep, Error> {
         loop {
             let outcome = self.session.poll(now)?;
             // Drain any admin/resend the core enqueued for this step (matches the
@@ -253,18 +289,13 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
             self.drain_outbound()?;
 
             match outcome {
-                PollOutcome::Message => return Ok(Some(self.session.message())),
-                // Clean, negotiated logout: the graceful terminal event.
-                PollOutcome::LoggedOut => {
-                    self.terminated = true;
-                    return Ok(Some(self.session.message()));
-                }
+                PollOutcome::Message => return Ok(RecvStep::Message),
+                PollOutcome::LoggedOut => return Ok(RecvStep::LoggedOut),
                 // Abnormal drop: a fault, surfaced as an error, not a message.
                 PollOutcome::Disconnected(reason) => {
-                    self.terminated = true;
                     return Err(Error::UnexpectedDisconnect { reason });
                 }
-                PollOutcome::Suppressed => return Ok(None),
+                PollOutcome::Suppressed => return Ok(RecvStep::Nothing),
                 // Buffer already drained above; loop to continue the resend.
                 PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
@@ -280,9 +311,8 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
                     }
                     let spare = self.session.read_spare();
                     match self.stream.read(spare) {
+                        // Peer closed the transport (FIN) without a FIX Logout.
                         Ok(0) => {
-                            // Peer closed the transport (FIN) without a FIX Logout.
-                            self.terminated = true;
                             return Err(Error::UnexpectedDisconnect {
                                 reason: DisconnectReason::PeerClosed,
                             });
@@ -291,11 +321,10 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
                         Err(e) if is_timeout(&e) => {
                             if let Some(reason) = self.session.on_timeout(now)? {
                                 self.drain_outbound()?;
-                                self.terminated = true;
                                 return Err(Error::UnexpectedDisconnect { reason });
                             }
                             self.drain_outbound()?;
-                            return Ok(None);
+                            return Ok(RecvStep::Nothing);
                         }
                         Err(e) => return Err(Error::Io(e)),
                     }

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -13,7 +13,7 @@ use nexus_fix_codec::{
 };
 use nexus_fix_engine::{
     CompId, DisconnectReason, FixConnection, FixJournal, Message, SessionConfig, SessionState,
-    State,
+    State, TransportError,
 };
 
 // ── mock dictionary ──────────────────────────────────────────────────────────
@@ -166,10 +166,15 @@ fn connect(port: u16, dir: &Path) -> FixConnection<TcpStream, MockDict> {
     )
 }
 
-fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> DisconnectReason {
+/// Drive `recv` until the session completes a clean, negotiated logout
+/// (`Message::LoggedOut`). Every scenario here ends in a peer-sent Logout, so any
+/// error is a failure and panics.
+fn drive(conn: &mut FixConnection<TcpStream, MockDict>) {
     loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
-            return reason;
+        match conn.recv(Instant::now()) {
+            Ok(Some(Message::LoggedOut { .. })) => return,
+            Ok(_) => {}
+            Err(e) => panic!("recv errored before clean logout: {e:?}"),
         }
     }
 }
@@ -196,7 +201,7 @@ fn conformance_logon_logout() {
     let (mut child, port) = spawn_peer("logon_logout");
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
-    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    drive(&mut conn);
     assert!(child.wait().unwrap().success());
 }
 
@@ -206,7 +211,7 @@ fn conformance_heartbeat() {
     let (mut child, port) = spawn_peer("heartbeat");
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
-    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    drive(&mut conn);
     assert!(child.wait().unwrap().success());
 }
 
@@ -217,19 +222,12 @@ fn conformance_resend() {
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
 
-    loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
-            panic!("disconnected before active: {reason:?}");
-        }
-        if conn.state().state() == State::Active {
-            break;
-        }
-    }
+    drive_to_active(&mut conn);
 
     let seq = conn.allocate_seq().unwrap();
     conn.send_app(seq, &new_order(seq)).unwrap();
 
-    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    drive(&mut conn);
     assert!(child.wait().unwrap().success());
 }
 
@@ -239,7 +237,7 @@ fn conformance_gap_fill() {
     let (mut child, port) = spawn_peer("gap_fill");
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
-    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    drive(&mut conn);
     assert!(child.wait().unwrap().success());
 }
 
@@ -249,7 +247,7 @@ fn conformance_seq_reset() {
     let (mut child, port) = spawn_peer("seq_reset");
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
-    assert_eq!(drive(&mut conn), DisconnectReason::Logout);
+    drive(&mut conn);
     assert!(child.wait().unwrap().success());
 }
 
@@ -275,19 +273,26 @@ fn connect_rt(port: u16, dir: &Path, read_timeout: Duration) -> FixConnection<Tc
     )
 }
 
-/// Drive `recv` to a disconnect, recording whether `Resending` was ever entered
-/// and whether an `Application` message surfaced. A `recv` error mid-scenario is
-/// a survivability failure — the engine must resolve every step to a message /
-/// suppression / clean disconnect, never a raw error — so it panics (surfacing a
-/// finding as a test failure).
-fn drive_observe(conn: &mut FixConnection<TcpStream, MockDict>) -> (DisconnectReason, bool, bool) {
+/// Drive `recv` to a terminal outcome, recording whether `Resending` was ever
+/// entered and whether an `Application` message surfaced. Returns the disconnect
+/// reason: `None` for a clean, negotiated logout (`Message::LoggedOut`), or
+/// `Some(reason)` for an abnormal end (`TransportError::UnexpectedDisconnect`).
+/// Any other `recv` error mid-scenario is a survivability failure — the engine
+/// must resolve every step to a message / suppression / logout / fault, never a
+/// raw transport error — so it panics (surfacing a finding as a test failure).
+fn drive_observe(
+    conn: &mut FixConnection<TcpStream, MockDict>,
+) -> (Option<DisconnectReason>, bool, bool) {
     let mut saw_resending = false;
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { reason })) => return (reason, saw_resending, saw_app),
+            Ok(Some(Message::LoggedOut { .. })) => return (None, saw_resending, saw_app),
             Ok(Some(Message::Application { .. })) => saw_app = true,
             Ok(Some(_) | None) => {}
+            Err(TransportError::UnexpectedDisconnect { reason }) => {
+                return (Some(reason), saw_resending, saw_app);
+            }
             Err(e) => panic!("recv errored mid-scenario: {e:?}"),
         }
         if conn.state().state() == State::Resending {
@@ -301,10 +306,8 @@ fn drive_observe(conn: &mut FixConnection<TcpStream, MockDict>) -> (DisconnectRe
 fn drive_to_active(conn: &mut FixConnection<TcpStream, MockDict>) {
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { reason })) => {
-                panic!("disconnected before active: {reason:?}")
-            }
-            Err(e) => panic!("recv errored before active: {e:?}"),
+            Ok(Some(Message::LoggedOut { .. })) => panic!("logged out before active"),
+            Err(e) => panic!("disconnected before active: {e:?}"),
             _ => {}
         }
         if conn.state().state() == State::Active {
@@ -340,7 +343,7 @@ fn conformance_app_seq_too_low() {
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::SeqNumTooLow);
+    assert_eq!(reason, Some(DisconnectReason::SeqNumTooLow));
     assert!(child.wait().unwrap().success());
 }
 
@@ -352,7 +355,7 @@ fn conformance_seq_too_low_poss_dup() {
     conn.connect(Instant::now()).unwrap();
     // The PossDup duplicate is ignored; the session survives to a clean logout.
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -367,7 +370,7 @@ fn conformance_app_in_order() {
         saw_app,
         "an in-order app must surface as Message::Application"
     );
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -382,7 +385,7 @@ fn conformance_resend_open_ended() {
     conn.send_app(seq, &new_order(seq)).unwrap();
     // The peer asserts the open-ended (EndSeqNo=0) replay covers everything sent.
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -399,7 +402,7 @@ fn conformance_resend_admin_and_app() {
     }
     // The peer asserts admin holes gap-fill and app messages replay with PossDup.
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -428,7 +431,7 @@ fn conformance_seq_reset_backward() {
     // A backward SequenceReset-Reset is Reject'd (peer asserts 35=3); the session
     // is NOT torn down — it continues to a clean logout.
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -461,7 +464,7 @@ fn conformance_test_request_long_id() {
     conn.connect(Instant::now()).unwrap();
     // The peer asserts the >64-byte TestReqID is echoed verbatim (no truncation).
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }
 
@@ -473,7 +476,7 @@ fn conformance_test_request_timeout() {
     let mut conn = connect_rt(port, dir.path(), Duration::from_millis(200));
     conn.connect(Instant::now()).unwrap();
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::TestRequestTimeout);
+    assert_eq!(reason, Some(DisconnectReason::TestRequestTimeout));
     assert!(child.wait().unwrap().success());
 }
 
@@ -489,6 +492,6 @@ fn conformance_seq_reset_gap_fill_below_possdup() {
     let mut conn = connect(port, dir.path());
     conn.connect(Instant::now()).unwrap();
     let (reason, _, _) = drive_observe(&mut conn);
-    assert_eq!(reason, DisconnectReason::Logout);
+    assert_eq!(reason, None);
     assert!(child.wait().unwrap().success());
 }

--- a/nexus-fix-engine/tests/session.rs
+++ b/nexus-fix-engine/tests/session.rs
@@ -653,12 +653,7 @@ fn initiated_logout_round_trip() {
         )
         .unwrap();
     assert_eq!(s.state(), State::Disconnected);
-    assert_eq!(
-        ctrl,
-        Control::Disconnected {
-            reason: DisconnectReason::Logout
-        }
-    );
+    assert_eq!(ctrl, Control::LoggedOut);
 }
 
 #[test]
@@ -679,12 +674,7 @@ fn counterparty_logout_is_confirmed() {
         )
         .unwrap();
     assert_eq!(s.state(), State::Disconnected);
-    assert_eq!(
-        ctrl,
-        Control::Disconnected {
-            reason: DisconnectReason::Logout
-        }
-    );
+    assert_eq!(ctrl, Control::LoggedOut);
     assert_eq!(recorder.len(), 1);
     assert_eq!(recorder.mt(0), b"5", "must confirm with a Logout");
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -145,12 +145,15 @@ fn tmp_dir(suffix: &str) -> TempDir {
     TempDir::new(suffix)
 }
 
-fn drive(
-    conn: &mut FixConnection<TcpStream, MockDict>,
-) -> Result<DisconnectReason, TransportError> {
+/// Drive the connection until it completes a clean, negotiated logout
+/// (`Message::LoggedOut`) and return `Ok(())`. Any transport error is
+/// propagated — an abnormal end surfaces as
+/// `Err(TransportError::UnexpectedDisconnect { .. })`. Every caller here drives a
+/// peer-initiated logout, so the clean path is the expected outcome.
+fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> Result<(), TransportError> {
     loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now())? {
-            return Ok(reason);
+        if let Some(Message::LoggedOut { .. }) = conn.recv(Instant::now())? {
+            return Ok(());
         }
     }
 }
@@ -356,8 +359,7 @@ fn initiator_logon_and_logout() {
     );
     conn.connect(Instant::now()).unwrap();
 
-    let reason = drive(&mut conn).unwrap();
-    assert_eq!(reason, DisconnectReason::Logout);
+    drive(&mut conn).unwrap();
 
     handle.join().unwrap();
 }
@@ -389,17 +391,16 @@ fn acceptor_receives_app_message() {
         journal(dir2.path()),
     );
 
-    let reason = loop {
+    loop {
         match conn.recv(Instant::now()).unwrap() {
-            Some(Message::Disconnected { reason }) => break reason,
+            Some(Message::LoggedOut { .. }) => break,
             Some(Message::Application { header: _ }) => {
                 received_app += 1;
             }
             Some(_) | None => {}
         }
-    };
+    }
 
-    assert_eq!(reason, DisconnectReason::Logout);
     assert_eq!(received_app, 1);
 
     handle.join().unwrap();
@@ -435,8 +436,10 @@ fn heartbeat_stale_seqnum_disconnects() {
     );
 
     let reason = loop {
-        if let Some(Message::Disconnected { reason }) = conn.recv(Instant::now()).unwrap() {
-            break reason;
+        match conn.recv(Instant::now()) {
+            Ok(_) => {}
+            Err(TransportError::UnexpectedDisconnect { reason }) => break reason,
+            Err(e) => panic!("unexpected transport error: {e:?}"),
         }
     };
     assert_eq!(reason, DisconnectReason::SeqNumTooLow);
@@ -488,8 +491,7 @@ fn resend_request_triggers_gap_fill() {
     );
     conn.connect(Instant::now()).unwrap();
 
-    let reason = drive(&mut conn).unwrap();
-    assert_eq!(reason, DisconnectReason::Logout);
+    drive(&mut conn).unwrap();
 
     handle.join().unwrap();
     let _ = dir_srv;
@@ -524,7 +526,7 @@ fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             Ok(Some(Message::Application { .. })) => saw_app = true,
             Ok(Some(_) | None) => {}
         }
@@ -588,7 +590,7 @@ fn out_of_sequence_admin_suppressed_and_resends() {
     let mut saw_admin = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             // The out-of-sequence Heartbeat must never surface.
             Ok(Some(Message::Heartbeat { .. })) => saw_admin = true,
             Ok(Some(_) | None) => {}
@@ -641,7 +643,7 @@ fn duplicate_admin_suppressed_no_resend() {
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             Ok(Some(Message::Application { .. })) => saw_app = true,
             Ok(Some(Message::Heartbeat { .. })) => saw_dup_admin = true,
             Ok(Some(_) | None) => {}
@@ -703,8 +705,7 @@ fn resend_request_huge_end_seq_clamped() {
         journal(dir.path()),
     );
     conn.connect(Instant::now()).unwrap();
-    let reason = drive(&mut conn).unwrap();
-    assert_eq!(reason, DisconnectReason::Logout);
+    drive(&mut conn).unwrap();
     handle.join().unwrap();
 }
 
@@ -736,7 +737,7 @@ fn corrupt_checksum_frame_counted_as_garbage() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             _ => {}
         }
     }
@@ -776,7 +777,7 @@ fn garbage_bytes_increment_counter() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             _ => {}
         }
     }
@@ -866,6 +867,138 @@ fn corrupt_checksum_frame() -> Vec<u8> {
 }
 
 #[test]
+fn peer_eof_surfaces_peer_closed_not_logout() {
+    // A peer that drops the socket (EOF) without sending a Logout is an abnormal
+    // drop, reported as UnexpectedDisconnect{PeerClosed} — NOT a fake clean
+    // Logout (the pre-#612 conflation). It is fatal and Displays legibly.
+    let dir = tmp_dir("peer_eof");
+    let mut conn: FixConnection<ChunkStream, MockDict> = FixConnection::from_parts(
+        ChunkStream::new(b""), // peer connected, then immediately closed
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(dir.path()),
+    );
+
+    let Err(err) = conn.recv(Instant::now()) else {
+        panic!("expected an error on peer EOF");
+    };
+    assert!(err.is_fatal(), "an abnormal disconnect is fatal");
+    assert!(matches!(
+        err,
+        TransportError::UnexpectedDisconnect {
+            reason: DisconnectReason::PeerClosed
+        }
+    ));
+    assert_eq!(err.to_string(), "unexpected disconnect: PeerClosed");
+}
+
+#[test]
+fn recv_after_abnormal_disconnect_is_closed() {
+    // Once a terminal outcome is surfaced the session is dead: every subsequent
+    // recv returns the fatal `Closed` (tungstenite's AlreadyClosed) — a caller-bug
+    // signal, never a fresh disconnect or a hang. Idempotent.
+    let dir = tmp_dir("recv_after_abnormal");
+    let mut conn: FixConnection<ChunkStream, MockDict> = FixConnection::from_parts(
+        ChunkStream::new(b""),
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(dir.path()),
+    );
+
+    // First recv terminates the session (peer EOF).
+    assert!(matches!(
+        conn.recv(Instant::now()),
+        Err(TransportError::UnexpectedDisconnect { .. })
+    ));
+
+    // Every recv after that is Closed.
+    for _ in 0..3 {
+        let Err(err) = conn.recv(Instant::now()) else {
+            panic!("expected Closed on a terminated session");
+        };
+        assert!(err.is_fatal());
+        assert!(matches!(err, TransportError::Closed));
+        assert_eq!(err.to_string(), "recv on a closed session");
+    }
+}
+
+#[test]
+fn recv_after_clean_logout_is_closed() {
+    // The clean-logout terminal (LoggedOut, on the Ok side) arms the same Closed
+    // guard as an abnormal disconnect: a recv after it returns Closed, not a
+    // re-read of a dead socket.
+    let dir = tmp_dir("logout_then_closed");
+    let (client_sock, server_sock) = loopback_pair();
+    client_sock
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(server_sock, target(), sender());
+        let mut buf = [0u8; 512];
+        let _ = peer.recv_msg(&mut buf); // the server's Logon
+        peer.send_logon(30);
+        peer.send_logout();
+        let _ = peer.recv_msg(&mut buf);
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        client_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(sender(), target()),
+        journal(dir.path()),
+    );
+    conn.connect(Instant::now()).unwrap();
+
+    // Drive to the clean logout terminal, then any further recv is Closed.
+    drive(&mut conn).unwrap();
+    assert!(matches!(
+        conn.recv(Instant::now()),
+        Err(TransportError::Closed)
+    ));
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn only_malformed_is_non_fatal() {
+    // The is_fatal() contract: exactly one variant (Malformed) is recoverable;
+    // every other error ends the session. Guards against a future variant being
+    // misclassified as recoverable and silently swallowed by a tolerant caller.
+    let recoverable = TransportError::Malformed {
+        skipped: 4,
+        count: 1,
+        reason: MalformedReason::Framing,
+    };
+    assert!(!recoverable.is_fatal());
+
+    for fatal in [
+        TransportError::UnexpectedDisconnect {
+            reason: DisconnectReason::CompIdMismatch,
+        },
+        TransportError::Closed,
+        TransportError::MessageTooLarge(9999),
+        TransportError::Io(std::io::Error::other("boom")),
+        TransportError::Protocol(SessionError::InvalidState),
+    ] {
+        assert!(fatal.is_fatal(), "{fatal} must be fatal");
+    }
+
+    // Display sanity for the two #612 variants.
+    assert_eq!(
+        TransportError::UnexpectedDisconnect {
+            reason: DisconnectReason::SeqNumTooLow
+        }
+        .to_string(),
+        "unexpected disconnect: SeqNumTooLow"
+    );
+    assert_eq!(
+        TransportError::Closed.to_string(),
+        "recv on a closed session"
+    );
+}
+
+#[test]
 fn sequence_reset_backward_ignored() {
     // Fix 4: SequenceReset Reset-mode with new_seq < next_inbound must be ignored.
     let dir = tmp_dir("seqreset_bwd");
@@ -893,7 +1026,7 @@ fn sequence_reset_backward_ignored() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::Disconnected { .. })) | Err(_) => break,
+            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
             _ => {}
         }
     }
@@ -979,8 +1112,7 @@ fn journal_recovers_admin_seqnums() {
         journal(dir.path()),
     );
     conn.connect(Instant::now()).unwrap();
-    let reason = drive(&mut conn).unwrap();
-    assert_eq!(reason, DisconnectReason::Logout);
+    drive(&mut conn).unwrap();
     handle.join().unwrap();
     drop(conn);
 
@@ -1090,12 +1222,12 @@ fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
 
     match conn.recv(Instant::now()) {
         Err(TransportError::MessageTooLarge(_)) => {}
+        Err(TransportError::UnexpectedDisconnect { reason }) => {
+            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
+        }
         Err(other) => panic!(
             "an inbound frame exceeding the reader buffer must be MessageTooLarge, got {other:?}"
         ),
-        Ok(Some(Message::Disconnected { reason })) => {
-            panic!("frame exceeding reader buffer was misread as a disconnect: {reason:?}")
-        }
         Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
     }
 }

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -1230,4 +1230,13 @@ fn frame_exceeding_reader_buffer_is_message_too_large_not_disconnect() {
         ),
         Ok(_) => panic!("frame exceeding reader buffer must not surface a message"),
     }
+
+    // MessageTooLarge is a *fatal* error (not a disconnect), so it terminates the
+    // session — the next recv must be Closed, not a re-read of the oversized frame.
+    // Regression guard: the terminated flag must arm on any fatal error, not just
+    // LoggedOut / UnexpectedDisconnect.
+    assert!(matches!(
+        conn.recv(Instant::now()),
+        Err(TransportError::Closed)
+    ));
 }

--- a/nexus-fix-harness/src/main.rs
+++ b/nexus-fix-harness/src/main.rs
@@ -132,8 +132,8 @@ fn main() {
         let mut app_msgs = 0usize;
         loop {
             match conn.recv(Instant::now()) {
-                Ok(Some(Message::Disconnected { reason })) => {
-                    println!("disconnected: {reason:?}, {app_msgs} app message(s)");
+                Ok(Some(Message::LoggedOut { .. })) => {
+                    println!("logged out cleanly, {app_msgs} app message(s)");
                     break;
                 }
                 Ok(Some(Message::Application { .. })) => {
@@ -145,8 +145,10 @@ fn main() {
                 // reader has resynced. Tolerate it and keep receiving, so an
                 // adversarial peer's garbage cannot end the session.
                 Err(e) if !e.is_fatal() => eprintln!("recoverable: {e}"),
+                // Fatal: an abnormal disconnect (UnexpectedDisconnect), I/O
+                // failure, or reuse-after-close. The session is over.
                 Err(e) => {
-                    eprintln!("error: {e}");
+                    eprintln!("session ended: {e}");
                     break;
                 }
             }


### PR DESCRIPTION
Closes #612. Second of the recv-contract cleanups (after #611 malformed→error).

## What

Session end was surfaced uniformly as `Message::Disconnected { reason }` on the
`Ok` side — including *abnormal* ends (comp-id mismatch, seqnum-too-low, timeouts),
which are faults. And a socket EOF was misreported as a clean `Logout`. This splits
session end by outcome:

| session end | before | after |
|---|---|---|
| clean, negotiated logout (peer 35=5, exchange completes) | `Message::Disconnected { Logout }` | `Ok(Some(Message::LoggedOut { msg }))` |
| CompIdMismatch / SeqNumTooLow / ProtocolViolation / SeqNumExhausted | `Message::Disconnected { reason }` | `Err(TransportError::UnexpectedDisconnect { reason })` |
| Logon / Logout / TestRequest / Reset timeout | `Message::Disconnected { reason }` | `Err(TransportError::UnexpectedDisconnect { reason })` |
| socket EOF (`read` → `Ok(0)`), no Logout | `Message::Disconnected { Logout }` ⚠️ | `Err(TransportError::UnexpectedDisconnect { PeerClosed })` |
| `recv` after any terminal outcome | (re-read / undefined) | `Err(TransportError::Closed)` |

A clean shutdown is a distinct terminal event on the `Ok` side (carrying the peer's
Logout so the caller can read `Text(58)`); a fault propagates through `recv()?`
toward reconnect/alert logic, the way it should. `is_fatal()` distinguishes the one
recoverable error (`Malformed`, from #611) from every terminal one.

## Type changes

- `Message`: `Disconnected { reason }` → **`LoggedOut { msg: D::Logout }`**.
- `DisconnectReason`: drops **`Logout`** (now `Message::LoggedOut`), adds **`PeerClosed`**
  (socket EOF, no FIX Logout — previously misreported as clean `Logout`). It is now
  purely the fault set. `ConnectionReset` (RST) stays an `io::Error` → `TransportError::Io`.
- `TransportError`: adds **`UnexpectedDisconnect { reason }`** and **`Closed`**. A `recv`
  after any terminal outcome returns `Closed` — tungstenite's `AlreadyClosed` model
  ("you're using a dead connection") — tracked by a `terminated` flag per connection.
- Internal: `Control::LoggedOut` + `PollOutcome::LoggedOut` for the clean path;
  abnormal keeps `Control::Disconnected { reason }` / `PollOutcome::Disconnected(reason)`.

Both the sync (`nexus-fix-engine`) and async (`nexus-async-fix-engine`) transports.

## Tests

- The full disconnect-assertion sweep across the unit/integration/conformance suites
  flips to `LoggedOut` or the new errors; the `drive()`/`drive_observe` helpers now
  return `None`=clean / `Some(reason)`=fault.
- New error coverage the old model never had: sync `peer_eof → PeerClosed`,
  `recv-after-abnormal → Closed`, `recv-after-clean-logout → Closed`, an
  `is_fatal()`/`Display` contract matrix; and async parity (`peer_eof → PeerClosed → Closed`).
- The Python adversarial harness (`nexus-fix-harness`) tolerates recoverable errors
  and breaks on fatal ones — 9/9 behave scenarios green (abnormal disconnects now
  close the socket via the error path).

## Also

- Fixed 4 pre-existing `redundant_explicit_links` doc errors in
  `nexus-async-fix-engine` (`WireStream` links) so its `cargo doc` builds — unrelated
  to the reform, folded in as cleanup.

## Follow-ups

- **#613** — `recv`/`try_recv`/`recv_timeout` naming (last of the three recv-contract
  cleanups).
- **#614** — same close-handling parity for nexus-web.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` — clean (engine, async, harness)
- `cargo test` — 191 engine + 20 async pass, both conformance suites 17/17
- `cargo doc` — clean (both crates)
- behave adversarial harness — 9/9
