### PR TITLE
nexus-notify: Events::drain() + poll_limit loss guard

### DIFF
--- a/nexus-notify/CHANGELOG.md
+++ b/nexus-notify/CHANGELOG.md
@@ -10,6 +10,30 @@ contained.
 
 ## [Unreleased]
 
+### Added
+
+- `Events::drain()`, a cursor-based draining iterator that removes
+  tokens as they're consumed. Unlike `Vec::drain`, stopping early
+  leaves the untaken remainder in the buffer instead of discarding it.
+
+### Breaking
+
+- **`Poller::poll_limit` / `LocalNotify::poll_limit` now `debug_assert!`
+  the previous batch was fully drained before clearing and refilling.**
+  Code that polled again without draining (or explicitly clearing) the
+  prior `Events` batch — previously legal, silently discarding the
+  leftover tokens — now panics in debug/test builds. Release builds
+  are unaffected (`debug_assertions` off).
+
+### Migration notes
+
+Most consumers are unaffected — `cargo update -p nexus-notify` is
+sufficient for any poll loop that already fully consumes `Events` each
+cycle. If a debug/test build starts panicking with "poll_limit called
+with undrained tokens still in the buffer," drain (`events.drain()`)
+or clear (`events.clear()`) the buffer before the next
+`poll`/`poll_limit` call.
+
 ## [1.0.2] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-notify/src/event_channel.rs
+++ b/nexus-notify/src/event_channel.rs
@@ -333,6 +333,7 @@ mod tests {
 
         receiver.try_recv_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         receiver.try_recv(&mut events);
         assert_eq!(events.len(), 7);
@@ -470,9 +471,11 @@ mod tests {
 
         receiver.recv_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         receiver.recv_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         receiver.try_recv(&mut events);
         assert_eq!(events.len(), 4);

--- a/nexus-notify/src/event_queue.rs
+++ b/nexus-notify/src/event_queue.rs
@@ -174,8 +174,18 @@ impl Poller {
     ///
     /// If `limit` is 0, the events buffer is cleared and no tokens
     /// are drained.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `events` still has undrained tokens
+    /// from a previous poll — see [`Events::drain`].
     #[inline]
     pub fn poll_limit(&self, events: &mut Events, limit: usize) {
+        debug_assert!(
+            events.is_drained(),
+            "poll_limit called with undrained tokens still in the buffer — \
+             drain the previous batch before polling again"
+        );
         events.clear();
         for _ in 0..limit {
             match self.rx.pop() {
@@ -227,8 +237,26 @@ impl std::error::Error for NotifyError {}
 /// Follows the mio `Events` pattern: allocate once at setup,
 /// pass to `poll()` each iteration. The buffer is cleared and
 /// refilled on each poll.
+///
+/// # Consuming tokens
+///
+/// [`drain`](Events::drain) removes tokens as they're taken; stopping
+/// early (breaking the loop, dropping the iterator) leaves the rest in
+/// the buffer instead of discarding them. This is a deliberate
+/// divergence from mio's `Events`, which exposes only borrowing
+/// accessors (`iter()`, `IntoIterator for &Events`): mio's readiness
+/// notifications re-fire on the next poll, so a token a caller fails to
+/// act on is self-correcting. These tokens are one-shot and deduped —
+/// one that isn't consumed here is gone for good — so `poll`/`poll_limit`
+/// refuse, in debug builds, to clear a buffer that still has undrained
+/// tokens in it.
 pub struct Events {
     tokens: Vec<Token>,
+    /// Read cursor. Tokens before `head` have been taken via `drain()`;
+    /// `clear()` resets it to 0. Keeping this on `Events` (rather than in
+    /// `Drain`) means partial consumption is a pointer bump, not a
+    /// `Vec::drain`-style memmove of the remainder.
+    head: usize,
 }
 
 impl Events {
@@ -238,25 +266,27 @@ impl Events {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             tokens: Vec::with_capacity(capacity),
+            head: 0,
         }
     }
 
-    /// Number of tokens from the last poll.
+    /// Number of undrained tokens from the last poll.
     #[inline]
     pub fn len(&self) -> usize {
-        self.tokens.len()
+        self.tokens.len() - self.head
     }
 
-    /// Returns true if no tokens fired.
+    /// Returns true if no undrained tokens remain.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.tokens.is_empty()
+        self.head == self.tokens.len()
     }
 
     /// Clear the buffer.
     #[inline]
     pub fn clear(&mut self) {
         self.tokens.clear();
+        self.head = 0;
     }
 
     /// Push a token into the buffer.
@@ -265,16 +295,36 @@ impl Events {
         self.tokens.push(token);
     }
 
-    /// View the fired tokens as a slice.
+    /// True if every token from the last poll has been drained.
+    ///
+    /// Used by `Poller::poll_limit`/`LocalNotify::poll_limit` to assert
+    /// the caller finished with the previous batch before clearing and
+    /// refilling.
     #[inline]
-    pub fn as_slice(&self) -> &[Token] {
-        &self.tokens
+    pub(crate) fn is_drained(&self) -> bool {
+        self.head == self.tokens.len()
     }
 
-    /// Iterate over the fired tokens.
+    /// View the undrained tokens as a slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[Token] {
+        &self.tokens[self.head..]
+    }
+
+    /// Iterate over the undrained tokens.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = Token> + '_ {
-        self.tokens.iter().copied()
+        self.tokens[self.head..].iter().copied()
+    }
+
+    /// Drain tokens by value, removing each as it's yielded.
+    ///
+    /// Unlike [`Vec::drain`], stopping early leaves the untaken
+    /// remainder in the buffer rather than discarding it — the cursor
+    /// only advances as far as `next()` was actually called.
+    #[inline]
+    pub fn drain(&mut self) -> Drain<'_> {
+        Drain { events: self }
     }
 }
 
@@ -284,7 +334,32 @@ impl<'a> IntoIterator for &'a Events {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.tokens.iter().copied()
+        self.tokens[self.head..].iter().copied()
+    }
+}
+
+/// Draining iterator over undrained [`Token`]s in an [`Events`] buffer.
+///
+/// Created by [`Events::drain`]. Advances the buffer's internal cursor
+/// as tokens are yielded; stopping early (dropping this iterator before
+/// it's exhausted) leaves everything past the cursor in place for the
+/// next `drain()` call.
+pub struct Drain<'a> {
+    events: &'a mut Events,
+}
+
+impl Iterator for Drain<'_> {
+    type Item = Token;
+
+    #[inline]
+    fn next(&mut self) -> Option<Token> {
+        if self.events.head < self.events.tokens.len() {
+            let token = self.events.tokens[self.events.head];
+            self.events.head += 1;
+            Some(token)
+        } else {
+            None
+        }
     }
 }
 
