### PR TITLE
docs(nexus-pool): add SAFETY comments to rdtsc intrinsic blocks

### DIFF
--- a/nexus-pool/benches/perf_local_pool.rs
+++ b/nexus-pool/benches/perf_local_pool.rs
@@ -12,6 +12,7 @@ const OPERATIONS: usize = 1_000_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-pool/benches/perf_sync_pool.rs
+++ b/nexus-pool/benches/perf_sync_pool.rs
@@ -16,6 +16,7 @@ const OPERATIONS: usize = 100_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)


### PR DESCRIPTION
Add `// SAFETY:` comments to the two `unsafe` rdtsc intrinsic blocks in `nexus-pool/benches/perf_local_pool.rs` and `perf_sync_pool.rs`.