### PR TITLE
docs(nexus-journal): add SAFETY comments to unsafe blocks

### DIFF
--- a/nexus-journal/src/append/frame.rs
+++ b/nexus-journal/src/append/frame.rs
@@ -18,6 +18,7 @@ pub(crate) const fn footprint(body: usize) -> usize {
 /// `base.add(offset)` must be 4-byte-aligned and within the mapping.
 #[inline]
 pub(crate) unsafe fn read_commit_len(base: *mut u8, offset: usize) -> u32 {
+    // SAFETY: caller guarantees base.add(offset) is 4-byte-aligned and within the mapping.
     unsafe { base.add(offset).cast::<u32>().read() }
 }
 
@@ -25,6 +26,7 @@ pub(crate) unsafe fn read_commit_len(base: *mut u8, offset: usize) -> u32 {
 /// `base.add(offset)` must be 4-byte-aligned and within the mapping.
 #[inline]
 pub(crate) unsafe fn write_commit_len(base: *mut u8, offset: usize, val: u32) {
+    // SAFETY: caller guarantees base.add(offset) is 4-byte-aligned and within the mapping.
     unsafe { base.add(offset).cast::<u32>().write(val) }
 }
 
@@ -32,6 +34,7 @@ pub(crate) unsafe fn write_commit_len(base: *mut u8, offset: usize, val: u32) {
 /// The frame header at `offset` must be published and within the mapping.
 #[inline]
 pub(crate) unsafe fn frame_kind(base: *mut u8, offset: usize) -> u16 {
+    // SAFETY: caller guarantees the frame header at offset is published and within the mapping.
     unsafe { std::ptr::read_unaligned(base.add(offset + 4).cast()) }
 }
 
@@ -40,6 +43,7 @@ pub(crate) unsafe fn frame_kind(base: *mut u8, offset: usize) -> u16 {
 /// reserved for this write.
 #[inline]
 pub(crate) unsafe fn write_frame_kind(base: *mut u8, offset: usize, kind: u16) {
+    // SAFETY: caller guarantees the 8-byte frame header at offset is within the mapping and reserved.
     unsafe {
         std::ptr::write_unaligned(base.add(offset + 4).cast::<u16>(), kind);
         std::ptr::write_unaligned(base.add(offset + 6).cast::<u16>(), 0);
@@ -51,6 +55,7 @@ pub(crate) unsafe fn write_frame_kind(base: *mut u8, offset: usize, kind: u16) {
 /// reserved for this write.
 #[inline]
 pub(crate) unsafe fn write_val<T: Pod>(base: *mut u8, offset: usize, val: T) {
+    // SAFETY: caller guarantees the offset range is within the mapping and reserved for this write.
     unsafe { std::ptr::write_unaligned(base.add(offset).cast(), val) }
 }
 
@@ -59,5 +64,6 @@ pub(crate) unsafe fn write_val<T: Pod>(base: *mut u8, offset: usize, val: T) {
 /// the data must be published.
 #[inline]
 pub(crate) unsafe fn read_val<T: Pod>(base: *mut u8, offset: usize) -> T {
+    // SAFETY: caller guarantees the offset range is within the mapping and the data is published.
     unsafe { std::ptr::read_unaligned(base.add(offset).cast()) }
 }

--- a/nexus-journal/src/rotating/conductor.rs
+++ b/nexus-journal/src/rotating/conductor.rs
@@ -62,6 +62,7 @@ impl SegmentSwap {
     /// # Safety
     /// `state` must be `SWAP_CLEAN` or `SWAP_DIRTY` (payload initialized).
     pub(crate) unsafe fn take(&self) -> Mapping {
+        // SAFETY: caller guarantees state is SWAP_CLEAN or SWAP_DIRTY (payload initialized).
         unsafe { (*self.inner.get()).assume_init_read() }
     }
 
@@ -70,6 +71,7 @@ impl SegmentSwap {
     /// # Safety
     /// `inner` must be uninit (caller just called `take()`).
     pub(crate) unsafe fn store_dirty(&self, mapping: Mapping) {
+        // SAFETY: caller guarantees inner is uninit (caller just called take()).
         unsafe { (*self.inner.get()).write(mapping) };
         self.state.store(SWAP_DIRTY, Ordering::Release);
     }
@@ -83,6 +85,7 @@ impl SegmentSwap {
     /// # Safety
     /// Called only from the conductor thread after `inner` was uninit.
     pub(crate) unsafe fn publish_clean(&self, mapping: Mapping) {
+        // SAFETY: caller is the conductor thread after inner was uninit.
         unsafe { (*self.inner.get()).write(mapping) };
         self.state.store(SWAP_CLEAN, Ordering::Release);
     }

--- a/nexus-journal/src/rotating/frame.rs
+++ b/nexus-journal/src/rotating/frame.rs
@@ -15,6 +15,7 @@ pub(crate) const fn footprint(body: usize) -> usize {
 /// `ptr` must be 4-byte-aligned and within the mapped region.
 #[inline]
 pub(crate) unsafe fn read_commit_len(ptr: *const u8) -> u32 {
+    // SAFETY: caller guarantees ptr is 4-byte-aligned and within the mapped region.
     unsafe { ptr.cast::<u32>().read() }
 }
 
@@ -22,6 +23,7 @@ pub(crate) unsafe fn read_commit_len(ptr: *const u8) -> u32 {
 /// `ptr` must be 4-byte-aligned and within the mapped region.
 #[inline]
 pub(crate) unsafe fn write_commit_len(ptr: *mut u8, val: u32) {
+    // SAFETY: caller guarantees ptr is 4-byte-aligned and within the mapped region.
     unsafe { ptr.cast::<u32>().write(val) }
 }
 


### PR DESCRIPTION
Adds // SAFETY: comments to 11 unsafe blocks in append and rotating frame/conductor helpers. Passes -W clippy::undocumented_unsafe_blocks.