### PR TITLE
nexus-notify: dedicated Drain tests + bench fix (#626)

### DIFF
--- a/nexus-notify/benches/event_queue.rs
+++ b/nexus-notify/benches/event_queue.rs
@@ -15,6 +15,7 @@ fn bench_notify(c: &mut Criterion) {
         let mut events = Events::with_capacity(4096);
         b.iter(|| {
             poller.poll(&mut events);
+            events.drain().for_each(drop);
             notifier.notify(token).ok();
         });
     });
@@ -69,6 +70,7 @@ fn bench_poll(c: &mut Criterion) {
                     notifier.notify(*t).ok();
                 }
                 poller.poll(&mut events);
+                events.drain().for_each(drop);
             });
         });
     }
@@ -94,8 +96,10 @@ fn bench_poll_limit(c: &mut Criterion) {
                     notifier.notify(*t).ok();
                 }
                 poller.poll_limit(&mut events, limit);
+                events.drain().for_each(drop);
                 // Drain rest
                 poller.poll(&mut events);
+                events.drain().for_each(drop);
             });
         });
     }
@@ -119,6 +123,7 @@ fn bench_channel_recv_wake(c: &mut Criterion) {
         b.iter(|| {
             sender.notify(token).ok();
             receiver.recv(&mut events);
+            events.drain().for_each(drop);
         });
     });
 
@@ -130,6 +135,7 @@ fn bench_channel_recv_wake(c: &mut Criterion) {
         b.iter(|| {
             sender.notify(token).ok();
             receiver.try_recv(&mut events);
+            events.drain().for_each(drop);
         });
     });
 

--- a/nexus-notify/src/event_queue.rs
+++ b/nexus-notify/src/event_queue.rs
@@ -711,4 +711,68 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events.iter().next().unwrap().index(), 5);
     }
+
+    // ====================================================
+    // Drain tests
+    // ====================================================
+
+    #[test]
+    fn drain_partial_leaves_remainder() {
+        let (notifier, poller) = event_queue(64);
+        let mut events = Events::with_capacity(64);
+
+        for i in 0..5 {
+            notifier.notify(Token::new(i)).unwrap();
+        }
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 5);
+
+        // Take only the first 2, then drop the iterator early.
+        {
+            let mut drain = events.drain();
+            assert_eq!(drain.next().unwrap().index(), 0);
+            assert_eq!(drain.next().unwrap().index(), 1);
+            // `drain` dropped here without exhausting — untaken tokens must survive.
+        }
+
+        assert_eq!(events.len(), 3);
+        let remaining: Vec<usize> = events.iter().map(Token::index).collect();
+        assert_eq!(remaining, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn drain_full_empties_buffer() {
+        let (notifier, poller) = event_queue(64);
+        let mut events = Events::with_capacity(64);
+
+        for i in 0..4 {
+            notifier.notify(Token::new(i)).unwrap();
+        }
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 4);
+
+        let drained: Vec<usize> = events.drain().map(Token::index).collect();
+        assert_eq!(drained, vec![0, 1, 2, 3]);
+        assert!(events.is_empty());
+        assert!(events.as_slice().is_empty());
+
+        // Buffer is fully consumed — next poll must not panic (is_drained() holds).
+        poller.poll(&mut events);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "undrained tokens still in the buffer")]
+    fn poll_limit_panics_on_undrained_buffer() {
+        let (notifier, poller) = event_queue(64);
+        let mut events = Events::with_capacity(64);
+
+        notifier.notify(Token::new(0)).unwrap();
+        poller.poll(&mut events);
+        assert_eq!(events.len(), 1);
+
+        // Buffer not drained — next poll must panic, not silently discard.
+        poller.poll(&mut events);
+    }
 }

--- a/nexus-notify/src/local.rs
+++ b/nexus-notify/src/local.rs
@@ -502,4 +502,20 @@ mod tests {
             notify.dispatch_list.capacity(),
         );
     }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "undrained tokens still in the buffer")]
+    fn poll_limit_panics_on_undrained_buffer() {
+        let mut notify = LocalNotify::with_capacity(4);
+        let mut events = Events::with_capacity(4);
+
+        let t = notify.register();
+        notify.mark(t);
+        notify.poll(&mut events);
+        assert_eq!(events.len(), 1);
+
+        // Buffer not drained — next poll must panic, not silently discard.
+        notify.poll(&mut events);
+    }
 }


### PR DESCRIPTION
## Summary
Closes out the two minor follow-ups noted on #626 after #628 landed:

- Dedicated `Drain` test coverage — `drain_partial_leaves_remainder`,
  `drain_full_empties_buffer`, and `poll_limit_panics_on_undrained_buffer`
  (both `Poller` and `LocalNotify`). The cursor mechanics and the
  panic guard were previously only exercised indirectly, through
  existing tests that happened to call `drain()` between polls.
- `benches/event_queue.rs` — the `poll`/`poll_limit`/`recv` closures
  left tokens undrained across `b.iter()` calls, tripping the
  `poll_limit` assert under `debug_assertions` (latent, not currently
  panicking under plain `cargo bench` since the bench profile has
  assertions off by default). Added `drain()` after each poll/recv
  call.

## Test plan
- [x] `cargo test -p nexus-notify` — 52 lib tests pass (up from 48)
- [x] `cargo clippy -p nexus-notify --all-targets` clean
- [x] `RUSTFLAGS="-C debug-assertions=on" cargo bench -p nexus-notify --bench event_queue` — every group ran its full sample count (up to ~800M iterations) with no panics
