### PR TITLE
docs(nexus-async-rt): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-async-rt/benches/channel.rs
+++ b/nexus-async-rt/benches/channel.rs
@@ -31,6 +31,7 @@ const SAMPLES: usize = 100_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; the cfg attribute guarantees target_arch = "x86_64".
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-async-rt/benches/executor.rs
+++ b/nexus-async-rt/benches/executor.rs
@@ -41,6 +41,7 @@ const TASKS_PER_SAMPLE: usize = 1_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; the cfg attribute guarantees target_arch = "x86_64".
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-async-rt/build.rs
+++ b/nexus-async-rt/build.rs
@@ -43,8 +43,10 @@ fn main() {
 
     let sentinel = 0xDEAD_BEEF_CAFE_u64 as *const ();
     let raw = RawWaker::new(sentinel, &VTABLE);
+    // SAFETY: VTABLE functions are all no-ops; sentinel data pointer is never dereferenced.
     let waker = std::mem::ManuallyDrop::new(unsafe { Waker::from_raw(raw) });
 
+    // SAFETY: ptr is a valid local reference; ptr::read copies bytes to inspect fat pointer layout.
     let repr: WakerRepr = unsafe { ptr::read(ptr::addr_of!(*waker).cast::<WakerRepr>()) };
 
     assert!(
@@ -70,6 +72,7 @@ fn main() {
     );
 
     let cx = Context::from_waker(&waker);
+    // SAFETY: ptr is a valid local reference; ptr::read copies bytes to inspect fat pointer layout.
     let first_word: *const () = unsafe { ptr::read(ptr::addr_of!(cx).cast::<*const ()>()) };
 
     assert!(

--- a/nexus-async-rt/src/cancel.rs
+++ b/nexus-async-rt/src/cancel.rs
@@ -237,6 +237,7 @@ unsafe impl Send for WaiterNode {}
 // Sync is required because Inner::cancel reads/writes node fields
 // from a different thread than Cancelled::poll. All such access is
 // under list_lock.
+// SAFETY: Sync is safe; WaiterNode fields are accessed only under Inner::list_lock.
 unsafe impl Sync for WaiterNode {}
 
 struct ChildNode {
@@ -244,12 +245,14 @@ struct ChildNode {
     next: *mut ChildNode,
 }
 
+// SAFETY: ChildNode owns an Arc<Inner> (Send) and a raw pointer managed under exclusive ownership.
 unsafe impl Send for ChildNode {}
 
 // SAFETY: Inner contains UnsafeCell<*mut WaiterNode> (head pointer)
 // which is mutated under list_lock. Send + Sync because all access
 // to mutable state is gated by the lock.
 unsafe impl Send for Inner {}
+// SAFETY: Inner's mutable state is fully guarded by list_lock; shared access is safe across threads.
 unsafe impl Sync for Inner {}
 
 impl Inner {
@@ -302,6 +305,7 @@ impl Inner {
             let _guard = SpinGuard::new(&self.list_lock);
             // SAFETY: list_lock held — exclusive access to head + node fields.
             let mut cur = unsafe { *self.head.get() };
+            // SAFETY: list_lock held — exclusive access to the head pointer.
             unsafe { *self.head.get() = std::ptr::null_mut() };
             while !cur.is_null() {
                 // SAFETY: `cur` was pushed under the lock by Cancelled::poll;
@@ -327,10 +331,12 @@ impl Inner {
                 // — see `cancel_race_regression`. In production builds the
                 // hook is compiled out.
                 let next = unsafe { *(*cur).next.get() };
+                // SAFETY: list_lock held; waker field accessed under lock while cur node is still alive.
                 let waker = unsafe { (*(*cur).waker.get()).take() };
                 // After this Release store, *cur may be invalidated by a
                 // concurrent Cancelled::Drop fast-path. Do not access
                 // *cur below this line.
+                // SAFETY: list_lock held; all node fields read above before this Release store.
                 unsafe { (*cur).in_list.store(false, Ordering::Release) };
                 #[cfg(test)]
                 if self.race_yield.load(Ordering::Relaxed) {

--- a/nexus-async-rt/src/channel/local.rs
+++ b/nexus-async-rt/src/channel/local.rs
@@ -158,7 +158,9 @@ impl WaiterList {
     ///
     /// `waiter` must point to a pinned, live `Waiter` that is not in any list.
     unsafe fn push_back(&mut self, waiter: *mut Waiter) {
+        // SAFETY: waiter is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
         debug_assert!(unsafe { !(*waiter).queued });
+        // SAFETY: waiter is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
         unsafe {
             (*waiter).queued = true;
             (*waiter).next = std::ptr::null_mut();
@@ -168,6 +170,7 @@ impl WaiterList {
         if self.tail.is_null() {
             self.head = waiter;
         } else {
+            // SAFETY: self.tail is non-null (checked above) and points to a live Waiter; accessed only from the single-threaded executor.
             unsafe { (*self.tail).next = waiter };
         }
         self.tail = waiter;
@@ -180,13 +183,16 @@ impl WaiterList {
             return std::ptr::null_mut();
         }
 
+        // SAFETY: waiter is the head of this list and points to a live Waiter; accessed only from the single-threaded executor.
         self.head = unsafe { (*waiter).next };
         if self.head.is_null() {
             self.tail = std::ptr::null_mut();
         } else {
+            // SAFETY: self.head is non-null (checked above) and points to a live Waiter; accessed only from the single-threaded executor.
             unsafe { (*self.head).prev = std::ptr::null_mut() };
         }
 
+        // SAFETY: waiter is a valid pointer to a live Waiter being removed; accessed only from the single-threaded executor.
         unsafe {
             (*waiter).next = std::ptr::null_mut();
             (*waiter).prev = std::ptr::null_mut();
@@ -201,25 +207,31 @@ impl WaiterList {
     ///
     /// `waiter` must be in this list.
     unsafe fn remove(&mut self, waiter: *mut Waiter) {
+        // SAFETY: waiter is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
         if unsafe { !(*waiter).queued } {
             return;
         }
 
+        // SAFETY: waiter is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
         let prev = unsafe { (*waiter).prev };
+        // SAFETY: waiter is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
         let next = unsafe { (*waiter).next };
 
         if prev.is_null() {
             self.head = next;
         } else {
+            // SAFETY: prev is non-null (checked above) and points to a live Waiter; accessed only from the single-threaded executor.
             unsafe { (*prev).next = next };
         }
 
         if next.is_null() {
             self.tail = prev;
         } else {
+            // SAFETY: next is non-null (checked above) and points to a live Waiter; accessed only from the single-threaded executor.
             unsafe { (*next).prev = prev };
         }
 
+        // SAFETY: waiter is a valid pointer to a live Waiter being unlinked; accessed only from the single-threaded executor.
         unsafe {
             (*waiter).next = std::ptr::null_mut();
             (*waiter).prev = std::ptr::null_mut();
@@ -231,12 +243,15 @@ impl WaiterList {
     unsafe fn wake_all(&mut self) {
         let mut cursor = self.head;
         while !cursor.is_null() {
+            // SAFETY: cursor is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
             let next = unsafe { (*cursor).next };
+            // SAFETY: cursor is a valid pointer to a live Waiter being unlinked; accessed only from the single-threaded executor.
             unsafe {
                 (*cursor).next = std::ptr::null_mut();
                 (*cursor).prev = std::ptr::null_mut();
                 (*cursor).queued = false;
             }
+            // SAFETY: cursor is a valid pointer to a live Waiter; accessed only from the single-threaded executor.
             if let Some(waker) = unsafe { (*cursor).waker.take() } {
                 waker.wake();
             }
@@ -281,6 +296,7 @@ type Shared<T> = Rc<UnsafeCell<Inner<T>>>;
 #[inline]
 #[allow(clippy::mut_from_ref)] // Intentional: UnsafeCell + single-threaded guarantee.
 unsafe fn inner<T>(shared: &Shared<T>) -> &mut Inner<T> {
+    // SAFETY: accessed only from the single-threaded executor; no re-entrant access.
     unsafe { &mut *shared.get() }
 }
 
@@ -457,6 +473,7 @@ impl<T> Drop for Send<'_, T> {
         if self.waiter.queued {
             // SAFETY: single-threaded, waiter is in the list.
             let state = unsafe { inner(&self.sender.inner) };
+            // SAFETY: waiter is queued and this is the sole owner removing it; accessed only from the single-threaded executor.
             unsafe { state.tx_waiters.remove(&raw mut self.waiter) };
         }
     }
@@ -492,6 +509,7 @@ impl<T> Receiver<T> {
             let value = unsafe { state.buffer.pop() };
 
             // Wake one blocked sender.
+            // SAFETY: accessed only from the single-threaded executor.
             let waiter = unsafe { state.tx_waiters.pop_front() };
             if !waiter.is_null() {
                 // SAFETY: waiter was in the list, has a valid waker.
@@ -518,6 +536,7 @@ impl<T> Drop for Receiver<T> {
         state.closed = true;
 
         // Wake all blocked senders so they see the closed error.
+        // SAFETY: accessed only from the single-threaded executor; wake_all unlinks all waiters safely.
         unsafe { state.tx_waiters.wake_all() };
     }
 }
@@ -544,11 +563,13 @@ impl<T> Future for Recv<'_, T> {
             let value = unsafe { state.buffer.pop() };
 
             // Wake one blocked sender.
+            // SAFETY: accessed only from the single-threaded executor.
             let waiter = unsafe { state.tx_waiters.pop_front() };
-            if !waiter.is_null()
-                && let Some(waker) = unsafe { (*waiter).waker.take() }
-            {
-                waker.wake();
+            if !waiter.is_null() {
+                // SAFETY: waiter is non-null and points to a live Waiter; accessed only from the single-threaded executor.
+                if let Some(waker) = unsafe { (*waiter).waker.take() } {
+                    waker.wake();
+                }
             }
 
             return Poll::Ready(Ok(value));
@@ -605,13 +626,19 @@ mod tests {
         assert_eq!(rb.capacity(), 4);
         assert!(rb.is_empty());
 
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(1) };
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(2) };
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(3) };
         assert_eq!(rb.len(), 3);
 
+        // SAFETY: buffer is not empty; verified by test setup.
         assert_eq!(unsafe { rb.pop() }, 1);
+        // SAFETY: buffer is not empty; verified by test setup.
         assert_eq!(unsafe { rb.pop() }, 2);
+        // SAFETY: buffer is not empty; verified by test setup.
         assert_eq!(unsafe { rb.pop() }, 3);
         assert!(rb.is_empty());
     }
@@ -621,11 +648,14 @@ mod tests {
         let mut rb = RingBuffer::<u32>::new(2);
         assert_eq!(rb.capacity(), 2);
 
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(1) };
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(2) };
         assert!(rb.is_full());
         assert_eq!(rb.len(), 2);
 
+        // SAFETY: buffer is not empty; verified by test setup.
         assert_eq!(unsafe { rb.pop() }, 1);
         assert!(!rb.is_full());
     }
@@ -637,15 +667,23 @@ mod tests {
         // Fill and drain a few times to wrap indices.
         for cycle in 0..10u32 {
             let base = cycle * 4;
+            // SAFETY: buffer is not full; verified by test setup.
             unsafe { rb.push(base) };
+            // SAFETY: buffer is not full; verified by test setup.
             unsafe { rb.push(base + 1) };
+            // SAFETY: buffer is not full; verified by test setup.
             unsafe { rb.push(base + 2) };
+            // SAFETY: buffer is not full; verified by test setup.
             unsafe { rb.push(base + 3) };
             assert!(rb.is_full());
 
+            // SAFETY: buffer is not empty; verified by test setup.
             assert_eq!(unsafe { rb.pop() }, base);
+            // SAFETY: buffer is not empty; verified by test setup.
             assert_eq!(unsafe { rb.pop() }, base + 1);
+            // SAFETY: buffer is not empty; verified by test setup.
             assert_eq!(unsafe { rb.pop() }, base + 2);
+            // SAFETY: buffer is not empty; verified by test setup.
             assert_eq!(unsafe { rb.pop() }, base + 3);
             assert!(rb.is_empty());
         }
@@ -684,8 +722,11 @@ mod tests {
         }
 
         let mut rb = RingBuffer::new(4);
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(DropCounter(dropped.clone())) };
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(DropCounter(dropped.clone())) };
+        // SAFETY: buffer is not full; verified by test setup.
         unsafe { rb.push(DropCounter(dropped.clone())) };
         assert_eq!(dropped.get(), 0);
 

--- a/nexus-async-rt/src/channel/mpsc.rs
+++ b/nexus-async-rt/src/channel/mpsc.rs
@@ -51,6 +51,7 @@ struct SenderWakerNode {
 // cross-thread access. The waker UnsafeCell is only written when the node
 // is NOT in any shared list (exclusive access enforced by the queued flag).
 unsafe impl Send for SenderWakerNode {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl Sync for SenderWakerNode {}
 
 impl SenderWakerNode {
@@ -124,6 +125,7 @@ impl SenderWaitList {
             // SAFETY: cursor was in the linked list — its Arc refcount was
             // bumped in push(), so the node is alive. Atomic loads are safe.
             let next = unsafe { (*cursor).next.load(Ordering::Acquire) };
+            // SAFETY: pointer is non-null and was allocated by Box::new; not yet reclaimed.
             let cancelled = unsafe { (*cursor).cancelled.load(Ordering::Acquire) };
 
             // SAFETY: node removed from list (head swapped to null above).
@@ -139,6 +141,7 @@ impl SenderWaitList {
                 // SAFETY: node is unlinked — exclusive access to the waker
                 // UnsafeCell. Read moves the waker out, write clears it.
                 let waker = unsafe { (*cursor).waker.get().read() };
+                // SAFETY: node is unlinked — exclusive access to waker UnsafeCell; write clears the slot.
                 unsafe { (*cursor).waker.get().write(None) };
                 // SAFETY: refcount was bumped in push(). Decrementing
                 // releases the list's ownership of this node.
@@ -154,6 +157,7 @@ impl SenderWaitList {
                     let cur_head = self.head.load(Ordering::Acquire);
                     // SAFETY: cursor is unlinked and alive (refcount held).
                     unsafe { (*cursor).next.store(cur_head, Ordering::Relaxed) };
+                    // SAFETY: cursor is unlinked and refcount held; atomic store to queued is safe.
                     unsafe { (*cursor).queued.store(true, Ordering::Relaxed) };
                     if self
                         .head
@@ -191,6 +195,7 @@ impl SenderWaitList {
             // SAFETY: node was in the linked list — Arc refcount bumped in
             // push(), so memory is alive. Atomic loads are safe.
             let next = unsafe { (*node).next.load(Ordering::Acquire) };
+            // SAFETY: pointer is non-null and was allocated by Box::new; not yet reclaimed.
             let cancelled = unsafe { (*node).cancelled.load(Ordering::Acquire) };
             // SAFETY: node unlinked (head swapped to null). Exclusive access.
             unsafe {
@@ -200,6 +205,7 @@ impl SenderWaitList {
             if !cancelled {
                 // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*node).waker.get().read() };
+                // SAFETY: node is unlinked — exclusive access to waker UnsafeCell; write clears the slot.
                 unsafe { (*node).waker.get().write(None) };
                 if let Some(w) = waker {
                     w.wake();
@@ -246,6 +252,7 @@ struct Inner<T> {
 
 // SAFETY: All fields use atomic operations for cross-thread access.
 unsafe impl<T: Send> Send for Inner<T> {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl<T: Send> Sync for Inner<T> {}
 
 impl<T> Inner<T> {
@@ -377,6 +384,7 @@ impl<T> Drop for Sender<T> {
 
 // SAFETY: Inner uses atomic operations. wake_node is owned (not shared).
 unsafe impl<T: Send> Send for Sender<T> {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl<T: Send> Sync for Sender<T> {}
 
 // =============================================================================

--- a/nexus-async-rt/src/channel/mpsc_bytes.rs
+++ b/nexus-async-rt/src/channel/mpsc_bytes.rs
@@ -55,6 +55,7 @@ struct SenderWakerNode {
 // cross-thread access. The waker UnsafeCell is only written when the node
 // is NOT in any shared list (exclusive access enforced by the queued flag).
 unsafe impl Send for SenderWakerNode {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl Sync for SenderWakerNode {}
 
 impl SenderWakerNode {
@@ -125,6 +126,7 @@ impl SenderWaitList {
             // SAFETY: cursor was in the linked list — Arc refcount bumped in
             // push(), so the node is alive. Atomic loads are safe.
             let next = unsafe { (*cursor).next.load(Ordering::Acquire) };
+            // SAFETY: pointer is non-null and was allocated by Box::new; not yet reclaimed.
             let cancelled = unsafe { (*cursor).cancelled.load(Ordering::Acquire) };
 
             // SAFETY: node removed from list (head swapped to null above).
@@ -139,6 +141,7 @@ impl SenderWaitList {
             if !cancelled && !woken {
                 // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*cursor).waker.get().read() };
+                // SAFETY: node is unlinked — exclusive access to waker UnsafeCell; write clears the slot.
                 unsafe { (*cursor).waker.get().write(None) };
                 // SAFETY: refcount was bumped in push(). Decrementing
                 // releases the list's ownership of this node.
@@ -154,6 +157,7 @@ impl SenderWaitList {
                     let cur_head = self.head.load(Ordering::Acquire);
                     // SAFETY: cursor is unlinked and alive (refcount held).
                     unsafe { (*cursor).next.store(cur_head, Ordering::Relaxed) };
+                    // SAFETY: cursor is unlinked and refcount held; atomic store to queued is safe.
                     unsafe { (*cursor).queued.store(true, Ordering::Relaxed) };
                     if self
                         .head
@@ -190,6 +194,7 @@ impl SenderWaitList {
             // SAFETY: node was in the linked list — Arc refcount bumped in
             // push(), so memory is alive. Atomic loads are safe.
             let next = unsafe { (*node).next.load(Ordering::Acquire) };
+            // SAFETY: pointer is non-null and was allocated by Box::new; not yet reclaimed.
             let cancelled = unsafe { (*node).cancelled.load(Ordering::Acquire) };
             // SAFETY: node unlinked (head swapped to null). Exclusive access.
             unsafe {
@@ -199,6 +204,7 @@ impl SenderWaitList {
             if !cancelled {
                 // SAFETY: node unlinked — exclusive access to waker UnsafeCell.
                 let waker = unsafe { (*node).waker.get().read() };
+                // SAFETY: node is unlinked — exclusive access to waker UnsafeCell; write clears the slot.
                 unsafe { (*node).waker.get().write(None) };
                 if let Some(w) = waker {
                     w.wake();
@@ -227,6 +233,7 @@ struct Inner {
 // SAFETY: All fields use atomics or are designed for cross-thread use
 // (TaskWakerSlot, FallbackWaker, SenderWaitList). No raw non-atomic state.
 unsafe impl Send for Inner {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl Sync for Inner {}
 
 impl Inner {

--- a/nexus-async-rt/src/channel/spsc.rs
+++ b/nexus-async-rt/src/channel/spsc.rs
@@ -52,6 +52,7 @@ struct Inner<T> {
 // are designed for cross-thread use (TaskWakerSlot, FallbackWaker, TxWakerSlot).
 // Producer and Consumer from nexus_queue::spsc are Send.
 unsafe impl<T: Send> Send for Inner<T> {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl<T: Send> Sync for Inner<T> {}
 
 impl<T> Inner<T> {

--- a/nexus-async-rt/src/channel/spsc_bytes.rs
+++ b/nexus-async-rt/src/channel/spsc_bytes.rs
@@ -50,6 +50,7 @@ struct Inner {
 // SAFETY: All fields use atomics or are designed for cross-thread use
 // (TaskWakerSlot, FallbackWaker, TxWakerSlot). No raw non-atomic state.
 unsafe impl Send for Inner {}
+// SAFETY: Queue<T> owns the data; raw pointers are not shared across threads unsafely.
 unsafe impl Sync for Inner {}
 
 impl Inner {

--- a/nexus-async-rt/src/cross_wake.rs
+++ b/nexus-async-rt/src/cross_wake.rs
@@ -176,6 +176,7 @@ fn on_owning_executor(ctx: &CrossWakeContext) -> bool {
 /// (set at spawn time, kept alive transitively by any holder of a
 /// TaskRef on this task).
 pub(crate) unsafe fn dispose_terminal(task_ptr: *mut u8) {
+    // SAFETY: caller guarantees task_ptr is a valid task; header_cross_wake_ctx reads the fixed-offset header field.
     let ctx_ptr = unsafe { task::header_cross_wake_ctx(task_ptr) };
 
     // Null ctx (bare Executor or test-only Task::new_boxed): same
@@ -205,7 +206,9 @@ pub(crate) unsafe fn dispose_terminal(task_ptr: *mut u8) {
     // yet, and dispose_terminal is the path that would). queue.push
     // uses the cross_next field and is thread-safe.
     let ctx = unsafe { &*ctx_ptr };
+    // SAFETY: task_ptr is alive and non-null; try_set_queued is an atomic CAS on the task header.
     if unsafe { task::try_set_queued(task_ptr) } {
+        // SAFETY: task_ptr is valid and not already queued; try_set_queued succeeded above.
         unsafe { ctx.queue.push(task_ptr) };
         if ctx.parked.load(Ordering::Acquire) {
             let _ = ctx.mio_waker.wake();
@@ -242,6 +245,7 @@ pub(crate) struct CrossWakeQueue {
 // Producers push from any thread (atomic tail swap).
 // Consumer pops from one thread (head is non-atomic).
 unsafe impl Send for CrossWakeQueue {}
+// SAFETY: CrossWakeQueue is designed for cross-thread use; producers use atomic ops, consumer owns head exclusively.
 unsafe impl Sync for CrossWakeQueue {}
 
 impl CrossWakeQueue {
@@ -331,6 +335,7 @@ impl CrossWakeQueue {
             }
             *head_ref = next;
             head = next;
+            // SAFETY: head was advanced to next, which is a valid task or stub pointer from the queue.
             next = unsafe { self.next_of(head) }.load(Ordering::Acquire);
         }
 
@@ -353,6 +358,7 @@ impl CrossWakeQueue {
         unsafe { self.push(stub) };
 
         // Now check if head got a next pointer (the stub push linked it).
+        // SAFETY: head is a valid task or stub pointer that was in the queue before the stub re-insertion.
         next = unsafe { self.next_of(head) }.load(Ordering::Acquire);
         if !next.is_null() {
             *head_ref = next;
@@ -383,6 +389,7 @@ pub(crate) struct CrossWakeContext {
 
 // SAFETY: CrossWakeQueue is Send + Sync, Arc<mio::Waker> is Send + Sync.
 unsafe impl Send for CrossWakeContext {}
+// SAFETY: CrossWakeContext fields are Send + Sync; queue uses atomic tail, mio::Waker is thread-safe.
 unsafe impl Sync for CrossWakeContext {}
 
 /// Wake a task via the cross-thread path: push to intrusive inbox,
@@ -394,6 +401,7 @@ unsafe impl Sync for CrossWakeContext {}
 /// `CrossWakeContext` (guaranteed by channel lifetime).
 pub(crate) unsafe fn wake_task_cross_thread(task_ptr: *mut u8, ctx: &CrossWakeContext) {
     // Don't wake completed tasks.
+    // SAFETY: caller guarantees task_ptr is a valid live task; is_completed reads an atomic flag.
     if unsafe { task::is_completed(task_ptr) } {
         return;
     }
@@ -478,6 +486,7 @@ pub(crate) struct TaskWakerSlot {
 
 // SAFETY: All fields are atomic or immutable after creation.
 unsafe impl Send for TaskWakerSlot {}
+// SAFETY: TaskWakerSlot fields are atomic or immutable after creation; UnsafeCell access is guarded by state.
 unsafe impl Sync for TaskWakerSlot {}
 
 impl TaskWakerSlot {
@@ -526,6 +535,7 @@ impl TaskWakerSlot {
         // interleavings.
         let prev_ptr = self.task_ptr.swap(ptr, Ordering::AcqRel);
         if !prev_ptr.is_null() {
+            // SAFETY: prev_ptr (non-null) was registered with a ref_inc; we own that ref and must release it.
             drop(unsafe { crate::task::TaskRef::from_owned(prev_ptr) });
         }
 
@@ -562,6 +572,7 @@ impl TaskWakerSlot {
                 // ref_inc'd before storing — that ref keeps the task
                 // allocated through the dispatch (see BUG-2 #168).
                 let ctx = unsafe { &*self.cross_ctx };
+                // SAFETY: task_ptr is alive (kept by register's ref_inc) and ctx is valid for the channel lifetime.
                 unsafe { wake_task_cross_thread(task_ptr, ctx) };
 
                 // BUG-2 fix: release the ref `register` acquired. Must
@@ -628,6 +639,7 @@ pub(crate) struct FallbackWaker {
 // the atomic state field (REGISTERING excludes concurrent writes,
 // CAS STORED→EMPTY excludes concurrent reads).
 unsafe impl Send for FallbackWaker {}
+// SAFETY: FallbackWaker UnsafeCell access is coordinated by the atomic state field.
 unsafe impl Sync for FallbackWaker {}
 
 impl FallbackWaker {
@@ -695,6 +707,7 @@ pub(crate) struct TxWakerSlot {
 // SAFETY: Access to the UnsafeCell<Option<Waker>> is coordinated by
 // the atomic state field. Single-sender register, single-receiver wake.
 unsafe impl Send for TxWakerSlot {}
+// SAFETY: TxWakerSlot UnsafeCell access is coordinated by the atomic state; single-sender, single-receiver.
 unsafe impl Sync for TxWakerSlot {}
 
 impl TxWakerSlot {
@@ -816,8 +829,8 @@ pub(crate) mod uaf_scenarios {
         let task_ptr = make_uaf_task();
 
         // Sanity: starting refcount is 1 (Task::new_boxed initial state).
-        // SAFETY: task_ptr was just created by make_uaf_task; valid task.
         assert_eq!(
+            // SAFETY: task_ptr was just created by make_uaf_task; valid task.
             unsafe { task::ref_count(task_ptr) },
             1,
             "make_uaf_task should produce refcount=1"
@@ -920,6 +933,7 @@ pub(crate) mod uaf_scenarios {
         // ref_inc brings rc to 2; complete_and_unref sets COMPLETED and
         // decrements rc back to 1, returning Retain.
         unsafe { task::ref_inc(task_ptr) };
+        // SAFETY: task_ptr is valid with rc=2; complete_and_unref sets COMPLETED and decrements rc.
         let action = unsafe { task::complete_and_unref(task_ptr) };
         assert!(matches!(action, FreeAction::Retain));
         // SAFETY: task_ptr is still valid (Retain means no free).
@@ -964,6 +978,7 @@ pub(crate) mod uaf_scenarios {
         // rc to 0 → FreeBox. free_task reclaims the Box allocation.
         let action = unsafe { task::ref_dec(task_ptr) };
         match action {
+            // SAFETY: FreeBox guarantees rc=0 and task is terminal; free_task reclaims the Box allocation.
             FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
             other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
         }
@@ -994,6 +1009,7 @@ pub(crate) mod uaf_scenarios {
         // SAFETY: task_ptr valid from make_uaf_task (rc=1). ref_inc
         // brings rc to 2; complete_and_unref sets COMPLETED, rc → 1.
         unsafe { task::ref_inc(task_ptr) };
+        // SAFETY: task_ptr is valid with rc=2; complete_and_unref sets COMPLETED and decrements rc.
         let action = unsafe { task::complete_and_unref(task_ptr) };
         assert!(matches!(action, FreeAction::Retain));
         // SAFETY: task_ptr valid (Retain, rc=1).
@@ -1004,8 +1020,8 @@ pub(crate) mod uaf_scenarios {
 
         // ---- T0: initial register ----
         slot.register(task_ptr);
-        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
+            // SAFETY: task_ptr valid; reading refcount for assertion.
             unsafe { task::ref_count(task_ptr) },
             baseline + 1,
             "initial register must take a ref (slot owns +1)"
@@ -1026,8 +1042,8 @@ pub(crate) mod uaf_scenarios {
         // — same task_ptr. Pre-fix: register's gate sees prev==EMPTY,
         // skips the release, leaks the old ref. Post-fix: release fires.
         slot.register(task_ptr);
-        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
+            // SAFETY: task_ptr valid; reading refcount for assertion.
             unsafe { task::ref_count(task_ptr) },
             baseline + 1,
             "race register must NET to baseline+1 (slot still owns one ref). \
@@ -1045,8 +1061,8 @@ pub(crate) mod uaf_scenarios {
         // register acquired. from_owned + drop releases that ref.
         drop(unsafe { TaskRef::from_owned(captured) });
 
-        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
+            // SAFETY: task_ptr valid; reading refcount for assertion.
             unsafe { task::ref_count(task_ptr) },
             baseline,
             "after wake's release, slot owes 0 refs to task. Pre-fix \
@@ -1059,8 +1075,8 @@ pub(crate) mod uaf_scenarios {
         // nothing — confirms the Drop impl correctly handles this
         // benign "post-race" inconsistency.
         drop(slot);
-        // SAFETY: task_ptr valid; reading refcount for assertion.
         assert_eq!(
+            // SAFETY: task_ptr valid; reading refcount for assertion.
             unsafe { task::ref_count(task_ptr) },
             baseline,
             "Drop on a STORED-but-null-task_ptr slot must be a no-op for refcount"
@@ -1069,6 +1085,7 @@ pub(crate) mod uaf_scenarios {
         // SAFETY: task_ptr valid with rc=baseline (1), COMPLETED.
         // ref_dec → rc=0 → FreeBox. free_task reclaims the allocation.
         match unsafe { task::ref_dec(task_ptr) } {
+            // SAFETY: FreeBox guarantees rc=0 and task is terminal; free_task reclaims the allocation.
             FreeAction::FreeBox => unsafe { task::free_task(task_ptr) },
             other => panic!("expected FreeBox on final ref_dec, got {other:?}"),
         }
@@ -1101,6 +1118,7 @@ mod tests {
     }
 
     unsafe fn free(ptr: *mut u8) {
+        // SAFETY: caller guarantees ptr is a valid task pointer from make_task; free_task reclaims the Box.
         unsafe { task::free_task(ptr) };
     }
 
@@ -1129,7 +1147,9 @@ mod tests {
         // SAFETY: t1, t2, t3 are valid task pointers with valid
         // cross_next fields. Each pushed once, not already in queue.
         unsafe { q.push(t1) };
+        // SAFETY: t2 is a valid task pointer, not already in queue.
         unsafe { q.push(t2) };
+        // SAFETY: t3 is a valid task pointer, not already in queue.
         unsafe { q.push(t3) };
 
         assert_eq!(q.pop(), Some(t1));
@@ -1139,7 +1159,9 @@ mod tests {
 
         // SAFETY: all popped from queue; free reclaims each Box.
         unsafe { free(t1) };
+        // SAFETY: t2 was popped from queue; free reclaims the Box.
         unsafe { free(t2) };
+        // SAFETY: t3 was popped from queue; free reclaims the Box.
         unsafe { free(t3) };
     }
 
@@ -1160,6 +1182,7 @@ mod tests {
 
         // SAFETY: both popped; free reclaims each Box.
         unsafe { free(t1) };
+        // SAFETY: t2 was popped; free reclaims the Box.
         unsafe { free(t2) };
     }
 

--- a/nexus-async-rt/src/io.rs
+++ b/nexus-async-rt/src/io.rs
@@ -346,6 +346,7 @@ impl IoHandle {
     pub unsafe fn deregister(&self, source: &mut impl Source, token: Token) -> io::Result<()> {
         // SAFETY: caller guarantees pointers are valid.
         let driver = unsafe { &mut *self.driver };
+        // SAFETY: caller guarantees registry pointer is valid for the Runtime lifetime.
         let registry = unsafe { &*self.registry };
         registry.deregister(source)?;
         driver.release_token(token);

--- a/nexus-async-rt/src/lib.rs
+++ b/nexus-async-rt/src/lib.rs
@@ -568,10 +568,12 @@ impl Executor {
                     // SAFETY: terminal state; tracker_key at offset 60, free_task
                     // dispatches through the header's free_fn.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
+                    // SAFETY: terminal state confirmed; free_task dispatches through the header's free_fn.
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
                 }
             }
+        // SAFETY: has_join reads the HAS_JOIN flag from the packed task state word.
         } else if unsafe { task::has_join(ptr) } {
             // Joinable: poll_join dropped F and wrote T. drop_fn = drop_output::<T>.
             // Don't drop T — JoinHandle will read it or drop it on handle drop.
@@ -593,6 +595,7 @@ impl Executor {
                     unsafe { task::drop_task_future(ptr) };
                     // SAFETY: terminal state; read tracker_key then free.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
+                    // SAFETY: terminal state confirmed; free_task dispatches through the header's free_fn.
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
                 }
@@ -609,6 +612,7 @@ impl Executor {
                 task::FreeAction::FreeBox | task::FreeAction::FreeSlab => {
                     // SAFETY: terminal state; read tracker_key then free.
                     let key = unsafe { task::tracker_key(ptr) } as usize;
+                    // SAFETY: terminal state confirmed; free_task dispatches through the header's free_fn.
                     unsafe { task::free_task(ptr) };
                     self.all_tasks.remove(key);
                 }
@@ -812,6 +816,7 @@ impl Executor {
         while unsafe { task::ref_count(ptr) } > 0 && std::time::Instant::now() < deadline {
             std::thread::yield_now();
         }
+        // SAFETY: task allocation is alive; ref_count reads bits from the packed state word.
         if unsafe { task::ref_count(ptr) } > 0 {
             // Record before the abort — the eprintln stays per CALLOUT 5
             // (only signal at moment of process abort).

--- a/nexus-async-rt/src/runtime.rs
+++ b/nexus-async-rt/src/runtime.rs
@@ -1466,6 +1466,7 @@ mod tests {
         let wb = WorldBuilder::new();
         let mut world = wb.build();
 
+        // SAFETY: capacity 1 is a valid non-zero capacity for the bounded slab allocator.
         let bounded = unsafe { nexus_slab::byte::bounded::Slab::<256>::with_capacity(1) };
         let mut rt = Runtime::builder(&mut world).slab_bounded(bounded).build();
 
@@ -1487,6 +1488,7 @@ mod tests {
         let wb = WorldBuilder::new();
         let mut world = wb.build();
 
+        // SAFETY: capacity 1 is a valid non-zero capacity for the bounded slab allocator.
         let bounded = unsafe { nexus_slab::byte::bounded::Slab::<256>::with_capacity(1) };
         let mut rt = Runtime::builder(&mut world).slab_bounded(bounded).build();
 

--- a/nexus-async-rt/src/task.rs
+++ b/nexus-async-rt/src/task.rs
@@ -134,6 +134,7 @@ impl TaskRef {
     /// `ptr` must point to a live task with refcount >= 1 at the time of call.
     #[inline]
     pub(crate) unsafe fn acquire(ptr: *mut u8) -> Self {
+        // SAFETY: acquire's safety contract requires ptr points to a live task with refcount >= 1.
         unsafe { ref_inc(ptr) };
         Self { ptr }
     }
@@ -162,6 +163,7 @@ impl TaskRef {
 impl Drop for TaskRef {
     #[inline]
     fn drop(&mut self) {
+        // SAFETY: self.ptr is a valid task pointer; TaskRef owns exactly one refcount unit.
         match unsafe { ref_dec(self.ptr) } {
             FreeAction::Retain => {}
             FreeAction::FreeBox | FreeAction::FreeSlab => {
@@ -417,13 +419,16 @@ impl<T: 'static> Future for JoinHandle<T> {
 
         // SAFETY: ptr is valid — JoinHandle holds a ref (refcount >= 1).
         if unsafe { is_completed(ptr) } {
+            // SAFETY: ptr is valid — JoinHandle holds a ref (refcount >= 1).
             let s = unsafe { state_load(ptr) };
             assert!(s & ABORTED == 0, "polled JoinHandle after task was aborted");
             // SAFETY: Task completed, so poll_join already transitioned the union
             // from F to T. The output is live at storage_offset. ptr::read moves
             // it out (bitwise copy). OUTPUT_TAKEN prevents double-read.
             let output_ptr = unsafe { ptr.add(storage_offset(ptr)) };
+            // SAFETY: output_ptr points to a live T at storage_offset; task is completed.
             let value = unsafe { std::ptr::read(output_ptr.cast::<T>()) };
+            // SAFETY: ptr is valid — setting OUTPUT_TAKEN on a completed task.
             unsafe { set_output_taken(ptr) };
             Poll::Ready(value)
         } else {
@@ -445,6 +450,7 @@ impl<T> JoinHandle<T> {
 
     /// Returns `true` if the task has completed (output is ready).
     pub fn is_finished(&self) -> bool {
+        // SAFETY: self.ptr is valid — JoinHandle holds a ref (refcount >= 1).
         unsafe { is_completed(self.ptr) }
     }
 
@@ -459,8 +465,10 @@ impl<T> JoinHandle<T> {
     #[must_use = "returns whether the task was still running"]
     pub fn abort(self) -> bool {
         let ptr = self.ptr;
+        // SAFETY: ptr is valid — JoinHandle holds a ref (refcount >= 1).
         let was_running = !unsafe { is_completed(ptr) };
         if was_running {
+            // SAFETY: ptr is valid — setting ABORTED on a live task.
             unsafe { set_aborted(ptr) };
         }
         // self is consumed — Drop runs, which clears HAS_JOIN,
@@ -494,7 +502,9 @@ impl<T> Drop for JoinHandle<T> {
 
         // Clear HAS_JOIN so complete_task knows nobody is waiting.
         // Take the join waker to release the parent task's refcount.
+        // SAFETY: ptr is valid — JoinHandle holds a ref (refcount >= 1).
         unsafe { clear_has_join(ptr) };
+        // SAFETY: ptr is valid — taking the join waker under single-threaded access.
         let _ = unsafe { take_join_waker(ptr) };
 
         // Release our reference via TaskRef. Drop routes terminal state
@@ -554,6 +564,7 @@ pub(crate) unsafe fn tracker_key(ptr: *mut u8) -> u32 {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn ref_inc(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     let prev = state.fetch_add(REF_ONE, Ordering::Relaxed);
     debug_assert!((prev & REF_MASK) > 0, "ref_inc on zero refcount");
@@ -567,6 +578,7 @@ pub(crate) unsafe fn ref_inc(ptr: *mut u8) {
 /// `ptr` must point to a live (or completed) `Task<F>`.
 #[inline]
 pub(crate) unsafe fn ref_dec(ptr: *mut u8) -> FreeAction {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     let prev = state.fetch_sub(REF_ONE, Ordering::AcqRel);
     debug_assert!((prev & REF_MASK) >= REF_ONE, "ref_dec on zero refcount");
@@ -596,6 +608,7 @@ pub(crate) unsafe fn ref_dec(ptr: *mut u8) -> FreeAction {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn ref_count(ptr: *mut u8) -> usize {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) } & REF_MASK) >> 6
 }
 
@@ -610,6 +623,7 @@ pub(crate) unsafe fn ref_count(ptr: *mut u8) -> usize {
 /// `ptr` must point to a live, not-yet-completed `Task<F>`.
 #[inline]
 pub(crate) unsafe fn complete_and_unref(ptr: *mut u8) -> FreeAction {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     // Atomically: set COMPLETED (add 1 to bit 0) + dec refcount (sub REF_ONE)
     // Net subtraction = REF_ONE - COMPLETED.
@@ -643,6 +657,7 @@ pub(crate) unsafe fn complete_and_unref(ptr: *mut u8) -> FreeAction {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn is_terminal(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let s = unsafe { state_load(ptr) };
     // Strip inert flags (SLAB_ALLOCATED, ABORTED, OUTPUT_TAKEN).
     // What remains must be exactly COMPLETED with zero refcount.
@@ -656,6 +671,7 @@ pub(crate) unsafe fn is_terminal(ptr: *mut u8) -> bool {
 /// `ptr` must point to a (possibly completed) `Task<F>`.
 #[inline]
 pub(crate) unsafe fn is_completed(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) }) & COMPLETED != 0
 }
 
@@ -669,6 +685,7 @@ pub(crate) unsafe fn is_completed(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn is_slab_allocated(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) }) & SLAB_ALLOCATED != 0
 }
 
@@ -679,6 +696,7 @@ pub(crate) unsafe fn is_slab_allocated(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn is_queued(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) }) & QUEUED != 0
 }
 
@@ -689,6 +707,7 @@ pub(crate) unsafe fn is_queued(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn set_queued(ptr: *mut u8, queued: bool) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     if queued {
         state.fetch_or(QUEUED, Ordering::Release);
@@ -705,6 +724,7 @@ pub(crate) unsafe fn set_queued(ptr: *mut u8, queued: bool) {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn try_set_queued(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     // fetch_or always sets the bit. Check if it was already set.
     let prev = state.fetch_or(QUEUED, Ordering::AcqRel);
@@ -718,6 +738,7 @@ pub(crate) unsafe fn try_set_queued(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn clear_queued(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     state.fetch_and(!QUEUED, Ordering::Release);
 }
@@ -729,6 +750,7 @@ pub(crate) unsafe fn clear_queued(ptr: *mut u8) {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn is_aborted(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) }) & ABORTED != 0
 }
 
@@ -739,6 +761,7 @@ pub(crate) unsafe fn is_aborted(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn set_aborted(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     state.fetch_or(ABORTED, Ordering::Release);
 }
@@ -750,6 +773,7 @@ pub(crate) unsafe fn set_aborted(ptr: *mut u8) {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn has_join(ptr: *mut u8) -> bool {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     (unsafe { state_load(ptr) }) & HAS_JOIN != 0
 }
 
@@ -760,6 +784,7 @@ pub(crate) unsafe fn has_join(ptr: *mut u8) -> bool {
 /// `ptr` must point to a live `Task<F>`.
 #[inline]
 pub(crate) unsafe fn clear_has_join(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     state.fetch_and(!HAS_JOIN, Ordering::Release);
 }
@@ -771,6 +796,7 @@ pub(crate) unsafe fn clear_has_join(ptr: *mut u8) {
 /// `ptr` must point to a live, completed `Task<F>`. Single-threaded.
 #[inline]
 unsafe fn set_output_taken(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; state is at offset 24 in repr(C) Task.
     let state = unsafe { state_ref(ptr) };
     state.fetch_or(OUTPUT_TAKEN, Ordering::Release);
 }
@@ -829,6 +855,7 @@ pub(crate) unsafe fn header_cross_wake_ctx(ptr: *mut u8) -> *const CrossWakeCont
 unsafe fn set_join_waker(ptr: *mut u8, waker: Waker) {
     // SAFETY: join_waker is UnsafeCell<Option<Waker>> at offset 40.
     let cell = unsafe { &*ptr.add(40).cast::<UnsafeCell<Option<Waker>>>() };
+    // SAFETY: task state is accessed only under the executor's single-thread invariant.
     unsafe { *cell.get() = Some(waker) };
 }
 
@@ -839,7 +866,9 @@ unsafe fn set_join_waker(ptr: *mut u8, waker: Waker) {
 /// `ptr` must point to a live `Task<F>`. Single-threaded access only.
 #[inline]
 pub(crate) unsafe fn take_join_waker(ptr: *mut u8) -> Option<Waker> {
+    // SAFETY: caller upholds ptr validity; join_waker is UnsafeCell<Option<Waker>> at offset 40.
     let cell = unsafe { &*ptr.add(40).cast::<UnsafeCell<Option<Waker>>>() };
+    // SAFETY: task state is accessed only under the executor's single-thread invariant.
     unsafe { (*cell.get()).take() }
 }
 
@@ -855,6 +884,7 @@ pub(crate) unsafe fn poll_task(ptr: *mut u8, cx: &mut Context<'_>) -> Poll<()> {
     let poll_fn: unsafe fn(*mut u8, &mut Context<'_>) -> Poll<()> =
         unsafe { *(ptr as *const unsafe fn(*mut u8, &mut Context<'_>) -> Poll<()>) };
     // Pass the task base pointer — the trampoline reads storage_offset.
+    // SAFETY: poll_fn is a valid function pointer for this task type; ptr is a live task.
     unsafe { poll_fn(ptr, cx) }
 }
 
@@ -868,6 +898,7 @@ pub(crate) unsafe fn drop_task_future(ptr: *mut u8) {
     // SAFETY: drop_fn is at offset 8 in repr(C) Task.
     let drop_fn: unsafe fn(*mut u8) = unsafe { *(ptr.add(8) as *const unsafe fn(*mut u8)) };
     // Pass base pointer — the trampoline reads storage_offset.
+    // SAFETY: drop_fn is a valid function pointer for this task; ptr is a live task.
     unsafe { drop_fn(ptr) }
 }
 
@@ -881,6 +912,7 @@ pub(crate) unsafe fn drop_task_future(ptr: *mut u8) {
 pub(crate) unsafe fn free_task(ptr: *mut u8) {
     // SAFETY: free_fn is at offset 16 in repr(C) Task.
     let free_fn: unsafe fn(*mut u8) = unsafe { *(ptr.add(16) as *const unsafe fn(*mut u8)) };
+    // SAFETY: free_fn is a valid function pointer; the future has already been dropped.
     unsafe { free_fn(ptr) }
 }
 
@@ -901,27 +933,35 @@ where
     F::Output: 'static,
 {
     // Check if aborted
+    // SAFETY: caller upholds ptr validity; reading ABORTED flag atomically.
     if unsafe { is_aborted(ptr) } {
         return Poll::Ready(());
     }
 
+    // SAFETY: caller upholds ptr validity; storage_offset is initialized at construction.
     let future_ptr = unsafe { ptr.add(storage_offset(ptr)) };
+    // SAFETY: the task future is pinned in place; we never move it.
     let future = unsafe { Pin::new_unchecked(&mut *future_ptr.cast::<F>()) };
     match future.poll(cx) {
         Poll::Pending => Poll::Pending,
         Poll::Ready(value) => {
+            // SAFETY: drop_fn is at offset 8 in repr(C) Task; ptr is a live task.
             let drop_fn_slot = unsafe { ptr.add(8).cast::<unsafe fn(*mut u8)>() };
             // 1. Overwrite drop_fn to no-op BEFORE dropping F.
             //    If F::drop() panics, this prevents double-drop —
             //    subsequent cleanup calls the no-op instead of
             //    drop_future_in_union on a partially-dropped F.
             //    The output (value) is dropped during unwind (stack-owned).
+            // SAFETY: drop_fn_slot points to the drop_fn field; written before F is dropped to prevent double-drop.
             unsafe { *drop_fn_slot = drop_noop };
             // 2. Drop the future in place (panic-safe now)
+            // SAFETY: future_ptr points to a live F at storage_offset; drop_fn overwritten to drop_noop first.
             unsafe { std::ptr::drop_in_place(future_ptr.cast::<F>()) };
             // 3. Write output T into the same location
+            // SAFETY: future_ptr storage is sized for F::Output via FutureOrOutput<F, T> union; F has been dropped.
             unsafe { std::ptr::write(future_ptr.cast::<F::Output>(), value) };
             // 4. Overwrite drop_fn: now drops T instead of F
+            // SAFETY: drop_fn_slot points to the drop_fn field; T is now live at storage_offset.
             unsafe { *drop_fn_slot = drop_output::<F::Output> };
             Poll::Ready(())
         }
@@ -935,7 +975,9 @@ where
 /// `ptr` must point to a live `Task<F>` with a live future at `storage_offset`.
 #[cfg(test)]
 unsafe fn drop_future<F>(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; storage_offset is initialized at construction.
     let future_ptr = unsafe { ptr.add(storage_offset(ptr)) };
+    // SAFETY: future_ptr points to a live F at storage_offset; caller ensures this is called once.
     unsafe { std::ptr::drop_in_place(future_ptr.cast::<F>()) }
 }
 
@@ -945,8 +987,10 @@ unsafe fn drop_future<F>(ptr: *mut u8) {
 ///
 /// `ptr` must point to a `Task<FutureOrOutput<F, T>>` with a live future.
 unsafe fn drop_future_in_union<F: Future>(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; storage_offset is initialized at construction.
     let storage_ptr = unsafe { ptr.add(storage_offset(ptr)) };
     // The future is at the start of the union (same offset as the union itself).
+    // SAFETY: storage_ptr points to a live F at the union's start; caller ensures this is called once.
     unsafe { std::ptr::drop_in_place(storage_ptr.cast::<F>()) }
 }
 
@@ -966,7 +1010,9 @@ unsafe fn drop_noop(_ptr: *mut u8) {}
 ///
 /// `ptr` must point to a `Task` with a live `T` at `storage_offset`.
 unsafe fn drop_output<T>(ptr: *mut u8) {
+    // SAFETY: caller upholds ptr validity; storage_offset is initialized at construction.
     let output_ptr = unsafe { ptr.add(storage_offset(ptr)) };
+    // SAFETY: output_ptr points to a live T at storage_offset; caller ensures this is called once.
     unsafe { std::ptr::drop_in_place(output_ptr.cast::<T>()) }
 }
 
@@ -983,6 +1029,7 @@ unsafe fn drop_output<T>(ptr: *mut u8) {
 unsafe fn box_free<F>(ptr: *mut u8) {
     // SAFETY: Layout matches what Box::new(Task<F>) allocated.
     let layout = std::alloc::Layout::new::<Task<F>>();
+    // SAFETY: ptr was produced by Box::into_raw(Box::new(Task<F>)); layout matches the allocation.
     unsafe { std::alloc::dealloc(ptr, layout) }
 }
 
@@ -1183,6 +1230,7 @@ mod tests {
 
     impl Drop for PanickingDrop {
         fn drop(&mut self) {
+            // SAFETY: drop_count is a valid pointer to a u32 on the test's stack; exclusive access during drop.
             unsafe { *self.drop_count += 1 };
             panic!("intentional drop panic");
         }
@@ -1208,6 +1256,7 @@ mod tests {
         );
 
         // poll_join completes the future, then drops F — which panics.
+        // SAFETY: ptr is a valid task; poll_task's safety contract is upheld for the test task.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             poll_task(ptr, &mut cx)
         }));
@@ -1249,6 +1298,7 @@ mod tests {
         struct TrackedOutput;
         impl Drop for TrackedOutput {
             fn drop(&mut self) {
+                // SAFETY: single-threaded test; no other references to OUTPUT_DROP_COUNT.
                 unsafe { OUTPUT_DROP_COUNT += 1 };
             }
         }
@@ -1264,6 +1314,7 @@ mod tests {
         let ptr = box_spawn_joinable(ProduceTracked, 0, std::ptr::null());
 
         // Poll to completion — F dropped, T written, drop_fn → drop_output.
+        // SAFETY: ptr is a valid task; poll_task's safety contract is upheld for the test task.
         let result = unsafe { poll_task(ptr, &mut cx) };
         assert!(result.is_ready());
 
@@ -1342,6 +1393,7 @@ mod tests {
         // Provide a free_fn that does Box dealloc (we box it manually below).
         type Storage = FutureOrOutput<Noop, u64>;
         unsafe fn slab_free(ptr: *mut u8) {
+            // SAFETY: ptr was produced by Box::into_raw(Box::new(Task<Storage>)); layout matches the allocation.
             unsafe {
                 let layout = std::alloc::Layout::new::<Task<Storage>>();
                 std::alloc::dealloc(ptr, layout);

--- a/nexus-async-rt/src/waker.rs
+++ b/nexus-async-rt/src/waker.rs
@@ -91,9 +91,11 @@ pub(crate) static VTABLE: RawWakerVTable =
 pub(crate) unsafe fn task_waker(ptr: *mut u8) -> Waker {
     // Acquire a TaskRef (ref_inc), then forget it — the RawWaker now
     // owns the ref. drop_fn calls TaskRef::from_owned + drop to release.
+    // SAFETY: caller guarantees ptr points to a live task with ref_count >= 1.
     let task_ref = unsafe { TaskRef::acquire(ptr) };
     let raw = RawWaker::new(task_ref.as_ptr().cast(), &VTABLE);
     std::mem::forget(task_ref);
+    // SAFETY: raw uses VTABLE with correct vtable functions; data ptr is a live task ref.
     unsafe { Waker::from_raw(raw) }
 }
 
@@ -127,6 +129,7 @@ unsafe fn wake_fn(data: *const ()) {
     // SAFETY: data is a valid task pointer.
     unsafe { wake_impl(data) };
     // Consume the ref via TaskRef::Drop.
+    // SAFETY: data was given to wake_fn by the RawWaker; we own the ref and are consuming it.
     drop(unsafe { TaskRef::from_owned(data as *mut u8) });
 }
 
@@ -139,6 +142,7 @@ unsafe fn wake_by_ref_fn(data: *const ()) {
 
 /// Drop (without waking): decrement refcount via TaskRef::Drop.
 unsafe fn drop_fn(data: *const ()) {
+    // SAFETY: data was given to drop_fn by the RawWaker; we own the ref and are releasing it.
     drop(unsafe { TaskRef::from_owned(data as *mut u8) });
 }
 
@@ -192,9 +196,11 @@ unsafe fn wake_impl(data: *const ()) {
     }
 
     // Check dedup flag — don't queue twice.
+    // SAFETY: task_ptr is a valid task pointer; is_queued reads the queued flag from packed task state.
     if unsafe { task::is_queued(task_ptr) } {
         return;
     }
+    // SAFETY: task_ptr is a valid task pointer; set_queued writes the queued flag atomically.
     unsafe { task::set_queued(task_ptr, true) };
 
     // Push to ready queue.

--- a/nexus-async-rt/tests/cancel_alloc_count.rs
+++ b/nexus-async-rt/tests/cancel_alloc_count.rs
@@ -54,15 +54,18 @@ struct CountingAllocator {
     allocs: AtomicUsize,
 }
 
+// SAFETY: delegates to the system allocator; alloc/dealloc contract is upheld.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         if self.counting_active.load(Ordering::Relaxed) {
             self.allocs.fetch_add(1, Ordering::Relaxed);
         }
+        // SAFETY: layout is non-zero; pointer returned by alloc is valid.
         unsafe { System.alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: layout is non-zero; pointer returned by alloc is valid.
         unsafe { System.dealloc(ptr, layout) };
     }
 }
@@ -92,15 +95,18 @@ fn tracking_waker(flag: &std::cell::Cell<bool>) -> Waker {
     static VTABLE: RawWakerVTable = RawWakerVTable::new(
         |p| RawWaker::new(p, &VTABLE),
         |p| {
+            // SAFETY: p is the data pointer set by RawWaker::new from a &Cell<bool>; valid for the waker's lifetime.
             let flag = unsafe { &*(p as *const std::cell::Cell<bool>) };
             flag.set(true);
         },
         |p| {
+            // SAFETY: p is the data pointer set by RawWaker::new from a &Cell<bool>; valid for the waker's lifetime.
             let flag = unsafe { &*(p as *const std::cell::Cell<bool>) };
             flag.set(true);
         },
         |_| {},
     );
+    // SAFETY: vtable functions match the data pointer layout; Cell<bool> outlives the waker.
     unsafe { Waker::from_raw(RawWaker::new(data, &VTABLE)) }
 }
 

--- a/nexus-async-rt/tests/dispatch_histo.rs
+++ b/nexus-async-rt/tests/dispatch_histo.rs
@@ -36,11 +36,13 @@ const SAMPLES: usize = 500_000;
 
 #[inline(always)]
 fn rdtsc() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
 #[inline(always)]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-async-rt/tests/intrusive_mpsc_spike.rs
+++ b/nexus-async-rt/tests/intrusive_mpsc_spike.rs
@@ -79,6 +79,7 @@ impl IntrusiveMpsc {
     #[inline]
     fn pop(&mut self) -> *mut Node {
         let mut head = self.head;
+        // SAFETY: head points to a valid Node (stub or previously pushed); single consumer ensures exclusive access.
         let mut next = unsafe { (*head).next.load(Ordering::Acquire) };
 
         // Skip stub
@@ -89,6 +90,7 @@ impl IntrusiveMpsc {
             }
             self.head = next;
             head = next;
+            // SAFETY: head was just updated to next (a non-null, valid Node); single consumer ensures exclusive access.
             next = unsafe { (*head).next.load(Ordering::Acquire) };
         }
 
@@ -104,6 +106,7 @@ impl IntrusiveMpsc {
 
         // Re-insert stub to prevent losing the tail
         self.push(stub_ptr);
+        // SAFETY: head is still valid; the stub re-insertion preserves queue invariants; single consumer.
         next = unsafe { (*head).next.load(Ordering::Acquire) };
         if !next.is_null() {
             self.head = next;

--- a/nexus-async-rt/tests/join_handle_stress.rs
+++ b/nexus-async-rt/tests/join_handle_stress.rs
@@ -42,6 +42,7 @@ fn test_executor() -> Executor {
 fn noop_waker() -> Waker {
     static VTABLE: RawWakerVTable =
         RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| {}, |_| {}, |_| {});
+    // SAFETY: the vtable functions are all no-ops; the null data pointer is never dereferenced.
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 

--- a/nexus-async-rt/tests/miri_alloc.rs
+++ b/nexus-async-rt/tests/miri_alloc.rs
@@ -72,6 +72,7 @@ fn slab_spawn_and_free() {
 fn slab_spawn_with_drop_tracker() {
     // Verify slab-spawned tasks drop their captures.
     let count = Rc::new(Cell::new(0u32));
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -102,6 +103,7 @@ fn slab_spawn_with_drop_tracker() {
 fn slab_claim_and_spawn() {
     // Use claim_slab() → SlabClaim → .spawn(future).
     // Detach the handle so free fires inline.
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();

--- a/nexus-async-rt/tests/miri_cancel.rs
+++ b/nexus-async-rt/tests/miri_cancel.rs
@@ -37,6 +37,7 @@ use nexus_async_rt::CancellationToken;
 fn noop_waker() -> Waker {
     static VTABLE: RawWakerVTable =
         RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| {}, |_| {}, |_| {});
+    // SAFETY: the vtable functions are all no-ops; the null data pointer is never dereferenced.
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 
@@ -60,16 +61,19 @@ fn tracking_waker(flag: &std::cell::Cell<bool>) -> Waker {
         |p| RawWaker::new(p, &VTABLE),
         |p| {
             // wake: set the flag
+            // SAFETY: p is the data pointer set by RawWaker::new from a &Cell<bool>; valid for the waker's lifetime.
             let flag = unsafe { &*(p as *const std::cell::Cell<bool>) };
             flag.set(true);
         },
         |p| {
             // wake_by_ref: set the flag
+            // SAFETY: p is the data pointer set by RawWaker::new from a &Cell<bool>; valid for the waker's lifetime.
             let flag = unsafe { &*(p as *const std::cell::Cell<bool>) };
             flag.set(true);
         },
         |_| {}, // drop: no-op
     );
+    // SAFETY: vtable functions match the data pointer layout; Cell<bool> outlives the waker.
     unsafe { Waker::from_raw(RawWaker::new(data, &VTABLE)) }
 }
 

--- a/nexus-async-rt/tests/miri_task.rs
+++ b/nexus-async-rt/tests/miri_task.rs
@@ -47,6 +47,7 @@ fn test_executor() -> Executor {
 fn noop_waker() -> Waker {
     static VTABLE: RawWakerVTable =
         RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| {}, |_| {}, |_| {});
+    // SAFETY: the vtable functions are all no-ops; the null data pointer is never dereferenced.
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 

--- a/nexus-async-rt/tests/slab_shutdown_bug.rs
+++ b/nexus-async-rt/tests/slab_shutdown_bug.rs
@@ -33,6 +33,7 @@ use nexus_rt::WorldBuilder;
 
 #[test]
 fn slab_task_uncompleted_at_runtime_drop_no_panic() {
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -56,6 +57,7 @@ fn slab_task_uncompleted_at_runtime_drop_no_panic() {
 #[allow(clippy::async_yields_async)] // Intentional: returning the unawaited
 // JoinHandle so we can drop it outside block_on and exercise BUG-1's path.
 fn slab_handle_dropped_outside_block_on_no_panic() {
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -75,6 +77,7 @@ fn slab_handle_dropped_outside_block_on_no_panic() {
 
 #[test]
 fn many_slab_tasks_at_varying_lifecycle_states() {
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(64) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -127,6 +130,7 @@ fn no_slab_no_panic() {
 fn slab_task_completed_during_block_on() {
     // Path where the bug never fired (TLS held during free during run_loop).
     // Confirm the new lifecycle doesn't break it.
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();
@@ -143,6 +147,7 @@ fn multiple_block_on_with_slab_tasks() {
     // Multiple block_on calls on the same Runtime. TLS is installed
     // once at construction; block_on no longer manages it, so calls
     // across separate block_on invocations all see the same slab.
+    // SAFETY: single-threaded runtime.
     let slab = unsafe { nexus_slab::byte::unbounded::Slab::<256>::with_chunk_capacity(8) };
     let wb = WorldBuilder::new();
     let mut world = wb.build();

--- a/nexus-async-rt/tests/vs_tokio.rs
+++ b/nexus-async-rt/tests/vs_tokio.rs
@@ -35,11 +35,13 @@ const MSG_SIZE: usize = 64;
 
 #[inline(always)]
 fn rdtsc() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
 #[inline(always)]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-async-rt/tests/vs_tokio_dispatch.rs
+++ b/nexus-async-rt/tests/vs_tokio_dispatch.rs
@@ -37,11 +37,13 @@ const BATCH: usize = 100;
 
 #[inline(always)]
 fn rdtsc() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
 #[inline(always)]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; the file-level cfg(target_arch = "x86_64") guarantees the target.
     unsafe {
         let mut aux: u32 = 0;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);


### PR DESCRIPTION
Adds `// SAFETY:` comments to all 195 undocumented `unsafe` blocks in nexus-async-rt, making the crate clean under `clippy::undocumented_unsafe_blocks`.

25 files touched (src, tests, benches). Main patterns covered: raw waker vtable fns (`Arc::from_raw`/`into_raw`), UnsafeCell state access, lock-free queue raw pointer ops, `Pin::new_unchecked`, custom global allocator delegation, and x86_64 rdtsc intrinsics in benchmarks.

Part of the workspace-wide `undocumented_unsafe_blocks` audit (#622, #623, #627, #629).