### PR TITLE
docs(nexus-ascii): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-ascii/examples/_bench_utils.rs
+++ b/nexus-ascii/examples/_bench_utils.rs
@@ -20,6 +20,7 @@ pub const WARMUP: usize = 10_000;
 #[inline]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
@@ -193,6 +194,7 @@ pub const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc_fenced_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -213,6 +215,7 @@ pub fn rdtsc_fenced_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc_fenced_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-ascii/examples/perf_ascii_str.rs
+++ b/nexus-ascii/examples/perf_ascii_str.rs
@@ -49,11 +49,13 @@ fn main() {
     });
 
     bench("from_bytes_unchecked (7B)", || {
+        // SAFETY: bytes_7 is valid ASCII.
         let s = unsafe { AsciiStr::from_bytes_unchecked(black_box(bytes_7)) };
         s.len() as u64
     });
 
     bench("from_bytes_unchecked (32B)", || {
+        // SAFETY: bytes_32 is valid ASCII.
         let s = unsafe { AsciiStr::from_bytes_unchecked(black_box(bytes_32)) };
         s.len() as u64
     });

--- a/nexus-ascii/examples/perf_builder.rs
+++ b/nexus-ascii/examples/perf_builder.rs
@@ -74,6 +74,7 @@ fn main() {
 
     bench_wide("push_bytes_unchecked (7B)", || {
         let mut builder: AsciiStringBuilder<32> = AsciiStringBuilder::new();
+        // SAFETY: b"BTC-USD" is valid ASCII.
         unsafe { builder.push_bytes_unchecked(black_box(b"BTC-USD")) };
         builder.len() as u64
     });
@@ -101,6 +102,7 @@ fn main() {
 
     bench_wide("push_raw_unchecked (7B in 16B buffer)", || {
         let mut builder: AsciiStringBuilder<32> = AsciiStringBuilder::new();
+        // SAFETY: raw_buffer contains valid ASCII followed by null padding.
         unsafe { builder.push_raw_unchecked(black_box(raw_buffer)) };
         builder.len() as u64
     });

--- a/nexus-ascii/examples/perf_char.rs
+++ b/nexus-ascii/examples/perf_char.rs
@@ -33,6 +33,7 @@ fn main() {
     });
 
     bench("new_unchecked", || {
+        // SAFETY: b'A' is valid ASCII.
         let c = unsafe { AsciiChar::new_unchecked(black_box(b'A')) };
         c.as_u8() as u64
     });

--- a/nexus-ascii/examples/perf_flat_string.rs
+++ b/nexus-ascii/examples/perf_flat_string.rs
@@ -55,6 +55,7 @@ fn main() {
     });
 
     bench_batched("from_bytes_unchecked (7B)", || {
+        // SAFETY: b"BTC-USD" is valid ASCII.
         let s: FlatAsciiString<32> =
             unsafe { FlatAsciiString::from_bytes_unchecked(black_box(b"BTC-USD")) };
         s.as_raw()[0] as u64
@@ -92,6 +93,7 @@ fn main() {
     });
 
     bench_batched("from_raw_unchecked (7B in 16B)", || {
+        // SAFETY: buffer_7 contains valid ASCII followed by null padding.
         let s: FlatAsciiString<16> =
             unsafe { FlatAsciiString::from_raw_unchecked(black_box(buffer_7)) };
         s.as_raw()[0] as u64
@@ -177,10 +179,12 @@ fn main() {
     });
 
     bench_batched("replaced_byte (unsafe)", || {
+        // SAFETY: b'_' is valid ASCII.
         unsafe { black_box(sym).replaced_byte(b'-', b'_') }.len() as u64
     });
 
     bench_batched("replace_first_byte (unsafe)", || {
+        // SAFETY: b'_' is valid ASCII.
         unsafe { black_box(sym).replace_first_byte(b'-', b'_') }.len() as u64
     });
 

--- a/nexus-ascii/examples/perf_flat_text.rs
+++ b/nexus-ascii/examples/perf_flat_text.rs
@@ -97,6 +97,7 @@ fn main() {
     });
 
     bench_batched("replaced_char_unchecked (unsafe)", || {
+        // SAFETY: underscore is a valid printable ASCII char.
         unsafe { black_box(sym).replaced_char_unchecked(minus, underscore) }.len() as u64
     });
 
@@ -108,6 +109,7 @@ fn main() {
     });
 
     bench_batched("replace_first_char_unchecked (unsafe)", || {
+        // SAFETY: underscore is a valid printable ASCII char.
         unsafe { black_box(sym).replace_first_char_unchecked(minus, underscore) }.len() as u64
     });
 

