### PR TITLE
FIX engine: split recv into pure receive + explicit clock servicing

### DIFF
--- a/nexus-async-fix-engine/CHANGELOG.md
+++ b/nexus-async-fix-engine/CHANGELOG.md
@@ -43,6 +43,13 @@ contained.
   terminal outcome is `Err(TransportError::Closed)`. `Message::Disconnected` is
   removed. (#612)
 
+- `recv`/`try_recv`/`tick`/`next_timeout` mirror the sync engine. `recv(now).await`
+  now yields `Message` directly (was `Option<Message>`) and no longer services
+  heartbeats internally — drive `tick` from a `select!` timer branch. This removes
+  the crate's internal `tokio::time` timer from the receive path, so the core is
+  driven only by the executor + the `WireStream`. There is no async `recv_timeout`;
+  compose `tokio::time::timeout(dur, conn.recv(now))`. (#613)
+
 ### Internal
 
 - Test scratch directories are now removed on drop. The `tmp_dir` helpers in

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -345,13 +345,14 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
     /// After any terminal outcome further calls return `Err(Closed)`. A malformed
     /// frame is a recoverable `Err(Malformed)` — the session stays live.
     ///
-    /// `now` is your duty-cycle clock reading. The core never reads the wall clock
-    /// itself — that is what keeps the session deterministically replayable — so read
-    /// `now` once per iteration, keep it monotonic, and pass the same value to
-    /// `recv`/[`try_recv`](Self::try_recv) and [`tick`](Self::tick). It stamps
-    /// `last_received` (the liveness clock); a `now` you let go stale backdates that
-    /// conservatively — at worst an early, peer-answered TestRequest, never a false
-    /// disconnect.
+    /// `now` is your clock reading, threaded in so the core never reads the wall clock
+    /// itself — that is what keeps the session deterministically replayable. The only
+    /// requirement is that `now` be **non-decreasing** across calls on the session
+    /// (`recv`, `try_recv`, `tick`); a real `Instant::now()` gives that for free, and a
+    /// replay feeds recorded stamps. It stamps `last_received` (the liveness clock), so
+    /// pass a reasonably fresh reading — a `now` you let go stale backdates it,
+    /// conservatively (at worst an early, peer-answered TestRequest, never a false
+    /// disconnect).
     ///
     /// **Cancellation:** dropping this future (e.g. losing a `select!` race) is safe
     /// at the socket read — the usual cancellation point — and for any message that
@@ -407,8 +408,7 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
     /// drive `tick` from a `select!` timer branch. Returns `Err(UnexpectedDisconnect)`
     /// if a deadline blew.
     ///
-    /// Pass the same duty-cycle `now` you give [`recv`](Self::recv) — one monotonic
-    /// reading per iteration, shared by both. See `recv` for the clock contract.
+    /// `now` follows the same non-decreasing clock contract as [`recv`](Self::recv).
     pub async fn tick(&mut self, now: Instant) -> Result<(), Error> {
         if self.terminated {
             return Err(Error::Closed);

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -345,6 +345,14 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
     /// After any terminal outcome further calls return `Err(Closed)`. A malformed
     /// frame is a recoverable `Err(Malformed)` — the session stays live.
     ///
+    /// `now` is your duty-cycle clock reading. The core never reads the wall clock
+    /// itself — that is what keeps the session deterministically replayable — so read
+    /// `now` once per iteration, keep it monotonic, and pass the same value to
+    /// `recv`/[`try_recv`](Self::try_recv) and [`tick`](Self::tick). It stamps
+    /// `last_received` (the liveness clock); a `now` you let go stale backdates that
+    /// conservatively — at worst an early, peer-answered TestRequest, never a false
+    /// disconnect.
+    ///
     /// **Cancellation:** dropping this future (e.g. losing a `select!` race) is safe
     /// at the socket read — the usual cancellation point — and for any message that
     /// carries no reply (application messages, plain heartbeats). A message that
@@ -371,10 +379,11 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
         Ok(self.finish(step))
     }
 
-    /// Returns the next ready message without awaiting, or `None` when nothing is
-    /// ready (a single `Pending` transport poll). A pure receive — never touches the
-    /// clock (see [`tick`](Self::tick)). After any terminal outcome further calls
-    /// return `Err(Closed)`.
+    /// Returns the next ready message, or `None` when nothing is ready — a single
+    /// non-blocking transport poll (`Pending` → `None`). Never awaits *inbound* bytes;
+    /// it is `async` only to flush an outbound reply the poll may enqueue. A pure
+    /// receive — never touches the clock (see [`tick`](Self::tick)). After any terminal
+    /// outcome further calls return `Err(Closed)`.
     pub async fn try_recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
         if self.terminated {
             return Err(Error::Closed);
@@ -397,6 +406,9 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
     /// the logon/logout/test-request/reset deadlines. No `recv*` method does this —
     /// drive `tick` from a `select!` timer branch. Returns `Err(UnexpectedDisconnect)`
     /// if a deadline blew.
+    ///
+    /// Pass the same duty-cycle `now` you give [`recv`](Self::recv) — one monotonic
+    /// reading per iteration, shared by both. See `recv` for the clock contract.
     pub async fn tick(&mut self, now: Instant) -> Result<(), Error> {
         if self.terminated {
             return Err(Error::Closed);

--- a/nexus-async-fix-engine/src/lib.rs
+++ b/nexus-async-fix-engine/src/lib.rs
@@ -7,7 +7,11 @@
 //! protocol logic (framing, the state machine, journaling, resend) lives in
 //! [`FixSession`]; this crate is the exact async analog of the blocking
 //! [`nexus_fix_engine::FixConnection`], differing only in that socket I/O is
-//! `.await`ed and heartbeat/TestRequest deadlines use `tokio::time`.
+//! `.await`ed. `recv`/`try_recv` never service the session clock — heartbeats and
+//! the logon/logout/test-request deadlines are the caller's policy: drive
+//! [`FixConnection::tick`] from a `select!` timer branch (the receive path no longer
+//! uses a `tokio::time` timer, so it is driven only by the executor and the
+//! [`WireStream`]).
 //!
 //! # Transports
 //!
@@ -31,14 +35,14 @@ use std::future::poll_fn;
 use std::io;
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::time::{Duration, Instant};
+use std::task::{Context, Poll, Waker};
+use std::time::Instant;
 
 use nexus_fix_codec::{FixDictionary, NoCustomizer, SessionCustomizer};
 use nexus_fix_engine::{
     DisconnectReason, FixJournal, FixSession, FrameReader, FrameWriter, Message, MessageReader,
     MessageWriter, PollOutcome, SessionConfig, SessionError, SessionState, State,
 };
-use tokio::time::timeout_at;
 
 /// Per-message resend reserve; see [`nexus_fix_engine::REFRAME_HEADROOM`].
 pub use nexus_fix_engine::REFRAME_HEADROOM;
@@ -56,17 +60,15 @@ pub use nexus_net::WireStream;
 /// `nexus-net-tokio` directly.
 pub use nexus_net_tokio::{AsyncReadAdapter, MaybeTls};
 
-/// Owned outcome of one [`FixConnection::recv`] step. Returned by the internal
-/// `recv_step` so `recv` can arm the terminated guard — on any fatal error or a
-/// clean logout — before borrowing `self` to reconstruct the borrowed message.
+/// Owned outcome of one buffered receive step ([`FixConnection::poll_buffered`]),
+/// so the public `recv`/`try_recv` can arm the terminated guard — on any fatal
+/// error or a clean logout — before borrowing `self` to reconstruct the message.
+#[derive(Clone, Copy)]
 enum RecvStep {
     /// A typed message is ready; call `message()`.
     Message,
     /// A clean, negotiated logout ended the session.
     LoggedOut,
-    /// Nothing to surface this step (a suppressed frame, or a read deadline with no
-    /// timer elapsed); the wrapper returns `Ok(None)`.
-    Nothing,
 }
 
 /// Async FIX session transport over any [`WireStream`].
@@ -334,110 +336,173 @@ impl<S: WireStream + Unpin, D: FixDictionary, C: SessionCustomizer> FixConnectio
         self.drain_outbound().await
     }
 
-    /// Processes buffered inbound frames, reading more bytes when needed and
-    /// firing heartbeat/TestRequest timers on read idle. Returns the next typed
-    /// [`Message`], or `None` when a step produced nothing to surface (an
-    /// out-of-sequence app, a session reject, or a fired timer that did not
-    /// disconnect). Mirrors the sync
-    /// [`FixConnection::recv`](nexus_fix_engine::FixConnection::recv) loop with
-    /// `.await` on the socket read and a `tokio::time` deadline in place of the
-    /// blocking socket read-timeout.
-    pub async fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+    /// Awaits the next inbound message.
+    ///
+    /// A pure receive: it never touches the session clock. Heartbeats and the
+    /// logon/logout/test-request deadlines are the caller's policy — drive
+    /// [`tick`](Self::tick) from a `select!` timer branch. A clean logout arrives
+    /// as [`Message::LoggedOut`]; an abnormal end as `Err(UnexpectedDisconnect)`.
+    /// After any terminal outcome further calls return `Err(Closed)`. A malformed
+    /// frame is a recoverable `Err(Malformed)` — the session stays live.
+    ///
+    /// **Cancellation:** dropping this future (e.g. losing a `select!` race) is safe
+    /// at the socket read — the usual cancellation point — and for any message that
+    /// carries no reply (application messages, plain heartbeats). A message that
+    /// triggers an outbound reply (a TestRequest, a resend, an acceptor Logon, the
+    /// Logout ack) flushes that reply before returning, so a future dropped *during
+    /// that write* — only reachable under write back-pressure — can drop the
+    /// just-processed message. With write headroom on the link the window never arises.
+    pub async fn recv(&mut self, now: Instant) -> Result<Message<'_, D>, Error> {
         if self.terminated {
             return Err(Error::Closed);
         }
-        match self.recv_step(now).await {
-            Ok(RecvStep::Message) => Ok(Some(self.session.message())),
-            // Clean, negotiated logout: the graceful terminal event.
-            Ok(RecvStep::LoggedOut) => {
-                self.terminated = true;
-                Ok(Some(self.session.message()))
-            }
-            Ok(RecvStep::Nothing) => Ok(None),
-            // Any fatal error ends the session, so the next `recv` is `Closed`; a
-            // recoverable error (`Malformed`) leaves the session live.
-            Err(e) => {
-                if e.is_fatal() {
-                    self.terminated = true;
+        let step = loop {
+            match self.poll_buffered(now).await {
+                Ok(Some(step)) => break step,
+                // No complete frame buffered — await more bytes and re-poll.
+                Ok(None) => {
+                    if let Err(e) = self.await_read().await {
+                        return Err(self.note_fatal(e));
+                    }
                 }
-                Err(e)
+                Err(e) => return Err(self.note_fatal(e)),
             }
-        }
+        };
+        Ok(self.finish(step))
     }
 
-    /// Advances the session one step, returning an *owned* outcome. Splitting this
-    /// from [`recv`](Self::recv) lets `recv` arm the terminated guard (on any fatal
-    /// error or a clean logout) before borrowing `self` to build the message.
-    async fn recv_step(&mut self, now: Instant) -> Result<RecvStep, Error> {
+    /// Returns the next ready message without awaiting, or `None` when nothing is
+    /// ready (a single `Pending` transport poll). A pure receive — never touches the
+    /// clock (see [`tick`](Self::tick)). After any terminal outcome further calls
+    /// return `Err(Closed)`.
+    pub async fn try_recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
+        let step = loop {
+            match self.poll_buffered(now).await {
+                Ok(Some(step)) => break step,
+                Ok(None) => match self.poll_read_once() {
+                    Ok(true) => {}                // got bytes — re-poll
+                    Ok(false) => return Ok(None), // Pending — nothing ready
+                    Err(e) => return Err(self.note_fatal(e)),
+                },
+                Err(e) => return Err(self.note_fatal(e)),
+            }
+        };
+        Ok(Some(self.finish(step)))
+    }
+
+    /// Services the session clock: sends any due Heartbeat/TestRequest and enforces
+    /// the logon/logout/test-request/reset deadlines. No `recv*` method does this —
+    /// drive `tick` from a `select!` timer branch. Returns `Err(UnexpectedDisconnect)`
+    /// if a deadline blew.
+    pub async fn tick(&mut self, now: Instant) -> Result<(), Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
+        let reason = match self.session.on_timeout(now) {
+            Ok(r) => r,
+            Err(e) => return Err(self.note_fatal(e)),
+        };
+        if let Err(e) = self.drain_outbound().await {
+            return Err(self.note_fatal(e));
+        }
+        reason.map_or(Ok(()), |reason| {
+            Err(self.note_fatal(Error::UnexpectedDisconnect { reason }))
+        })
+    }
+
+    /// The earliest instant at which [`tick`](Self::tick) next has work — the next
+    /// heartbeat, TestRequest, or deadline. `None` when disconnected. Use it to size
+    /// a `select!` sleep.
+    pub fn next_timeout(&self) -> Option<Instant> {
+        self.session.state().next_timeout()
+    }
+
+    /// Arms the terminated guard on a fatal error (so the next call is `Closed`) and
+    /// hands the error back; a recoverable `Malformed` leaves the session live.
+    fn note_fatal(&mut self, e: Error) -> Error {
+        if e.is_fatal() {
+            self.terminated = true;
+        }
+        e
+    }
+
+    /// Reconstructs the borrowed message for a completed step, arming the guard on a
+    /// clean logout (the graceful terminal event).
+    fn finish(&mut self, step: RecvStep) -> Message<'_, D> {
+        if matches!(step, RecvStep::LoggedOut) {
+            self.terminated = true;
+        }
+        self.session.message()
+    }
+
+    /// Poll + drain buffered inbound frames without reading the transport.
+    /// `Some(step)` when a message/logout is ready, `None` when a read is needed.
+    /// Suppressed frames and in-progress resends are consumed internally.
+    async fn poll_buffered(&mut self, now: Instant) -> Result<Option<RecvStep>, Error> {
         loop {
             let outcome = self.session.poll(now)?;
-            // Drain any admin/resend the core enqueued for this step (matches the
-            // sync wrapper, which flushes after every protocol handler).
+            // Flush admin/resend the core enqueued — for a terminal outcome this is the
+            // final message (a Logout ack, a Reject), which MUST reach the wire before
+            // the caller's loop ends, so the drain stays after `poll`. See `recv` for
+            // the cancellation caveat this implies.
             self.drain_outbound().await?;
-
             match outcome {
-                PollOutcome::Message => return Ok(RecvStep::Message),
-                PollOutcome::LoggedOut => return Ok(RecvStep::LoggedOut),
-                // Abnormal drop: a fault, surfaced as an error, not a message.
+                PollOutcome::Message => return Ok(Some(RecvStep::Message)),
+                PollOutcome::LoggedOut => return Ok(Some(RecvStep::LoggedOut)),
                 PollOutcome::Disconnected(reason) => {
                     return Err(Error::UnexpectedDisconnect { reason });
                 }
-                PollOutcome::Suppressed => return Ok(RecvStep::Nothing),
-                // Buffer already drained above; loop to continue the resend.
-                PollOutcome::ResendPending => {}
+                // A buffered frame processed with nothing to surface, or a resend in
+                // progress: keep draining buffered data.
+                PollOutcome::Suppressed | PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
-                    // An empty spare means the reader buffer is full with a single
-                    // incomplete frame that cannot grow (compaction reclaimed
-                    // nothing). `poll_fill_into` would reject a zero-length spare
-                    // with `InvalidInput`; surface the real cause instead — a frame
-                    // larger than the reader buffer. Identical to the sync wrapper's
-                    // guard.
+                    // Empty spare = the buffer is full with one incomplete frame that
+                    // cannot grow: a frame larger than the reader buffer. (Also the
+                    // zero-length slice `poll_fill_into` would reject.)
                     if self.session.read_spare().is_empty() {
                         return Err(Error::MessageTooLarge(
                             self.session.reader_capacity().saturating_add(1),
                         ));
                     }
-                    // No socket-level read timeout on an async stream, so bound
-                    // the read with the session's next heartbeat/TestRequest
-                    // deadline (60s fallback when the state machine has no timer).
-                    let deadline = self.session.state().next_timeout().map_or_else(
-                        || tokio::time::Instant::now() + Duration::from_secs(60),
-                        tokio::time::Instant::from_std,
-                    );
-                    // Fill the session's inbound buffer copy-free: `poll_fill_into`
-                    // reads into `read_spare()` and commits via `read_filled` itself,
-                    // returning the delivered count (`Ok(0)` = EOF). Cap the pull at
-                    // the current spare length.
-                    let max = self.session.read_spare().len();
-                    match timeout_at(
-                        deadline,
-                        poll_fn(|cx| {
-                            Pin::new(&mut self.stream).poll_fill_into(cx, &mut self.session, max)
-                        }),
-                    )
-                    .await
-                    {
-                        // Peer closed the transport (FIN) without a FIX Logout.
-                        Ok(Ok(0)) => {
-                            return Err(Error::UnexpectedDisconnect {
-                                reason: DisconnectReason::PeerClosed,
-                            });
-                        }
-                        // Bytes already committed to the session by `poll_fill_into`;
-                        // loop to parse them.
-                        Ok(Ok(_n)) => {}
-                        Ok(Err(e)) => return Err(Error::Io(e)),
-                        Err(_elapsed) => {
-                            if let Some(reason) = self.session.on_timeout(now)? {
-                                self.drain_outbound().await?;
-                                return Err(Error::UnexpectedDisconnect { reason });
-                            }
-                            self.drain_outbound().await?;
-                            return Ok(RecvStep::Nothing);
-                        }
-                    }
+                    return Ok(None);
                 }
             }
+        }
+    }
+
+    /// Awaits one copy-free fill from the transport. `poll_fill_into` reads into
+    /// `read_spare()` and commits via `read_filled`, returning the delivered count
+    /// (`Ok(0)` = EOF).
+    async fn await_read(&mut self) -> Result<(), Error> {
+        let max = self.session.read_spare().len();
+        let n = poll_fn(|cx| Pin::new(&mut self.stream).poll_fill_into(cx, &mut self.session, max))
+            .await
+            .map_err(Error::Io)?;
+        if n == 0 {
+            // Peer closed the transport (FIN) without a FIX Logout.
+            return Err(Error::UnexpectedDisconnect {
+                reason: DisconnectReason::PeerClosed,
+            });
+        }
+        Ok(())
+    }
+
+    /// Polls the transport once with a no-op waker (non-blocking). `Ok(true)` = bytes
+    /// delivered, `Ok(false)` = `Pending` (nothing ready). A read of `Ok(0)` is EOF.
+    fn poll_read_once(&mut self) -> Result<bool, Error> {
+        let max = self.session.read_spare().len();
+        let mut cx = Context::from_waker(Waker::noop());
+        match Pin::new(&mut self.stream).poll_fill_into(&mut cx, &mut self.session, max) {
+            // Peer closed the transport (FIN) without a FIX Logout.
+            Poll::Ready(Ok(0)) => Err(Error::UnexpectedDisconnect {
+                reason: DisconnectReason::PeerClosed,
+            }),
+            Poll::Ready(Ok(_n)) => Ok(true),
+            Poll::Ready(Err(e)) => Err(Error::Io(e)),
+            Poll::Pending => Ok(false),
         }
     }
 

--- a/nexus-async-fix-engine/tests/async_conformance.rs
+++ b/nexus-async-fix-engine/tests/async_conformance.rs
@@ -159,10 +159,54 @@ async fn connect(port: u16, dir: &Path) -> FixConnection<AsyncReadAdapter<TcpStr
 /// error is a failure and panics.
 async fn drive(conn: &mut FixConnection<AsyncReadAdapter<TcpStream>, MockDict>) {
     loop {
-        match conn.recv(Instant::now()).await {
-            Ok(Some(Message::LoggedOut { .. })) => return,
-            Ok(_) => {}
-            Err(e) => panic!("recv errored before clean logout: {e:?}"),
+        match step(conn).await {
+            Step::Logout => return,
+            Step::Disconnect(reason) => panic!("disconnected before clean logout: {reason:?}"),
+            _ => {}
+        }
+    }
+}
+
+/// One owned outcome of a reactor step — a received message summarized, or a
+/// disconnect. `recv` is pure, so the driver services the clock itself.
+enum Step {
+    Logout,
+    Application,
+    Other,
+    Disconnect(DisconnectReason),
+}
+
+/// Sleep until `deadline`, or forever if `None` (no clock work pending).
+async fn sleep_until_opt(deadline: Option<Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(tokio::time::Instant::from_std(d)).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Race `recv` against the session's next heartbeat/timeout deadline; if the
+/// deadline wins, `recv` is cancelled — safe here, since the loopback link has
+/// write headroom so `recv` is only ever dropped at the read (see its cancellation
+/// note) — and the clock is serviced via `tick`, then we retry. Returns the next
+/// message summarized, or a disconnect (from `recv` or a blown `tick` deadline).
+async fn step(conn: &mut FixConnection<AsyncReadAdapter<TcpStream>, MockDict>) -> Step {
+    loop {
+        let deadline = conn.next_timeout();
+        tokio::select! {
+            r = conn.recv(Instant::now()) => return match r {
+                Ok(Message::LoggedOut { .. }) => Step::Logout,
+                Ok(Message::Application { .. }) => Step::Application,
+                Ok(_) => Step::Other,
+                Err(TransportError::UnexpectedDisconnect { reason }) => Step::Disconnect(reason),
+                Err(e) => panic!("recv errored mid-scenario: {e:?}"),
+            },
+            () = sleep_until_opt(deadline) => match conn.tick(Instant::now()).await {
+                Ok(()) => {} // serviced the clock — loop and receive again
+                Err(TransportError::UnexpectedDisconnect { reason }) => {
+                    return Step::Disconnect(reason);
+                }
+                Err(e) => panic!("tick errored mid-scenario: {e:?}"),
+            },
         }
     }
 }
@@ -243,9 +287,9 @@ async fn conformance_seq_reset() {
 //
 // Mirror of the sync `fix_conformance.rs` cases over the tokio transport, so the
 // two drivers stay in lockstep. See `.claude/fix-battletest-findings.md` for the
-// pass/finding disposition and the FIX 4.4 rationale behind each assertion. The
-// async `recv` derives its read deadline from `next_timeout()`, so the timer
-// scenario needs no special socket timeout here.
+// pass/finding disposition and the FIX 4.4 rationale behind each assertion. `recv`
+// is pure, so the `step` reactor above services the clock via `tick` at each
+// `next_timeout()` deadline — that is what drives the timer scenarios.
 
 type Conn = FixConnection<AsyncReadAdapter<TcpStream>, MockDict>;
 
@@ -259,17 +303,18 @@ async fn drive_observe(conn: &mut Conn) -> (Option<DisconnectReason>, bool, bool
     let mut saw_resending = false;
     let mut saw_app = false;
     loop {
-        match conn.recv(Instant::now()).await {
-            Ok(Some(Message::LoggedOut { .. })) => return (None, saw_resending, saw_app),
-            Ok(Some(Message::Application { .. })) => saw_app = true,
-            Ok(Some(_) | None) => {}
-            Err(TransportError::UnexpectedDisconnect { reason }) => {
-                return (Some(reason), saw_resending, saw_app);
-            }
-            Err(e) => panic!("recv errored mid-scenario: {e:?}"),
-        }
+        let outcome = step(conn).await;
+        // The Resending transition can happen during a suppressed gap frame that
+        // `step` consumes internally; it persists until the session ends, so observe
+        // it after every step — including the terminal one.
         if conn.state().state() == State::Resending {
             saw_resending = true;
+        }
+        match outcome {
+            Step::Logout => return (None, saw_resending, saw_app),
+            Step::Application => saw_app = true,
+            Step::Disconnect(reason) => return (Some(reason), saw_resending, saw_app),
+            Step::Other => {}
         }
     }
 }
@@ -277,9 +322,9 @@ async fn drive_observe(conn: &mut Conn) -> (Option<DisconnectReason>, bool, bool
 /// Drive until the session reaches `Active`, panicking on an early disconnect.
 async fn drive_to_active(conn: &mut Conn) {
     loop {
-        match conn.recv(Instant::now()).await {
-            Ok(Some(Message::LoggedOut { .. })) => panic!("logged out before active"),
-            Err(e) => panic!("disconnected before active: {e:?}"),
+        match step(conn).await {
+            Step::Logout => panic!("logged out before active"),
+            Step::Disconnect(reason) => panic!("disconnected before active: {reason:?}"),
             _ => {}
         }
         if conn.state().state() == State::Active {

--- a/nexus-fix-engine/CHANGELOG.md
+++ b/nexus-fix-engine/CHANGELOG.md
@@ -80,6 +80,23 @@ contained.
 
 ### Changed
 
+- The recv contract is split into pure receiving + explicit clock servicing, so no
+  method conflates the two:
+  - `recv(now) -> Result<Message, Error>` (was `Result<Option<Message>, Error>`) —
+    **blocks** until a message and never returns `None`.
+  - `try_recv(now) -> Result<Option<Message>, Error>` — non-blocking; `None` when
+    nothing is ready.
+  - `recv_timeout` is intentionally not provided: a bounded wait is `try_recv` on a
+    socket with a read timeout set (`None` = the timeout elapsed).
+  - `tick(now) -> Result<(), Error>` — sends any due Heartbeat/TestRequest and
+    enforces the logon/logout/test-request/reset deadlines (`Err(UnexpectedDisconnect)`
+    when one blows). No `recv*` method touches the clock; the caller drives `tick` on
+    its own schedule (a bounded `try_recv` loop, or a separate thread).
+  - `next_timeout() -> Option<Instant>` — when `tick` next has work.
+
+  Which blocking behavior `recv`/`try_recv` exhibit is selected by the caller's socket
+  mode (blocking / non-blocking / read-timeout), the same contract as tungstenite. (#613)
+
 - Session end is split by outcome. A clean, negotiated logout surfaces as
   `Message::LoggedOut { msg }` (`Ok`, carrying the peer's Logout 35=5 so the caller
   can read `Text(58)`); an abnormal disconnect surfaces as

--- a/nexus-fix-engine/examples/blocking_session.rs
+++ b/nexus-fix-engine/examples/blocking_session.rs
@@ -117,12 +117,12 @@ fn run_acceptor(listener: &TcpListener, dir: &Path) {
     let mut n = 0usize;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) => {
+            Ok(Message::LoggedOut { .. }) => {
                 println!("acceptor: logged out cleanly, {n} app message(s) received");
                 break;
             }
-            Ok(Some(Message::Application { .. })) => n += 1,
-            Ok(Some(_) | None) => {}
+            Ok(Message::Application { .. }) => n += 1,
+            Ok(_) => {}
             Err(e) => {
                 eprintln!("acceptor error: {e}");
                 break;
@@ -148,7 +148,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) => {
+            Ok(Message::LoggedOut { .. }) => {
                 eprintln!("initiator: logged out before active");
                 return;
             }
@@ -156,7 +156,7 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
                 eprintln!("initiator error: {e}");
                 return;
             }
-            Ok(Some(_) | None) => {}
+            Ok(_) => {}
         }
         if conn.state().state() == State::Active {
             break;
@@ -180,8 +180,9 @@ fn run_initiator(addr: std::net::SocketAddr, dir: &Path) {
     conn.logout(Instant::now()).unwrap();
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(_)) | Err(_) => break,
-            Ok(None) => {}
+            // The logout completed (LoggedOut) or the peer dropped — either ends it.
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
+            Ok(_) => {}
         }
     }
 }

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -260,6 +260,14 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
     /// [`tick`](Self::tick) on your own schedule (a bounded `try_recv` loop, or a
     /// separate thread).
     ///
+    /// `now` is your duty-cycle clock reading. The core never reads the wall clock
+    /// itself — that is what keeps the session deterministically replayable — so read
+    /// `now` once per iteration, keep it monotonic, and pass the same value to
+    /// `recv`/[`try_recv`](Self::try_recv) and [`tick`](Self::tick). It stamps
+    /// `last_received` (the liveness clock); a `now` you let go stale backdates that
+    /// conservatively — at worst an early, peer-answered TestRequest, never a false
+    /// disconnect.
+    ///
     /// Requires a **blocking** socket. On one this parks in the read syscall until
     /// bytes arrive; a read timeout (`SO_RCVTIMEO`) is transparent — a no-data wake
     /// is retried, so `recv` returns only with a message or an error and one
@@ -319,6 +327,9 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
     /// the logon/logout/test-request/reset deadlines. No `recv*` method does this —
     /// the caller drives `tick` on its own schedule (`select!` in async, a timeout
     /// loop in sync). Returns `Err(UnexpectedDisconnect)` if a deadline blew.
+    ///
+    /// Pass the same duty-cycle `now` you give [`recv`](Self::recv) — one monotonic
+    /// reading per iteration, shared by both. See `recv` for the clock contract.
     pub fn tick(&mut self, now: Instant) -> Result<(), Error> {
         if self.terminated {
             return Err(Error::Closed);

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -20,17 +20,15 @@ use crate::session::{DisconnectReason, SessionState, State};
 
 pub use crate::fix_session::{Error, REFRAME_HEADROOM};
 
-/// Owned outcome of one [`FixConnection::recv`] step. Returned by the internal
-/// `recv_step` so `recv` can arm the terminated guard — on any fatal error or a
-/// clean logout — before borrowing `self` to reconstruct the borrowed message.
+/// Owned outcome of one buffered receive step ([`FixConnection::poll_buffered`]),
+/// so the public `recv`/`try_recv` can arm the terminated guard — on any fatal
+/// error or a clean logout — before borrowing `self` to reconstruct the message.
+#[derive(Clone, Copy)]
 enum RecvStep {
     /// A typed message is ready; call `message()`.
     Message,
     /// A clean, negotiated logout ended the session.
     LoggedOut,
-    /// Nothing to surface this step (a suppressed frame, or a read timeout with no
-    /// deadline elapsed); the wrapper returns `Ok(None)`.
-    Nothing,
 }
 
 /// Blocking FIX session transport.
@@ -255,81 +253,168 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
         self.drain_outbound()
     }
 
-    pub fn recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+    /// Blocks until the next inbound message.
+    ///
+    /// A pure receive: it never touches the session clock. Heartbeats and the
+    /// logon/logout/test-request deadlines are the caller's policy — run
+    /// [`tick`](Self::tick) on your own schedule (a bounded `try_recv` loop, or a
+    /// separate thread).
+    ///
+    /// Requires a **blocking** socket. On one this parks in the read syscall until
+    /// bytes arrive; a read timeout (`SO_RCVTIMEO`) is transparent — a no-data wake
+    /// is retried, so `recv` returns only with a message or an error and one
+    /// read-timeout socket can back both `recv` and [`try_recv`](Self::try_recv). A
+    /// **non-blocking** socket is a misuse: the retry has nothing to wait on and
+    /// becomes a busy-spin. Use [`try_recv`](Self::try_recv) for non-blocking receipt.
+    ///
+    /// A clean logout arrives as [`Message::LoggedOut`]; an abnormal end as
+    /// `Err(UnexpectedDisconnect)`. After any terminal outcome further calls return
+    /// `Err(Closed)`. A malformed frame is a recoverable `Err(Malformed)` — the
+    /// session stays live and the caller may call again.
+    pub fn recv(&mut self, now: Instant) -> Result<Message<'_, D>, Error> {
         if self.terminated {
             return Err(Error::Closed);
         }
-        match self.recv_step(now) {
-            Ok(RecvStep::Message) => Ok(Some(self.session.message())),
-            // Clean, negotiated logout: the graceful terminal event.
-            Ok(RecvStep::LoggedOut) => {
-                self.terminated = true;
-                Ok(Some(self.session.message()))
-            }
-            Ok(RecvStep::Nothing) => Ok(None),
-            // Any fatal error ends the session, so the next `recv` is `Closed`; a
-            // recoverable error (`Malformed`) leaves the session live.
-            Err(e) => {
-                if e.is_fatal() {
-                    self.terminated = true;
+        let step = loop {
+            match self.poll_buffered(now) {
+                Ok(Some(step)) => break step,
+                // No complete frame buffered — block for more bytes and re-poll.
+                Ok(None) => {
+                    if let Err(e) = self.blocking_read() {
+                        return Err(self.note_fatal(e));
+                    }
                 }
-                Err(e)
+                Err(e) => return Err(self.note_fatal(e)),
             }
-        }
+        };
+        Ok(self.finish(step))
     }
 
-    /// Advances the session one step, returning an *owned* outcome. Splitting this
-    /// from [`recv`](Self::recv) lets `recv` arm the terminated guard (on any fatal
-    /// error or a clean logout) before borrowing `self` to build the message.
-    fn recv_step(&mut self, now: Instant) -> Result<RecvStep, Error> {
+    /// Returns the next ready message without blocking, or `None` when nothing is
+    /// ready.
+    ///
+    /// A pure receive: never touches the clock (see [`tick`](Self::tick)). Requires
+    /// a **non-blocking** socket — or one with a read timeout, for a bounded wait,
+    /// where `None` means the timeout elapsed. After any terminal outcome further
+    /// calls return `Err(Closed)`.
+    pub fn try_recv(&mut self, now: Instant) -> Result<Option<Message<'_, D>>, Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
+        let step = loop {
+            match self.poll_buffered(now) {
+                Ok(Some(step)) => break step,
+                Ok(None) => match self.read_available() {
+                    Ok(true) => {}                // got bytes — re-poll
+                    Ok(false) => return Ok(None), // nothing ready
+                    Err(e) => return Err(self.note_fatal(e)),
+                },
+                Err(e) => return Err(self.note_fatal(e)),
+            }
+        };
+        Ok(Some(self.finish(step)))
+    }
+
+    /// Services the session clock: sends any due Heartbeat/TestRequest and enforces
+    /// the logon/logout/test-request/reset deadlines. No `recv*` method does this —
+    /// the caller drives `tick` on its own schedule (`select!` in async, a timeout
+    /// loop in sync). Returns `Err(UnexpectedDisconnect)` if a deadline blew.
+    pub fn tick(&mut self, now: Instant) -> Result<(), Error> {
+        if self.terminated {
+            return Err(Error::Closed);
+        }
+        let reason = match self.session.on_timeout(now) {
+            Ok(r) => r,
+            Err(e) => return Err(self.note_fatal(e)),
+        };
+        if let Err(e) = self.drain_outbound() {
+            return Err(self.note_fatal(e));
+        }
+        reason.map_or(Ok(()), |reason| {
+            Err(self.note_fatal(Error::UnexpectedDisconnect { reason }))
+        })
+    }
+
+    /// The earliest instant at which [`tick`](Self::tick) next has work — the next
+    /// heartbeat, TestRequest, or deadline. `None` when disconnected. Use it to size
+    /// a bounded `try_recv` wait or a `select!` sleep.
+    pub fn next_timeout(&self) -> Option<Instant> {
+        self.session.state().next_timeout()
+    }
+
+    /// Arms the terminated guard on a fatal error (so the next call is `Closed`) and
+    /// hands the error back. A recoverable `Malformed` leaves the session live.
+    fn note_fatal(&mut self, e: Error) -> Error {
+        if e.is_fatal() {
+            self.terminated = true;
+        }
+        e
+    }
+
+    /// Reconstructs the borrowed message for a completed step, arming the guard on a
+    /// clean logout (the graceful terminal event).
+    fn finish(&mut self, step: RecvStep) -> Message<'_, D> {
+        if matches!(step, RecvStep::LoggedOut) {
+            self.terminated = true;
+        }
+        self.session.message()
+    }
+
+    /// Poll + drain buffered inbound frames without reading the socket. `Some(step)`
+    /// when a message/logout is ready, `None` when a socket read is needed. Suppressed
+    /// frames and in-progress resends are consumed internally.
+    fn poll_buffered(&mut self, now: Instant) -> Result<Option<RecvStep>, Error> {
         loop {
             let outcome = self.session.poll(now)?;
-            // Drain any admin/resend the core enqueued for this step (matches the
-            // original, which flushed after every protocol handler).
+            // Flush any admin/resend the core enqueued (matches the original, which
+            // flushed after every protocol handler).
             self.drain_outbound()?;
-
             match outcome {
-                PollOutcome::Message => return Ok(RecvStep::Message),
-                PollOutcome::LoggedOut => return Ok(RecvStep::LoggedOut),
-                // Abnormal drop: a fault, surfaced as an error, not a message.
+                PollOutcome::Message => return Ok(Some(RecvStep::Message)),
+                PollOutcome::LoggedOut => return Ok(Some(RecvStep::LoggedOut)),
                 PollOutcome::Disconnected(reason) => {
                     return Err(Error::UnexpectedDisconnect { reason });
                 }
-                PollOutcome::Suppressed => return Ok(RecvStep::Nothing),
-                // Buffer already drained above; loop to continue the resend.
-                PollOutcome::ResendPending => {}
+                // A buffered frame processed with nothing to surface, or a resend in
+                // progress: keep draining buffered data.
+                PollOutcome::Suppressed | PollOutcome::ResendPending => {}
                 PollOutcome::NeedMoreBytes => {
-                    // An empty spare means the reader buffer is full with a single
-                    // incomplete frame that cannot grow (compaction reclaimed
-                    // nothing). Reading into a zero-length slice yields `Ok(0)`,
-                    // which the `Ok(0)` arm below would misread as EOF. Surface it
-                    // as the real cause: a frame larger than the reader buffer.
+                    // Empty spare = the buffer is full with one incomplete frame that
+                    // cannot grow: a frame larger than the reader buffer.
                     if self.session.read_spare().is_empty() {
                         return Err(Error::MessageTooLarge(
                             self.session.reader_capacity().saturating_add(1),
                         ));
                     }
-                    let spare = self.session.read_spare();
-                    match self.stream.read(spare) {
-                        // Peer closed the transport (FIN) without a FIX Logout.
-                        Ok(0) => {
-                            return Err(Error::UnexpectedDisconnect {
-                                reason: DisconnectReason::PeerClosed,
-                            });
-                        }
-                        Ok(n) => self.session.read_filled(n),
-                        Err(e) if is_timeout(&e) => {
-                            if let Some(reason) = self.session.on_timeout(now)? {
-                                self.drain_outbound()?;
-                                return Err(Error::UnexpectedDisconnect { reason });
-                            }
-                            self.drain_outbound()?;
-                            return Ok(RecvStep::Nothing);
-                        }
-                        Err(e) => return Err(Error::Io(e)),
-                    }
+                    return Ok(None);
                 }
             }
+        }
+    }
+
+    /// Blocks until at least one byte arrives: a read yielding no data is retried.
+    /// Never services the clock.
+    fn blocking_read(&mut self) -> Result<(), Error> {
+        // Each read blocks; retry a spurious no-data wake until bytes arrive.
+        while !self.read_available()? {}
+        Ok(())
+    }
+
+    /// One socket read. `Ok(true)` = bytes delivered, `Ok(false)` = no data ready
+    /// (would-block / read timeout). A read of `Ok(0)` is a peer EOF.
+    fn read_available(&mut self) -> Result<bool, Error> {
+        let spare = self.session.read_spare();
+        match self.stream.read(spare) {
+            // Peer closed the transport (FIN) without a FIX Logout.
+            Ok(0) => Err(Error::UnexpectedDisconnect {
+                reason: DisconnectReason::PeerClosed,
+            }),
+            Ok(n) => {
+                self.session.read_filled(n);
+                Ok(true)
+            }
+            Err(e) if is_timeout(&e) => Ok(false),
+            Err(e) => Err(Error::Io(e)),
         }
     }
 

--- a/nexus-fix-engine/src/transport.rs
+++ b/nexus-fix-engine/src/transport.rs
@@ -260,13 +260,14 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
     /// [`tick`](Self::tick) on your own schedule (a bounded `try_recv` loop, or a
     /// separate thread).
     ///
-    /// `now` is your duty-cycle clock reading. The core never reads the wall clock
-    /// itself — that is what keeps the session deterministically replayable — so read
-    /// `now` once per iteration, keep it monotonic, and pass the same value to
-    /// `recv`/[`try_recv`](Self::try_recv) and [`tick`](Self::tick). It stamps
-    /// `last_received` (the liveness clock); a `now` you let go stale backdates that
-    /// conservatively — at worst an early, peer-answered TestRequest, never a false
-    /// disconnect.
+    /// `now` is your clock reading, threaded in so the core never reads the wall clock
+    /// itself — that is what keeps the session deterministically replayable. The only
+    /// requirement is that `now` be **non-decreasing** across calls on the session
+    /// (`recv`, `try_recv`, `tick`); a real `Instant::now()` gives that for free, and a
+    /// replay feeds recorded stamps. It stamps `last_received` (the liveness clock), so
+    /// pass a reasonably fresh reading — a `now` you let go stale backdates it,
+    /// conservatively (at worst an early, peer-answered TestRequest, never a false
+    /// disconnect).
     ///
     /// Requires a **blocking** socket. On one this parks in the read syscall until
     /// bytes arrive; a read timeout (`SO_RCVTIMEO`) is transparent — a no-data wake
@@ -328,8 +329,7 @@ impl<S: Read + Write, D: FixDictionary, C: SessionCustomizer> FixConnection<S, D
     /// the caller drives `tick` on its own schedule (`select!` in async, a timeout
     /// loop in sync). Returns `Err(UnexpectedDisconnect)` if a deadline blew.
     ///
-    /// Pass the same duty-cycle `now` you give [`recv`](Self::recv) — one monotonic
-    /// reading per iteration, shared by both. See `recv` for the clock contract.
+    /// `now` follows the same non-decreasing clock contract as [`recv`](Self::recv).
     pub fn tick(&mut self, now: Instant) -> Result<(), Error> {
         if self.terminated {
             return Err(Error::Closed);

--- a/nexus-fix-engine/tests/fix_conformance.rs
+++ b/nexus-fix-engine/tests/fix_conformance.rs
@@ -152,8 +152,10 @@ fn spawn_peer(scenario: &str) -> (ChildGuard, u16) {
 
 fn connect(port: u16, dir: &Path) -> FixConnection<TcpStream, MockDict> {
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    // Short read timeout so `try_recv` returns `None` promptly when the peer is
+    // idle — that is the driver's cue to `tick` the clock at fine granularity.
     stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
+        .set_read_timeout(Some(Duration::from_millis(50)))
         .unwrap();
     FixConnection::from_parts(
         stream,
@@ -171,10 +173,46 @@ fn connect(port: u16, dir: &Path) -> FixConnection<TcpStream, MockDict> {
 /// error is a failure and panics.
 fn drive(conn: &mut FixConnection<TcpStream, MockDict>) {
     loop {
-        match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) => return,
-            Ok(_) => {}
-            Err(e) => panic!("recv errored before clean logout: {e:?}"),
+        match step(conn) {
+            Step::Logout => return,
+            Step::Disconnect(reason) => panic!("disconnected before clean logout: {reason:?}"),
+            _ => {}
+        }
+    }
+}
+
+/// One owned outcome of a reactor step — a received message summarized, or a
+/// disconnect. `recv` is pure, so the driver services the clock itself.
+enum Step {
+    Logout,
+    Application,
+    Other,
+    Disconnect(DisconnectReason),
+}
+
+/// One reactor step: receive the next message, or — when no inbound arrives within
+/// the socket read timeout — service the clock via `tick` and retry. `try_recv`
+/// on a read-timeout socket returns `None` when the timeout elapses, which is the
+/// signal to `tick`. Returns the message summarized, or a disconnect (from `recv`
+/// or a blown `tick` deadline).
+fn step(conn: &mut FixConnection<TcpStream, MockDict>) -> Step {
+    loop {
+        let now = Instant::now();
+        match conn.try_recv(now) {
+            Ok(Some(Message::LoggedOut { .. })) => return Step::Logout,
+            Ok(Some(Message::Application { .. })) => return Step::Application,
+            Ok(Some(_)) => return Step::Other,
+            Ok(None) => match conn.tick(now) {
+                Ok(()) => {} // serviced the clock — retry
+                Err(TransportError::UnexpectedDisconnect { reason }) => {
+                    return Step::Disconnect(reason);
+                }
+                Err(e) => panic!("tick errored mid-scenario: {e:?}"),
+            },
+            Err(TransportError::UnexpectedDisconnect { reason }) => {
+                return Step::Disconnect(reason);
+            }
+            Err(e) => panic!("recv errored mid-scenario: {e:?}"),
         }
     }
 }
@@ -286,17 +324,18 @@ fn drive_observe(
     let mut saw_resending = false;
     let mut saw_app = false;
     loop {
-        match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) => return (None, saw_resending, saw_app),
-            Ok(Some(Message::Application { .. })) => saw_app = true,
-            Ok(Some(_) | None) => {}
-            Err(TransportError::UnexpectedDisconnect { reason }) => {
-                return (Some(reason), saw_resending, saw_app);
-            }
-            Err(e) => panic!("recv errored mid-scenario: {e:?}"),
-        }
+        let outcome = step(conn);
+        // The Resending transition can happen during a suppressed gap frame that
+        // `step` consumes internally; it persists until the session ends, so observe
+        // it after every step — including the terminal one.
         if conn.state().state() == State::Resending {
             saw_resending = true;
+        }
+        match outcome {
+            Step::Logout => return (None, saw_resending, saw_app),
+            Step::Application => saw_app = true,
+            Step::Disconnect(reason) => return (Some(reason), saw_resending, saw_app),
+            Step::Other => {}
         }
     }
 }
@@ -305,9 +344,9 @@ fn drive_observe(
 /// error. Used by the resend scenarios that inject app messages once live.
 fn drive_to_active(conn: &mut FixConnection<TcpStream, MockDict>) {
     loop {
-        match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) => panic!("logged out before active"),
-            Err(e) => panic!("disconnected before active: {e:?}"),
+        match step(conn) {
+            Step::Logout => panic!("logged out before active"),
+            Step::Disconnect(reason) => panic!("disconnected before active: {reason:?}"),
             _ => {}
         }
         if conn.state().state() == State::Active {

--- a/nexus-fix-engine/tests/transport.rs
+++ b/nexus-fix-engine/tests/transport.rs
@@ -152,7 +152,7 @@ fn tmp_dir(suffix: &str) -> TempDir {
 /// peer-initiated logout, so the clean path is the expected outcome.
 fn drive(conn: &mut FixConnection<TcpStream, MockDict>) -> Result<(), TransportError> {
     loop {
-        if let Some(Message::LoggedOut { .. }) = conn.recv(Instant::now())? {
+        if let Message::LoggedOut { .. } = conn.recv(Instant::now())? {
             return Ok(());
         }
     }
@@ -393,11 +393,11 @@ fn acceptor_receives_app_message() {
 
     loop {
         match conn.recv(Instant::now()).unwrap() {
-            Some(Message::LoggedOut { .. }) => break,
-            Some(Message::Application { header: _ }) => {
+            Message::LoggedOut { .. } => break,
+            Message::Application { header: _ } => {
                 received_app += 1;
             }
-            Some(_) | None => {}
+            _ => {}
         }
     }
 
@@ -526,9 +526,9 @@ fn inbound_gap_sends_resend_request_and_suppresses_app_message() {
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
-            Ok(Some(Message::Application { .. })) => saw_app = true,
-            Ok(Some(_) | None) => {}
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
+            Ok(Message::Application { .. }) => saw_app = true,
+            Ok(_) => {}
         }
     }
 
@@ -590,10 +590,10 @@ fn out_of_sequence_admin_suppressed_and_resends() {
     let mut saw_admin = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
             // The out-of-sequence Heartbeat must never surface.
-            Ok(Some(Message::Heartbeat { .. })) => saw_admin = true,
-            Ok(Some(_) | None) => {}
+            Ok(Message::Heartbeat { .. }) => saw_admin = true,
+            Ok(_) => {}
         }
     }
 
@@ -643,10 +643,10 @@ fn duplicate_admin_suppressed_no_resend() {
     let mut saw_app = false;
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
-            Ok(Some(Message::Application { .. })) => saw_app = true,
-            Ok(Some(Message::Heartbeat { .. })) => saw_dup_admin = true,
-            Ok(Some(_) | None) => {}
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
+            Ok(Message::Application { .. }) => saw_app = true,
+            Ok(Message::Heartbeat { .. }) => saw_dup_admin = true,
+            Ok(_) => {}
         }
     }
 
@@ -737,7 +737,7 @@ fn corrupt_checksum_frame_counted_as_garbage() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
             _ => {}
         }
     }
@@ -777,7 +777,7 @@ fn garbage_bytes_increment_counter() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
             _ => {}
         }
     }
@@ -999,6 +999,64 @@ fn only_malformed_is_non_fatal() {
 }
 
 #[test]
+fn try_recv_none_and_tick_services_clock_when_idle() {
+    // The pure-receive + explicit-clock contract: after establishing, `try_recv` is
+    // `None` while idle, `next_timeout` reports the next deadline, and `tick` past it
+    // makes the engine speak (a Heartbeat or TestRequest) — no `recv*` method does that.
+    let dir = tmp_dir("try_recv_tick");
+    let (client_sock, server_sock) = loopback_pair();
+    server_sock
+        .set_read_timeout(Some(Duration::from_millis(50)))
+        .unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut peer = Peer::new(client_sock, sender(), target());
+        let mut buf = [0u8; 512];
+        peer.send_logon(1); // HeartBtInt=1 → engine adopts a 1s heartbeat interval
+        // Read until the engine speaks unprompted — a Heartbeat (35=0) or a
+        // TestRequest (35=1), whichever the deadline produces — draining the reply.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut saw_admin = false;
+        while std::time::Instant::now() < deadline && !saw_admin {
+            match peer.stream.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    saw_admin = buf[..n]
+                        .windows(5)
+                        .any(|w| w == b"35=0\x01" || w == b"35=1\x01");
+                }
+                Err(_) => {}
+            }
+        }
+        assert!(
+            saw_admin,
+            "tick must service the clock (Heartbeat or TestRequest)"
+        );
+    });
+
+    let mut conn: FixConnection<TcpStream, MockDict> = FixConnection::from_parts(
+        server_sock,
+        SessionState::new(Duration::from_secs(30)),
+        session_cfg(target(), sender()),
+        journal(dir.path()),
+    );
+    let t0 = Instant::now();
+
+    // Acceptor: process the peer's Logon (the engine auto-replies), reaching Active.
+    while conn.try_recv(t0).unwrap().is_none() {}
+    assert_eq!(conn.state().state(), State::Active);
+
+    // Idle: try_recv yields nothing, and next_timeout reports the next deadline.
+    assert!(matches!(conn.try_recv(t0), Ok(None)));
+    assert!(conn.next_timeout().is_some());
+
+    // Tick past the deadline → the engine speaks unprompted (Heartbeat/TestRequest).
+    conn.tick(t0 + Duration::from_secs(2)).unwrap();
+
+    handle.join().unwrap();
+}
+
+#[test]
 fn sequence_reset_backward_ignored() {
     // Fix 4: SequenceReset Reset-mode with new_seq < next_inbound must be ignored.
     let dir = tmp_dir("seqreset_bwd");
@@ -1026,7 +1084,7 @@ fn sequence_reset_backward_ignored() {
 
     loop {
         match conn.recv(Instant::now()) {
-            Ok(Some(Message::LoggedOut { .. })) | Err(_) => break,
+            Ok(Message::LoggedOut { .. }) | Err(_) => break,
             _ => {}
         }
     }

--- a/nexus-fix-harness/src/main.rs
+++ b/nexus-fix-harness/src/main.rs
@@ -132,14 +132,14 @@ fn main() {
         let mut app_msgs = 0usize;
         loop {
             match conn.recv(Instant::now()) {
-                Ok(Some(Message::LoggedOut { .. })) => {
+                Ok(Message::LoggedOut { .. }) => {
                     println!("logged out cleanly, {app_msgs} app message(s)");
                     break;
                 }
-                Ok(Some(Message::Application { .. })) => {
+                Ok(Message::Application { .. }) => {
                     app_msgs += 1;
                 }
-                Ok(Some(_) | None) => {}
+                Ok(_) => {}
                 // A recoverable error (a malformed frame: bad checksum, lying
                 // BodyLength, or garbage framing) leaves the session intact — the
                 // reader has resynced. Tolerate it and keep receiving, so an


### PR DESCRIPTION
Split the recv contract into **pure receiving** and **explicit clock servicing**, so
no method conflates the two. Receiving a message and enforcing session timers are
separate concerns; folding a heartbeat timer into `recv` made the control flow
implicit and the cancellation story murky. The caller now drives the clock on its own
schedule — a `select!` timer branch in async, a bounded `try_recv` loop (or a separate
thread) in sync.

## New surface

| Method | Behavior |
|---|---|
| `recv(now) -> Result<Message, Error>` | **Blocks** until a message. Never returns `None` (was `Result<Option<Message>>`). |
| `try_recv(now) -> Result<Option<Message>, Error>` | Non-blocking. `None` when nothing is ready. |
| `tick(now) -> Result<(), Error>` | Sends any due Heartbeat/TestRequest and enforces the logon/logout/test-request/reset deadlines. `Err(UnexpectedDisconnect)` when one blows. |
| `next_timeout() -> Option<Instant>` | When `tick` next has work — sizes a `select!` sleep or a bounded `try_recv` wait. |

**No `recv*` method touches the clock.** `recv_timeout` is intentionally gone: a
bounded wait is `try_recv` on a read-timeout socket (`None` = the timeout elapsed), or
`tokio::time::timeout(dur, conn.recv(now))` in async.

## Which blocking behavior you get is the caller's socket mode

`recv`/`try_recv` don't hard-code blocking vs non-blocking — the socket does, the same
contract as tungstenite:

- **Blocking socket** → `recv` parks in the read syscall until a message. A read
  timeout (`SO_RCVTIMEO`) is transparent to `recv` (a no-data wake is retried), so one
  read-timeout socket backs both `recv` (blocks through) and `try_recv` (returns on the
  timeout).
- **Non-blocking socket** → use `try_recv`. Handing one to `recv` is a documented
  misuse (the retry has nothing to wait on and busy-spins).

## Async: no more internal timer on the receive path

The async `recv` loses its internal `tokio::time::timeout_at` — the receive path is now
driven only by the executor + the `WireStream`. That removes the last `tokio::time`
coupling from receiving, so the core stays runtime-agnostic over any `WireStream`
(kernel-bypass transports included); timers become a `select!` branch the caller owns.

**Cancellation caveat (documented on `recv`):** a dropped `recv` future is safe at the
socket read and for any message that carries no reply. A message that emits an outbound
reply (a TestRequest ack, a resend, an acceptor Logon, the Logout ack) flushes that
reply before returning, so a future dropped *during that write* — only reachable under
write back-pressure — can drop the just-processed message. Draining the reply *after*
the poll is required so a terminal ack reaches the wire before the caller's loop ends;
draining before the poll deadlocks the logout. Application messages are always
cancel-safe.

## Tests

The conformance `drive` helpers are rewritten as reactor loops — `tokio::select!`
(`recv` vs `sleep_until(next_timeout)` → `tick`) in async, `try_recv` + `tick` against a
50 ms read-timeout socket in sync. Besides re-establishing the timeout scenarios that
used to lean on `recv`'s internal timer, they double as the reference caller loop for
the new API.

## Verification

`cargo fmt --check`, `clippy --all-features --all-targets -D warnings`, full test suites
for both engines (0 failures), `cargo doc`, and the behave adversarial harness (9/9) all
green.
