### PR TITLE
ci: add miri job for nexus-slab, nexus-smartptr, nexus-collections

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,3 +160,19 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.94.0
     - name: Loom model checks (all loom_* tests)
       run: ./tools/loom.sh
+
+  miri:
+    runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-ignore-leaks
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri
+    - name: miri (nexus-slab)
+      run: cargo miri test -p nexus-slab --test miri_tests
+    - name: miri (nexus-smartptr)
+      run: cargo miri test -p nexus-smartptr --test miri_tests
+    - name: miri (nexus-collections)
+      run: cargo miri test -p nexus-collections --test miri_tests --features slab

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -169,8 +169,9 @@ jobs:
     - uses: actions/checkout@v4
     # Pin to a dated nightly; bump by hand when miri's tree-borrows or stacked-borrows
     # change enough to require an update.
-    - uses: dtolnay/rust-toolchain@nightly-2026-07-19
+    - uses: dtolnay/rust-toolchain@nightly
       with:
+        toolchain: nightly-2026-07-19
         components: miri
     - name: miri (nexus-slab)
       run: cargo miri test -p nexus-slab --test miri_tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,7 +167,9 @@ jobs:
       MIRIFLAGS: -Zmiri-ignore-leaks
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    # Pin to a dated nightly; bump by hand when miri's tree-borrows or stacked-borrows
+    # change enough to require an update.
+    - uses: dtolnay/rust-toolchain@nightly-2026-07-19
       with:
         components: miri
     - name: miri (nexus-slab)


### PR DESCRIPTION
Wires the existing miri_tests targets into CI. The script and test files are already in the repo; this adds a job that runs them on every push.

Uses a nightly toolchain (miri requires it) with MIRIFLAGS=-Zmiri-ignore-leaks, matching what tools/miri.sh does today. The collections test runs with --features slab per its required-features declaration.
