### PR TITLE
docs(nexus-slot): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-slot/benches/perf_slot.rs
+++ b/nexus-slot/benches/perf_slot.rs
@@ -22,6 +22,7 @@ struct Quote {
     _padding: [u8; 216],
 }
 
+// SAFETY: Quote is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
 unsafe impl Pod for Quote {}
 
 impl Quote {

--- a/nexus-slot/benches/perf_slot_latency.rs
+++ b/nexus-slot/benches/perf_slot_latency.rs
@@ -21,6 +21,7 @@ struct Message {
     _padding: [u8; 56],
 }
 
+// SAFETY: Message is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
 unsafe impl Pod for Message {}
 
 fn main() {
@@ -88,6 +89,7 @@ fn main() {
 #[inline]
 fn rdtsc() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-slot/benches/profile_slot.rs
+++ b/nexus-slot/benches/profile_slot.rs
@@ -45,6 +45,7 @@ impl Default for Quote {
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-slot/src/spmc.rs
+++ b/nexus-slot/src/spmc.rs
@@ -58,6 +58,7 @@ struct Inner<T> {
 // and the seqlock protocol ensures no torn reads. T: Send is required because
 // values cross thread boundaries. writer_alive uses atomic ordering for visibility.
 unsafe impl<T: Send> Send for Inner<T> {}
+// SAFETY: same as Send; seqlock atomics make concurrent immutable access safe across threads.
 unsafe impl<T: Send> Sync for Inner<T> {}
 
 /// The writing half of a shared conflated slot.
@@ -312,6 +313,7 @@ mod tests {
         b: u64,
     }
 
+    // SAFETY: TestData is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
     unsafe impl Pod for TestData {}
 
     // ========================================================================
@@ -544,6 +546,7 @@ mod tests {
             value: u64,
             check: u64,
         }
+        // SAFETY: Checkable is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
         unsafe impl Pod for Checkable {}
 
         let (mut writer, mut reader1) = shared_slot::<Checkable>();

--- a/nexus-slot/src/spsc.rs
+++ b/nexus-slot/src/spsc.rs
@@ -51,6 +51,7 @@ struct Inner<T> {
 // word-at-a-time atomics (atomic_store/atomic_load), and the seqlock protocol
 // ensures no torn reads. T: Send is required because values cross thread boundaries.
 unsafe impl<T: Send> Send for Inner<T> {}
+// SAFETY: same as Send; seqlock atomics make concurrent immutable access safe across threads.
 unsafe impl<T: Send> Sync for Inner<T> {}
 
 /// The writing half of a conflated slot.
@@ -304,6 +305,7 @@ mod tests {
         b: u64,
     }
 
+    // SAFETY: TestData is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
     unsafe impl Pod for TestData {}
 
     // ========================================================================
@@ -468,6 +470,7 @@ mod tests {
             value: u64,
             check: u64,
         }
+        // SAFETY: Checkable is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
         unsafe impl Pod for Checkable {}
 
         let (mut writer, mut reader) = slot::<Checkable>();
@@ -504,6 +507,7 @@ mod tests {
             seq: u64,
             data: [u64; 31],
         }
+        // SAFETY: Large is repr(C) with only Copy fields, no heap pointers, no Drop, all bit patterns valid.
         unsafe impl Pod for Large {}
 
         let (mut writer, mut reader) = slot::<Large>();


### PR DESCRIPTION
Add `// SAFETY:` comments to eleven undocumented `unsafe` blocks across five files:

- `src/spmc.rs`: `Sync for Inner` impl + two `Pod` impls for test structs
- `src/spsc.rs`: `Sync for Inner` impl + three `Pod` impls for test structs
- `benches/perf_slot_latency.rs`: `Pod` impl for `Message` + rdtsc intrinsic block
- `benches/perf_slot.rs`: `Pod` impl for `Quote`
- `benches/profile_slot.rs`: rdtsc intrinsic block