### PR TITLE
docs(nexus-inference): add SAFETY comments to unsafe blocks

### DIFF
--- a/nexus-inference/src/bnn.rs
+++ b/nexus-inference/src/bnn.rs
@@ -258,6 +258,7 @@ impl Bnn {
 
         // SAFETY: predict is not reentrant. Scratch is !Sync, preventing concurrent access.
         let bits_a = unsafe { self.bits_a.get_mut() };
+        // SAFETY: same as above.
         let bits_b = unsafe { self.bits_b.get_mut() };
         #[cfg(not(all(
             target_arch = "x86_64",
@@ -266,6 +267,7 @@ impl Bnn {
                 all(target_feature = "avx2", target_feature = "fma")
             )
         )))]
+        // SAFETY: same as above.
         let float_scratch = unsafe { self.float_scratch.get_mut() };
 
         // fused input: matmul + binarize in one pass

--- a/nexus-inference/src/lib.rs
+++ b/nexus-inference/src/lib.rs
@@ -162,6 +162,7 @@ impl<T> Scratch<T> {
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     pub(crate) unsafe fn get_mut(&self) -> &mut T {
+        // SAFETY: caller guarantees no other references exist per the Safety doc comment.
         unsafe { &mut *self.0.get() }
     }
 }

--- a/nexus-inference/src/mlp.rs
+++ b/nexus-inference/src/mlp.rs
@@ -185,6 +185,7 @@ impl Mlp {
 
         // SAFETY: predict is not reentrant. Scratch is !Sync, preventing concurrent access.
         let scratch_a = unsafe { self.scratch_a.get_mut() };
+        // SAFETY: same as above.
         let scratch_b = unsafe { self.scratch_b.get_mut() };
 
         let n_layers = self.layer_sizes.len() - 1;

--- a/nexus-inference/src/quantized_mlp.rs
+++ b/nexus-inference/src/quantized_mlp.rs
@@ -230,7 +230,9 @@ impl QuantizedMlp {
 
         // SAFETY: predict is not reentrant. Scratch is !Sync, preventing concurrent access.
         let scratch_f32 = unsafe { self.scratch_f32.get_mut() };
+        // SAFETY: same as above.
         let scratch_i8 = unsafe { self.scratch_i8.get_mut() };
+        // SAFETY: same as above.
         let scratch_i32 = unsafe { self.scratch_i32.get_mut() };
 
         let n_layers = self.layers.len();


### PR DESCRIPTION
Adds // SAFETY: comments to 6 unsafe blocks in bnn.rs, mlp.rs, quantized_mlp.rs, and lib.rs. Passes -W clippy::undocumented_unsafe_blocks.