### PR TITLE
docs(nexus-web): add SAFETY comments to unsafe blocks

### DIFF
--- a/nexus-web/examples/bench_loopback_rest.rs
+++ b/nexus-web/examples/bench_loopback_rest.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -25,6 +26,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-web/examples/perf_body_writer.rs
+++ b/nexus-web/examples/perf_body_writer.rs
@@ -35,6 +35,7 @@ const ORDER: Order = Order {
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -43,6 +44,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-web/examples/perf_rest.rs
+++ b/nexus-web/examples/perf_rest.rs
@@ -16,6 +16,7 @@ use std::io::{self, Cursor, Read, Write};
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -24,6 +25,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-web/examples/perf_tls.rs
+++ b/nexus-web/examples/perf_tls.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -25,6 +26,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-web/examples/perf_vs_tungstenite.rs
+++ b/nexus-web/examples/perf_vs_tungstenite.rs
@@ -14,6 +14,7 @@ use std::io::Cursor;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -22,6 +23,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-web/examples/perf_ws.rs
+++ b/nexus-web/examples/perf_ws.rs
@@ -15,6 +15,7 @@ use std::hint::black_box;
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         std::arch::x86_64::_mm_lfence();
         std::arch::x86_64::_rdtsc()
@@ -23,6 +24,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; this example targets x86_64 only.
     unsafe {
         let mut aux = 0u32;
         let tsc = std::arch::x86_64::__rdtscp(&raw mut aux);


### PR DESCRIPTION
Adds // SAFETY: comments to 12 unsafe blocks across 6 example files (all rdtsc intrinsic usages). Passes -W clippy::undocumented_unsafe_blocks.