--- a/nexus-ascii/examples/perf_from_raw.rs
+++ b/nexus-ascii/examples/perf_from_raw.rs
@@ -40,6 +40,7 @@ fn main() {
     });
 
     bench_wide("from_raw_unchecked (7B in 16B buffer)", || {
+        // SAFETY: buffer_7 contains valid ASCII followed by null padding.
         let s: AsciiString<16> = unsafe { AsciiString::from_raw_unchecked(black_box(buffer_7)) };
         s.len() as u64
     });
@@ -73,6 +74,7 @@ fn main() {
     });
 
     bench_wide("from_raw_unchecked (20B in 32B buffer)", || {
+        // SAFETY: buffer_20 contains valid ASCII followed by null padding.
         let s: AsciiString<32> = unsafe { AsciiString::from_raw_unchecked(black_box(buffer_20)) };
         s.len() as u64
     });
@@ -240,6 +242,7 @@ fn main() {
 
     // from_bytes_unchecked (no null search, no validation)
     bench_wide("from_bytes_unchecked (7B, no null search)", || {
+        // SAFETY: bytes_7 is valid ASCII.
         let s: AsciiString<16> = unsafe { AsciiString::from_bytes_unchecked(black_box(bytes_7)) };
         s.len() as u64
     });

--- a/nexus-ascii/examples/perf_hash.rs
+++ b/nexus-ascii/examples/perf_hash.rs
@@ -35,6 +35,7 @@ const ITERATIONS: usize = 100_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; this file only runs on x86_64.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-ascii/examples/perf_iteration.rs
+++ b/nexus-ascii/examples/perf_iteration.rs
@@ -50,8 +50,9 @@ fn main() {
         black_box(&s8).get(100).map_or(0, |c| c.as_u8() as u64)
     });
 
