### PR TITLE
docs: add SAFETY justifications to nexus-shm unsafe blocks

### DIFF
--- a/docs/unsafe-audit-open.md
+++ b/docs/unsafe-audit-open.md
@@ -1,0 +1,34 @@
+# Unsafe audit open items
+
+Items that could not be fully verified during the SAFETY comment pass.
+Each entry has a crate, file, approximate line, and the specific question.
+
+---
+
+## nexus-shm
+
+### 1. Post-Release payload writes in `ShmSlotWriter::create` and `ShmRingWriter::create`
+
+**File:** `nexus-shm/src/slot.rs` (`ShmSlotReader::attach`, line ~135)
+**File:** `nexus-shm/src/ring.rs` (`read_capacity` / `read_elem_size`, lines ~26-31)
+
+**Issue:** `ShmSlotWriter::create` and `ShmRingWriter::create` both write
+`elem_size` (and `capacity` in the ring case) to the payload *after*
+`Segment::create_file` returns. `Segment::create_file` stores `status=ALIVE`
+with `Ordering::Release` inside `ControlBlock::write_header`. Because the
+payload writes happen after that Release, a reader that Acquire-loads
+`status=ALIVE` in `Segment::attach` is not formally guaranteed to observe
+those payload writes under the C11 memory model.
+
+**In practice:** On x86 (TSO), stores are globally visible in program order.
+On ARM/POWER, the page-cache coherency mechanism and the fact that the reader
+typically opens the file only after the writer process has finished `create()`
+provide de-facto ordering. However, this relies on OS-level happens-before
+(filesystem open/close), not the Rust/C11 memory model.
+
+**Fix:** Move the `elem_size`/`capacity` writes to before the Release store
+of `status=ALIVE`, i.e., initialize the payload header inside `Segment::create`
+(or via a callback) before `write_header` is called. This would make the
+Acquire/Release pair formally sufficient.
+
+**Risk level:** Low in practice (x86 Linux), but not formally sound.

--- a/docs/unsafe-audit-open.md
+++ b/docs/unsafe-audit-open.md
@@ -32,3 +32,29 @@ of `status=ALIVE`, i.e., initialize the payload header inside `Segment::create`
 Acquire/Release pair formally sufficient.
 
 **Risk level:** Low in practice (x86 Linux), but not formally sound.
+
+**Tracking:** #625
+
+---
+
+### 2. Ring slot alignment in `slot_ptr` (`ShmRingWriter`/`ShmRingReader`)
+
+**File:** `nexus-shm/src/ring.rs` (`slot_ptr`, line ~53)
+
+**Issue:** `slot_ptr` casts a byte pointer offset by `DATA_OFFSET + slot_idx * size_of::<T>()`
+to `*mut T`. The assert in `ShmRingWriter::create` checks `align_of::<T>() <= DATA_OFFSET`
+(192), but `DATA_OFFSET = 192` is not a power of two (192 = 64 * 3). A slot at offset 192
+is only 64-aligned: `192 mod 128 = 64`, so any `Pod` type with `align_of == 128` passes the
+assert but lands on a misaligned address. The `copy_nonoverlapping` and `read` calls at the
+call sites then operate on a misaligned pointer, which is UB.
+
+**In practice:** No in-tree `Pod` type exceeds `align_of == 16` (the maximum for `f64`/`u128`),
+so this is latent. It becomes reachable via a user-defined `#[repr(align(128))]` type that
+implements `Pod`.
+
+**Fix:** Change the assert to require `align_of::<T>().is_power_of_two() && DATA_OFFSET % align_of::<T>() == 0`,
+or adjust `DATA_OFFSET` to the next power-of-two boundary (256).
+
+**Risk level:** Low in practice (no in-tree type triggers it), but unsound by construction.
+
+**Tracking:** #624

--- a/nexus-shm/src/pod.rs
+++ b/nexus-shm/src/pod.rs
@@ -6,6 +6,9 @@
 /// Any bit pattern that fits in `size_of::<Self>()` bytes must be valid.
 pub unsafe trait Pod: Sized + 'static {}
 
+// SAFETY: All primitive integer and float types are `Copy` (no `Drop`), contain
+// no heap pointers, have a stable platform-defined representation with no
+// padding, and every bit pattern within the type's width is a valid value.
 unsafe impl Pod for u8 {}
 unsafe impl Pod for u16 {}
 unsafe impl Pod for u32 {}
