### PR TITLE
docs(nexus-platform): add SAFETY comment to Sync impl for Mapping

### DIFF
--- a/nexus-platform/src/mapping/mod.rs
+++ b/nexus-platform/src/mapping/mod.rs
@@ -272,6 +272,8 @@ impl Drop for Mapping {
 // state. Concurrent access to the mapped contents must be synchronized
 // by the caller — the handle itself is safe to move across threads.
 unsafe impl Send for Mapping {}
+// SAFETY: same as Send; the Mapping handle has no interior mutability,
+// so shared references can cross thread boundaries safely.
 unsafe impl Sync for Mapping {}
 
 // ── POSIX shared memory (forwarded to platform backend) ──────────


### PR DESCRIPTION
Add `// SAFETY:` comment to the `unsafe impl Sync for Mapping {}` at `nexus-platform/src/mapping/mod.rs`. The preceding `Send` impl already had a comment; `Sync` was missing one.