-    bench("get_unchecked(0)", || unsafe {
-        black_box(&s8).get_unchecked(0).as_u8() as u64
+    bench("get_unchecked(0)", || {
+        // SAFETY: index 0 is within bounds of an 8-byte string.
+        unsafe { black_box(&s8).get_unchecked(0).as_u8() as u64 }
     });
 
     // =========================================================================

--- a/nexus-ascii/examples/perf_string.rs
+++ b/nexus-ascii/examples/perf_string.rs
@@ -51,6 +51,7 @@ fn main() {
 
     // from_bytes_unchecked
     bench_batched("from_bytes_unchecked (7B)", || {
+        // SAFETY: b"BTC-USD" is valid ASCII.
         let s: AsciiString<32> =
             unsafe { AsciiString::from_bytes_unchecked(black_box(b"BTC-USD")) };
         s.as_raw()[0] as u64

--- a/nexus-ascii/examples/perf_vs_ascii_crate.rs
+++ b/nexus-ascii/examples/perf_vs_ascii_crate.rs
@@ -138,6 +138,7 @@ fn main() {
     bench_wide("std: make_ascii_uppercase (7B, in-place)", || {
         ss7_buf.as_mut_str().make_ascii_uppercase();
         // Reset for next iteration
+        // SAFETY: b"btc-usd" is valid UTF-8 and same length as the string.
         unsafe { ss7_buf.as_bytes_mut().copy_from_slice(b"btc-usd") };
         black_box(ss7_buf.len() as u64)
     });
@@ -161,6 +162,7 @@ fn main() {
     let mut ss20_buf = String::from("order-id-abcdefghij");
     bench_wide("std: make_ascii_uppercase (20B, in-place)", || {
         ss20_buf.as_mut_str().make_ascii_uppercase();
+        // SAFETY: b"order-id-abcdefghij" is valid UTF-8 and same length as the string.
         unsafe {
             ss20_buf
                 .as_bytes_mut()
@@ -188,6 +190,7 @@ fn main() {
     let mut ss38_buf = String::from("abcdefghijklmnopqrstuvwxyz-0123456789a");
     bench_wide("std: make_ascii_uppercase (38B, in-place)", || {
         ss38_buf.as_mut_str().make_ascii_uppercase();
+        // SAFETY: replacement is valid UTF-8 and same length as the original string.
         unsafe {
             ss38_buf
                 .as_bytes_mut()

--- a/nexus-ascii/src/builder.rs
+++ b/nexus-ascii/src/builder.rs
@@ -739,6 +739,7 @@ mod tests {
     #[test]
     fn test_push_bytes_unchecked() {
         let mut builder: AsciiStringBuilder<32> = AsciiStringBuilder::new();
+        // SAFETY: b"Hello" is valid ASCII.
         unsafe { builder.push_bytes_unchecked(b"Hello") };
         assert_eq!(builder.as_str(), "Hello");
     }
@@ -783,6 +784,7 @@ mod tests {
         let buffer: [u8; 16] = *b"USD\0\0\0\0\0\0\0\0\0\0\0\0\0";
         let mut builder: AsciiStringBuilder<32> = AsciiStringBuilder::new();
         builder.push_str("BTC-").unwrap();
+        // SAFETY: buffer contains valid ASCII bytes followed by null padding.
         unsafe { builder.push_raw_unchecked(buffer) };
         assert_eq!(builder.as_str(), "BTC-USD");
     }

--- a/nexus-ascii/src/char.rs
+++ b/nexus-ascii/src/char.rs
@@ -702,6 +702,7 @@ mod tests {
     #[test]
     fn new_unchecked_valid() {
         for b in 0..=127 {
+            // SAFETY: b is in 0..=127, the valid ASCII range.
             let c = unsafe { AsciiChar::new_unchecked(b) };
             assert_eq!(c.as_u8(), b);
         }

--- a/nexus-ascii/src/flat_string.rs
+++ b/nexus-ascii/src/flat_string.rs
@@ -1873,8 +1873,8 @@ mod tests {
     #[test]
     fn replace_first_byte() {
         let s: FlatAsciiString<32> = FlatAsciiString::try_from("a-b-c").unwrap();
-        // SAFETY: b'_' is valid ASCII
         assert_eq!(
+            // SAFETY: b'_' is valid ASCII
             unsafe { s.replace_first_byte(b'-', b'_') }.as_str(),
             "a_b-c"
         );
@@ -1969,8 +1969,8 @@ mod tests {
     #[test]
     fn replaced() {
         let s: FlatAsciiString<32> = FlatAsciiString::try_from("foo bar foo").unwrap();
-        // SAFETY: b"baz" is valid ASCII
         assert_eq!(
+            // SAFETY: b"baz" is valid ASCII
             unsafe { s.replaced(b"foo", b"baz") }.as_str(),
             "baz bar baz"
         );
@@ -1986,8 +1986,8 @@ mod tests {
     #[test]
     fn replace_first() {
         let s: FlatAsciiString<32> = FlatAsciiString::try_from("foo bar foo").unwrap();
-        // SAFETY: b"baz" is valid ASCII
         assert_eq!(
+            // SAFETY: b"baz" is valid ASCII
             unsafe { s.replace_first(b"foo", b"baz") }.as_str(),
             "baz bar foo"
         );

--- a/nexus-ascii/src/format.rs
+++ b/nexus-ascii/src/format.rs
@@ -125,6 +125,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -139,6 +140,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -162,6 +164,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -176,6 +179,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -190,6 +194,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -213,6 +218,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -227,6 +233,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -241,6 +248,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -264,6 +272,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -278,6 +287,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
 
@@ -292,6 +302,7 @@ macro_rules! impl_format_int_generic {
                         capacity: CAP,
                     });
                 }
+                // SAFETY: digits are always ASCII
                 Ok(unsafe { Self::$from_bytes(formatted) })
             }
         }

--- a/nexus-ascii/src/hash/xxh3_sse2.rs
+++ b/nexus-ascii/src/hash/xxh3_sse2.rs
@@ -40,6 +40,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse2")]
 unsafe fn hash_long_sse2(data: &[u8], seed: u64) -> u64 {
+    // SAFETY: #[target_feature(enable = "sse2")] guarantees SSE2 is available.
     unsafe {
         let len = data.len();
 
@@ -132,6 +133,7 @@ unsafe fn accumulate_stripe_sse2(
     stripe: *const u8,
     secret_offset: usize,
 ) {
+    // SAFETY: #[target_feature(enable = "sse2")] guarantees SSE2 is available.
     unsafe {
         let secret_ptr = SECRET.as_ptr().add(secret_offset);
 
@@ -191,6 +193,7 @@ unsafe fn scramble_acc_sse2(
     acc2: &mut __m128i,
     acc3: &mut __m128i,
 ) {
+    // SAFETY: #[target_feature(enable = "sse2")] guarantees SSE2 is available.
     unsafe {
         let prime = _mm_set1_epi32(PRIME32_1 as i32);
         let secret_ptr = SECRET.as_ptr().add(128);

--- a/nexus-ascii/src/simd/scalar.rs
+++ b/nexus-ascii/src/simd/scalar.rs
@@ -188,6 +188,7 @@ pub fn eq_ignore_ascii_case(a: &[u8], b: &[u8]) -> bool {
     while i + 8 <= len {
         // SAFETY: We just checked that i + 8 <= len
         let word_a = unsafe { a.as_ptr().add(i).cast::<[u8; 8]>().read_unaligned() };
+        // SAFETY: We just checked that i + 8 <= len
         let word_b = unsafe { b.as_ptr().add(i).cast::<[u8; 8]>().read_unaligned() };
 
         if !eq_ignore_ascii_case_word(u64::from_ne_bytes(word_a), u64::from_ne_bytes(word_b)) {
@@ -353,6 +354,7 @@ pub fn make_lowercase(bytes: &mut [u8]) {
         };
         let word = u64::from_ne_bytes(chunk);
         let lower = to_lowercase_word(word);
+        // SAFETY: len >= 8, so len - 8 is valid; write to last 8 bytes.
         unsafe {
             bytes
                 .as_mut_ptr()
@@ -388,6 +390,7 @@ pub fn make_uppercase(bytes: &mut [u8]) {
         let upper = to_uppercase_word(word);
 
         // Write back
+        // SAFETY: We just checked that i + 8 <= len
         unsafe {
             bytes
                 .as_mut_ptr()
@@ -413,6 +416,7 @@ pub fn make_uppercase(bytes: &mut [u8]) {
         };
         let word = u64::from_ne_bytes(chunk);
         let upper = to_uppercase_word(word);
+        // SAFETY: len >= 8, so len - 8 is valid; write to last 8 bytes.
         unsafe {
             bytes
                 .as_mut_ptr()
@@ -491,6 +495,7 @@ pub fn contains_control_chars(bytes: &[u8]) -> bool {
     // 1. len >= 8 (checked above)
     // 2. Re-checking bytes is harmless for OR operation
     if i < len {
+        // SAFETY: len >= 8 (checked above), so len - 8 is valid.
         let chunk: [u8; 8] = unsafe {
             bytes
                 .as_ptr()
@@ -544,6 +549,7 @@ pub fn is_all_printable(bytes: &[u8]) -> bool {
     // 1. len >= 8 (checked above)
     // 2. Re-checking bytes is harmless for AND operation
     if i < len {
+        // SAFETY: len >= 8 (checked above), so len - 8 is valid.
         let chunk: [u8; 8] = unsafe {
             bytes
                 .as_ptr()
@@ -622,6 +628,7 @@ pub fn is_all_numeric(bytes: &[u8]) -> bool {
 
     // Handle remainder by checking last 8 bytes (overlapping)
     if i < len {
+        // SAFETY: len >= 8 (checked above), so len - 8 is valid.
         let chunk: [u8; 8] = unsafe {
             bytes
                 .as_ptr()
@@ -712,6 +719,7 @@ pub fn is_all_alphanumeric(bytes: &[u8]) -> bool {
 
     // Handle remainder by checking last 8 bytes (overlapping)
     if i < len {
+        // SAFETY: len >= 8 (checked above), so len - 8 is valid.
         let chunk: [u8; 8] = unsafe {
             bytes
                 .as_ptr()

--- a/nexus-ascii/src/str_ref.rs
+++ b/nexus-ascii/src/str_ref.rs
@@ -711,6 +711,7 @@ impl AsciiStr {
         let pos = self.find_byte(delimiter.as_u8())?;
         // SAFETY: pos is within bounds, and bytes contain valid ASCII
         let before = unsafe { AsciiStr::from_bytes_unchecked(&self.0[..pos]) };
+        // SAFETY: pos is within bounds, and bytes contain valid ASCII
         let after = unsafe { AsciiStr::from_bytes_unchecked(&self.0[pos + 1..]) };
         Some((before, after))
     }
@@ -1101,12 +1102,14 @@ mod tests {
 
     #[test]
     fn from_bytes_unchecked() {
+        // SAFETY: b"test" is valid ASCII.
         let s = unsafe { AsciiStr::from_bytes_unchecked(b"test") };
         assert_eq!(s.as_str(), "test");
     }
 
     #[test]
     fn from_str_unchecked() {
+        // SAFETY: "test" is valid ASCII.
         let s = unsafe { AsciiStr::from_str_unchecked("test") };
         assert_eq!(s.len(), 4);
     }
@@ -1128,6 +1131,7 @@ mod tests {
     #[test]
     fn get_unchecked_valid() {
         let s = AsciiStr::try_from_bytes(b"ABC").unwrap();
+        // SAFETY: indices 0 and 2 are within bounds of "ABC" (len = 3).
         unsafe {
             assert_eq!(s.get_unchecked(0), AsciiChar::A);
             assert_eq!(s.get_unchecked(2), AsciiChar::C);

--- a/nexus-ascii/src/string.rs
+++ b/nexus-ascii/src/string.rs
@@ -128,6 +128,7 @@ const EMPTY_HEADER: u64 = hash::pack_header(0, hash::hash_const::<0>(&[]));
 /// - `dst` and `src` must not overlap
 #[inline(always)]
 pub(crate) unsafe fn copy_short(dst: *mut u8, src: *const u8, len: usize) {
+    // SAFETY: caller guarantees dst/src validity, len, and non-overlap per function preconditions.
     unsafe {
         if len > 32 {
             core::ptr::copy_nonoverlapping(src, dst, len);
@@ -1582,6 +1583,7 @@ impl<const CAP: usize> AsciiString<CAP> {
         let pos = bytes.iter().position(|&b| b == delimiter.as_u8())?;
         // SAFETY: pos is within bounds, and bytes contain valid ASCII
         let before = unsafe { AsciiStr::from_bytes_unchecked(&bytes[..pos]) };
+        // SAFETY: pos is within bounds, and bytes contain valid ASCII
         let after = unsafe { AsciiStr::from_bytes_unchecked(&bytes[pos + 1..]) };
         Some((before, after))
     }
@@ -2293,6 +2295,7 @@ impl<const CAP: usize> Ord for AsciiString<CAP> {
             // SAFETY: CAP.is_multiple_of(8) guarantees i + 8 <= CAP
             let a =
                 u64::from_be_bytes(unsafe { self.data.as_ptr().add(i).cast::<[u8; 8]>().read() });
+            // SAFETY: CAP.is_multiple_of(8) guarantees i + 8 <= CAP
             let b =
                 u64::from_be_bytes(unsafe { other.data.as_ptr().add(i).cast::<[u8; 8]>().read() });
             match a.cmp(&b) {
@@ -3126,6 +3129,7 @@ mod tests {
     #[test]
     fn get_unchecked_valid() {
         let s: AsciiString<32> = AsciiString::try_from("ABC").unwrap();
+        // SAFETY: indices 0, 1, 2 are within bounds of "ABC" (len = 3).
         unsafe {
             assert_eq!(s.get_unchecked(0), AsciiChar::A);
             assert_eq!(s.get_unchecked(1), AsciiChar::B);
@@ -3743,6 +3747,7 @@ mod tests {
     #[test]
     fn from_raw_unchecked_basic() {
         let buffer: [u8; 16] = *b"BTC-USD\0\0\0\0\0\0\0\0\0";
+        // SAFETY: buffer contains valid ASCII bytes followed by null padding.
         let s: AsciiString<16> = unsafe { AsciiString::from_raw_unchecked(buffer) };
         assert_eq!(s.as_str(), "BTC-USD");
         assert_eq!(s.len(), 7);
@@ -3751,6 +3756,7 @@ mod tests {
     #[test]
     fn from_raw_unchecked_no_null() {
         let buffer: [u8; 8] = *b"BTCUSDT!";
+        // SAFETY: buffer is all valid ASCII, fully filled.
         let s: AsciiString<8> = unsafe { AsciiString::from_raw_unchecked(buffer) };
         assert_eq!(s.len(), 8);
     }
@@ -3758,6 +3764,7 @@ mod tests {
     #[test]
     fn from_raw_unchecked_empty() {
         let buffer: [u8; 8] = [0u8; 8];
+        // SAFETY: buffer is all null bytes; represents an empty string.
         let s: AsciiString<8> = unsafe { AsciiString::from_raw_unchecked(buffer) };
         assert!(s.is_empty());
     }
@@ -3766,6 +3773,7 @@ mod tests {
     fn from_raw_unchecked_matches_checked() {
         let buffer: [u8; 16] = *b"ETH-USDT\0\0\0\0\0\0\0\0";
         let checked: AsciiString<16> = AsciiString::try_from_raw(buffer).unwrap();
+        // SAFETY: buffer contains valid ASCII bytes followed by null padding.
         let unchecked: AsciiString<16> = unsafe { AsciiString::from_raw_unchecked(buffer) };
 
         assert_eq!(checked, unchecked);
@@ -4376,6 +4384,7 @@ mod tests {
 
     #[test]
     fn from_str_unchecked_basic() {
+        // SAFETY: "hello" is valid ASCII.
         let s: AsciiString<16> = unsafe { AsciiString::from_str_unchecked("hello") };
         assert_eq!(s.as_str(), "hello");
         assert_eq!(s.len(), 5);
@@ -4383,12 +4392,14 @@ mod tests {
 
     #[test]
     fn from_str_unchecked_empty() {
+        // SAFETY: "" is valid ASCII.
         let s: AsciiString<16> = unsafe { AsciiString::from_str_unchecked("") };
         assert!(s.is_empty());
     }
 
     #[test]
     fn from_str_unchecked_matches_checked() {
+        // SAFETY: "test123" is valid ASCII.
         let unchecked: AsciiString<16> = unsafe { AsciiString::from_str_unchecked("test123") };
         let checked: AsciiString<16> = AsciiString::try_from_str("test123").unwrap();
         assert_eq!(unchecked, checked);

--- a/nexus-ascii/src/text.rs
+++ b/nexus-ascii/src/text.rs
@@ -729,6 +729,7 @@ impl<const CAP: usize> AsciiText<CAP> {
         let pos = bytes.iter().position(|&b| b == delimiter.as_u8())?;
         // SAFETY: pos is within bounds, AsciiText guarantees printable ASCII
         let before = unsafe { AsciiTextStr::from_bytes_unchecked(&bytes[..pos]) };
+        // SAFETY: pos is within bounds, AsciiText guarantees printable ASCII
         let after = unsafe { AsciiTextStr::from_bytes_unchecked(&bytes[pos + 1..]) };
         Some((before, after))
     }
@@ -1390,6 +1391,7 @@ mod tests {
     #[test]
     fn test_from_ascii_string_unchecked() {
         let s: AsciiString<32> = AsciiString::try_from("Hello").unwrap();
+        // SAFETY: s was created from "Hello" which is valid printable ASCII.
         let text: AsciiText<32> = unsafe { AsciiText::from_ascii_string_unchecked(s) };
         assert_eq!(text.as_str(), "Hello");
     }
@@ -1740,6 +1742,7 @@ mod tests {
 
     #[test]
     fn from_str_unchecked_basic() {
+        // SAFETY: "hello" is valid printable ASCII.
         let text: AsciiText<16> = unsafe { AsciiText::from_str_unchecked("hello") };
         assert_eq!(text.as_str(), "hello");
         assert_eq!(text.len(), 5);
@@ -1747,6 +1750,7 @@ mod tests {
 
     #[test]
     fn from_str_unchecked_matches_checked() {
+        // SAFETY: "test123" is valid printable ASCII.
         let unchecked: AsciiText<16> = unsafe { AsciiText::from_str_unchecked("test123") };
         let checked: AsciiText<16> = AsciiText::try_from_str("test123").unwrap();
         assert_eq!(unchecked, checked);
@@ -1759,12 +1763,14 @@ mod tests {
 
     #[test]
     fn from_bytes_unchecked_basic() {
+        // SAFETY: b"hello" is valid printable ASCII.
         let text: AsciiText<16> = unsafe { AsciiText::from_bytes_unchecked(b"hello") };
         assert_eq!(text.as_str(), "hello");
     }
 
     #[test]
     fn from_bytes_unchecked_matches_checked() {
+        // SAFETY: b"test" is valid printable ASCII.
         let unchecked: AsciiText<16> = unsafe { AsciiText::from_bytes_unchecked(b"test") };
         let checked: AsciiText<16> = AsciiText::try_from_bytes(b"test").unwrap();
         assert_eq!(unchecked, checked);

--- a/nexus-ascii/src/text_ref.rs
+++ b/nexus-ascii/src/text_ref.rs
@@ -479,6 +479,7 @@ impl AsciiTextStr {
         let pos = self.find_byte(delimiter.as_u8())?;
         // SAFETY: pos is within bounds, AsciiTextStr guarantees printable ASCII
         let before = unsafe { AsciiTextStr::from_bytes_unchecked(&self.0[..pos]) };
+        // SAFETY: pos is within bounds, AsciiTextStr guarantees printable ASCII
         let after = unsafe { AsciiTextStr::from_bytes_unchecked(&self.0[pos + 1..]) };
         Some((before, after))
     }
@@ -866,6 +867,7 @@ mod tests {
 
     #[test]
     fn from_bytes_unchecked() {
+        // SAFETY: b"test" is valid printable ASCII.
         let s = unsafe { AsciiTextStr::from_bytes_unchecked(b"test") };
         assert_eq!(s.as_str(), "test");
     }


### PR DESCRIPTION
Add `// SAFETY:` comments to every `unsafe` block in nexus-ascii so the crate passes `cargo clippy -p nexus-ascii --all-targets -W clippy::undocumented_unsafe_blocks` with zero warnings.

Covered: format.rs macro bodies, SIMD scalar/SSE2 intrinsics, str_ref/string/text/text_ref split_once helpers, flat_string test helpers, and all example bench files.