### PR TITLE
docs(nexus-stats-detection): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-stats-detection/src/bocpd.rs
+++ b/nexus-stats-detection/src/bocpd.rs
@@ -172,8 +172,8 @@ impl BocpdF64 {
             simd_math::ln_inplace(&mut self.scratch2[..self.active]);
 
             // Pass 3: combine and find CP mass max.
-            // SAFETY: same invariant as Pass 1.
             let mut max_cp_term = f64::NEG_INFINITY;
+            // SAFETY: same invariant as Pass 1.
             unsafe {
                 let p_alpha = self.pre.alpha.as_ptr();
                 let p_lng = self.pre.lng_base.as_ptr();
@@ -198,10 +198,10 @@ impl BocpdF64 {
 
             // CP mass: exp-sum (SIMD when available).
             // Reuse scratch2 for the terms since pass 2 is done with it.
-            // SAFETY: same invariant as Pass 1.
             cp_terms = if max_cp_term == f64::NEG_INFINITY {
                 f64::NEG_INFINITY
             } else {
+                // SAFETY: same invariant as Pass 1.
                 unsafe {
                     let p_lp = self.log_posterior.as_ptr();
                     let p_sc = self.scratch.as_ptr();

--- a/nexus-stats-smoothing/src/windowed_median.rs
+++ b/nexus-stats-smoothing/src/windowed_median.rs
@@ -80,6 +80,7 @@ impl WindowedMedianF64 {
         // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
         // exclusively owned. We need both slices simultaneously plus scalar fields.
         let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
+        // SAFETY: same as above for sorted buffer.
         let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
 
         if self.count >= window as u64 {
@@ -453,6 +454,7 @@ impl WindowedMedianI64 {
         // SAFETY: both buffers allocated with capacity `window`, all elements initialized,
         // exclusively owned. We need both slices simultaneously plus scalar fields.
         let ring = unsafe { core::slice::from_raw_parts_mut(self.ring, window) };
+        // SAFETY: same as above for sorted buffer.
         let sorted = unsafe { core::slice::from_raw_parts_mut(self.sorted, window) };
 
         if self.count >= window as u64 {


### PR DESCRIPTION
Add `// SAFETY:` comments to four undocumented `unsafe` blocks:

- `nexus-stats-detection/src/bocpd.rs`: two blocks where the existing SAFETY comment was separated from the `unsafe` keyword by intervening statements; moved the comments to immediately precede each block
- `nexus-stats-smoothing/src/windowed_median.rs`: two paired `from_raw_parts_mut` calls where the SAFETY comment covered only the first; added `// SAFETY: same as above` before each second call (appears twice in the file)