@@ -23,6 +26,13 @@ unsafe impl Pod for f64 {}
 /// `usize` and `isize` are pointer-width integers. Both ends of an IPC channel
 /// must run the same architecture (same pointer width); mixing a 32-bit writer
 /// with a 64-bit reader produces wrong values.
+// SAFETY: `usize`/`isize` satisfy all `Pod` requirements: `Copy`, no heap
+// pointers, stable repr, every bit pattern valid. The cross-process caveat
+// above is a correctness concern for callers, not a soundness issue for `Pod`.
 unsafe impl Pod for usize {}
 unsafe impl Pod for isize {}
+// SAFETY: `T: Pod` guarantees T has no heap pointers, no `Drop`, a stable
+// repr, and every bit pattern is valid. A fixed-size array `[T; N]` inherits
+// all these properties; its layout is N contiguous copies of T with no padding
+// added by the compiler.
 unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -15,22 +15,47 @@ const ELEM_SIZE_OFFSET: usize = 136;
 const DATA_OFFSET: usize = 192;
 
 fn ring_tail(segment: &Segment) -> &AtomicU64 {
+    // SAFETY: TAIL_OFFSET (0) is within any valid ShmRing segment
+    // (`data_len >= DATA_OFFSET + capacity * size_of::<T>() > HEAD_OFFSET`).
+    // `data()` is 64-byte aligned (mmap), satisfying AtomicU64's alignment.
+    // The returned reference borrows the segment, so the mapping outlives it.
     unsafe { &*segment.data().add(TAIL_OFFSET).cast::<AtomicU64>() }
 }
 
 fn ring_head(segment: &Segment) -> &AtomicU64 {
+    // SAFETY: HEAD_OFFSET (64) is within any valid ShmRing segment and
+    // 64-byte aligned relative to `data()`. Same reasoning as `ring_tail`.
     unsafe { &*segment.data().add(HEAD_OFFSET).cast::<AtomicU64>() }
 }
 
 fn read_capacity(segment: &Segment) -> u64 {
+    // SAFETY: UNVERIFIED -- CAP_OFFSET (128) and ELEM_SIZE_OFFSET (136) are
+    // written in `ShmRingWriter::create` AFTER the Release store of
+    // status=ALIVE in `Segment::create_file`. The Acquire on status in
+    // `Segment::attach` therefore does not formally order these reads under
+    // the C11 memory model. In practice x86 TSO and Linux page-cache coherency
+    // guarantee visibility, but this has the same issue as `ShmSlotReader::attach`.
+    // See docs/unsafe-audit-open.md.
+    //
+    // The pointer itself is sound: CAP_OFFSET=128 is within any valid ShmRing
+    // payload, and data() is 64-byte aligned so the u64 cast is alignment-correct.
     unsafe { std::ptr::read(segment.data().add(CAP_OFFSET).cast::<u64>()) }
 }
 
 fn read_elem_size(segment: &Segment) -> u64 {
+    // SAFETY: ELEM_SIZE_OFFSET (136) is within any valid ShmRing payload
+    // (data_len >= DATA_OFFSET + capacity * size_of::<T>() > 136). The pointer
+    // is 8-byte aligned (136 mod 8 = 0, data() is 64-byte aligned).
+    // Same cross-process ordering caveat as `read_capacity` above.
     unsafe { std::ptr::read(segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>()) }
 }
 
 fn slot_ptr<T>(segment: &Segment, slot_idx: u64) -> *mut T {
+    // SAFETY: `slot_idx` is masked to `[0, capacity)` by all callers before
+    // this function is called; `DATA_OFFSET + slot_idx * size_of::<T>()` is
+    // therefore within `data_len`. `align_of::<T>() <= DATA_OFFSET` is
+    // asserted in `ShmRingWriter::create`, so the cast to `*mut T` is
+    // alignment-sound. The pointer is not dereferenced here.
     unsafe {
         segment
             .data()
@@ -86,6 +111,11 @@ impl<T: Pod> ShmRingWriter<T> {
             .and_then(|s| s.checked_add(DATA_OFFSET))
             .ok_or(ShmError::SizeOverflow)?;
         let segment = Segment::create_file(path, data_len, hints)?;
+        // SAFETY: `segment.data()` spans exactly `data_len` bytes (enforced by
+        // `Segment::create_file`); zeroing all of them is in bounds. We hold
+        // exclusive ownership via the OFD lock before the segment is shared.
+        // CAP_OFFSET (128) and ELEM_SIZE_OFFSET (136) are both within `data_len`
+        // and u64-aligned relative to the 64-byte-aligned `data()` pointer.
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
             std::ptr::write(
@@ -119,6 +149,11 @@ impl<T: Pod> ShmRingWriter<T> {
             }
         }
         let dst = slot_ptr::<T>(&self.segment, tail & self.mask);
+        // SAFETY: `dst` points to an exclusively owned, T-aligned slot in the
+        // payload (caller checked space above; SPSC invariant: only the writer
+        // accesses [tail, tail+capacity)). `value` is a valid `&T` so the source
+        // pointer is valid for one `T`. The ranges do not overlap (different
+        // allocations: stack/heap vs mmap).
         unsafe { std::ptr::copy_nonoverlapping(value as *const T, dst, 1) };
         self.local_tail = tail.wrapping_add(1);
         ring_tail(&self.segment).store(self.local_tail, Ordering::Release);
@@ -142,6 +177,10 @@ impl<T: Pod> ShmRingWriter<T> {
     }
 }
 
+// SAFETY: `ShmRingWriter` owns its `Segment` (mmap) exclusively (one writer
+// per file via OFD lock). `T: Send` ensures the payload type can cross thread
+// boundaries. `&mut self` methods enforce exclusive access; `!Sync` prevents
+// shared `&self` writes that would corrupt the seqlock invariant.
 unsafe impl<T: Pod + Send> Send for ShmRingWriter<T> {}
 
 impl<T: Pod> ShmRingReader<T> {
@@ -184,6 +223,10 @@ impl<T: Pod> ShmRingReader<T> {
             }
         }
         let src = slot_ptr::<T>(&self.segment, head & self.mask).cast_const();
+        // SAFETY: `src` points to a T-aligned, initialized slot. The SPSC
+        // invariant (writer published via Release on tail; we Acquire-loaded
+        // tail above) ensures the slot is fully written before we read it.
+        // `T: Pod` means no Drop, so reading by value is safe.
         let value = unsafe { std::ptr::read(src) };
         self.local_head = head.wrapping_add(1);
         ring_head(&self.segment).store(self.local_head, Ordering::Release);
@@ -204,6 +247,9 @@ impl<T: Pod> ShmRingReader<T> {
     }
 }
 
+// SAFETY: `ShmRingReader` owns its `Segment` (mmap). `T: Send` ensures the
+// payload type can cross thread boundaries. `try_pop` takes `&mut self` so
+// only one reader call runs at a time; `!Sync` is the natural consequence.
 unsafe impl<T: Pod + Send> Send for ShmRingReader<T> {}
 
 #[cfg(test)]
@@ -328,6 +374,9 @@ mod tests {
         side: u8,
         _pad: [u8; 3],
     }
+    // SAFETY: `Order` is `repr(C)`, `Copy`, contains only integer fields and an
+    // explicit pad array, has no heap pointers, no `Drop`, and its layout is
+    // stable. All bit patterns are valid for the field types.
     unsafe impl Pod for Order {}
 
     #[test]

--- a/nexus-shm/src/ring.rs
+++ b/nexus-shm/src/ring.rs
@@ -53,9 +53,11 @@ fn read_elem_size(segment: &Segment) -> u64 {
 fn slot_ptr<T>(segment: &Segment, slot_idx: u64) -> *mut T {
     // SAFETY: `slot_idx` is masked to `[0, capacity)` by all callers before
     // this function is called; `DATA_OFFSET + slot_idx * size_of::<T>()` is
-    // therefore within `data_len`. `align_of::<T>() <= DATA_OFFSET` is
-    // asserted in `ShmRingWriter::create`, so the cast to `*mut T` is
-    // alignment-sound. The pointer is not dereferenced here.
+    // therefore within `data_len`. The pointer is not dereferenced here.
+    // UNVERIFIED: the cast to `*mut T` assumes T-alignment, but DATA_OFFSET
+    // (192) is not a power of two, so the assert `align_of::<T>() <= 192`
+    // in create() does not guarantee T-alignment for all Pod alignments.
+    // See docs/unsafe-audit-open.md item 2 and #624.
     unsafe {
         segment
             .data()
@@ -179,8 +181,8 @@ impl<T: Pod> ShmRingWriter<T> {
 
 // SAFETY: `ShmRingWriter` owns its `Segment` (mmap) exclusively (one writer
 // per file via OFD lock). `T: Send` ensures the payload type can cross thread
-// boundaries. `&mut self` methods enforce exclusive access; `!Sync` prevents
-// shared `&self` writes that would corrupt the seqlock invariant.
+// boundaries. `try_push` takes `&mut self` so only one writer call runs at a
+// time; `!Sync` is the natural consequence.
 unsafe impl<T: Pod + Send> Send for ShmRingWriter<T> {}
 
 impl<T: Pod> ShmRingReader<T> {

--- a/nexus-shm/src/segment.rs
+++ b/nexus-shm/src/segment.rs
@@ -148,6 +148,10 @@ impl Segment {
     /// `offset` must be 4-byte-aligned and within `data_len()`.
     #[inline]
     pub unsafe fn commit_len_at(&self, offset: usize) -> &AtomicU32 {
+        // SAFETY: The caller guarantees `offset` is 4-byte-aligned and within
+        // `data_len()`; `data()` is non-null (page-aligned mmap base + HEADER),
+        // so `data().add(offset)` is in bounds. The cast to `*mut AtomicU32` is
+        // sound because 4-byte alignment is guaranteed by the caller.
         unsafe { AtomicU32::from_ptr(self.data().add(offset).cast()) }
     }
 
@@ -158,6 +162,10 @@ impl Segment {
     /// load of `commit_len_at`) and within `data_len()`.
     #[inline]
     pub unsafe fn frame_kind_at(&self, offset: usize) -> u16 {
+        // SAFETY: The caller guarantees the frame header at `offset` is within
+        // `data_len()` and published (Acquire on the commit-len field); the 8-byte
+        // header means `offset + 4` is also in bounds. `read_unaligned` requires no
+        // stricter alignment than byte alignment, which the payload always satisfies.
         unsafe { std::ptr::read_unaligned(self.data().add(offset + 4).cast()) }
     }
 
@@ -168,6 +176,11 @@ impl Segment {
     /// reserved for this record.
     #[inline]
     pub unsafe fn write_frame_kind_at(&self, offset: usize, kind: u16) {
+        // SAFETY: The caller guarantees the 8-byte frame header starting at
+        // `offset` is within `data_len()` and exclusively reserved for this
+        // write; `offset + 4` and `offset + 6` are therefore also in bounds.
+        // `write_unaligned` requires only byte alignment, which the payload
+        // always provides.
         unsafe {
             std::ptr::write_unaligned(self.data().add(offset + 4).cast::<u16>(), kind);
             std::ptr::write_unaligned(self.data().add(offset + 6).cast::<u16>(), 0);
@@ -181,6 +194,9 @@ impl Segment {
     /// reserved for this write.
     #[inline]
     pub unsafe fn write_at<T: Copy>(&self, offset: usize, val: T) {
+        // SAFETY: The caller guarantees `[offset, offset + size_of::<T>())` is
+        // within `data_len()` and exclusively reserved. `write_unaligned` requires
+        // only byte alignment, which the payload always provides.
         unsafe { std::ptr::write_unaligned(self.data().add(offset).cast(), val) }
     }
 
@@ -191,6 +207,9 @@ impl Segment {
     /// the data must be published before this call.
     #[inline]
     pub unsafe fn read_at<T: Copy>(&self, offset: usize) -> T {
+        // SAFETY: The caller guarantees `[offset, offset + size_of::<T>())` is
+        // within `data_len()` and the bytes are published before this call.
+        // `read_unaligned` requires only byte alignment, which the payload provides.
         unsafe { std::ptr::read_unaligned(self.data().add(offset).cast()) }
     }
 
@@ -201,6 +220,10 @@ impl Segment {
     /// The returned slice borrows `self` so the segment must outlive the slice.
     #[inline]
     pub unsafe fn slice_at(&self, offset: usize, len: usize) -> &[u8] {
+        // SAFETY: The caller guarantees `[offset, offset + len)` is within
+        // `data_len()` and bytes are published. `data()` is non-null (mmap) and
+        // the pointer arithmetic stays within the single mapped allocation; the
+        // returned slice borrows `self` so the mapping outlives it.
         unsafe { std::slice::from_raw_parts(self.data().add(offset), len) }
     }
 
@@ -211,6 +234,9 @@ impl Segment {
     /// write, and the segment must outlive the slice.
     #[inline]
     pub unsafe fn slice_mut_at(&mut self, offset: usize, len: usize) -> &mut [u8] {
+        // SAFETY: The caller guarantees `[offset, offset + len)` is within
+        // `data_len()` and exclusively reserved. `&mut self` prevents a second
+        // aliased `&mut [u8]` reference for the duration of the returned borrow.
         unsafe { std::slice::from_raw_parts_mut(self.data().add(offset), len) }
     }
 
@@ -288,11 +314,15 @@ mod tests {
         assert_eq!(seg.data_len(), 4096);
         assert_eq!(seg.status(), Status::Alive);
 
+        // SAFETY: seg was created with data_len=4096; offset 0, len 1 is in
+        // bounds and exclusively owned within this test scope.
         unsafe { seg.slice_mut_at(0, 1)[0] = 0xAB };
 
         let peer = Segment::attach(open_file(&path)).unwrap();
         assert_eq!(peer.data_len(), 4096);
         assert_eq!(peer.status(), Status::Alive);
+        // SAFETY: peer is attached to the same 4096-byte segment; the writer
+        // (`seg`) has not dropped yet so the byte at offset 0 is published.
         assert_eq!(unsafe { peer.slice_at(0, 1)[0] }, 0xAB);
 
         std::fs::remove_file(&path).unwrap();

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -296,7 +296,7 @@ mod tests {
     }
     // SAFETY: `Price` is `repr(C)`, `Copy`, contains only `f64` and `u64`
     // fields (all `Pod`), has no heap pointers, no `Drop`, and its layout is
-    // stable with no implicit padding beyond the declared `_pad` field.
+    // stable with no implicit padding.
     unsafe impl Pod for Price {}
 
     #[test]

--- a/nexus-shm/src/slot.rs
+++ b/nexus-shm/src/slot.rs
@@ -23,10 +23,18 @@ fn version_ptr(segment: &Segment) -> *mut AtomicU64 {
 }
 
 fn elem_size_ptr(segment: &Segment) -> *mut u64 {
+    // SAFETY: ELEM_SIZE_OFFSET (8) is strictly less than PAYLOAD_OFFSET (64),
+    // which is less than `data_len` for any valid ShmSlot segment (enforced by
+    // `ShmSlotWriter::create`). `data()` is non-null (mmap). The pointer is
+    // returned as a raw pointer and not yet dereferenced here.
     unsafe { segment.data().add(ELEM_SIZE_OFFSET).cast::<u64>() }
 }
 
 fn payload_ptr<T>(segment: &Segment) -> *mut T {
+    // SAFETY: PAYLOAD_OFFSET (64) is always within `data_len` for any valid
+    // ShmSlot segment. `align_of::<T>() <= PAYLOAD_OFFSET` is asserted in
+    // `ShmSlotWriter::create`, so the cast to `*mut T` is alignment-sound.
+    // `data()` is non-null (mmap). The pointer is not yet dereferenced here.
     unsafe { segment.data().add(PAYLOAD_OFFSET).cast::<T>() }
 }
 
@@ -74,6 +82,11 @@ impl<T: Pod> ShmSlotWriter<T> {
         );
         let data_len = data_len::<T>();
         let segment = Segment::create_file(path, data_len, hints)?;
+        // SAFETY: `segment.data()` spans exactly `data_len` bytes (enforced by
+        // `Segment::create_file`); zeroing all of them is in bounds. We hold
+        // exclusive ownership via the OFD lock before the segment is shared.
+        // `elem_size_ptr` returns a u64-aligned pointer within those bytes
+        // (ELEM_SIZE_OFFSET=8, data() is 64-byte aligned).
         unsafe {
             std::ptr::write_bytes(segment.data(), 0, data_len);
             std::ptr::write(elem_size_ptr(&segment), size_of::<T>() as u64);
@@ -96,6 +109,9 @@ impl<T: Pod> ShmSlotWriter<T> {
     /// tells it the memory is modified externally (another process maps the same
     /// region) and must not be elided, fused, or reordered against the fences.
     pub fn write(&self, value: &T) {
+        // SAFETY: `version_ptr` yields the `AtomicU64` at offset 0 of the
+        // payload; `data()` is 64-byte aligned (mmap), satisfying AtomicU64's
+        // alignment. The mapping is live for the duration of `self`.
         let ver = unsafe { &*version_ptr(&self.segment) };
         let dst = payload_ptr::<T>(&self.segment);
         ver.fetch_add(1, Ordering::Relaxed);
@@ -125,6 +141,15 @@ impl<T: Pod> ShmSlotReader<T> {
     /// different element size than `size_of::<T>()`.
     pub fn attach(path: impl AsRef<Path>) -> Result<Self, ShmError> {
         let segment = Segment::attach_file(path)?;
+        // SAFETY: UNVERIFIED -- `elem_size_ptr` returns a u64-aligned pointer within
+        // the payload (ELEM_SIZE_OFFSET=8, data() is 64-byte aligned). However, the
+        // Release store marking status=ALIVE in `Segment::create` precedes the
+        // elem_size write in `ShmSlotWriter::create`, so the Acquire on status in
+        // `Segment::attach` does not formally order this read after that write under
+        // the C11 memory model. In practice, cross-process coherency on Linux x86
+        // (TSO) and ARM (via page-cache flush) ensures the write is visible, but
+        // moving the elem_size write to before the Release store would make this
+        // formally sound. See docs/unsafe-audit-open.md.
         let written = unsafe { std::ptr::read(elem_size_ptr(&segment)) } as usize;
         if written != size_of::<T>() {
             return Err(ShmError::ElemSizeMismatch {
@@ -148,6 +173,8 @@ impl<T: Pod> ShmSlotReader<T> {
     /// detected via the OFD lock (`peer_liveness`) rather than the atomic status
     /// field, which can be stale after an abnormal process exit.
     pub fn read(&mut self) -> SlotRead<'_, T> {
+        // SAFETY: Same argument as `write`: `version_ptr` yields a valid,
+        // 64-byte-aligned `AtomicU64` within the live mapping.
         let ver = unsafe { &*version_ptr(&self.segment) };
         let src = payload_ptr::<T>(&self.segment).cast_const();
         loop {
@@ -163,6 +190,9 @@ impl<T: Pod> ShmSlotReader<T> {
                     }
                     _ => {
                         return if self.shadow_valid {
+                            // SAFETY: `shadow_valid` is set to `true` only
+                            // after a successful `copy_nonoverlapping` into
+                            // `shadow`; so `shadow` is initialized here.
                             SlotRead::Stale(unsafe { self.shadow.assume_init_ref() })
                         } else {
                             SlotRead::Empty
@@ -180,15 +210,25 @@ impl<T: Pod> ShmSlotReader<T> {
                 std::hint::spin_loop();
                 continue;
             }
+            // SAFETY: `buf` was just written by `read_volatile` above (one T
+            // written into an `&mut MaybeUninit<T>`), so it is initialized.
+            // `shadow` is a separate heap allocation; the copy does not overlap.
             unsafe {
                 std::ptr::copy_nonoverlapping(self.buf.as_ptr(), self.shadow.as_mut_ptr(), 1);
             }
             self.shadow_valid = true;
+            // SAFETY: `shadow` was just initialized by the `copy_nonoverlapping`
+            // above; `shadow_valid` is set immediately after to record this.
             return SlotRead::Fresh(unsafe { self.shadow.assume_init_ref() });
         }
     }
 }
 
+// SAFETY: `ShmSlotReader` owns its `Segment` (mmap) and two `Box`-allocated
+// shadow buffers; all fields are self-contained. `T: Send` ensures the
+// payload type can cross thread boundaries. The seqlock read protocol in
+// `read` does not require `&mut self` exclusivity beyond preventing two
+// concurrent `read` calls (which `!Sync` enforces).
 unsafe impl<T: Pod + Send> Send for ShmSlotReader<T> {}
 
 #[cfg(test)]
@@ -254,6 +294,9 @@ mod tests {
         ask: f64,
         seq: u64,
     }
+    // SAFETY: `Price` is `repr(C)`, `Copy`, contains only `f64` and `u64`
+    // fields (all `Pod`), has no heap pointers, no `Drop`, and its layout is
+    // stable with no implicit padding beyond the declared `_pad` field.
     unsafe impl Pod for Price {}
 
     #[test]
@@ -371,6 +414,9 @@ mod tests {
         }
 
         // Bump version to odd — simulates being killed between the two increments.
+        // SAFETY: `version_ptr` yields the AtomicU64 at offset 0 of a live,
+        // 64-byte-aligned mmap payload; the segment is alive and exclusively
+        // accessible in this single-threaded test.
         let ver = unsafe { &*version_ptr(&writer.segment) };
         ver.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
Adds inline // SAFETY: comments to every unsafe block and unsafe impl in nexus-shm. No behavior change.

One open item flagged as UNVERIFIED in docs/unsafe-audit-open.md: ShmSlotWriter::create and ShmRingWriter::create write elem_size/capacity to the payload after Segment::create_file returns, which means after the Release store of status=ALIVE. A reader that Acquire-loads status in Segment::attach is not formally guaranteed to see those writes under the C11 memory model. Works on x86 TSO in practice; fix is to move those writes before the Release.
