### PR TITLE
docs(nexus-net): add SAFETY comments to rdtsc intrinsic unsafe blocks

### DIFF
--- a/nexus-net/examples/perf_buf.rs
+++ b/nexus-net/examples/perf_buf.rs
@@ -15,6 +15,7 @@ use std::hint::black_box;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -23,6 +24,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);


### PR DESCRIPTION
Add `// SAFETY:` comments to the two undocumented `unsafe` blocks in `nexus-net/examples/perf_buf.rs` (rdtsc intrinsics). Fixes `clippy::undocumented_unsafe_blocks` for this crate.