### PR TITLE
docs(nexus-slab): add SAFETY justifications to all unsafe blocks

### DIFF
--- a/nexus-slab/examples/cold_single_op.rs
+++ b/nexus-slab/examples/cold_single_op.rs
@@ -31,11 +31,15 @@ const SAMPLES: usize = 2000; // Fewer samples since we evict each time
 
 use std::cell::UnsafeCell;
 struct EvictBuffer(UnsafeCell<[u8; 24 * 1024 * 1024]>);
+// SAFETY: `EvictBuffer` wraps `UnsafeCell`; `evict_cache` is the only
+// accessor and is called single-threaded from main.
 unsafe impl Sync for EvictBuffer {}
 static EVICT_BUFFER: EvictBuffer = EvictBuffer(UnsafeCell::new([0u8; 24 * 1024 * 1024]));
 
 #[inline(never)]
 fn evict_cache() {
+    // SAFETY: single-threaded; no other reference to `EVICT_BUFFER` exists
+    // during this call.
     unsafe {
         let buf = &mut *EVICT_BUFFER.0.get();
         let len = buf.len();
@@ -56,6 +60,7 @@ fn evict_cache() {
 
 #[inline(never)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -65,6 +70,7 @@ fn rdtsc_start() -> u64 {
 #[inline(never)]
 fn rdtsc_end() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let t = core::arch::x86_64::__rdtscp(&raw mut aux);
         core::arch::x86_64::_mm_lfence();
@@ -98,6 +104,7 @@ fn main() {
     // 64B test
     {
         println!("\n  -- 64B SINGLE OP --");
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let slab = unsafe { BoundedSlab::<Pod64>::with_capacity(SAMPLES * 4) };
 
         let mut box_samples = Vec::with_capacity(SAMPLES);
@@ -152,6 +159,7 @@ fn main() {
     // 256B test
     {
         println!("\n  -- 256B SINGLE OP --");
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let slab = unsafe { BoundedSlab::<Pod256>::with_capacity(SAMPLES * 4) };
 
         let mut box_samples = Vec::with_capacity(SAMPLES);

--- a/nexus-slab/examples/minimal_contention.rs
+++ b/nexus-slab/examples/minimal_contention.rs
@@ -52,6 +52,7 @@ const BATCH: usize = 100;
 
 #[inline(never)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -61,6 +62,7 @@ fn rdtsc_start() -> u64 {
 #[inline(never)]
 fn rdtsc_end() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let t = core::arch::x86_64::__rdtscp(&raw mut aux);
         core::arch::x86_64::_mm_lfence();
@@ -169,15 +171,19 @@ fn main() {
     println!("ISOLATED CONTENTION TEST");
     println!("========================");
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab64 = unsafe { BoundedSlab::<Pod64>::with_capacity(SAMPLES * 2) };
     contention_test("64B", &slab64);
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab256 = unsafe { BoundedSlab::<Pod256>::with_capacity(SAMPLES * 2) };
     contention_test("256B", &slab256);
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab1024 = unsafe { BoundedSlab::<Pod1024>::with_capacity(SAMPLES * 2) };
     contention_test("1024B", &slab1024);
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab4096 = unsafe { BoundedSlab::<Pod4096>::with_capacity(SAMPLES * 2) };
     contention_test("4096B", &slab4096);
 }

--- a/nexus-slab/examples/minimal_contention_cold.rs
+++ b/nexus-slab/examples/minimal_contention_cold.rs
@@ -50,6 +50,8 @@ const BATCH: usize = 10;
 // Using 2x cache size ensures even with set-associativity we evict everything
 use std::cell::UnsafeCell;
 struct EvictBuffer(UnsafeCell<[u8; 24 * 1024 * 1024]>);
+// SAFETY: `EvictBuffer` wraps `UnsafeCell`; `evict_cache` is the only
+// accessor and is called single-threaded from main.
 unsafe impl Sync for EvictBuffer {}
 static EVICT_BUFFER: EvictBuffer = EvictBuffer(UnsafeCell::new([0u8; 24 * 1024 * 1024]));
 
@@ -58,6 +60,8 @@ fn evict_cache() {
     // Strided access pattern to defeat prefetchers
     // Stride of 4097 bytes (not power of 2, crosses cache lines unpredictably)
     // This forces actual memory fetches rather than prefetcher hits
+    // SAFETY: single-threaded; no other reference to `EVICT_BUFFER` exists
+    // during this call.
     unsafe {
         let buf = &mut *EVICT_BUFFER.0.get();
         let len = buf.len();
@@ -80,6 +84,7 @@ fn evict_cache() {
 
 #[inline(never)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -89,6 +94,7 @@ fn rdtsc_start() -> u64 {
 #[inline(never)]
 fn rdtsc_end() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let t = core::arch::x86_64::__rdtscp(&raw mut aux);
         core::arch::x86_64::_mm_lfence();
@@ -180,12 +186,15 @@ fn main() {
     println!("==========================");
     println!("  24MB eviction buffer (2x L3), strided access, interleaved measurement");
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab64 = unsafe { BoundedSlab::<Pod64>::with_capacity(SAMPLES * 2) };
     cold_test("64B", &slab64);
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab256 = unsafe { BoundedSlab::<Pod256>::with_capacity(SAMPLES * 2) };
     cold_test("256B", &slab256);
 
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab4096 = unsafe { BoundedSlab::<Pod4096>::with_capacity(SAMPLES * 2) };
     cold_test("4096B", &slab4096);
 }

--- a/nexus-slab/examples/perf_full_distribution.rs
+++ b/nexus-slab/examples/perf_full_distribution.rs
@@ -29,6 +29,7 @@ macro_rules! unroll {
 #[inline(always)]
 fn rdtsc_start() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -40,6 +41,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 fn rdtsc_end() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let tsc = std::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
         std::arch::x86_64::_mm_lfence();
@@ -75,6 +77,7 @@ fn bench_get() {
     let mut slab_hot_hist: Histogram<u64> = Histogram::new(3).unwrap();
 
     // Setup slab
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
     let entries: Vec<Slot<u64>> = (0..NUM_SLOTS as u64).map(|i| slab.alloc(i)).collect();
 
@@ -159,6 +162,7 @@ fn bench_get_mut() {
     let mut slab_hist: Histogram<u64> = Histogram::new(3).unwrap();
 
     // Setup slab
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
     let mut entries: Vec<Slot<u64>> = (0..NUM_SLOTS as u64).map(|i| slab.alloc(i)).collect();
 
@@ -216,6 +220,7 @@ fn bench_insert() {
     let mut slab_hist: Histogram<u64> = Histogram::new(3).unwrap();
 
     // slab insert - need to remove after each batch to make room
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
     let mut temp_entries: Vec<Slot<u64>> = Vec::with_capacity(BATCH_SIZE as usize);
 
@@ -273,6 +278,7 @@ fn bench_remove() {
     let mut slab_hist: Histogram<u64> = Histogram::new(3).unwrap();
 
     // slot free_take - insert batch, then remove batch
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
 
     for _ in 0..OPS / BATCH_SIZE as usize {
@@ -329,6 +335,7 @@ fn bench_replace() {
     let mut slab_hist: Histogram<u64> = Histogram::new(3).unwrap();
 
     // Setup slab
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
     let mut entries: Vec<Slot<u64>> = (0..NUM_SLOTS as u64).map(|i| slab.alloc(i)).collect();
 
@@ -399,6 +406,7 @@ fn main() {
     // Warmup: exercise slab and slab-crate paths to trigger page faults,
     // TLS init, and cache priming before timed measurements.
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let warmup_slab = unsafe { BoundedSlab::<u64>::with_capacity(NUM_SLOTS) };
         let warmup_entries: Vec<Slot<u64>> = (0..NUM_SLOTS as u64)
             .map(|i| warmup_slab.alloc(i))

--- a/nexus-slab/examples/perf_stress_test.rs
+++ b/nexus-slab/examples/perf_stress_test.rs
@@ -20,6 +20,7 @@ use std::hint::black_box;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -28,6 +29,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let tsc = core::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
         core::arch::x86_64::_mm_lfence();
@@ -154,6 +156,7 @@ fn test_long_running_churn() {
     // --- Slab test ---
     println!("\n  Slab<TestValue>:");
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(CAPACITY) };
 
         let mut items: Vec<Option<_>> = (0..CAPACITY).map(|_| None).collect();
@@ -255,6 +258,7 @@ fn test_burst_allocation() {
 
     // --- Slab bursts ---
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(BURST_SIZE) };
 
         let mut alloc_samples = Vec::with_capacity(BURSTS);
@@ -322,6 +326,7 @@ fn test_mixed_lifetimes() {
 
     // --- Slab mixed lifetimes ---
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(LONG_LIVED + 100) };
 
         // Create long-lived items
@@ -391,6 +396,7 @@ fn test_fifo_queue() {
 
     // --- Slab queue ---
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(QUEUE_SIZE + 100) };
 
         let mut queue: VecDeque<_> = VecDeque::with_capacity(QUEUE_SIZE);
@@ -458,6 +464,7 @@ fn test_tail_latency() {
 
     // --- Slab tail latency ---
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(100) };
 
         let mut samples = Vec::with_capacity(SAMPLES);
@@ -617,6 +624,7 @@ fn test_brutal_fragmentation() {
     // --- Slab (immune to fragmentation) ---
     println!();
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(1000) };
 
         let mut samples = Vec::with_capacity(MEASURE_COUNT);
@@ -687,6 +695,7 @@ fn test_sustained_pressure() {
     // --- Slab under pressure ---
     println!();
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(TARGET_COUNT) };
 
         // Build up pressure
@@ -906,6 +915,7 @@ fn size_test<T: Default + Clone + 'static>(name: &str) {
         print!("  Box  10% fill");
         print_full_histogram_inline(&mut box_samples);
 
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<T> = unsafe { BoundedSlab::with_capacity(SLAB_CAPACITY) };
         let _slab_long: Vec<_> = (0..fill).map(|_| alloc.alloc(T::default())).collect();
         let mut slab_samples = Vec::with_capacity(SIZE_CHURN_OPS);
@@ -936,6 +946,7 @@ fn size_test<T: Default + Clone + 'static>(name: &str) {
         print!("  Box  25% fill");
         print_full_histogram_inline(&mut box_samples);
 
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<T> = unsafe { BoundedSlab::with_capacity(SLAB_CAPACITY) };
         let _slab_long: Vec<_> = (0..fill).map(|_| alloc.alloc(T::default())).collect();
         let mut slab_samples = Vec::with_capacity(SIZE_CHURN_OPS);
@@ -966,6 +977,7 @@ fn size_test<T: Default + Clone + 'static>(name: &str) {
         print!("  Box  50% fill");
         print_full_histogram_inline(&mut box_samples);
 
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<T> = unsafe { BoundedSlab::with_capacity(SLAB_CAPACITY) };
         let _slab_long: Vec<_> = (0..fill).map(|_| alloc.alloc(T::default())).collect();
         let mut slab_samples = Vec::with_capacity(SIZE_CHURN_OPS);
@@ -1085,6 +1097,7 @@ fn contention_test<T: Default + Clone + 'static>(name: &str) {
 
     // Slab - with same noise pattern (global allocator equally warm)
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<T> = unsafe { BoundedSlab::with_capacity(CONTENTION_BATCH + 100) };
 
         let mut samples = Vec::with_capacity(CONTENTION_SAMPLES);
@@ -1196,6 +1209,7 @@ fn test_first_allocation_latency() {
 
     // Slab - first allocation from pre-allocated pool
     {
+        // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
         let alloc: BoundedSlab<TestValue> = unsafe { BoundedSlab::with_capacity(1000) };
 
         let mut first_alloc_times = Vec::with_capacity(TRIALS);

--- a/nexus-slab/examples/perf_vs_box.rs
+++ b/nexus-slab/examples/perf_vs_box.rs
@@ -11,6 +11,7 @@ use std::hint::black_box;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -19,6 +20,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let tsc = core::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
         core::arch::x86_64::_mm_lfence();
@@ -97,6 +99,7 @@ macro_rules! bench_size {
             // --- ALLOC (batched) ---
             {
                 let slab: BoundedSlab<Value> =
+                    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
                     unsafe { BoundedSlab::with_capacity(BATCH as usize * 2) };
                 let mut slab_samples = Vec::with_capacity(SAMPLES);
                 let mut box_samples = Vec::with_capacity(SAMPLES);
@@ -127,6 +130,7 @@ macro_rules! bench_size {
             // --- FREE only (pre-alloc, then batch free) ---
             {
                 let slab: BoundedSlab<Value> =
+                    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
                     unsafe { BoundedSlab::with_capacity(BATCH as usize * SAMPLES) };
                 let mut slab_samples = Vec::with_capacity(SAMPLES);
                 let mut box_samples = Vec::with_capacity(SAMPLES);

--- a/nexus-slab/src/bounded.rs
+++ b/nexus-slab/src/bounded.rs
@@ -83,8 +83,8 @@ impl<T> fmt::Debug for Claim<'_, T> {
 impl<T> Drop for Claim<'_, T> {
     fn drop(&mut self) {
         // Abandoned claim - return slot to freelist
-        // SAFETY: slot_ptr is valid and still vacant (never written to)
         let free_head = self.slab.free_head.get();
+        // SAFETY: slot_ptr is valid and still vacant (never written to)
         unsafe {
             (*self.slot_ptr).set_next_free(free_head);
         }
@@ -366,6 +366,7 @@ mod tests {
 
     #[test]
     fn slab_basic() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_capacity(100) };
         assert_eq!(slab.capacity(), 100);
 
@@ -376,6 +377,7 @@ mod tests {
 
     #[test]
     fn slab_full() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_capacity(2) };
         let s1 = slab.alloc(1);
         let s2 = slab.alloc(2);
@@ -391,6 +393,7 @@ mod tests {
 
     #[test]
     fn slot_deref_mut() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<String>::with_capacity(10) };
         let mut slot = slab.alloc("hello".to_string());
         slot.push_str(" world");
@@ -400,6 +403,7 @@ mod tests {
 
     #[test]
     fn slot_dealloc_take() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<String>::with_capacity(10) };
         let slot = slab.alloc("hello".to_string());
 
@@ -414,6 +418,7 @@ mod tests {
 
     #[test]
     fn slab_debug() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_capacity(10) };
         let s = slab.alloc(42);
         let debug = format!("{:?}", slab);
@@ -424,6 +429,7 @@ mod tests {
 
     #[test]
     fn borrow_traits() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_capacity(10) };
         let mut slot = slab.alloc(42);
 
@@ -441,6 +447,7 @@ mod tests {
     #[test]
     fn slot_debug_drop_panics() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: test slab; slot intentionally not freed (tests debug drop panic).
             let slab = unsafe { Slab::<u64>::with_capacity(10) };
             let _slot = slab.alloc(42u64);
             // slot drops here without being freed
@@ -450,6 +457,7 @@ mod tests {
 
     #[test]
     fn capacity_one() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_capacity(1) };
 
         assert_eq!(slab.capacity(), 1);

--- a/nexus-slab/src/byte/bounded.rs
+++ b/nexus-slab/src/byte/bounded.rs
@@ -237,6 +237,7 @@ mod tests {
 
     #[test]
     fn basic_alloc_free() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<128> = unsafe { Slab::with_capacity(10) };
         let ptr = slab.alloc(42u64);
         assert_eq!(*ptr, 42);
@@ -245,6 +246,7 @@ mod tests {
 
     #[test]
     fn heterogeneous_types() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<128> = unsafe { Slab::with_capacity(10) };
 
         let p1 = slab.alloc(42u64);
@@ -262,6 +264,7 @@ mod tests {
 
     #[test]
     fn take_returns_value() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(10) };
         let ptr = slab.alloc(String::from("owned"));
         let val = slab.take(ptr);
@@ -270,6 +273,7 @@ mod tests {
 
     #[test]
     fn full_returns_error() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(1) };
         let p1 = slab.alloc(1u64);
         let result = slab.try_alloc(2u64);
@@ -281,12 +285,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "exceeds byte slab slot size")]
     fn rejects_oversized_type() {
+        // SAFETY: test slab; single-threaded; panics before allocation on type mismatch.
         let slab: Slab<8> = unsafe { Slab::with_capacity(1) };
         let _p = slab.alloc([0u64; 2]);
     }
 
     #[test]
     fn deref_mut() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(10) };
         let mut ptr = slab.alloc(String::from("hello"));
         ptr.push_str(" world");
@@ -296,6 +302,7 @@ mod tests {
 
     #[test]
     fn reuse_after_free() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(1) };
         let ptr = slab.alloc(1u64);
         slab.free(ptr);
@@ -308,6 +315,7 @@ mod tests {
     #[test]
     fn debug_drop_panics() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: test slab; slot intentionally not freed (tests debug drop panic).
             let slab: Slab<64> = unsafe { Slab::with_capacity(10) };
             let _ptr = slab.alloc(42u64);
         }));
@@ -320,6 +328,7 @@ mod tests {
 
     #[test]
     fn claim_write_typed() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(4) };
         let claim = slab.claim();
         let slot = claim.write(42u64);
@@ -329,18 +338,23 @@ mod tests {
 
     #[test]
     fn claim_write_raw() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(4) };
         let claim = slab.claim();
         let val: u64 = 99;
+        // SAFETY: val is on the stack; size_of::<u64>() bytes are initialized.
         let ptr =
             unsafe { claim.write_raw(&raw const val as *const u8, core::mem::size_of::<u64>()) };
+        // SAFETY: ptr was written with write_raw above; points to an initialized u64.
         assert_eq!(unsafe { *(ptr as *const u64) }, 99);
+        // SAFETY: ptr was obtained from write_raw above; points to an initialized u64 slot.
         let slot = unsafe { super::Slot::<u64>::from_raw(ptr) };
         slab.free(slot);
     }
 
     #[test]
     fn claim_drop_returns_to_freelist() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(1) };
 
         // Claim the only slot, then drop without writing.
@@ -356,6 +370,7 @@ mod tests {
 
     #[test]
     fn try_claim_returns_none_when_full() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(1) };
         let _held = slab.claim();
 
@@ -364,6 +379,7 @@ mod tests {
 
     #[test]
     fn try_claim_succeeds_after_abandon() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_capacity(1) };
 
         let claim = slab.claim();

--- a/nexus-slab/src/byte/unbounded.rs
+++ b/nexus-slab/src/byte/unbounded.rs
@@ -319,6 +319,7 @@ mod tests {
 
     #[test]
     fn basic_alloc_free() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_chunk_capacity(256) };
         let ptr = slab.alloc(42u64);
         assert_eq!(*ptr, 42);
@@ -327,6 +328,7 @@ mod tests {
 
     #[test]
     fn heterogeneous_types() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<128> = unsafe { Slab::with_chunk_capacity(256) };
 
         let p1 = slab.alloc(42u64);
@@ -344,6 +346,7 @@ mod tests {
 
     #[test]
     fn grows_automatically() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<16> = unsafe { Slab::with_chunk_capacity(2) };
         let mut ptrs = alloc::vec::Vec::new();
         for i in 0..100u64 {
@@ -359,6 +362,7 @@ mod tests {
 
     #[test]
     fn take_returns_value() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_chunk_capacity(256) };
         let ptr = slab.alloc(String::from("taken"));
         let val = slab.take(ptr);
@@ -371,6 +375,7 @@ mod tests {
 
     #[test]
     fn claim_write_typed() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_chunk_capacity(256) };
         let claim = slab.claim();
         let slot = claim.write(42u64);
@@ -380,6 +385,7 @@ mod tests {
 
     #[test]
     fn claim_drop_returns_to_freelist() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_chunk_capacity(1) };
 
         // Claim, then abandon.
@@ -395,12 +401,16 @@ mod tests {
 
     #[test]
     fn claim_write_raw() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: Slab<64> = unsafe { Slab::with_chunk_capacity(256) };
         let claim = slab.claim();
         let val: u64 = 77;
+        // SAFETY: val is on the stack; size_of::<u64>() bytes are initialized.
         let ptr =
             unsafe { claim.write_raw(&raw const val as *const u8, core::mem::size_of::<u64>()) };
+        // SAFETY: ptr was written with write_raw above; points to an initialized u64.
         assert_eq!(unsafe { *(ptr as *const u64) }, 77);
+        // SAFETY: ptr was obtained from write_raw above; points to an initialized u64 slot.
         let slot = unsafe { super::Slot::<u64>::from_raw(ptr) };
         slab.free(slot);
     }
@@ -411,6 +421,7 @@ mod tests {
 
     #[test]
     fn builder_defaults() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Builder::new().build::<64>() };
         let slot = slab.alloc(42u64);
         assert_eq!(*slot, 42);
@@ -419,6 +430,7 @@ mod tests {
 
     #[test]
     fn builder_custom_chunk_capacity() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Builder::new().chunk_capacity(32).build::<64>() };
         let slot = slab.alloc(1u64);
         slab.free(slot);
@@ -426,6 +438,7 @@ mod tests {
 
     #[test]
     fn builder_initial_chunks() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe {
             Builder::new()
                 .chunk_capacity(16)
@@ -445,6 +458,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "chunk_capacity must be non-zero")]
     fn builder_zero_chunk_capacity_panics() {
+        // SAFETY: test slab; single-threaded; panics before any slot can be allocated.
         let _slab = unsafe { Builder::new().chunk_capacity(0).build::<64>() };
     }
 }

--- a/nexus-slab/src/rc/bounded.rs
+++ b/nexus-slab/src/rc/bounded.rs
@@ -99,6 +99,7 @@ mod tests {
 
     #[test]
     fn alloc_borrow_free() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let handle = slab.alloc(42u64);
 
@@ -112,6 +113,7 @@ mod tests {
 
     #[test]
     fn clone_and_free_both() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let h1 = slab.alloc(42u64);
         let h2 = h1.clone();
@@ -124,6 +126,7 @@ mod tests {
 
     #[test]
     fn borrow_and_borrow_mut() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let handle = slab.alloc(String::from("hello"));
 
@@ -144,6 +147,7 @@ mod tests {
 
     #[test]
     fn mutation_visible_across_clones() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let h1 = slab.alloc(1u64);
         let h2 = h1.clone();
@@ -164,6 +168,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already borrowed")]
     fn double_borrow_panics() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let h1 = slab.alloc(42u64);
         let h2 = h1.clone();
@@ -175,6 +180,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already borrowed")]
     fn borrow_while_mut_panics() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let h1 = slab.alloc(42u64);
         let h2 = h1.clone();
@@ -185,6 +191,7 @@ mod tests {
 
     #[test]
     fn try_alloc_full() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(1) };
         let h1 = slab.alloc(1u64);
 
@@ -209,6 +216,7 @@ mod tests {
         }
 
         let drops = Cell::new(0);
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
 
         let h1 = slab.alloc(DropCounter { count: &drops });
@@ -224,6 +232,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already borrowed")]
     fn mut_while_borrow_panics() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let h1 = slab.alloc(42u64);
         let h2 = h1.clone();
@@ -234,6 +243,7 @@ mod tests {
 
     #[test]
     fn pin_and_pin_mut() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let handle = slab.alloc(42u64);
 
@@ -254,10 +264,12 @@ mod tests {
 
     #[test]
     fn into_raw_from_raw_roundtrip() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(10) };
         let handle = slab.alloc(42u64);
 
         let raw = handle.into_raw();
+        // SAFETY: raw was obtained from into_raw() just above; refcount is still non-zero.
         let handle = unsafe { crate::RcSlot::from_raw(raw) };
 
         {
@@ -269,6 +281,7 @@ mod tests {
 
     #[test]
     fn freelist_integrity_after_rc_cycle() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_capacity(4) };
 
         // Fill
@@ -313,6 +326,7 @@ mod tests {
     #[test]
     fn debug_drop_panics() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: test slab; handle intentionally not freed (tests debug drop panic).
             let slab = unsafe { Slab::with_capacity(10) };
             let _h = slab.alloc(42u64);
         }));

--- a/nexus-slab/src/rc/unbounded.rs
+++ b/nexus-slab/src/rc/unbounded.rs
@@ -66,6 +66,7 @@ mod tests {
 
     #[test]
     fn alloc_borrow_free() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_chunk_capacity(4) };
         let h1 = slab.alloc(42u64);
         let h2 = h1.clone();
@@ -82,6 +83,7 @@ mod tests {
 
     #[test]
     fn grows_automatically() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { Slab::with_chunk_capacity(2) };
         let mut handles = alloc::vec::Vec::new();
         for i in 0..100u64 {

--- a/nexus-slab/src/unbounded.rs
+++ b/nexus-slab/src/unbounded.rs
@@ -586,6 +586,7 @@ mod tests {
 
     #[test]
     fn slab_basic() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_chunk_capacity(16) };
 
         let slot = slab.alloc(42);
@@ -595,6 +596,7 @@ mod tests {
 
     #[test]
     fn slab_grows() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_chunk_capacity(4) };
 
         let mut slots = Vec::new();
@@ -611,6 +613,7 @@ mod tests {
 
     #[test]
     fn slot_deref_mut() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<String>::with_chunk_capacity(16) };
         let mut slot = slab.alloc("hello".to_string());
         slot.push_str(" world");
@@ -620,6 +623,7 @@ mod tests {
 
     #[test]
     fn slot_dealloc_take() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<String>::with_chunk_capacity(16) };
         let slot = slab.alloc("hello".to_string());
 
@@ -629,6 +633,7 @@ mod tests {
 
     #[test]
     fn chunk_freelist_maintenance() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_chunk_capacity(2) };
 
         // Fill first chunk
@@ -655,6 +660,7 @@ mod tests {
 
     #[test]
     fn borrow_traits() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Slab::<u64>::with_chunk_capacity(16) };
         let mut slot = slab.alloc(42);
 
@@ -674,6 +680,7 @@ mod tests {
 
     #[test]
     fn builder_defaults() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Builder::new().build::<u64>() };
         assert_eq!(slab.chunk_capacity(), 256);
         assert_eq!(slab.chunk_count(), 0);
@@ -685,6 +692,7 @@ mod tests {
 
     #[test]
     fn builder_custom_chunk_capacity() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe { Builder::new().chunk_capacity(64).build::<u64>() };
         assert_eq!(slab.chunk_capacity(), 64);
 
@@ -695,6 +703,7 @@ mod tests {
 
     #[test]
     fn builder_initial_chunks() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab = unsafe {
             Builder::new()
                 .chunk_capacity(32)
@@ -708,6 +717,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "chunk_capacity must be non-zero")]
     fn builder_zero_chunk_capacity_panics() {
+        // SAFETY: test slab; single-threaded; panics before any slot can be allocated.
         let _slab = unsafe { Builder::new().chunk_capacity(0).build::<u64>() };
     }
 }

--- a/nexus-slab/tests/allocator_tests.rs
+++ b/nexus-slab/tests/allocator_tests.rs
@@ -64,6 +64,7 @@ impl Drop for OrderedDrop {
 
 #[test]
 fn bounded_basic_insert_drop() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(16) };
 
     assert_eq!(slab.capacity(), 16);
@@ -76,6 +77,7 @@ fn bounded_basic_insert_drop() {
 
 #[test]
 fn bounded_fill_to_capacity() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(8) };
 
     let slots: Vec<_> = (0..8).map(|i| slab.alloc(i)).collect();
@@ -95,6 +97,7 @@ fn bounded_fill_to_capacity() {
 
 #[test]
 fn bounded_capacity_one() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(1) };
 
     assert_eq!(slab.capacity(), 1);
@@ -117,6 +120,7 @@ fn bounded_capacity_one() {
 
 #[test]
 fn unbounded_basic_insert_drop() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(8) };
 
     let slot = slab.alloc(100);
@@ -127,6 +131,7 @@ fn unbounded_basic_insert_drop() {
 
 #[test]
 fn unbounded_grows_automatically() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
 
     let initial_cap = slab.capacity();
@@ -153,6 +158,7 @@ fn unbounded_grows_automatically() {
 
 #[test]
 fn slot_deref() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let mut slot = slab.alloc(42);
@@ -167,6 +173,7 @@ fn slot_deref() {
 
 #[test]
 fn slot_dealloc_take() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(4) };
 
     let slot = slab.alloc("hello".to_string());
@@ -178,6 +185,7 @@ fn slot_dealloc_take() {
 
 #[test]
 fn slot_debug_format() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let slot = slab.alloc(42);
@@ -201,6 +209,7 @@ fn slot_size_is_8_bytes() {
 
 #[test]
 fn multiple_slots_same_slab() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(10) };
 
     let slot1 = slab.alloc(1);
@@ -230,7 +239,9 @@ fn multiple_slots_same_slab() {
 
 #[test]
 fn multiple_slabs_independent() {
+    // SAFETY: test slabs; single-threaded, all slots freed before drop.
     let slab_a = unsafe { BoundedSlab::<u64>::with_capacity(4) };
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab_b = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let slot_a = slab_a.alloc(1);
@@ -250,6 +261,7 @@ fn multiple_slabs_independent() {
 #[test]
 #[should_panic(expected = "slab full")]
 fn panic_insert_when_full() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(2) };
 
     let _s1 = slab.alloc(1);
@@ -260,6 +272,7 @@ fn panic_insert_when_full() {
 #[test]
 #[should_panic(expected = "capacity must be non-zero")]
 fn panic_zero_capacity() {
+    // SAFETY: test slab; single-threaded; panics before any slot can be allocated.
     let _ = unsafe { BoundedSlab::<u64>::with_capacity(0) };
 }
 
@@ -271,6 +284,7 @@ fn panic_zero_capacity() {
 fn drop_called_on_free() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));
@@ -286,6 +300,7 @@ fn drop_called_on_free() {
 fn drop_called_multiple() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(10) };
 
     let s1 = slab.alloc(DropTracker(1));
@@ -304,6 +319,7 @@ fn drop_called_multiple() {
 fn drop_called_on_dealloc_take() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));
@@ -319,6 +335,7 @@ fn drop_called_on_dealloc_take() {
 fn drop_not_called_on_leak() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded; slot intentionally leaked (disarmed via into_raw).
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));
@@ -334,6 +351,7 @@ fn drop_not_called_on_leak() {
 
 #[test]
 fn stress_fill_drain_cycle() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(100) };
 
     for cycle in 0..10 {
@@ -355,6 +373,7 @@ fn stress_fill_drain_cycle() {
 
 #[test]
 fn stress_interleaved_insert_remove() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(50) };
 
     let mut slots = Vec::new();
@@ -383,6 +402,7 @@ fn stress_interleaved_insert_remove() {
 
 #[test]
 fn stress_slot_reuse() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(1) };
 
     for i in 0..1000 {
@@ -395,6 +415,7 @@ fn stress_slot_reuse() {
 
 #[test]
 fn stress_unbounded_growth() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(16) };
 
     let slots: Vec<_> = (0..1000).map(|i| slab.alloc(i)).collect();
@@ -413,6 +434,7 @@ fn stress_unbounded_growth() {
 
 #[test]
 fn stress_unbounded_churn() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(8) };
 
     let mut slots = Vec::new();
@@ -443,6 +465,7 @@ fn stress_unbounded_churn() {
 
 #[test]
 fn freelist_lifo_order() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     // Insert 4 items
@@ -479,6 +502,7 @@ fn freelist_lifo_order() {
 
 #[test]
 fn type_string() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(10) };
 
     let slot = slab.alloc("hello world".to_string());
@@ -545,6 +569,7 @@ fn type_option() {
 
 #[test]
 fn type_tuple() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<(u64, String, bool)>::with_capacity(10) };
 
     let slot = slab.alloc((42, "hello".to_string(), true));
@@ -558,6 +583,7 @@ fn type_tuple() {
 
 #[test]
 fn type_large_struct() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<LargeStruct>::with_capacity(10) };
 
     let mut data = [0u64; 128];
@@ -577,6 +603,7 @@ fn type_large_struct() {
 
 #[test]
 fn type_zst() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<ZeroSized>::with_capacity(100) };
 
     assert_eq!(std::mem::size_of::<ZeroSized>(), 0);
@@ -590,6 +617,7 @@ fn type_zst() {
 
 #[test]
 fn type_unit() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<()>::with_capacity(10) };
 
     let slot = slab.alloc(());
@@ -605,6 +633,7 @@ fn type_unit() {
 
 #[test]
 fn large_capacity() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(100_000) };
 
     assert_eq!(slab.capacity(), 100_000);
@@ -619,6 +648,7 @@ fn large_capacity() {
 
 #[test]
 fn unbounded_default_chunk_capacity() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4096) };
 
     // First insert should trigger chunk allocation
@@ -631,6 +661,7 @@ fn unbounded_default_chunk_capacity() {
 
 #[test]
 fn slab_debug_format() {
+    // SAFETY: test slab; single-threaded, no slots allocated.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(10) };
     let debug = format!("{:?}", slab);
     assert!(debug.contains("Slab"));
@@ -643,6 +674,7 @@ fn slab_debug_format() {
 
 #[test]
 fn slot_clone_ptr() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let slot = slab.alloc(42);
@@ -671,6 +703,7 @@ fn byte_slab_drop_type() {
 
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab: ByteSlab<64> = unsafe { ByteSlab::with_capacity(4) };
 
     // Alloc a String (heap-allocated, has Drop)
@@ -695,6 +728,7 @@ fn byte_slab_drop_on_take() {
 
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab: ByteSlab<64> = unsafe { ByteSlab::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));

--- a/nexus-slab/tests/miri_tests.rs
+++ b/nexus-slab/tests/miri_tests.rs
@@ -56,6 +56,7 @@ pub struct Large {
 
 #[test]
 fn miri_bounded_basic() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(8) };
 
     let slot = slab.alloc(42);
@@ -66,6 +67,7 @@ fn miri_bounded_basic() {
 
 #[test]
 fn miri_unbounded_basic() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
 
     let slot = slab.alloc(42);
@@ -76,6 +78,7 @@ fn miri_unbounded_basic() {
 
 #[test]
 fn miri_multiple_inserts() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(8) };
 
     let s1 = slab.alloc(1);
@@ -93,6 +96,7 @@ fn miri_multiple_inserts() {
 
 #[test]
 fn miri_slot_deref_mut() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let mut slot = slab.alloc(42);
@@ -105,6 +109,7 @@ fn miri_slot_deref_mut() {
 
 #[test]
 fn miri_slot_replace() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let mut slot = slab.alloc(1);
@@ -118,6 +123,7 @@ fn miri_slot_replace() {
 
 #[test]
 fn miri_slot_into_inner() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let slot = slab.alloc(42);
@@ -134,6 +140,7 @@ fn miri_slot_into_inner() {
 fn miri_drop_on_slot_drop() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     {
@@ -149,6 +156,7 @@ fn miri_drop_on_slot_drop() {
 fn miri_drop_on_into_inner() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));
@@ -164,6 +172,7 @@ fn miri_drop_on_into_inner() {
 fn miri_drop_on_replace() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let mut slot = slab.alloc(DropTracker(1));
@@ -180,6 +189,7 @@ fn miri_drop_on_replace() {
 fn miri_no_drop_after_leak() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded; slot intentionally leaked (tests drop suppression).
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let slot = slab.alloc(DropTracker(1));
@@ -195,6 +205,7 @@ fn miri_no_drop_after_leak() {
 
 #[test]
 fn miri_string_insert_drop() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(4) };
 
     let slot = slab.alloc("hello world".to_string());
@@ -205,7 +216,7 @@ fn miri_string_insert_drop() {
 
 #[test]
 fn miri_vec_insert_drop() {
-    // SAFETY: slab outlives all slots
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Vec<u64>>::with_capacity(4) };
 
     let slot = slab.alloc(vec![1, 2, 3, 4, 5]);
@@ -216,7 +227,7 @@ fn miri_vec_insert_drop() {
 
 #[test]
 fn miri_box_insert_drop() {
-    // SAFETY: slab outlives all slots
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Box<[u8; 1024]>>::with_capacity(4) };
 
     let slot = slab.alloc(Box::new([0u8; 1024]));
@@ -227,6 +238,7 @@ fn miri_box_insert_drop() {
 
 #[test]
 fn miri_string_into_inner() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(4) };
 
     let slot = slab.alloc("hello".to_string());
@@ -237,7 +249,7 @@ fn miri_string_into_inner() {
 
 #[test]
 fn miri_vec_replace() {
-    // SAFETY: slab outlives all slots
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Vec<u64>>::with_capacity(4) };
 
     let mut slot = slab.alloc(vec![1, 2, 3]);
@@ -256,6 +268,7 @@ fn miri_vec_replace() {
 
 #[test]
 fn miri_slot_reuse_bounded() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(2) };
 
     // Fill
@@ -290,6 +303,7 @@ fn miri_slot_reuse_bounded() {
 
 #[test]
 fn miri_slot_reuse_single() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(1) };
 
     let mut last_ptr = std::ptr::null_mut();
@@ -312,6 +326,7 @@ fn miri_slot_reuse_single() {
 
 #[test]
 fn miri_unbounded_growth() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
 
     // Fill multiple chunks
@@ -332,6 +347,7 @@ fn miri_unbounded_growth() {
 
 #[test]
 fn miri_unbounded_string_growth() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<String>::with_chunk_capacity(4) };
 
     let slots: Vec<_> = (0..12)
@@ -355,6 +371,7 @@ fn miri_unbounded_string_growth() {
 
 #[test]
 fn miri_capacity_one() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(1) };
 
     let slot = slab.alloc(42);
@@ -370,6 +387,7 @@ fn miri_capacity_one() {
 
 #[test]
 fn miri_zst() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<ZeroSized>::with_capacity(10) };
 
     let slot = slab.alloc(ZeroSized);
@@ -380,6 +398,7 @@ fn miri_zst() {
 
 #[test]
 fn miri_large_struct() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Large>::with_capacity(4) };
 
     let mut data = [0u64; 128];
@@ -401,6 +420,7 @@ fn miri_large_struct() {
 
 #[test]
 fn miri_bounded_claim_abandon() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     // Claim and abandon — should return slot to freelist
@@ -419,6 +439,7 @@ fn miri_bounded_claim_abandon() {
 
 #[test]
 fn miri_bounded_claim_abandon_capacity_one() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(1) };
 
     // Claim and abandon
@@ -436,6 +457,7 @@ fn miri_bounded_claim_abandon_capacity_one() {
 
 #[test]
 fn miri_unbounded_claim_abandon() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
 
     // Allocate and free to ensure chunk exists
@@ -457,6 +479,7 @@ fn miri_unbounded_claim_abandon() {
 
 #[test]
 fn miri_unbounded_claim_abandon_full_chunk() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(2) };
 
     // Fill first chunk
@@ -484,6 +507,7 @@ fn miri_unbounded_claim_abandon_full_chunk() {
 
 #[test]
 fn miri_bounded_claim_write() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
 
     let claim = slab.claim().unwrap();
@@ -495,6 +519,7 @@ fn miri_bounded_claim_write() {
 
 #[test]
 fn miri_bounded_claim_write_string() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(4) };
 
     let claim = slab.claim().unwrap();
@@ -508,6 +533,7 @@ fn miri_bounded_claim_write_string() {
 fn miri_bounded_claim_write_drop_type() {
     reset_drop_count();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<DropTracker>::with_capacity(4) };
 
     let claim = slab.claim().unwrap();
@@ -520,6 +546,7 @@ fn miri_bounded_claim_write_drop_type() {
 
 #[test]
 fn miri_unbounded_claim_write() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
 
     let claim = slab.claim();
@@ -540,6 +567,7 @@ mod rc_tests {
 
     #[test]
     fn miri_rc_alloc_clone_borrow_free() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { RcSlab::<u64>::with_capacity(8) };
 
         let h1 = slab.alloc(42);
@@ -576,6 +604,7 @@ mod rc_tests {
     fn miri_rc_drop_counter() {
         reset_drop_count();
 
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { RcSlab::<DropTracker>::with_capacity(8) };
 
         let h1 = slab.alloc(DropTracker(1));
@@ -597,6 +626,7 @@ mod rc_tests {
 
     #[test]
     fn miri_rc_sequential_borrows_across_clones() {
+        // SAFETY: test slab; single-threaded, all handles freed before drop.
         let slab = unsafe { RcSlab::<String>::with_capacity(8) };
 
         let h1 = slab.alloc(String::from("hello"));
@@ -646,6 +676,7 @@ mod byte_tests {
 
     #[test]
     fn miri_byte_bounded_alloc_write_free() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteBoundedSlab<64> = unsafe { ByteBoundedSlab::with_capacity(8) };
 
         let ptr = slab.alloc(42u64);
@@ -655,6 +686,7 @@ mod byte_tests {
 
     #[test]
     fn miri_byte_bounded_alloc_write_different_types() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteBoundedSlab<64> = unsafe { ByteBoundedSlab::with_capacity(8) };
 
         // Write a u64 (8 bytes)
@@ -671,6 +703,7 @@ mod byte_tests {
 
     #[test]
     fn miri_byte_bounded_abandon_claim() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteBoundedSlab<64> = unsafe { ByteBoundedSlab::with_capacity(1) };
 
         // Claim and drop without writing — slot returns to freelist
@@ -687,6 +720,7 @@ mod byte_tests {
 
     #[test]
     fn miri_byte_unbounded_alloc_write_free() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteUnboundedSlab<64> = unsafe { ByteUnboundedSlab::with_chunk_capacity(4) };
 
         let ptr = slab.alloc(42u64);
@@ -696,6 +730,7 @@ mod byte_tests {
 
     #[test]
     fn miri_byte_unbounded_multiple_chunks() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteUnboundedSlab<64> = unsafe { ByteUnboundedSlab::with_chunk_capacity(2) };
 
         // Alloc enough to span multiple chunks
@@ -719,6 +754,7 @@ mod byte_tests {
     fn miri_byte_slab_drop_tracker() {
         reset_drop_count();
 
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteBoundedSlab<64> = unsafe { ByteBoundedSlab::with_capacity(4) };
 
         let ptr = slab.alloc(DropTracker(1));
@@ -732,6 +768,7 @@ mod byte_tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn miri_byte_claim_write_aligned_type() {
+        // SAFETY: test slab; single-threaded, all slots freed before drop.
         let slab: ByteBoundedSlab<64> = unsafe { ByteBoundedSlab::with_capacity(4) };
 
         // f64 has alignment 8 — must be respected
@@ -758,10 +795,11 @@ fn miri_bounded_alloc_through_stored_pointer() {
     // Simulate the async-rt pattern: store raw pointer, cast to &Slab,
     // alloc (claim + write), read, free. Exercises the full provenance
     // chain through a stored pointer round-trip.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
     let slab_ptr: *const BoundedSlab<u64> = &raw const slab;
 
-    // Access through raw pointer → &Slab (same as TLS round-trip)
+    // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
     let slab_ref = unsafe { &*slab_ptr };
     let slot = slab_ref.alloc(42u64);
     assert_eq!(*slot, 42);
@@ -772,10 +810,12 @@ fn miri_bounded_alloc_through_stored_pointer() {
 fn miri_bounded_alloc_cycle_through_stored_pointer() {
     // Multiple alloc/free cycles through stored pointer — exercises freelist
     // pointer provenance across reuse.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(2) };
     let slab_ptr: *const BoundedSlab<u64> = &raw const slab;
 
     for i in 0..10u64 {
+        // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
         let slab_ref = unsafe { &*slab_ptr };
         let slot = slab_ref.alloc(i);
         assert_eq!(*slot, i);
@@ -787,9 +827,11 @@ fn miri_bounded_alloc_cycle_through_stored_pointer() {
 fn miri_bounded_two_slots_through_stored_pointer() {
     // Claim two slots via alloc, free in reverse order.
     // Exercises freelist pointer provenance when multiple slots are live.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<String>::with_capacity(4) };
     let slab_ptr: *const BoundedSlab<String> = &raw const slab;
 
+    // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
     let slab_ref = unsafe { &*slab_ptr };
     let slot1 = slab_ref.alloc(String::from("first"));
     let slot2 = slab_ref.alloc(String::from("second"));
@@ -805,9 +847,11 @@ fn miri_bounded_two_slots_through_stored_pointer() {
 fn miri_bounded_claim_write_through_stored_pointer() {
     // Two-phase alloc (claim + write) through stored pointer.
     // Exercises claim_ptr → write_value provenance chain.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(4) };
     let slab_ptr: *const BoundedSlab<u64> = &raw const slab;
 
+    // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
     let slab_ref = unsafe { &*slab_ptr };
     let claim = slab_ref.claim().unwrap();
     let slot = claim.write(99u64);
@@ -818,10 +862,12 @@ fn miri_bounded_claim_write_through_stored_pointer() {
 #[test]
 fn miri_unbounded_claim_write_through_stored_pointer() {
     // Same pattern for unbounded slab — exercises chunk-based allocation.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(4) };
     let slab_ptr: *const UnboundedSlab<u64> = &raw const slab;
 
     for i in 0..20u64 {
+        // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
         let slab_ref = unsafe { &*slab_ptr };
         let slot = slab_ref.alloc(i);
         assert_eq!(*slot, i);
@@ -832,9 +878,11 @@ fn miri_unbounded_claim_write_through_stored_pointer() {
 #[test]
 fn miri_unbounded_stored_pointer_cross_chunk() {
     // Allocate enough to trigger chunk growth, all through stored pointer.
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(2) };
     let slab_ptr: *const UnboundedSlab<u64> = &raw const slab;
 
+    // SAFETY: slab_ptr was obtained from &slab on the current stack; still valid.
     let slab_ref = unsafe { &*slab_ptr };
 
     // 6 allocs with capacity 2 per chunk = 3 chunks

--- a/nexus-slab/tests/random_tests.rs
+++ b/nexus-slab/tests/random_tests.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 /// Test that values are never corrupted
 #[test]
 fn bounded_value_integrity_random() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(50) };
 
     let mut rng = proptest::test_runner::TestRng::deterministic_rng(
@@ -80,6 +81,7 @@ fn bounded_value_integrity_random() {
 /// Test capacity is never exceeded (separate tests for each capacity)
 #[test]
 fn bounded_capacity_never_exceeded_1() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(1) };
 
     let mut slots = Vec::new();
@@ -98,6 +100,7 @@ fn bounded_capacity_never_exceeded_1() {
 
 #[test]
 fn bounded_capacity_never_exceeded_10() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(10) };
 
     let mut slots = Vec::new();
@@ -116,6 +119,7 @@ fn bounded_capacity_never_exceeded_10() {
 
 #[test]
 fn bounded_capacity_never_exceeded_50() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(50) };
 
     let mut slots = Vec::new();
@@ -135,6 +139,7 @@ fn bounded_capacity_never_exceeded_50() {
 /// Test fill/drain cycles maintain integrity
 #[test]
 fn bounded_fill_drain_integrity() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(20) };
 
     for cycle in 0..10 {
@@ -162,6 +167,7 @@ fn bounded_fill_drain_integrity() {
 
 #[test]
 fn unbounded_value_integrity_random() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(8) };
 
     let mut rng = proptest::test_runner::TestRng::deterministic_rng(
@@ -216,6 +222,7 @@ fn unbounded_value_integrity_random() {
 
 #[test]
 fn unbounded_growth_maintains_integrity() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { UnboundedSlab::<u64>::with_chunk_capacity(8) };
 
     // Test with increasing counts in a single slab
@@ -242,6 +249,7 @@ fn unbounded_growth_maintains_integrity() {
 
 #[test]
 fn freelist_no_duplicates() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(20) };
 
     let mut rng = proptest::test_runner::TestRng::deterministic_rng(
@@ -283,6 +291,7 @@ fn freelist_no_duplicates() {
 
 #[test]
 fn freelist_reuses_freed_slots() {
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<u64>::with_capacity(10) };
 
     let mut slots: Vec<Slot<u64>> = Vec::new();
@@ -344,6 +353,7 @@ fn get_counter() -> usize {
 fn drop_count_matches_inserts() {
     reset_counter();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Counted>::with_capacity(100) };
 
     let count = 50;
@@ -363,6 +373,7 @@ fn drop_count_matches_inserts() {
 fn into_inner_prevents_drop() {
     reset_counter();
 
+    // SAFETY: test slab; single-threaded, all slots freed before drop.
     let slab = unsafe { BoundedSlab::<Counted>::with_capacity(100) };
 
     let count = 20;


### PR DESCRIPTION
Adds \`// SAFETY:\` comments to every \`unsafe {}\` block in nexus-slab (production code, all test files, and all example files) and \`# Safety\` sections to \`unsafe fn\` doc comments.

Part of the workspace-wide unsafe audit. nexus-shm was covered in #622.

Covers:
- \`src/bounded.rs\`, \`src/unbounded.rs\`
- \`src/byte/bounded.rs\`, \`src/byte/unbounded.rs\`
- \`src/rc/bounded.rs\`, \`src/rc/unbounded.rs\`
- \`tests/miri_tests.rs\`, \`tests/allocator_tests.rs\`, \`tests/random_tests.rs\`
- \`examples/\` (all six benchmark examples)

Zero warnings under \`-W clippy::undocumented_unsafe_blocks --all-targets\`.