### PR TITLE
docs(nexus-queue): add SAFETY comments to unsafe blocks

### DIFF
--- a/nexus-queue/benches/bench_crossbeam.rs
+++ b/nexus-queue/benches/bench_crossbeam.rs
@@ -18,6 +18,7 @@ const THROUGHPUT_COUNT: u64 = 1_000_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-queue/benches/bench_mpsc.rs
+++ b/nexus-queue/benches/bench_mpsc.rs
@@ -23,6 +23,7 @@ const SAMPLES: u64 = 1_000_000;
 #[inline]
 fn rdtscp() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe { core::arch::x86_64::__rdtscp(&raw mut aux) }
 }
 

--- a/nexus-queue/benches/bench_mpsc_pingpong.rs
+++ b/nexus-queue/benches/bench_mpsc_pingpong.rs
@@ -16,6 +16,7 @@ const SAMPLES: u64 = 100_000;
 #[inline]
 fn rdtscp() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe { core::arch::x86_64::__rdtscp(&raw mut aux) }
 }
 

--- a/nexus-queue/benches/bench_rtrb.rs
+++ b/nexus-queue/benches/bench_rtrb.rs
@@ -15,6 +15,7 @@ const THROUGHPUT_COUNT: u64 = 1_000_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-queue/benches/bench_spmc.rs
+++ b/nexus-queue/benches/bench_spmc.rs
@@ -27,6 +27,7 @@ const THROUGHPUT_MSGS: u64 = 10_000_000;
 #[inline]
 fn rdtscp() -> u64 {
     let mut aux: u32 = 0;
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe { core::arch::x86_64::__rdtscp(&raw mut aux) }
 }
 

--- a/nexus-queue/benches/bench_spsc.rs
+++ b/nexus-queue/benches/bench_spsc.rs
@@ -22,6 +22,7 @@ const THROUGHPUT_COUNT: u64 = 1_000_000;
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn rdtscp() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         core::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-queue/src/mpsc.rs
+++ b/nexus-queue/src/mpsc.rs
@@ -165,6 +165,8 @@ struct Shared<T> {
 // SAFETY: Shared contains atomics and raw pointers. Access is synchronized via
 // the turn counters. T: Send ensures data can move between threads.
 unsafe impl<T: Send> Send for Shared<T> {}
+// SAFETY: same as Send — all shared state is atomic; cross-thread access is
+// coordinated by the turn counters.
 unsafe impl<T: Send> Sync for Shared<T> {}
 
 impl<T> Drop for Shared<T> {

--- a/nexus-queue/src/spmc.rs
+++ b/nexus-queue/src/spmc.rs
@@ -191,6 +191,8 @@ struct Shared<T> {
 // SAFETY: Shared contains atomics and raw pointers. Access is synchronized via
 // the turn counters. T: Send ensures data can move between threads.
 unsafe impl<T: Send> Send for Shared<T> {}
+// SAFETY: same as Send — all shared state is atomic; cross-thread access is
+// coordinated by the turn counters.
 unsafe impl<T: Send> Sync for Shared<T> {}
 
 impl<T> Drop for Shared<T> {

--- a/nexus-queue/src/spsc.rs
+++ b/nexus-queue/src/spsc.rs
@@ -158,6 +158,8 @@ struct Shared<T> {
 // The buffer is only accessed through Producer (write) and Consumer (read), which
 // are !Sync. T: Send ensures the data can be transferred between threads.
 unsafe impl<T: Send> Send for Shared<T> {}
+// SAFETY: same as Send — all shared state is atomic; access is coordinated by
+// Producer (write) and Consumer (read), which are !Sync.
 unsafe impl<T: Send> Sync for Shared<T> {}
 
 #[cfg(not(loom))]


### PR DESCRIPTION
Adds // SAFETY: comments to 6 unsafe blocks in bench files (all rdtsc intrinsic usages). Passes -W clippy::undocumented_unsafe_blocks.