### PR TITLE
docs(nexus-collections): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-collections/benches/perf_batched.rs
+++ b/nexus-collections/benches/perf_batched.rs
@@ -27,6 +27,7 @@ const STEADY_SIZE: usize = 25_000;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -35,6 +36,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);
@@ -78,7 +80,9 @@ impl Xorshift {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let heap_slab = unsafe { Slab::<HeapNode<u64>>::with_capacity(CAPACITY) };
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let list_slab = unsafe { Slab::<ListNode<u64>>::with_capacity(CAPACITY) };
 
     let mut rng = Xorshift::new(0xDEAD_BEEF_CAFE_BABEu64);
@@ -199,11 +203,13 @@ fn main() {
         let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..WARMUP {
             seq!(I in 0..100 { heap.link(&h[I]); });
+            // SAFETY: each slot was linked in the preceding seq!; the precondition (node is linked) is upheld.
             seq!(I in 0..100 { unsafe { heap.unlink_unchecked(&h[I], &heap_slab) }; });
         }
         for _ in 0..SAMPLES {
             seq!(I in 0..100 { heap.link(&h[I]); });
             let s = rdtsc_start();
+            // SAFETY: each slot was linked in the preceding seq!; the precondition (node is linked) is upheld.
             seq!(I in 0..100 { unsafe { heap.unlink_unchecked(&h[I], &heap_slab) }; });
             let e = rdtsc_end();
             samples.push((e - s) / BATCH as u64);
@@ -388,11 +394,13 @@ fn main() {
         let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..WARMUP {
             seq!(I in 0..100 { list.link_back(&h[I]); });
+            // SAFETY: each slot was linked in the preceding seq!; the precondition (node is linked) is upheld.
             seq!(I in 0..100 { unsafe { list.unlink_unchecked(&h[I], &list_slab) }; });
         }
         for _ in 0..SAMPLES {
             seq!(I in 0..100 { list.link_back(&h[I]); });
             let s = rdtsc_start();
+            // SAFETY: each slot was linked in the preceding seq!; the precondition (node is linked) is upheld.
             seq!(I in 0..100 { unsafe { list.unlink_unchecked(&h[I], &list_slab) }; });
             let e = rdtsc_end();
             samples.push((e - s) / BATCH as u64);
@@ -426,10 +434,12 @@ fn main() {
         seq!(I in 0..100 { list.link_back(&h[I]); });
         let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..WARMUP {
+            // SAFETY: all slots are currently linked in the list; move_to_front_unchecked precondition is met.
             seq!(I in 0..100 { unsafe { list.move_to_front_unchecked(&h[I]) }; });
         }
         for _ in 0..SAMPLES {
             let s = rdtsc_start();
+            // SAFETY: all slots are currently linked in the list; move_to_front_unchecked precondition is met.
             seq!(I in 0..100 { unsafe { list.move_to_front_unchecked(&h[I]) }; });
             let e = rdtsc_end();
             samples.push((e - s) / BATCH as u64);
@@ -464,10 +474,12 @@ fn main() {
         seq!(I in 0..100 { list.link_back(&h[I]); });
         let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..WARMUP {
+            // SAFETY: all slots are currently linked in the list; move_to_back_unchecked precondition is met.
             seq!(I in 0..100 { unsafe { list.move_to_back_unchecked(&h[I]) }; });
         }
         for _ in 0..SAMPLES {
             let s = rdtsc_start();
+            // SAFETY: all slots are currently linked in the list; move_to_back_unchecked precondition is met.
             seq!(I in 0..100 { unsafe { list.move_to_back_unchecked(&h[I]) }; });
             let e = rdtsc_end();
             samples.push((e - s) / BATCH as u64);

--- a/nexus-collections/benches/perf_btree.rs
+++ b/nexus-collections/benches/perf_btree.rs
@@ -23,6 +23,7 @@ const SMALL_SIZE: usize = 100;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -31,6 +32,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);
@@ -74,6 +76,7 @@ impl Xorshift {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab =
         unsafe { nexus_slab::bounded::Slab::<BTreeNode<u64, u64, B>>::with_capacity(CAPACITY) };
 

--- a/nexus-collections/benches/perf_codegen.rs
+++ b/nexus-collections/benches/perf_codegen.rs
@@ -22,6 +22,7 @@ fn heap_link(heap: &mut Heap<u64>, h: &RcSlot<HeapNode<u64>>) {
 
 #[inline(never)]
 unsafe fn heap_link_unchecked(heap: &mut Heap<u64>, h: &RcSlot<HeapNode<u64>>) {
+    // SAFETY: caller of this unsafe fn ensures h is not currently linked in the heap.
     unsafe { heap.link_unchecked(h) };
 }
 
@@ -41,6 +42,7 @@ unsafe fn heap_unlink_unchecked(
     h: &RcSlot<HeapNode<u64>>,
     slab: &Slab<HeapNode<u64>>,
 ) {
+    // SAFETY: caller of this unsafe fn ensures h is currently linked in the heap.
     unsafe { heap.unlink_unchecked(h, slab) };
 }
 
@@ -69,6 +71,7 @@ fn list_link_back(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
 
 #[inline(never)]
 unsafe fn list_link_back_unchecked(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
+    // SAFETY: caller of this unsafe fn ensures h is not currently linked in the list.
     unsafe { list.link_back_unchecked(h) };
 }
 
@@ -79,6 +82,7 @@ fn list_link_front(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
 
 #[inline(never)]
 unsafe fn list_link_front_unchecked(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
+    // SAFETY: caller of this unsafe fn ensures h is not currently linked in the list.
     unsafe { list.link_front_unchecked(h) };
 }
 
@@ -93,6 +97,7 @@ unsafe fn list_unlink_unchecked(
     h: &RcSlot<ListNode<u64>>,
     slab: &Slab<ListNode<u64>>,
 ) {
+    // SAFETY: caller of this unsafe fn ensures h is currently linked in the list.
     unsafe { list.unlink_unchecked(h, slab) };
 }
 
@@ -122,6 +127,7 @@ fn list_move_to_front(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
 
 #[inline(never)]
 unsafe fn list_move_to_front_unchecked(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
+    // SAFETY: caller of this unsafe fn ensures h is linked in list; precondition forwarded.
     unsafe { list.move_to_front_unchecked(h) };
 }
 
@@ -132,11 +138,14 @@ fn list_move_to_back(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
 
 #[inline(never)]
 unsafe fn list_move_to_back_unchecked(list: &mut List<u64>, h: &RcSlot<ListNode<u64>>) {
+    // SAFETY: caller of this unsafe fn ensures h is linked in list; precondition forwarded.
     unsafe { list.move_to_back_unchecked(h) };
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let heap_slab = unsafe { Slab::<HeapNode<u64>>::with_capacity(100) };
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let list_slab = unsafe { Slab::<ListNode<u64>>::with_capacity(100) };
 
     // Heap
@@ -151,8 +160,11 @@ fn main() {
     black_box(heap_peek(&heap));
     heap_unlink(&mut heap, &h3, &heap_slab);
     // unchecked link + unlink
+    // SAFETY: h3 was just unlinked; the node is not currently in the heap.
     unsafe { heap_link_unchecked(&mut heap, &h3) };
+    // SAFETY: h2 is linked in the heap; the precondition (node is linked) is upheld.
     unsafe { heap_unlink_unchecked(&mut heap, &h2, &heap_slab) };
+    // SAFETY: h3 was linked at the line above; the precondition (node is linked) is upheld.
     unsafe { heap_unlink_unchecked(&mut heap, &h3, &heap_slab) };
     while let Some(p) = heap_pop(&mut heap) {
         black_box(p.borrow().value());
@@ -175,14 +187,19 @@ fn main() {
     list_link_front(&mut list, &l3);
     list_link_back(&mut list, &l4);
     list_move_to_front(&mut list, &l2);
+    // SAFETY: l4 is linked in the list; the precondition (node is linked) is upheld.
     unsafe { list_move_to_front_unchecked(&mut list, &l4) };
     list_move_to_back(&mut list, &l3);
+    // SAFETY: l1 is linked in the list; the precondition (node is linked) is upheld.
     unsafe { list_move_to_back_unchecked(&mut list, &l1) };
     list_unlink(&mut list, &l4, &list_slab);
     // unchecked link variants
+    // SAFETY: l4 was just unlinked; the node is not currently in the list.
     unsafe { list_link_back_unchecked(&mut list, &l4) };
     list_unlink(&mut list, &l4, &list_slab);
+    // SAFETY: l4 was just unlinked; the node is not currently in the list.
     unsafe { list_link_front_unchecked(&mut list, &l4) };
+    // SAFETY: l4 was linked at the line above; the precondition (node is linked) is upheld.
     unsafe { list_unlink_unchecked(&mut list, &l4, &list_slab) };
     while let Some(p) = list_pop_front(&mut list) {
         black_box(&p.borrow().value);

--- a/nexus-collections/benches/perf_heap_cycles.rs
+++ b/nexus-collections/benches/perf_heap_cycles.rs
@@ -38,6 +38,7 @@ impl Xorshift {
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -46,6 +47,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);
@@ -73,6 +75,7 @@ fn print_row(label: &str, samples: &mut [u64]) {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let slab = unsafe { Slab::<HeapNode<u64>>::with_capacity(CAPACITY) };
     let mut rng = Xorshift::new(0xDEAD_BEEF_CAFE_BABEu64);
 

--- a/nexus-collections/benches/perf_list_cycles.rs
+++ b/nexus-collections/benches/perf_list_cycles.rs
@@ -22,6 +22,7 @@ const BATCH: usize = 100;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -30,6 +31,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);
@@ -57,6 +59,7 @@ fn print_row(label: &str, samples: &mut [u64]) {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let slab = unsafe { Slab::<ListNode<u64>>::with_capacity(CAPACITY) };
 
     println!("LIST OPERATION LATENCY (cycles/op) — batched, {BATCH} ops/sample");

--- a/nexus-collections/benches/perf_push_hist.rs
+++ b/nexus-collections/benches/perf_push_hist.rs
@@ -20,6 +20,7 @@ const N: usize = 50_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)
@@ -64,7 +65,9 @@ fn new_hist() -> Histogram<u64> {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let heap_slab = unsafe { Slab::<HeapNode<u64>>::with_capacity(CAPACITY) };
+    // SAFETY: single-threaded benchmark; slab outlives all allocated nodes.
     let list_slab = unsafe { Slab::<ListNode<u64>>::with_capacity(CAPACITY) };
 
     let mut rng = Xorshift::new(0xDEAD_BEEF_CAFE_BABEu64);
@@ -175,6 +178,7 @@ fn main() {
         }
         for h in &heap_handles {
             let s = rdtscp();
+            // SAFETY: every handle in `heap_handles` was linked into the heap above; the precondition (node is linked) is upheld.
             unsafe { heap.unlink_unchecked(h, &heap_slab) };
             let e = rdtscp();
             let _ = hist.record(e.wrapping_sub(s));
@@ -352,6 +356,7 @@ fn main() {
         }
         for h in &list_handles {
             let s = rdtscp();
+            // SAFETY: every handle in `list_handles` was linked into the list above; the precondition (node is linked) is upheld.
             unsafe { list.unlink_unchecked(h, &list_slab) };
             let e = rdtscp();
             let _ = hist.record(e.wrapping_sub(s));
@@ -385,6 +390,7 @@ fn main() {
         }
         for h in &list_handles {
             let s = rdtscp();
+            // SAFETY: all handles are currently linked in the list; move_to_front_unchecked precondition is met.
             unsafe { list.move_to_front_unchecked(h) };
             let e = rdtscp();
             let _ = hist.record(e.wrapping_sub(s));
@@ -419,6 +425,7 @@ fn main() {
         }
         for h in list_handles.iter().rev() {
             let s = rdtscp();
+            // SAFETY: all handles are currently linked in the list; move_to_back_unchecked precondition is met.
             unsafe { list.move_to_back_unchecked(h) };
             let e = rdtscp();
             let _ = hist.record(e.wrapping_sub(s));

--- a/nexus-collections/benches/perf_rbtree.rs
+++ b/nexus-collections/benches/perf_rbtree.rs
@@ -22,6 +22,7 @@ const SMALL_SIZE: usize = 100;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -30,6 +31,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);
@@ -73,6 +75,7 @@ impl Xorshift {
 }
 
 fn main() {
+    // SAFETY: single-threaded benchmark; slab outlives all allocated slots.
     let slab = unsafe { nexus_slab::bounded::Slab::<RbNode<u64, u64>>::with_capacity(CAPACITY) };
 
     let mut rng = Xorshift::new(0xDEAD_BEEF_CAFE_BABEu64);

--- a/nexus-collections/benches/perf_std_btreemap.rs
+++ b/nexus-collections/benches/perf_std_btreemap.rs
@@ -19,6 +19,7 @@ const SMALL_SIZE: usize = 100;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -27,6 +28,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; benchmark is x86_64-only.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-collections/src/btree.rs
+++ b/nexus-collections/src/btree.rs
@@ -102,6 +102,7 @@ unsafe fn node_deref<K, V, const B: usize>(ptr: NodePtr<K, V, B>) -> *const BTre
 unsafe fn node_deref_mut<K, V, const B: usize>(ptr: NodePtr<K, V, B>) -> *mut BTreeNode<K, V, B> {
     // Use value_ptr_mut to avoid creating &SlotCell which would give
     // read-only provenance under stacked borrows.
+    // SAFETY: ptr is non-null and points to an occupied SlotCell per caller contract.
     unsafe { nexus_slab::shared::SlotCell::value_ptr_mut(ptr) }
 }
 
@@ -111,11 +112,13 @@ unsafe fn node_deref_mut<K, V, const B: usize>(ptr: NodePtr<K, V, B>) -> *mut BT
 
 /// # Safety: `ptr` must be a valid non-null B-tree node.
 unsafe fn node_len<K, V, const B: usize>(ptr: NodePtr<K, V, B>) -> usize {
+    // SAFETY: ptr is non-null and points to an occupied SlotCell per caller contract.
     unsafe { (*node_deref(ptr)).len as usize }
 }
 
 /// # Safety: `ptr` must be a valid non-null B-tree node.
 unsafe fn node_is_leaf<K, V, const B: usize>(ptr: NodePtr<K, V, B>) -> bool {
+    // SAFETY: ptr is non-null and points to an occupied SlotCell per caller contract.
     unsafe { (*node_deref(ptr)).leaf }
 }
 
@@ -139,6 +142,7 @@ unsafe fn value_at_mut<'a, K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize
 
 /// # Safety: `ptr` must be a valid non-leaf node, `i <= node.len`.
 unsafe fn child_at<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) -> NodePtr<K, V, B> {
+    // SAFETY: ptr is non-null and points to an occupied SlotCell; i <= node.len per caller.
     unsafe { (*node_deref(ptr)).children[i] }
 }
 
@@ -175,7 +179,9 @@ unsafe fn search_in_node<K, V, const B: usize, C: Compare<K>>(
 unsafe fn take_kv<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) -> (K, V) {
     // SAFETY: keys[i] and values[i] are initialized for i < node.len.
     let node = unsafe { &*node_deref(ptr) };
+    // SAFETY: keys[i] is initialized for i < node.len per caller contract.
     let k = unsafe { node.keys[i].assume_init_read() };
+    // SAFETY: same invariant as above; values[i] is initialized for i < node.len.
     let v = unsafe { node.values[i].assume_init_read() };
     (k, v)
 }
@@ -196,6 +202,8 @@ unsafe fn shift_right<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) {
     let node = unsafe { &mut *node_deref_mut(ptr) };
     let len = node.len as usize;
     if i < len {
+        // SAFETY: keys/values at [i..len) are initialized; len < B-1 ensures [i+1..len+1)
+        // is within the array. ptr::copy handles overlapping regions (memmove semantics).
         unsafe {
             let kp = node.keys.as_mut_ptr();
             ptr::copy(kp.add(i).cast_const(), kp.add(i + 1), len - i);
@@ -204,6 +212,8 @@ unsafe fn shift_right<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) {
         }
     }
     if !node.leaf && i < len {
+        // SAFETY: internal node has valid children at [i+1..=len]; len < B-1 so
+        // shifting to [i+2..=len+1] fits in the children array of size B.
         unsafe {
             let cp = node.children.as_mut_ptr();
             ptr::copy(cp.add(i + 1).cast_const(), cp.add(i + 2), len - i);
@@ -228,6 +238,8 @@ unsafe fn shift_left<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) {
     let node = unsafe { &mut *node_deref_mut(ptr) };
     let len = node.len as usize;
     if i + 1 < len {
+        // SAFETY: [i+1..len) are initialized keys/values (caller moved out slot i);
+        // ptr::copy handles overlap when shifting left by 1 over len-i-1 elements.
         unsafe {
             let kp = node.keys.as_mut_ptr();
             ptr::copy(kp.add(i + 1).cast_const(), kp.add(i), len - i - 1);
@@ -236,6 +248,8 @@ unsafe fn shift_left<K, V, const B: usize>(ptr: NodePtr<K, V, B>, i: usize) {
         }
     }
     if !node.leaf && i + 2 <= len {
+        // SAFETY: internal node with `len` keys has valid children at [i+2..=len];
+        // shifting to [i+1..len-1] removes the right child of the eliminated separator.
         unsafe {
             let cp = node.children.as_mut_ptr();
             ptr::copy(cp.add(i + 2).cast_const(), cp.add(i + 1), len - i - 1);
@@ -291,6 +305,7 @@ unsafe fn split_child_core<K, V, const B: usize>(
     // root init, so it points to an occupied SlotCell. right_ptr was just
     // allocated by the caller. No other references exist to either node.
     let child_node = unsafe { &mut *node_deref_mut(child) };
+    // SAFETY: right_ptr was just allocated by the caller and points to an occupied SlotCell.
     let right_node = unsafe { &mut *node_deref_mut(right_ptr) };
     let child_is_leaf = child_node.leaf;
 
@@ -336,6 +351,7 @@ unsafe fn split_child_core<K, V, const B: usize>(
     // out; the slot becomes logically uninitialized (child.len set to mid
     // below, so it won't be accessed again).
     let median_key = unsafe { child_node.keys[mid].assume_init_read() };
+    // SAFETY: same invariant as above; values[mid] is initialized because child was full (len == B-1).
     let median_value = unsafe { child_node.values[mid].assume_init_read() };
     child_node.len = mid as u16;
 
@@ -469,6 +485,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             debug_assert!(path_len < MAX_DEPTH);
             path[path_len] = (current, 0);
             path_len += 1;
+            // SAFETY: current is a valid internal node; children[0] is the leftmost valid child.
             let next = unsafe { child_at(current, 0) };
             current = next;
         }
@@ -476,6 +493,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // SAFETY: current is a valid leaf node with at least 1 key (tree is non-empty).
         // take_kv reads initialized key/value at index 0. shift_left closes the gap.
         let result = unsafe { take_kv(current, 0) };
+        // SAFETY: current is a valid leaf; shift_left closes the gap and decrements len.
         unsafe { shift_left(current, 0) };
         self.fixup_after_remove(slab, current, &path, path_len);
         self.len -= 1;
@@ -497,10 +515,12 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // which starts as self.root (non-null, checked above) and each iteration
         // replaces it with a valid child pointer from a valid internal node.
         while !unsafe { node_is_leaf(current) } {
+            // SAFETY: current is a valid internal node on this loop iteration.
             let len = unsafe { node_len(current) };
             debug_assert!(path_len < MAX_DEPTH);
             path[path_len] = (current, len);
             path_len += 1;
+            // SAFETY: current is a valid internal node; children[len] is the rightmost valid child.
             let next = unsafe { child_at(current, len) };
             current = next;
         }
@@ -509,7 +529,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // take_kv reads initialized key/value at the last index. Decrementing len
         // logically removes the last slot (already moved out by take_kv).
         let last = unsafe { node_len(current) } - 1;
+        // SAFETY: last == node.len - 1 < node.len, so keys[last] and values[last] are initialized.
         let result = unsafe { take_kv(current, last) };
+        // SAFETY: current is a valid node; take_kv moved out the last slot, decrementing len is sound.
         unsafe { (*node_deref_mut(current)).len -= 1 };
         self.fixup_after_remove(slab, current, &path, path_len);
         self.len -= 1;
@@ -854,10 +876,12 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         path: &[(NodePtr<K, V, B>, usize); MAX_DEPTH],
         path_len: usize,
     ) -> (K, V) {
+        // SAFETY: node is a valid B-tree node from the downward traversal; node_is_leaf reads the leaf flag.
         if unsafe { node_is_leaf(node) } {
             // SAFETY: idx < node.len, so take_kv reads initialized slots.
             // shift_left closes the gap and decrements len.
             let result = unsafe { take_kv(node, idx) };
+            // SAFETY: node is a valid leaf; shift_left closes the gap at idx and decrements len.
             unsafe { shift_left(node, idx) };
             self.fixup_after_remove(slab, node, path, path_len);
             result
@@ -875,7 +899,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             // child (B-tree invariant: internal node with len keys has len+1
             // children). We walk down rightmost children until we hit a leaf.
             let mut pred_node = unsafe { child_at(node, idx) };
+            // SAFETY: pred_node is non-null — initially children[idx] of an internal node, then a valid child on each iteration.
             while !unsafe { node_is_leaf(pred_node) } {
+                // SAFETY: pred_node is a valid internal node on this iteration.
                 let plen = unsafe { node_len(pred_node) };
                 debug_assert!(ext_len < MAX_DEPTH);
                 ext_path[ext_len] = (pred_node, plen);
@@ -896,6 +922,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             // values[pred_idx] are initialized. assume_init_read moves
             // the values out; we immediately write replacements into node.
             let pred_k = unsafe { (*node_deref(pred_node)).keys[pred_idx].assume_init_read() };
+            // SAFETY: same invariant as above; values[pred_idx] is initialized for pred_idx < pred_node.len.
             let pred_v = unsafe { (*node_deref(pred_node)).values[pred_idx].assume_init_read() };
 
             // SAFETY: node is valid, idx < node.len. We overwrite the
@@ -944,6 +971,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
 
             if node == self.root {
                 if len == 0 {
+                    // SAFETY: node is the root with 0 keys; node_is_leaf reads the flag to decide how to collapse.
                     if unsafe { node_is_leaf(node) } {
                         // SAFETY: empty leaf root — tree is now empty.
                         // free_node drops 0 elements (len == 0) and frees
@@ -955,6 +983,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                         // SAFETY: internal root with 0 keys has exactly 1
                         // child at children[0] (post-merge). Promote it.
                         let new_root = unsafe { child_at(node, 0) };
+                        // SAFETY: node is the old root with 0 keys; free_node drops nothing and returns its slab slot.
                         unsafe { free_node(node, slab) };
                         self.root = new_root;
                         self.depth -= 1;
@@ -970,6 +999,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             // SAFETY: depth > 0 here (node != root), so path[depth-1] is
             // a valid (parent, child_idx) pair from the downward traversal.
             let (parent, child_idx) = path[depth - 1];
+            // SAFETY: parent is a valid node from path[], which holds valid traversal pointers.
             let parent_len = unsafe { node_len(parent) };
 
             // Try borrowing from left sibling.
@@ -977,7 +1007,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 // SAFETY: parent is a valid internal node and child_idx-1
                 // is a valid child index (child_idx > 0).
                 let left = unsafe { child_at(parent, child_idx - 1) };
+                // SAFETY: left is a valid node obtained from child_at on a valid parent.
                 if unsafe { node_len(left) } > min {
+                    // SAFETY: parent is valid, child_idx > 0, and left has more than min keys (checked above).
                     unsafe { Self::rotate_right(parent, child_idx) };
                     return;
                 }
@@ -988,7 +1020,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 // SAFETY: child_idx < parent_len, so child_idx+1 <= parent_len
                 // which is a valid child index for an internal node.
                 let right = unsafe { child_at(parent, child_idx + 1) };
+                // SAFETY: right is a valid node obtained from child_at on a valid parent.
                 if unsafe { node_len(right) } > min {
+                    // SAFETY: parent is valid, child_idx < parent_len, and right has more than min keys (checked above).
                     unsafe { Self::rotate_left(parent, child_idx) };
                     return;
                 }
@@ -1032,7 +1066,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let parent_node = unsafe { &mut *node_deref_mut(parent) };
         let child = parent_node.children[child_idx];
         let left = parent_node.children[child_idx - 1];
+        // SAFETY: child is the valid pointer at parent.children[child_idx]; distinct slab allocation from parent.
         let child_node = unsafe { &mut *node_deref_mut(child) };
+        // SAFETY: left is the valid pointer at parent.children[child_idx-1]; distinct slab allocation from parent and child.
         let left_node = unsafe { &mut *node_deref_mut(left) };
         let child_len = child_node.len as usize;
         let left_len = left_node.len as usize;
@@ -1043,6 +1079,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // After shift, [1..child_len+1) are initialized. child_len < B-1
         // (child was deficient), so index child_len is within the array.
         if child_len > 0 {
+            // SAFETY: child has child_len initialized keys/values at [0..child_len); child_len < B-1 so the shift destination is within bounds.
             unsafe {
                 let kp = child_node.keys.as_mut_ptr();
                 ptr::copy(kp.cast_const(), kp.add(1), child_len);
@@ -1065,6 +1102,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // moves the value out; we immediately write a replacement below.
         child_node.keys[0] =
             MaybeUninit::new(unsafe { parent_node.keys[p_idx].assume_init_read() });
+        // SAFETY: same as above — p_idx < parent.len so values[p_idx] is initialized.
         child_node.values[0] =
             MaybeUninit::new(unsafe { parent_node.values[p_idx].assume_init_read() });
         if !child_node.leaf {
@@ -1076,6 +1114,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // and left.keys[left_len-1] is initialized. Promoting it into parent.
         parent_node.keys[p_idx] =
             MaybeUninit::new(unsafe { left_node.keys[left_len - 1].assume_init_read() });
+        // SAFETY: same as above — left.values[left_len-1] is initialized (left_len > min).
         parent_node.values[p_idx] =
             MaybeUninit::new(unsafe { left_node.values[left_len - 1].assume_init_read() });
 
@@ -1104,7 +1143,9 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         let parent_node = unsafe { &mut *node_deref_mut(parent) };
         let child = parent_node.children[child_idx];
         let right = parent_node.children[child_idx + 1];
+        // SAFETY: child is the valid pointer at parent.children[child_idx]; distinct slab allocation from parent.
         let child_node = unsafe { &mut *node_deref_mut(child) };
+        // SAFETY: right is the valid pointer at parent.children[child_idx+1]; distinct slab allocation from parent and child.
         let right_node = unsafe { &mut *node_deref_mut(right) };
         let child_len = child_node.len as usize;
         let right_len = right_node.len as usize;
@@ -1116,6 +1157,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // within the array bounds.
         child_node.keys[child_len] =
             MaybeUninit::new(unsafe { parent_node.keys[p_idx].assume_init_read() });
+        // SAFETY: same as above — p_idx < parent.len so values[p_idx] is initialized.
         child_node.values[child_len] =
             MaybeUninit::new(unsafe { parent_node.values[p_idx].assume_init_read() });
         if !child_node.leaf {
@@ -1128,6 +1170,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // initialized. Promoting it into the parent at p_idx.
         parent_node.keys[p_idx] =
             MaybeUninit::new(unsafe { right_node.keys[0].assume_init_read() });
+        // SAFETY: same as above — right.values[0] is initialized (right_len > min >= 1).
         parent_node.values[p_idx] =
             MaybeUninit::new(unsafe { right_node.values[0].assume_init_read() });
 
@@ -1136,6 +1179,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // has right_len-1 initialized elements. ptr::copy handles the
         // overlapping source/dest correctly.
         if right_len > 1 {
+            // SAFETY: right_len > 1 so [1..right_len) has right_len-1 initialized elements; ptr::copy handles overlapping regions.
             unsafe {
                 let kp = right_node.keys.as_mut_ptr();
                 ptr::copy(kp.add(1).cast_const(), kp, right_len - 1);
@@ -1183,6 +1227,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // SAFETY: left and right are distinct slab-allocated nodes. We take
         // &mut of left (will be modified) and & of right (read-only, then freed).
         let left_node = unsafe { &mut *node_deref_mut(left) };
+        // SAFETY: right is the valid pointer at parent.children[merge_idx+1]; distinct slab allocation from parent and left.
         let right_node = unsafe { &*node_deref(right) };
         let left_len = left_node.len as usize;
         let right_len = right_node.len as usize;
@@ -1192,6 +1237,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // left_len == min < B-1, so keys[left_len] is within array bounds.
         left_node.keys[left_len] =
             MaybeUninit::new(unsafe { (*node_deref(parent)).keys[merge_idx].assume_init_read() });
+        // SAFETY: same as above — merge_idx < parent.len so values[merge_idx] is initialized.
         left_node.values[left_len] =
             MaybeUninit::new(unsafe { (*node_deref(parent)).values[merge_idx].assume_init_read() });
 
@@ -1200,6 +1246,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         // == 2*min + 1 == B-1, so destination indices are within [0, B-1).
         // Source and destination are in different nodes — no overlap.
         if right_len > 0 {
+            // SAFETY: right has right_len initialized keys/values at [0..right_len); destination in left starts at left_len+1; nodes are distinct so no overlap.
             unsafe {
                 ptr::copy_nonoverlapping(
                     right_node.keys.as_ptr(),
@@ -1272,6 +1319,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                     // SAFETY: we initialized keys[0] and values[0] above before try_alloc.
                     // The alloc failed, returning the node. Read back the initialized slots.
                     let k = unsafe { node.keys[0].assume_init_read() };
+                    // SAFETY: same as above — values[0] was initialized before the failed alloc.
                     let v = unsafe { node.values[0].assume_init_read() };
                     return Err(Full((k, v)));
                 }
@@ -1325,6 +1373,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             if unsafe { node_is_leaf(current) } {
                 // SAFETY: current is a valid leaf with room (root was split if full).
                 unsafe { shift_right(current, idx) };
+                // SAFETY: current is a valid leaf node; &mut self ensures no aliasing.
                 let node = unsafe { &mut *node_deref_mut(current) };
                 node.keys[idx] = MaybeUninit::new(key);
                 node.values[idx] = MaybeUninit::new(value);
@@ -1427,6 +1476,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             if unsafe { node_is_leaf(current) } {
                 // SAFETY: current is a valid leaf with room (proactive split).
                 unsafe { shift_right(current, idx) };
+                // SAFETY: current is a valid leaf node; &mut self ensures no aliasing.
                 let node = unsafe { &mut *node_deref_mut(current) };
                 node.keys[idx] = MaybeUninit::new(key);
                 node.values[idx] = MaybeUninit::new(value);
@@ -1486,11 +1536,13 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             }
             // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf node; node_len reads the len field.
                 if idx < unsafe { node_len(current) } {
                     return (current, idx as u16);
                 }
                 return result;
             }
+            // SAFETY: current is a valid internal node; node_len reads the len field.
             if idx < unsafe { node_len(current) } {
                 result = (current, idx as u16);
             }
@@ -1509,6 +1561,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
             if found {
                 // SAFETY: current is a valid node.
                 if unsafe { node_is_leaf(current) } {
+                    // SAFETY: current is a valid leaf node; node_len reads the len field.
                     if idx + 1 < unsafe { node_len(current) } {
                         return (current, (idx + 1) as u16);
                     }
@@ -1518,17 +1571,20 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
                 let mut c = unsafe { child_at(current, idx + 1) };
                 // SAFETY: c is a valid child node; loop descends leftmost children.
                 while !unsafe { node_is_leaf(c) } {
+                    // SAFETY: c is an internal node; child_at(c, 0) is the leftmost valid child.
                     c = unsafe { child_at(c, 0) };
                 }
                 return (c, 0);
             }
             // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf node; node_len reads the len field.
                 if idx < unsafe { node_len(current) } {
                     return (current, idx as u16);
                 }
                 return result;
             }
+            // SAFETY: current is a valid internal node; node_len reads the len field.
             if idx < unsafe { node_len(current) } {
                 result = (current, idx as u16);
             }
@@ -1593,6 +1649,7 @@ impl<K, V, const B: usize, C: Compare<K>> BTree<K, V, B, C> {
         for i in 1..len {
             // SAFETY: keys[i-1] and keys[i] are initialized for i < len.
             let prev = unsafe { node.keys[i - 1].assume_init_ref() };
+            // SAFETY: keys[i] is initialized for i < len (same reasoning as above).
             let curr = unsafe { node.keys[i].assume_init_ref() };
             assert!(C::cmp(prev, curr) == Ordering::Less);
         }
@@ -1747,6 +1804,7 @@ impl<K, V, const B: usize, C> BTree<K, V, B, C> {
         loop {
             // SAFETY: current is non-null (root checked above, then valid children).
             let len = unsafe { node_len(current) };
+            // SAFETY: current is a valid node; node_is_leaf reads the leaf flag.
             if unsafe { node_is_leaf(current) } {
                 // SAFETY: current is a valid leaf with at least 1 key; len-1 is valid.
                 return Some(unsafe { (key_at(current, len - 1), value_at(current, len - 1)) });
@@ -1790,6 +1848,7 @@ impl<K, V, const B: usize, C> BTree<K, V, B, C> {
             for i in 0..=len {
                 let child = node.children[i];
                 if !child.is_null() {
+                    // SAFETY: child is a valid non-null node pointer from this internal node; exclusively owned.
                     unsafe { Self::clear_subtree(child, slab) };
                 }
             }
@@ -1848,12 +1907,14 @@ fn init_lower_bound_stack<K, V, const B: usize, C: Compare<K>>(
         }
         // SAFETY: current is a valid node.
         if unsafe { node_is_leaf(current) } {
+            // SAFETY: current is a valid leaf node; node_len reads the len field.
             if idx < unsafe { node_len(current) } {
                 stack[*stack_len] = (current, idx as u16);
                 *stack_len += 1;
             }
             return;
         }
+        // SAFETY: current is a valid internal node; node_len reads the len field.
         if idx < unsafe { node_len(current) } {
             stack[*stack_len] = (current, idx as u16);
             *stack_len += 1;
@@ -1876,6 +1937,7 @@ fn init_upper_bound_stack<K, V, const B: usize, C: Compare<K>>(
         if found {
             // SAFETY: current is a valid node.
             if unsafe { node_is_leaf(current) } {
+                // SAFETY: current is a valid leaf node; node_len reads the len field.
                 if idx + 1 < unsafe { node_len(current) } {
                     stack[*stack_len] = (current, (idx + 1) as u16);
                     *stack_len += 1;
@@ -1891,12 +1953,14 @@ fn init_upper_bound_stack<K, V, const B: usize, C: Compare<K>>(
         }
         // SAFETY: current is a valid node.
         if unsafe { node_is_leaf(current) } {
+            // SAFETY: current is a valid leaf node; node_len reads the len field.
             if idx < unsafe { node_len(current) } {
                 stack[*stack_len] = (current, idx as u16);
                 *stack_len += 1;
             }
             return;
         }
+        // SAFETY: current is a valid internal node; node_len reads the len field.
         if idx < unsafe { node_len(current) } {
             stack[*stack_len] = (current, idx as u16);
             *stack_len += 1;
@@ -2192,6 +2256,7 @@ impl<'a, K, V, const B: usize, C: Compare<K>, S: SlabOps<BTreeNode<K, V, B>>>
     pub fn insert(&mut self, value: V) -> V {
         // SAFETY: self.node is a valid node; self.idx < node.len; values[idx] initialized.
         let slot = unsafe { &mut (*node_deref_mut(self.node)).values[self.idx] };
+        // SAFETY: values[self.idx] is initialized (self.idx < node.len by OccupiedEntry invariant).
         let old = unsafe { slot.assume_init_read() };
         *slot = MaybeUninit::new(value);
         old
@@ -2284,6 +2349,7 @@ impl<K, V, const B: usize, C: Compare<K>, S: SlabOps<BTreeNode<K, V, B>>>
         if (idx as usize) >= unsafe { node_len(node) } {
             return None;
         }
+        // SAFETY: idx < node.len (checked above); node is a valid traversal-stack node.
         Some(unsafe { key_at(node, idx as usize) })
     }
 
@@ -2297,6 +2363,7 @@ impl<K, V, const B: usize, C: Compare<K>, S: SlabOps<BTreeNode<K, V, B>>>
         if (idx as usize) >= unsafe { node_len(node) } {
             return None;
         }
+        // SAFETY: idx < node.len (checked above); node is a valid traversal-stack node.
         Some(unsafe { value_at(node, idx as usize) })
     }
 
@@ -2310,6 +2377,7 @@ impl<K, V, const B: usize, C: Compare<K>, S: SlabOps<BTreeNode<K, V, B>>>
         if (idx as usize) >= unsafe { node_len(node) } {
             return None;
         }
+        // SAFETY: idx < node.len (checked above); node is a valid traversal-stack node; &mut self ensures exclusivity.
         Some(unsafe { value_at_mut(node, idx as usize) })
     }
 

--- a/nexus-collections/src/heap.rs
+++ b/nexus-collections/src/heap.rs
@@ -181,6 +181,7 @@ unsafe fn link<T: Ord>(a: NodePtr<T>, b: NodePtr<T>) -> NodePtr<T> {
 
     // SAFETY: both pointers guaranteed non-null and valid by caller.
     let a_node = unsafe { node_deref(a) };
+    // SAFETY: same as above; b is non-null and valid by caller.
     let b_node = unsafe { node_deref(b) };
 
     let (winner, winner_node, loser, loser_node) = if a_node.value() <= b_node.value() {

--- a/nexus-collections/src/list.rs
+++ b/nexus-collections/src/list.rs
@@ -334,6 +334,7 @@ impl<T> List<T> {
             panic_wrong_list();
         }
 
+        // SAFETY: handle is a live RcSlot with refcount >= 1.
         let new_node = unsafe { node_deref(handle.as_ptr()) };
         if new_node.is_linked() {
             panic_already_linked();
@@ -373,6 +374,7 @@ impl<T> List<T> {
             panic_wrong_list();
         }
 
+        // SAFETY: handle is a live RcSlot with refcount >= 1.
         let new_node = unsafe { node_deref(handle.as_ptr()) };
         if new_node.is_linked() {
             panic_already_linked();
@@ -645,17 +647,20 @@ impl<T> List<T> {
 
         // SAFETY: prev/next are valid linked nodes if non-null (maintained by list ops).
         if !prev.is_null() {
+            // SAFETY: prev is non-null and a valid linked predecessor.
             unsafe { node_deref(prev) }.set_next(next);
         }
         if next.is_null() {
             self.tail = prev;
         } else {
+            // SAFETY: next is non-null and a valid linked successor.
             unsafe { node_deref(next) }.set_prev(prev);
         }
 
         node.set_prev(ptr::null_mut());
         node.set_next(self.head);
         if !self.head.is_null() {
+            // SAFETY: head is non-null and points to a linked node with refcount >= 2.
             unsafe { node_deref(self.head) }.set_prev(ptr);
         }
         self.head = ptr;
@@ -680,17 +685,20 @@ impl<T> List<T> {
 
         // SAFETY: prev/next are valid linked nodes if non-null.
         if !prev.is_null() {
+            // SAFETY: prev is non-null and a valid linked predecessor.
             unsafe { node_deref(prev) }.set_next(next);
         }
         if next.is_null() {
             self.tail = prev;
         } else {
+            // SAFETY: next is non-null and a valid linked successor.
             unsafe { node_deref(next) }.set_prev(prev);
         }
 
         node.set_prev(ptr::null_mut());
         node.set_next(self.head);
         if !self.head.is_null() {
+            // SAFETY: head is non-null and points to a linked node with refcount >= 2.
             unsafe { node_deref(self.head) }.set_prev(ptr);
         }
         self.head = ptr;
@@ -718,17 +726,20 @@ impl<T> List<T> {
 
         // SAFETY: prev/next are valid linked nodes if non-null.
         if !next.is_null() {
+            // SAFETY: next is non-null and a valid linked successor.
             unsafe { node_deref(next) }.set_prev(prev);
         }
         if prev.is_null() {
             self.head = next;
         } else {
+            // SAFETY: prev is non-null and a valid linked predecessor.
             unsafe { node_deref(prev) }.set_next(next);
         }
 
         node.set_next(ptr::null_mut());
         node.set_prev(self.tail);
         if !self.tail.is_null() {
+            // SAFETY: tail is non-null and points to a linked node with refcount >= 2.
             unsafe { node_deref(self.tail) }.set_next(ptr);
         }
         self.tail = ptr;
@@ -753,17 +764,20 @@ impl<T> List<T> {
 
         // SAFETY: prev/next are valid linked nodes if non-null.
         if !next.is_null() {
+            // SAFETY: next is non-null and a valid linked successor.
             unsafe { node_deref(next) }.set_prev(prev);
         }
         if prev.is_null() {
             self.head = next;
         } else {
+            // SAFETY: prev is non-null and a valid linked predecessor.
             unsafe { node_deref(prev) }.set_next(next);
         }
 
         node.set_next(ptr::null_mut());
         node.set_prev(self.tail);
         if !self.tail.is_null() {
+            // SAFETY: tail is non-null and points to a linked node with refcount >= 2.
             unsafe { node_deref(self.tail) }.set_next(ptr);
         }
         self.tail = ptr;

--- a/nexus-collections/src/rbtree.rs
+++ b/nexus-collections/src/rbtree.rs
@@ -159,6 +159,7 @@ unsafe fn node_deref<K, V>(ptr: NodePtr<K, V>) -> *const RbNode<K, V> {
 unsafe fn node_deref_mut<K, V>(ptr: NodePtr<K, V>) -> *mut RbNode<K, V> {
     // Use value_ptr_mut to avoid creating &SlotCell which would give
     // read-only provenance under stacked borrows.
+    // SAFETY: ptr is non-null and points to an occupied SlotCell per caller contract.
     unsafe { nexus_slab::shared::SlotCell::value_ptr_mut(ptr) }
 }
 
@@ -223,6 +224,7 @@ unsafe fn successor<K, V>(ptr: NodePtr<K, V>) -> NodePtr<K, V> {
     let node = unsafe { &*node_deref(ptr) };
     let right = node.right.get();
     if !right.is_null() {
+        // SAFETY: right is non-null (checked above) and a valid tree node.
         return unsafe { tree_minimum(right) };
     }
     let mut current = ptr;
@@ -246,6 +248,7 @@ unsafe fn predecessor<K, V>(ptr: NodePtr<K, V>) -> NodePtr<K, V> {
     let node = unsafe { &*node_deref(ptr) };
     let left = node.left.get();
     if !left.is_null() {
+        // SAFETY: left is non-null (checked above) and a valid tree node.
         return unsafe { tree_maximum(left) };
     }
     let mut current = ptr;
@@ -672,6 +675,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         if !end.is_null() {
             // SAFETY: front and end are non-null valid tree nodes from lower/upper_bound.
             let front_key = unsafe { &(*node_deref(front)).key };
+            // SAFETY: same as above; end is non-null and a valid tree node from lower/upper_bound.
             let end_key = unsafe { &(*node_deref(end)).key };
             if C::cmp(front_key, end_key) != Ordering::Less {
                 return (ptr::null_mut(), ptr::null_mut());
@@ -752,6 +756,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         // non-null by the RB-tree fixup algorithm that calls this.
         let x_node = unsafe { &*node_deref(x) };
         let y = x_node.right.get();
+        // SAFETY: y is non-null per the caller-guaranteed invariant above; it is a valid tree node.
         let y_node = unsafe { &*node_deref(y) };
 
         let b = y_node.left.get();
@@ -784,6 +789,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         // non-null by the RB-tree fixup algorithm that calls this.
         let x_node = unsafe { &*node_deref(x) };
         let y = x_node.left.get();
+        // SAFETY: y is non-null per the caller-guaranteed invariant above; it is a valid tree node.
         let y_node = unsafe { &*node_deref(y) };
 
         let b = y_node.right.get();
@@ -850,6 +856,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
 
             // SAFETY: grandparent is non-null (parent is red, so not root).
             if parent == unsafe { (*node_deref(grandparent)).left.get() } {
+                // SAFETY: same as above; grandparent is non-null and a valid tree node.
                 let uncle = unsafe { (*node_deref(grandparent)).right.get() };
                 if is_red(uncle) {
                     set_color(parent, COLOR_BLACK);
@@ -860,15 +867,18 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
                     // SAFETY: parent is non-null and valid.
                     if z == unsafe { (*node_deref(parent)).right.get() } {
                         z = parent;
+                        // SAFETY: z was just set to parent which is non-null and a valid tree node.
                         unsafe { self.rotate_left(z) };
                     }
                     let parent = get_parent(z);
                     let grandparent = get_parent(parent);
                     set_color(parent, COLOR_BLACK);
                     set_color(grandparent, COLOR_RED);
+                    // SAFETY: grandparent is non-null (parent is red, not root) and a valid tree node.
                     unsafe { self.rotate_right(grandparent) };
                 }
             } else {
+                // SAFETY: grandparent is non-null (parent is red, not root) and a valid tree node.
                 let uncle = unsafe { (*node_deref(grandparent)).left.get() };
                 if is_red(uncle) {
                     set_color(parent, COLOR_BLACK);
@@ -879,12 +889,14 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
                     // SAFETY: parent is non-null and valid.
                     if z == unsafe { (*node_deref(parent)).left.get() } {
                         z = parent;
+                        // SAFETY: z was just set to parent which is non-null and a valid tree node.
                         unsafe { self.rotate_right(z) };
                     }
                     let parent = get_parent(z);
                     let grandparent = get_parent(parent);
                     set_color(parent, COLOR_BLACK);
                     set_color(grandparent, COLOR_RED);
+                    // SAFETY: grandparent is non-null (parent is red, not root) and a valid tree node.
                     unsafe { self.rotate_left(grandparent) };
                 }
             }
@@ -917,14 +929,18 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
             y_original_color = z_color;
             x = z_right;
             x_parent = get_parent(z);
+            // SAFETY: z is a valid non-null tree node; transplant accepts null for v.
             unsafe { self.transplant(z, z_right) };
         } else if z_right.is_null() {
             y_original_color = z_color;
             x = z_left;
             x_parent = get_parent(z);
+            // SAFETY: z is a valid non-null tree node; z_left is non-null (else branch).
             unsafe { self.transplant(z, z_left) };
         } else {
+            // SAFETY: z_right is non-null (both children present in this branch).
             let y = unsafe { tree_minimum(z_right) };
+            // SAFETY: y is non-null — tree_minimum returns a valid node from a non-null input.
             let y_node = unsafe { &*node_deref(y) };
             y_original_color = y_node.parent_color.get() & COLOR_MASK;
             x = y_node.right.get();
@@ -933,18 +949,23 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
                 x_parent = y;
             } else {
                 x_parent = get_parent(y);
+                // SAFETY: y is a valid non-null node (in-order successor); transplant accepts null for v.
                 unsafe { self.transplant(y, x) };
+                // SAFETY: y is non-null and a valid tree node; setting right via Cell is safe.
                 unsafe { (*node_deref(y)).right.set(z_right) };
                 set_parent(z_right, y);
             }
 
+            // SAFETY: z and y are both valid non-null tree nodes.
             unsafe { self.transplant(z, y) };
+            // SAFETY: y is non-null and a valid tree node; setting left via Cell is safe.
             unsafe { (*node_deref(y)).left.set(z_left) };
             set_parent(z_left, y);
             set_color(y, z_color);
         }
 
         if y_original_color == COLOR_BLACK {
+            // SAFETY: x_parent is a valid node; x may be null (treated as nil leaf).
             unsafe { self.delete_fixup(x, x_parent) };
         }
     }
@@ -962,14 +983,19 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
         while x != self.root && !is_red(x) {
             // SAFETY: x_parent is non-null (x is not the root).
             if x == unsafe { (*node_deref(x_parent)).left.get() } {
+                // SAFETY: same as above; x_parent is non-null and a valid tree node.
                 let mut w = unsafe { (*node_deref(x_parent)).right.get() };
                 if is_red(w) {
                     set_color(w, COLOR_BLACK);
                     set_color(x_parent, COLOR_RED);
+                    // SAFETY: x_parent is non-null and a valid tree node; w is red so rotation valid.
                     unsafe { self.rotate_left(x_parent) };
+                    // SAFETY: x_parent is still a valid non-null tree node after the rotation.
                     w = unsafe { (*node_deref(x_parent)).right.get() };
                 }
+                // SAFETY: w is non-null — RB-tree black-height invariant guarantees a non-nil sibling.
                 let w_left = unsafe { (*node_deref(w)).left.get() };
+                // SAFETY: same as above; w is a valid non-null sibling node.
                 let w_right = unsafe { (*node_deref(w)).right.get() };
                 if !is_red(w_left) && !is_red(w_right) {
                     set_color(w, COLOR_RED);
@@ -979,26 +1005,36 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
                     if !is_red(w_right) {
                         set_color(w_left, COLOR_BLACK);
                         set_color(w, COLOR_RED);
+                        // SAFETY: w is non-null and a valid tree node.
                         unsafe { self.rotate_right(w) };
+                        // SAFETY: x_parent is still a valid non-null tree node after the rotation.
                         w = unsafe { (*node_deref(x_parent)).right.get() };
                     }
+                    // SAFETY: x_parent is non-null and a valid tree node.
                     let parent_color =
                         unsafe { (*node_deref(x_parent)).parent_color.get() } & COLOR_MASK;
                     set_color(w, parent_color);
                     set_color(x_parent, COLOR_BLACK);
+                    // SAFETY: w is non-null and valid; its right child is non-null (w_right is red).
                     set_color(unsafe { (*node_deref(w)).right.get() }, COLOR_BLACK);
+                    // SAFETY: x_parent is non-null and a valid tree node.
                     unsafe { self.rotate_left(x_parent) };
                     x = self.root;
                 }
             } else {
+                // SAFETY: x_parent is non-null and a valid tree node.
                 let mut w = unsafe { (*node_deref(x_parent)).left.get() };
                 if is_red(w) {
                     set_color(w, COLOR_BLACK);
                     set_color(x_parent, COLOR_RED);
+                    // SAFETY: x_parent is non-null and a valid tree node; w is red so rotation valid.
                     unsafe { self.rotate_right(x_parent) };
+                    // SAFETY: x_parent is still a valid non-null tree node after the rotation.
                     w = unsafe { (*node_deref(x_parent)).left.get() };
                 }
+                // SAFETY: w is non-null — RB-tree black-height invariant guarantees a non-nil sibling.
                 let w_left = unsafe { (*node_deref(w)).left.get() };
+                // SAFETY: same as above; w is a valid non-null sibling node.
                 let w_right = unsafe { (*node_deref(w)).right.get() };
                 if !is_red(w_right) && !is_red(w_left) {
                     set_color(w, COLOR_RED);
@@ -1008,14 +1044,19 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
                     if !is_red(w_left) {
                         set_color(w_right, COLOR_BLACK);
                         set_color(w, COLOR_RED);
+                        // SAFETY: w is non-null and a valid tree node.
                         unsafe { self.rotate_left(w) };
+                        // SAFETY: x_parent is still a valid non-null tree node after the rotation.
                         w = unsafe { (*node_deref(x_parent)).left.get() };
                     }
+                    // SAFETY: x_parent is non-null and a valid tree node.
                     let parent_color =
                         unsafe { (*node_deref(x_parent)).parent_color.get() } & COLOR_MASK;
                     set_color(w, parent_color);
                     set_color(x_parent, COLOR_BLACK);
+                    // SAFETY: w is non-null and valid; its left child is non-null (w_left is red).
                     set_color(unsafe { (*node_deref(w)).left.get() }, COLOR_BLACK);
+                    // SAFETY: x_parent is non-null and a valid tree node.
                     unsafe { self.rotate_right(x_parent) };
                     x = self.root;
                 }
@@ -1048,6 +1089,7 @@ impl<K, V, C: Compare<K>> RbTree<K, V, C> {
 
         // SAFETY: root is non-null (checked above) and a valid tree node.
         let actual_min = unsafe { tree_minimum(self.root) };
+        // SAFETY: root is non-null (checked above) and a valid tree node.
         let actual_max = unsafe { tree_maximum(self.root) };
         assert_eq!(self.leftmost, actual_min, "leftmost cache mismatch");
         assert_eq!(self.rightmost, actual_max, "rightmost cache mismatch");
@@ -1407,6 +1449,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
         let ptr = self.front;
         // SAFETY: ptr is non-null (len > 0) and a valid tree node from traversal.
         let node = unsafe { &*node_deref(ptr) };
+        // SAFETY: ptr is non-null and a valid tree node; successor follows right-subtree/parent pointers within the live tree.
         self.front = unsafe { successor(ptr) };
         self.len -= 1;
         Some((&node.key, &node.value))
@@ -1529,6 +1572,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Range<'a, K, V> {
         let ptr = self.front;
         // SAFETY: ptr is non-null and a valid tree node within the range.
         let node = unsafe { &*node_deref(ptr) };
+        // SAFETY: ptr is non-null and a valid tree node; successor follows right-subtree/parent pointers within the live tree.
         self.front = unsafe { successor(ptr) };
         Some((&node.key, &node.value))
     }
@@ -1550,6 +1594,7 @@ impl<'a, K: 'a, V: 'a> Iterator for RangeMut<'a, K, V> {
         let ptr = self.front;
         // SAFETY: ptr is non-null and a valid tree node within the range.
         let next = unsafe { successor(ptr) };
+        // SAFETY: ptr is non-null and a valid tree node; &mut self ensures exclusivity over the value.
         let node = unsafe { &mut *node_deref_mut(ptr) };
         self.front = next;
         Some((&node.key, &mut node.value))

--- a/nexus-collections/tests/btree_test.rs
+++ b/nexus-collections/tests/btree_test.rs
@@ -5,6 +5,7 @@ use nexus_slab::bounded::Slab;
 use nexus_slab::unbounded::Slab as UnboundedSlab;
 
 fn make_slab() -> Slab<BTreeNode<u64, u64, 8>> {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     unsafe { Slab::with_capacity(200) }
 }
 
@@ -221,6 +222,7 @@ fn many_inserts_and_removes() {
 
 #[test]
 fn custom_b_4() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 4>> = unsafe { Slab::with_capacity(200) };
     let mut tree = BTree::<u64, u64, 4>::new();
 
@@ -245,6 +247,7 @@ fn custom_b_4() {
 #[test]
 fn unbounded_insert() {
     let slab: UnboundedSlab<BTreeNode<u64, u64, 8>> =
+        // SAFETY: single-threaded test; slab outlives all allocated slots.
         unsafe { UnboundedSlab::with_chunk_capacity(8) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -277,6 +280,7 @@ fn unbounded_insert() {
 fn drop_non_empty_btree_panics() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let slab: UnboundedSlab<BTreeNode<u64, u64, 8>> =
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
             unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = BTree::<u64, u64, 8>::new();
         tree.insert(&slab, 1, 100);
@@ -298,6 +302,7 @@ fn drop_non_empty_btree_panics() {
 fn drop_non_empty_btree_during_unwind_no_double_panic() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let slab: UnboundedSlab<BTreeNode<u64, u64, 8>> =
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
             unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = BTree::<u64, u64, 8>::new();
         tree.insert(&slab, 1, 100);
@@ -312,6 +317,7 @@ fn drop_non_empty_btree_during_unwind_no_double_panic() {
 #[test]
 fn non_empty_drop_panics_in_debug() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: single-threaded test; slab outlives all allocated slots.
         let slab = unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = BTree::<u64, u64, 8>::new();
         tree.insert(&slab, 1, 100);

--- a/nexus-collections/tests/compare_test.rs
+++ b/nexus-collections/tests/compare_test.rs
@@ -6,10 +6,12 @@ use nexus_collections::slab::rbtree::{RbNode, RbTree};
 use nexus_slab::bounded::Slab;
 
 fn make_rb_slab() -> Slab<RbNode<u64, String>> {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     unsafe { Slab::with_capacity(200) }
 }
 
 fn make_bt_slab() -> Slab<BTreeNode<u64, String, 8>> {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     unsafe { Slab::with_capacity(500) }
 }
 

--- a/nexus-collections/tests/cursor_test.rs
+++ b/nexus-collections/tests/cursor_test.rs
@@ -4,6 +4,7 @@ use nexus_collections::slab::list::{List, ListNode};
 use nexus_slab::rc::bounded::Slab;
 
 fn make_slab() -> Slab<ListNode<u64>> {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     unsafe { Slab::with_capacity(100) }
 }
 

--- a/nexus-collections/tests/heap_test.rs
+++ b/nexus-collections/tests/heap_test.rs
@@ -5,6 +5,7 @@ use nexus_slab::rc::bounded::Slab;
 use nexus_slab::rc::unbounded::Slab as UnboundedSlab;
 
 fn make_slab() -> Slab<HeapNode<u64>> {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     unsafe { Slab::with_capacity(100) }
 }
 
@@ -87,6 +88,7 @@ fn contains() {
 
 #[test]
 fn try_push_full() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: Slab<HeapNode<u64>> = unsafe { Slab::with_capacity(1) };
     let mut heap = Heap::new();
 
@@ -174,6 +176,7 @@ fn unlink_wrong_heap_panics() {
 
 #[test]
 fn unbounded_push_and_pop() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab = unsafe { UnboundedSlab::<HeapNode<u64>>::with_chunk_capacity(4) };
     let mut heap = Heap::new();
 
@@ -209,6 +212,7 @@ fn unbounded_push_and_pop() {
 
 #[test]
 fn stress_heap_push_pop_cycle() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: Slab<HeapNode<u64>> = unsafe { Slab::with_capacity(10_000) };
     let mut heap = Heap::new();
 
@@ -339,6 +343,7 @@ fn drop_non_empty_heap_during_unwind_no_double_panic() {
 #[test]
 fn non_empty_drop_panics_in_debug() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: single-threaded test; slab outlives all allocated nodes.
         let slab = unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut heap = Heap::new();
         heap.push(&slab, 42u64);

--- a/nexus-collections/tests/list_test.rs
+++ b/nexus-collections/tests/list_test.rs
@@ -12,10 +12,12 @@ struct Order {
 }
 
 fn make_slab() -> Slab<ListNode<Order>> {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     unsafe { Slab::with_capacity(100) }
 }
 
 fn make_u64_slab() -> Slab<ListNode<u64>> {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     unsafe { Slab::with_capacity(100) }
 }
 
@@ -341,6 +343,7 @@ fn is_head_is_tail() {
 
 #[test]
 fn unbounded_push_back_and_pop_front() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab = unsafe { UnboundedSlab::<ListNode<u64>>::with_chunk_capacity(4) };
     let mut list = List::new();
 
@@ -371,6 +374,7 @@ fn unbounded_push_back_and_pop_front() {
 
 #[test]
 fn unbounded_push_front_and_pop_back() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab = unsafe { UnboundedSlab::<ListNode<u64>>::with_chunk_capacity(4) };
     let mut list = List::new();
 
@@ -395,6 +399,7 @@ fn unbounded_push_front_and_pop_back() {
 
 #[test]
 fn stress_list_push_pop_cycle() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab = unsafe { Slab::<ListNode<u64>>::with_capacity(10_000) };
     let mut list = List::new();
 
@@ -586,6 +591,7 @@ fn drop_non_empty_list_during_unwind_no_double_panic() {
 #[test]
 fn non_empty_drop_panics_in_debug() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: single-threaded test; slab outlives all allocated nodes.
         let slab = unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut list = List::new();
         let order = Order {

--- a/nexus-collections/tests/miri_tests.rs
+++ b/nexus-collections/tests/miri_tests.rs
@@ -43,6 +43,7 @@ fn get_drop_count() -> usize {
 
 #[test]
 fn list_link_unlink_basic() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -72,6 +73,7 @@ fn list_link_unlink_basic() {
 
 #[test]
 fn list_clear_drops_refs() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -94,6 +96,7 @@ fn list_clear_drops_refs() {
 
 #[test]
 fn list_cursor_traverse_and_remove() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -119,6 +122,7 @@ fn list_cursor_traverse_and_remove() {
 
 #[test]
 fn list_link_front_back_interleaved() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -148,6 +152,7 @@ fn list_link_front_back_interleaved() {
 
 #[test]
 fn list_single_element() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -167,6 +172,7 @@ fn list_single_element() {
 fn list_drop_tracker() {
     reset_drop_count();
 
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<ListNode<DropTracker>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut list = List::new();
 
@@ -194,6 +200,7 @@ fn list_drop_tracker() {
 
 #[test]
 fn heap_push_pop_basic() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -216,6 +223,7 @@ fn heap_push_pop_basic() {
 
 #[test]
 fn heap_push_pop_reverse_sorted() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -238,6 +246,7 @@ fn heap_push_pop_reverse_sorted() {
 
 #[test]
 fn heap_clear() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -256,6 +265,7 @@ fn heap_clear() {
 
 #[test]
 fn heap_decrease_key() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -282,6 +292,7 @@ fn heap_decrease_key() {
 
 #[test]
 fn heap_single_element() {
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<u64>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -300,6 +311,7 @@ fn heap_single_element() {
 fn heap_drop_tracker() {
     reset_drop_count();
 
+    // SAFETY: single-threaded test; slab outlives all allocated nodes.
     let slab: RcSlab<HeapNode<DropTracker>> = unsafe { RcSlab::with_chunk_capacity(32) };
     let mut heap = Heap::new();
 
@@ -320,6 +332,7 @@ fn heap_drop_tracker() {
 
 #[test]
 fn rbtree_insert_ascending() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -338,6 +351,7 @@ fn rbtree_insert_ascending() {
 
 #[test]
 fn rbtree_insert_descending() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -355,6 +369,7 @@ fn rbtree_insert_descending() {
 
 #[test]
 fn rbtree_insert_random_pattern() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -369,6 +384,7 @@ fn rbtree_insert_random_pattern() {
 
 #[test]
 fn rbtree_remove_leaf() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -387,6 +403,7 @@ fn rbtree_remove_leaf() {
 
 #[test]
 fn rbtree_remove_node_with_one_child() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -406,6 +423,7 @@ fn rbtree_remove_node_with_one_child() {
 
 #[test]
 fn rbtree_remove_node_with_two_children() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -425,6 +443,7 @@ fn rbtree_remove_node_with_two_children() {
 
 #[test]
 fn rbtree_insert_remove_stress() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = RbTree::new();
 
@@ -458,6 +477,7 @@ fn rbtree_insert_remove_stress() {
 
 #[test]
 fn rbtree_clear() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -472,6 +492,7 @@ fn rbtree_clear() {
 
 #[test]
 fn rbtree_iteration() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -491,6 +512,7 @@ fn rbtree_iteration() {
 
 #[test]
 fn rbtree_range_iteration() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -506,6 +528,7 @@ fn rbtree_range_iteration() {
 
 #[test]
 fn rbtree_entry_api() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -544,6 +567,7 @@ fn rbtree_entry_api() {
 
 #[test]
 fn rbtree_first_last_pop() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -569,6 +593,7 @@ fn rbtree_first_last_pop() {
 fn rbtree_drop_tracker() {
     reset_drop_count();
 
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, DropTracker>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = RbTree::new();
 
@@ -587,6 +612,7 @@ fn rbtree_drop_tracker() {
 
 #[test]
 fn btree_insert_until_split() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -605,6 +631,7 @@ fn btree_insert_until_split() {
 
 #[test]
 fn btree_insert_causing_cascade_split() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -620,6 +647,7 @@ fn btree_insert_causing_cascade_split() {
 
 #[test]
 fn btree_remove_from_leaf() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -637,6 +665,7 @@ fn btree_remove_from_leaf() {
 
 #[test]
 fn btree_remove_causing_merge() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -657,6 +686,7 @@ fn btree_remove_causing_merge() {
 
 #[test]
 fn btree_remove_causing_redistribution() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -676,6 +706,7 @@ fn btree_remove_causing_redistribution() {
 
 #[test]
 fn btree_insert_remove_stress() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -705,6 +736,7 @@ fn btree_insert_remove_stress() {
 
 #[test]
 fn btree_clear() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -719,6 +751,7 @@ fn btree_clear() {
 
 #[test]
 fn btree_iteration() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -739,6 +772,7 @@ fn btree_iteration() {
 
 #[test]
 fn btree_entry_insert_and_remove() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -777,6 +811,7 @@ fn btree_entry_insert_and_remove() {
 
 #[test]
 fn btree_range() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(64) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -792,6 +827,7 @@ fn btree_range() {
 
 #[test]
 fn btree_first_last_pop() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, u64, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, u64, 8>::new();
 
@@ -814,6 +850,7 @@ fn btree_first_last_pop() {
 fn btree_drop_tracker() {
     reset_drop_count();
 
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<BTreeNode<u64, DropTracker, 8>> = unsafe { Slab::with_chunk_capacity(32) };
     let mut tree = BTree::<u64, DropTracker, 8>::new();
 

--- a/nexus-collections/tests/rbtree_test.rs
+++ b/nexus-collections/tests/rbtree_test.rs
@@ -5,10 +5,12 @@ use nexus_slab::bounded::Slab;
 use nexus_slab::unbounded::Slab as UnboundedSlab;
 
 fn make_slab() -> Slab<RbNode<u64, String>> {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     unsafe { Slab::with_capacity(200) }
 }
 
 fn make_u64_slab() -> Slab<RbNode<u64, u64>> {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     unsafe { Slab::with_capacity(200) }
 }
 
@@ -254,6 +256,7 @@ fn many_inserts_and_removes() {
 #[test]
 fn reverse_comparator() {
     use nexus_collections::slab::Reverse;
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_capacity(100) };
     let mut tree = RbTree::with_comparator(Reverse);
 
@@ -273,6 +276,7 @@ fn reverse_comparator() {
 
 #[test]
 fn unbounded_insert() {
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let slab: UnboundedSlab<RbNode<u64, u64>> = unsafe { UnboundedSlab::with_chunk_capacity(8) };
     let mut tree = RbTree::new();
 
@@ -312,6 +316,7 @@ fn slab_ops_trait_generic() {
     }
 
     // Test with bounded slab
+    // SAFETY: single-threaded test; slab outlives all allocated slots.
     let bounded_slab: Slab<RbNode<u64, u64>> = unsafe { Slab::with_capacity(100) };
     let mut tree = RbTree::new();
     tree.try_insert(&bounded_slab, 1, 10).unwrap();
@@ -321,6 +326,7 @@ fn slab_ops_trait_generic() {
 
     // Test with unbounded slab
     let unbounded_slab: UnboundedSlab<RbNode<u64, u64>> =
+        // SAFETY: single-threaded test; slab outlives all allocated slots.
         unsafe { UnboundedSlab::with_chunk_capacity(8) };
     let mut tree = RbTree::new();
     tree.insert(&unbounded_slab, 1, 10);
@@ -340,6 +346,7 @@ fn slab_ops_trait_generic() {
 fn drop_non_empty_tree_panics() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let slab: UnboundedSlab<RbNode<u64, u64>> =
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
             unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = RbTree::new();
         tree.insert(&slab, 1, 100);
@@ -363,6 +370,7 @@ fn drop_non_empty_tree_panics() {
 fn drop_non_empty_tree_during_unwind_no_double_panic() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let slab: UnboundedSlab<RbNode<u64, u64>> =
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
             unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = RbTree::new();
         tree.insert(&slab, 1, 100);
@@ -380,6 +388,7 @@ fn drop_non_empty_tree_during_unwind_no_double_panic() {
 #[test]
 fn non_empty_drop_panics_in_debug() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: single-threaded test; slab outlives all allocated slots.
         let slab = unsafe { UnboundedSlab::with_chunk_capacity(8) };
         let mut tree = RbTree::<u64, u64>::new();
         tree.insert(&slab, 1, 100);


### PR DESCRIPTION
Covers `undocumented_unsafe_blocks` for nexus-collections under `--all-targets`: all `unsafe {}` blocks in src, tests, and benches now have `// SAFETY:` comments.

19 files, 244 lines added. Zero clippy warnings under `-W clippy::undocumented_unsafe_blocks`.

Part of the workspace-wide SAFETY audit (follows #622 nexus-shm, #623 nexus-slab).