### PR TITLE
docs(nexus-timer): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-timer/benches/perf_timer.rs
+++ b/nexus-timer/benches/perf_timer.rs
@@ -24,6 +24,7 @@ const STEADY_SIZE: usize = 100_000;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -32,6 +33,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let tsc = std::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
         std::arch::x86_64::_mm_lfence();

--- a/nexus-timer/src/level.rs
+++ b/nexus-timer/src/level.rs
@@ -250,9 +250,11 @@ mod tests {
         assert!(ws.is_empty());
 
         let e1 = make_entry(&slab, 10, 100);
+        // SAFETY: e1 is a valid slab-allocated pointer; slot invariant upheld.
         unsafe { ws.push_entry(e1) };
         assert!(!ws.is_empty());
 
+        // SAFETY: e1 was pushed above and is still in the list.
         unsafe { ws.remove_entry(e1) };
         assert!(ws.is_empty());
 
@@ -270,6 +272,7 @@ mod tests {
         let e2 = make_entry(&slab, 20, 2);
         let e3 = make_entry(&slab, 30, 3);
 
+        // SAFETY: e1/e2/e3 are valid slab-allocated pointers; slot invariant upheld.
         unsafe {
             ws.push_entry(e1);
             ws.push_entry(e2);
@@ -277,19 +280,23 @@ mod tests {
         }
 
         // Remove middle
+        // SAFETY: e2 was pushed above and is still in the list.
         unsafe { ws.remove_entry(e2) };
         // Head should still be e1, e1.next = e3
         assert_eq!(ws.entry_head(), e1);
+        // SAFETY: e1 and e3 are valid slab-allocated pointers still in the list.
         unsafe {
             assert_eq!(entry_ref(e1).next(), e3);
             assert_eq!(entry_ref(e3).prev(), e1);
         }
 
         // Remove head
+        // SAFETY: e1 is still in the list.
         unsafe { ws.remove_entry(e1) };
         assert_eq!(ws.entry_head(), e3);
 
         // Remove last
+        // SAFETY: e3 is still in the list.
         unsafe { ws.remove_entry(e3) };
         assert!(ws.is_empty());
 


### PR DESCRIPTION
Add `// SAFETY:` comments to nine undocumented `unsafe` blocks:

- `nexus-timer/src/level.rs`: seven blocks in tests (`push_entry`, `remove_entry`, `entry_ref` calls on slab-allocated pointers)
- `nexus-timer/benches/perf_timer.rs`: two rdtsc x86_64 intrinsic blocks