@@ -393,6 +468,7 @@ mod tests {
         notifier.notify(Token::new(10)).unwrap();
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         poller.poll(&mut events);
         assert!(events.is_empty());
@@ -422,6 +498,7 @@ mod tests {
         notifier.notify(t).unwrap();
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         notifier.notify(t).unwrap();
         poller.poll(&mut events);
@@ -439,7 +516,7 @@ mod tests {
             notifier.notify(t).unwrap();
             poller.poll(&mut events);
             assert_eq!(events.len(), 1);
-            assert_eq!(events.iter().next().unwrap().index(), 5);
+            assert_eq!(events.drain().next().unwrap().index(), 5);
         }
     }
 
@@ -451,6 +528,7 @@ mod tests {
         notifier.notify(Token::new(0)).unwrap();
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         notifier.notify(Token::new(1)).unwrap();
         poller.poll(&mut events);
@@ -512,6 +590,7 @@ mod tests {
 
         poller.poll_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         poller.poll(&mut events);
         assert_eq!(events.len(), 7);
@@ -528,6 +607,7 @@ mod tests {
 
         poller.poll_limit(&mut events, 100);
         assert_eq!(events.len(), 5);
+        events.drain().for_each(drop);
 
         poller.poll(&mut events);
         assert!(events.is_empty());
@@ -557,11 +637,11 @@ mod tests {
         }
 
         poller.poll_limit(&mut events, 2);
-        let indices: Vec<usize> = events.iter().map(Token::index).collect();
+        let indices: Vec<usize> = events.drain().map(Token::index).collect();
         assert_eq!(indices, vec![10, 20]);
 
         poller.poll_limit(&mut events, 2);
-        let indices: Vec<usize> = events.iter().map(Token::index).collect();
+        let indices: Vec<usize> = events.drain().map(Token::index).collect();
         assert_eq!(indices, vec![30, 40]);
 
         poller.poll(&mut events);
@@ -580,12 +660,15 @@ mod tests {
 
         poller.poll_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         poller.poll_limit(&mut events, 3);
         assert_eq!(events.len(), 3);
+        events.drain().for_each(drop);
 
         poller.poll(&mut events);
         assert_eq!(events.len(), 4);
+        events.drain().for_each(drop);
 
         poller.poll(&mut events);
         assert!(events.is_empty());
@@ -601,7 +684,7 @@ mod tests {
         }
 
         poller.poll_limit(&mut events, 3);
-        let drained: Vec<usize> = events.iter().map(Token::index).collect();
+        let drained: Vec<usize> = events.drain().map(Token::index).collect();
         assert_eq!(drained.len(), 3);
 
         // Re-notify a token NOT yet drained — flag is still true. Conflated.
@@ -621,6 +704,7 @@ mod tests {
         notifier.notify(t).unwrap();
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         notifier.notify(t).unwrap();
         poller.poll(&mut events);

--- a/nexus-notify/src/lib.rs
+++ b/nexus-notify/src/lib.rs
@@ -137,8 +137,9 @@
 //!
 //! // Drain only 10 per iteration (oldest first)
 //! poller.poll_limit(&mut events, 10);
-//! assert_eq!(events.len(), 10);
-//! assert_eq!(events.as_slice()[0].index(), 0);  // FIFO: oldest first
+//! let batch: Vec<usize> = events.drain().map(|t| t.index()).collect();
+//! assert_eq!(batch.len(), 10);
+//! assert_eq!(batch[0], 0);  // FIFO: oldest first
 //!
 //! // Remaining 90 stay in the queue
 //! poller.poll(&mut events);
@@ -153,5 +154,5 @@ pub mod local;
 mod loom_impl;
 
 pub use event_channel::{Receiver, Sender, event_channel};
-pub use event_queue::{Events, Notifier, NotifyError, Poller, Token, event_queue};
+pub use event_queue::{Drain, Events, Notifier, NotifyError, Poller, Token, event_queue};
 pub use local::LocalNotify;

--- a/nexus-notify/src/local.rs
+++ b/nexus-notify/src/local.rs
@@ -184,8 +184,18 @@ impl LocalNotify {
     /// Tokens appear in mark order (FIFO).
     ///
     /// Mirrors [`Poller::poll_limit`](crate::Poller::poll_limit).
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `events` still has undrained tokens
+    /// from a previous poll — see [`Events::drain`](crate::Events::drain).
     #[inline]
     pub fn poll_limit(&mut self, events: &mut Events, limit: usize) {
+        debug_assert!(
+            events.is_drained(),
+            "poll_limit called with undrained tokens still in the buffer — \
+             drain the previous batch before polling again"
+        );
         events.clear();
         let remaining = self.dispatch_list.len() - self.dispatch_head;
         let drain_count = remaining.min(limit);
@@ -312,6 +322,7 @@ mod tests {
         notify.mark(t);
         notify.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         // Cycle 2 — same token fires again
         notify.mark(t);
@@ -370,6 +381,7 @@ mod tests {
         for &t in &boundary {
             assert!(events.as_slice().contains(&t));
         }
+        events.drain().for_each(drop);
 
         // Second cycle — bits cleared correctly across word boundaries
         for &t in &boundary {
@@ -414,6 +426,7 @@ mod tests {
         notify.poll_limit(&mut events, 2);
         assert_eq!(events.len(), 2);
         assert_eq!(notify.notified_count(), 3); // 3 remaining
+        events.drain().for_each(drop);
 
         // Drain rest
         notify.poll(&mut events);
@@ -477,6 +490,7 @@ mod tests {
                 notify.mark(t);
             }
             notify.poll_limit(&mut events, limit);
+            events.drain().for_each(drop);
         }
 
         // Physical length must stay bounded regardless of tick count.

--- a/nexus-notify/tests/event_queue.rs
+++ b/nexus-notify/tests/event_queue.rs
@@ -106,7 +106,7 @@ fn stress_no_lost_tokens() {
 
     while !handle.is_finished() {
         poller.poll(&mut events);
-        for t in &events {
+        for t in events.drain() {
             seen[t.index()] = true;
         }
     }
@@ -114,7 +114,7 @@ fn stress_no_lost_tokens() {
     handle.join().unwrap();
 
     poller.poll(&mut events);
-    for t in &events {
+    for t in events.drain() {
         seen[t.index()] = true;
     }
 
@@ -133,7 +133,7 @@ fn stress_poll_limit_fifo() {
     let mut all_indices = Vec::new();
     for _ in 0..4 {
         poller.poll_limit(&mut events, 5);
-        let chunk: Vec<usize> = events.iter().map(Token::index).collect();
+        let chunk: Vec<usize> = events.drain().map(Token::index).collect();
         assert_eq!(chunk.len(), 5);
         all_indices.extend(chunk);
     }
@@ -176,6 +176,7 @@ fn roundtrip_smoke() {
                 }
                 std::hint::spin_loop();
             }
+            events.drain().for_each(drop);
             n_rev.notify(t_rev).unwrap();
         }
     });
@@ -190,6 +191,7 @@ fn roundtrip_smoke() {
             }
             std::hint::spin_loop();
         }
+        events.drain().for_each(drop);
     }
 
     worker.join().unwrap();

--- a/nexus-notify/tests/loom_event_queue.rs
+++ b/nexus-notify/tests/loom_event_queue.rs
@@ -75,6 +75,7 @@ fn re_notification_after_poll() {
         notifier.notify(Token::new(2)).unwrap();
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
+        events.drain().for_each(drop);
 
         let handle = thread::spawn(move || {
             notifier.notify(Token::new(2)).unwrap();
@@ -100,6 +101,7 @@ fn concurrent_notify_and_poll() {
         let mut events = Events::with_capacity(4);
         poller.poll(&mut events);
         let first_poll = events.len();
+        events.drain().for_each(drop);
 
         handle.join().unwrap();
 

--- a/nexus-notify/tests/miri_event_queue.rs
+++ b/nexus-notify/tests/miri_event_queue.rs
@@ -81,6 +81,7 @@ fn notify_after_drain_works() {
     notifier.notify(t).unwrap();
     poller.poll(&mut events);
     assert_eq!(events.len(), 1);
+    events.drain().for_each(drop);
 
     // Second cycle — flag was cleared on poll, must accept new notify.
     notifier.notify(t).unwrap();
@@ -109,7 +110,7 @@ fn fill_to_capacity_then_drain() {
     poller.poll(&mut events);
     assert_eq!(events.len(), CAP);
 
-    let order: Vec<usize> = events.iter().map(Token::index).collect();
+    let order: Vec<usize> = events.drain().map(Token::index).collect();
     assert_eq!(order, (0..CAP).collect::<Vec<_>>());
 
     // Refill — flags were cleared, must work again.
@@ -267,5 +268,6 @@ fn racing_notifies_conflate_to_one_polled_event() {
         poller.poll(&mut events);
         assert_eq!(events.len(), 1);
         assert_eq!(events.iter().next().unwrap().index(), 0);
+        events.drain().for_each(drop);
     }
 }

--- a/nexus-rt/src/reactor.rs
+++ b/nexus-rt/src/reactor.rs
@@ -912,7 +912,7 @@ impl ReactorSystem {
 
         // Dispatch — each reactor is moved out before run(), put back after.
         // &mut ReactorNotify is scoped tightly to avoid aliasing during run().
-        for token in self.events.iter() {
+        for token in self.events.drain() {
             let idx = token.index();
             // SAFETY: notify_ptr is valid for World's lifetime. Scoped &mut
             // is dropped before reactor.run() to avoid aliasing.

--- a/nexus-rt/src/world.rs
+++ b/nexus-rt/src/world.rs
@@ -1088,7 +1088,7 @@ impl World {
 
         // Dispatch — each reactor is moved out before run(), put back after.
         // &mut ReactorNotify is scoped tightly to avoid aliasing during run().
-        for token in events.iter() {
+        for token in events.drain() {
             let idx = token.index();
             let reactor = {
                 // SAFETY: notify_ptr is stable. Scoped — &mut is dropped


### PR DESCRIPTION
- Add `Events::drain()` — a cursor-based draining iterator that removes tokens as they're consumed, leaving any untaken remainder in the buffer if the caller stops early (instead of `Vec::drain`'s memmove-the-remainder-on-drop behavior)
- The cursor (`head`) lives on `Events` itself, not on the `Drain` iterator, so partial drain is a pointer bump rather than an O(remaining) shift — same approach as `LocalNotify`'s `dispatch_head` cursor (#618)
- `Poller::poll_limit` and `LocalNotify::poll_limit` now `debug_assert!` that the previous batch was fully drained before clearing and refilling, turning what was previously a silent, unrecoverable token loss into a loud panic in debug/test builds
- Document the deliberate divergence from mio's `Events` (borrow-only accessors) directly on the type, per the design discussion on #626

Part of #626. Follow-up (not in this PR): update `nexus-rt`'s two dispatch loops to use `drain()`, add dedicated `Drain`-specific test coverage, fix the same read-without-drain pattern in `benches/event_queue.rs`.

## Test plan
- [x] `cargo test -p nexus-notify` — lib, integration, and doctests all pass
- [x] `RUSTFLAGS="--cfg loom" cargo test -p nexus-notify --test loom_event_queue` passes
- [x] `cargo clippy -p nexus-notify --all-targets` clean
- [x] Existing tests/doctests that polled repeatedly without draining updated to call `.drain()` between polls, rather than relaxing the new assert
