### PR TITLE
docs(nexus-fix-codegen-tests): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -181,6 +181,7 @@ impl FixDecimal {
         }
 
         debug_assert!(self.scale <= 19);
+        // SAFETY: self.scale <= 19, and POW10 has 20 entries indexed 0..=19.
         let scale_pow = unsafe { *POW10.get_unchecked(self.scale as usize) };
         let integer = abs / scale_pow;
         let frac = abs % scale_pow;
@@ -215,6 +216,7 @@ impl fmt::Display for FixDecimal {
             return write!(f, "{}", self.mantissa);
         }
         debug_assert!(self.scale <= 19);
+        // SAFETY: self.scale <= 19, and POW10 has 20 entries indexed 0..=19.
         let divisor = unsafe { *POW10.get_unchecked(self.scale as usize) };
         let abs = self.mantissa.unsigned_abs();
         let integer = abs / divisor;

--- a/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
+++ b/nexus-fix-codegen-tests/benches/perf_decode_cycles.rs
@@ -9,6 +9,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 fn rdtsc_fenced_start() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -22,6 +23,7 @@ fn rdtsc_fenced_start() -> u64 {
 #[inline(always)]
 fn rdtsc_fenced_end() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);


### PR DESCRIPTION
Add `// SAFETY:` comments to undocumented `unsafe` blocks in two files:

- `nexus-fix-codec/src/types.rs` (two `POW10.get_unchecked` calls guarded by `debug_assert!(self.scale <= 19)`)
- `nexus-fix-codegen-tests/benches/perf_decode_cycles.rs` (two rdtsc x86_64 intrinsic blocks)

Fixes `clippy::undocumented_unsafe_blocks` for these crates.