### PR TITLE
docs(nexus-logbuf): add SAFETY comments to rdtsc intrinsic blocks

### DIFF
--- a/nexus-logbuf/benches/perf_mpsc_latency.rs
+++ b/nexus-logbuf/benches/perf_mpsc_latency.rs
@@ -21,6 +21,7 @@ const BUFFER_SIZE: usize = 64 * 1024;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-logbuf/benches/perf_spsc_latency.rs
+++ b/nexus-logbuf/benches/perf_spsc_latency.rs
@@ -18,6 +18,7 @@ const BUFFER_SIZE: usize = 64 * 1024;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)


### PR DESCRIPTION
Add `// SAFETY:` comments to the two `unsafe` rdtsc intrinsic blocks in `nexus-logbuf/benches/perf_spsc_latency.rs` and `perf_mpsc_latency.rs`.