### PR TITLE
perf(notify): O(1) reset in bench_poll/bench_poll_limit (#626)

### DIFF
--- a/nexus-notify/benches/event_queue.rs
+++ b/nexus-notify/benches/event_queue.rs
@@ -70,7 +70,7 @@ fn bench_poll(c: &mut Criterion) {
                     notifier.notify(*t).ok();
                 }
                 poller.poll(&mut events);
-                events.drain().for_each(drop);
+                events.clear();
             });
         });
     }
@@ -96,10 +96,10 @@ fn bench_poll_limit(c: &mut Criterion) {
                     notifier.notify(*t).ok();
                 }
                 poller.poll_limit(&mut events, limit);
-                events.drain().for_each(drop);
+                events.clear();
                 // Drain rest
                 poller.poll(&mut events);
-                events.drain().for_each(drop);
+                events.clear();
             });
         });
     }


### PR DESCRIPTION
## Summary
Review nit from #638: `bench_poll`'s N-loop and `bench_poll_limit`
collect up to 256 tokens per iteration, so resetting via
`events.drain().for_each(drop)` added an O(N) consume pass inside the
timed region — work the benchmark isn't meant to measure.
`events.clear()` satisfies the same `poll_limit` precondition in O(1)
and keeps these benches measuring the poll/poll_limit path in
isolation. `bench_notify` and `bench_channel_recv_wake` are
unaffected — they never hold more than one token, so `drain()` there
was already O(1).

## Test plan
- [x] `cargo clippy -p nexus-notify --all-targets` clean
- [x] `RUSTFLAGS="-C debug-assertions=on" cargo bench -p nexus-notify --bench event_queue -- poll` — `poll` and `poll_limit` groups run to completion with no panics