### PR TITLE
docs(nexus-smartptr): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-smartptr/build.rs
+++ b/nexus-smartptr/build.rs
@@ -37,6 +37,7 @@ fn main() {
     let data_ptr: *const u8 = &raw const val as *const u8;
     let trait_ptr: *const dyn Probe = &val as &dyn Probe;
 
+    // SAFETY: trait_ptr is a valid local reference; ptr::read copies its bytes to inspect fat pointer layout.
     let decomposed: FatPtr = unsafe { ptr::read(ptr::addr_of!(trait_ptr).cast::<FatPtr>()) };
 
     assert!(
@@ -48,6 +49,7 @@ fn main() {
     // Slice: data pointer first, length second.
     let array = [1_u8, 2, 3];
     let slice: &[u8] = &array;
+    // SAFETY: slice is a valid local reference; ptr::read copies its bytes to inspect fat pointer layout.
     let slice_repr: SlicePtr = unsafe { ptr::read(ptr::addr_of!(slice).cast::<SlicePtr>()) };
 
     assert!(

--- a/nexus-smartptr/src/flat.rs
+++ b/nexus-smartptr/src/flat.rs
@@ -135,6 +135,7 @@ impl<T: ?Sized, B: Buffer> Flat<T, B> {
             // SAFETY: metadata was written at offset 0 during construction.
             // Reading as *const () preserves provenance.
             let metadata = Metadata(unsafe { base.cast::<*const ()>().read() });
+            // SAFETY: buffer has at least META_SIZE capacity (verified at construction).
             let data = unsafe { base.add(META_SIZE) }.cast::<()>();
             // SAFETY: data points to the value, metadata matches the concrete type.
             unsafe { meta::make_ptr(data, metadata) }
@@ -149,10 +150,14 @@ impl<T: ?Sized, B: Buffer> Flat<T, B> {
     fn as_mut_ptr(&mut self) -> *mut T {
         let base = self.inner.as_mut_ptr().cast::<u8>();
         if meta::is_fat_ptr::<T>() {
+            // SAFETY: metadata written at offset 0 during construction.
             let metadata = Metadata(unsafe { base.cast::<*const ()>().read() });
+            // SAFETY: buffer has at least META_SIZE capacity (verified at construction).
             let data = unsafe { base.add(META_SIZE) }.cast::<()>();
+            // SAFETY: data points to value, metadata matches the concrete type.
             unsafe { meta::make_ptr_mut(data, metadata) }
         } else {
+            // SAFETY: value at offset 0; Sized T needs no metadata.
             unsafe { meta::make_ptr_mut(base.cast::<()>(), Metadata::NULL) }
         }
     }
@@ -244,6 +249,7 @@ impl<T: ?Sized, B: Buffer> Drop for Flat<T, B> {
 // MaybeUninit<B> is raw storage, not a meaningful Send/Sync participant.
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T: ?Sized + Send, B: Buffer> Send for Flat<T, B> {}
+// SAFETY: same as Send above; Sync depends only on T.
 unsafe impl<T: ?Sized + Sync, B: Buffer> Sync for Flat<T, B> {}
 
 #[cfg(test)]
@@ -274,6 +280,7 @@ mod tests {
 
     fn make_flat_greet<V: Greet + 'static, B: Buffer>(val: V) -> Flat<dyn Greet, B> {
         let ptr: *const dyn Greet = &val as &dyn Greet;
+        // SAFETY: ptr coerced from val above; metadata matches V.
         unsafe { Flat::new_raw(val, ptr) }
     }
 
@@ -351,6 +358,7 @@ mod tests {
 
         fn make<V: Increment + 'static, B: Buffer>(val: V) -> Flat<dyn Increment, B> {
             let ptr: *const dyn Increment = &val as &dyn Increment;
+            // SAFETY: ptr coerced from val above; metadata matches V.
             unsafe { Flat::new_raw(val, ptr) }
         }
 
@@ -426,6 +434,7 @@ mod tests {
     fn display_trait_object() {
         let val: u32 = 42;
         let ptr: *const dyn Display = &val as &dyn Display;
+        // SAFETY: ptr coerced from val above; metadata matches V.
         let f: Flat<dyn Display, B32> = unsafe { Flat::new_raw(val, ptr) };
         assert_eq!(format!("{}", &*f), "42");
     }

--- a/nexus-smartptr/src/flex.rs
+++ b/nexus-smartptr/src/flex.rs
@@ -208,6 +208,7 @@ impl<T: ?Sized, B: Buffer> Flex<T, B> {
         if hp.is_null() {
             // Inline: value lives after the overhead.
             let base = self.inner.as_ptr().cast::<u8>();
+            // SAFETY: VALUE_OFFSET is within buffer bounds (enforced by const assert).
             unsafe { base.add(Self::VALUE_OFFSET) }.cast::<()>()
         } else {
             hp.cast::<()>().cast_const()
@@ -220,6 +221,7 @@ impl<T: ?Sized, B: Buffer> Flex<T, B> {
         let hp = self.heap_ptr();
         if hp.is_null() {
             let base = self.inner.as_mut_ptr().cast::<u8>();
+            // SAFETY: VALUE_OFFSET is within buffer bounds (enforced by const assert).
             unsafe { base.add(Self::VALUE_OFFSET) }.cast::<()>()
         } else {
             hp.cast::<()>()
@@ -234,8 +236,10 @@ impl<T: ?Sized, B: Buffer> Flex<T, B> {
             let base = self.inner.as_ptr().cast::<u8>();
             // SAFETY: metadata at offset 0, preserved from construction.
             let metadata = Metadata(unsafe { base.cast::<*const ()>().read() });
+            // SAFETY: data and metadata come from a valid Flex; metadata matches the concrete type.
             unsafe { meta::make_ptr(data, metadata) }
         } else {
+            // SAFETY: Sized T; data is a valid data pointer.
             unsafe { meta::make_ptr(data, Metadata::NULL) }
         }
     }
@@ -246,9 +250,12 @@ impl<T: ?Sized, B: Buffer> Flex<T, B> {
         let data = self.data_ptr_mut();
         if meta::is_fat_ptr::<T>() {
             let base = self.inner.as_ptr().cast::<u8>();
+            // SAFETY: metadata written at offset 0 during construction.
             let metadata = Metadata(unsafe { base.cast::<*const ()>().read() });
+            // SAFETY: data and metadata come from a valid Flex; metadata matches the concrete type.
             unsafe { meta::make_ptr_mut(data, metadata) }
         } else {
+            // SAFETY: Sized T; data is a valid data pointer.
             unsafe { meta::make_ptr_mut(data, Metadata::NULL) }
         }
     }
@@ -335,6 +342,7 @@ impl<T: ?Sized, B: Buffer> Drop for Flex<T, B> {
 // MaybeUninit<B> is raw storage, not a meaningful Send/Sync participant.
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T: ?Sized + Send, B: Buffer> Send for Flex<T, B> {}
+// SAFETY: same as Send above; Sync depends only on T.
 unsafe impl<T: ?Sized + Sync, B: Buffer> Sync for Flex<T, B> {}
 
 #[cfg(test)]
@@ -365,6 +373,7 @@ mod tests {
 
     fn make_flex_greet<V: Greet + 'static, B: Buffer>(val: V) -> Flex<dyn Greet, B> {
         let ptr: *const dyn Greet = &val as &dyn Greet;
+        // SAFETY: ptr coerced from val above; metadata matches V.
         unsafe { Flex::new_raw(val, ptr) }
     }
 
@@ -484,6 +493,7 @@ mod tests {
 
         fn make<V: Increment + 'static, B: Buffer>(val: V) -> Flex<dyn Increment, B> {
             let ptr: *const dyn Increment = &val as &dyn Increment;
+            // SAFETY: ptr coerced from val above; metadata matches V.
             unsafe { Flex::new_raw(val, ptr) }
         }
 
@@ -525,6 +535,7 @@ mod tests {
 
         fn make<V: Accumulate + 'static, B: Buffer>(val: V) -> Flex<dyn Accumulate, B> {
             let ptr: *const dyn Accumulate = &val as &dyn Accumulate;
+            // SAFETY: ptr coerced from val above; metadata matches V.
             unsafe { Flex::new_raw(val, ptr) }
         }
 
@@ -610,6 +621,7 @@ mod tests {
     fn display_trait_object_inline() {
         let val: u32 = 42;
         let ptr: *const dyn Display = &val as &dyn Display;
+        // SAFETY: ptr coerced from val above; metadata matches V.
         let f: Flex<dyn Display, B32> = unsafe { Flex::new_raw(val, ptr) };
         assert!(f.is_inline());
         assert_eq!(format!("{}", &*f), "42");

--- a/nexus-smartptr/src/meta.rs
+++ b/nexus-smartptr/src/meta.rs
@@ -54,6 +54,7 @@ pub(crate) fn extract_metadata<T: ?Sized>(ptr: *const T) -> Metadata {
     // [data_ptr, metadata_ptr]. We read the second word as a pointer to
     // preserve provenance.
     let words = core::ptr::addr_of!(ptr).cast::<*const ()>();
+    // SAFETY: verified fat pointer above; second word is the metadata pointer.
     let metadata = unsafe { words.add(1).read() };
     Metadata(metadata)
 }
@@ -72,6 +73,7 @@ pub(crate) fn extract_metadata<T: ?Sized>(ptr: *const T) -> Metadata {
 pub(crate) unsafe fn make_ptr<T: ?Sized>(data: *const (), meta: Metadata) -> *const T {
     let mut result: mem::MaybeUninit<*const T> = mem::MaybeUninit::uninit();
     let words = result.as_mut_ptr().cast::<*const ()>();
+    // SAFETY: MaybeUninit<*const T> is written word-by-word; caller upholds data/meta validity.
     unsafe {
         words.write(data);
         if is_fat_ptr::<T>() {
@@ -110,7 +112,9 @@ mod tests {
         // SAFETY: data points to val, meta extracted from same concrete type.
         let reconstructed: *const dyn Display = unsafe { make_ptr(data, meta) };
 
+        // SAFETY: trait_ptr is a valid reference to val.
         let original = unsafe { &*trait_ptr };
+        // SAFETY: reconstructed points to val with the correct vtable.
         let recovered = unsafe { &*reconstructed };
         assert_eq!(format!("{original}"), format!("{recovered}"));
     }
@@ -127,6 +131,7 @@ mod tests {
 
         // SAFETY: data points to val, meta from same concrete type.
         let reconstructed: *mut dyn Debug = unsafe { make_ptr_mut(data, meta) };
+        // SAFETY: reconstructed points to val with the correct vtable.
         let recovered = unsafe { &*reconstructed };
         assert_eq!(format!("{recovered:?}"), "[1, 2, 3]");
     }
@@ -139,6 +144,7 @@ mod tests {
 
         // SAFETY: data points to val. For Sized T, meta is ignored.
         let reconstructed: *const u64 = unsafe { make_ptr(data, meta) };
+        // SAFETY: reconstructed points to val, a valid u64.
         assert_eq!(unsafe { *reconstructed }, 99);
     }
 
@@ -167,9 +173,12 @@ mod tests {
 
         // SAFETY: both a and b are u64, meta extracted from u64's Display vtable.
         let ptr_a: *const dyn Display = unsafe { make_ptr(&raw const a as *const (), meta) };
+        // SAFETY: b is u64; meta extracted from u64's Display vtable, compatible.
         let ptr_b: *const dyn Display = unsafe { make_ptr(&raw const b as *const (), meta) };
 
+        // SAFETY: ptr_a points to a, a valid u64.
         assert_eq!(format!("{}", unsafe { &*ptr_a }), "100");
+        // SAFETY: ptr_b points to b, a valid u64.
         assert_eq!(format!("{}", unsafe { &*ptr_b }), "200");
     }
 
@@ -184,6 +193,7 @@ mod tests {
 
         // SAFETY: data points to val, meta carries the slice length.
         let reconstructed: *const [u32] = unsafe { make_ptr(data, meta) };
+        // SAFETY: reconstructed points to val with the correct length metadata.
         let recovered = unsafe { &*reconstructed };
         assert_eq!(recovered.len(), 4);
         assert_eq!(recovered, &[10, 20, 30, 40]);


### PR DESCRIPTION
Adds `// SAFETY:` comments to all 33 undocumented `unsafe` blocks in nexus-smartptr, making the crate clean under `clippy::undocumented_unsafe_blocks`.

Files touched: `build.rs`, `src/flat.rs`, `src/flex.rs`, `src/meta.rs` (4 files, 33 insertions).

Part of the workspace-wide `undocumented_unsafe_blocks` audit (#622, #623, #627).