### PR TITLE
docs(nexus-id): add SAFETY comments to unsafe blocks

### DIFF
--- a/nexus-id/benches/perf_benchmark.rs
+++ b/nexus-id/benches/perf_benchmark.rs
@@ -34,6 +34,7 @@ const WARMUP: usize = 10_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-id/benches/perf_id_hashing.rs
+++ b/nexus-id/benches/perf_id_hashing.rs
@@ -21,6 +21,7 @@ const WARMUP: usize = 10_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-id/benches/perf_snowflake.rs
+++ b/nexus-id/benches/perf_snowflake.rs
@@ -22,6 +22,7 @@ const WARMUP: usize = 10_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-id/benches/perf_uuid.rs
+++ b/nexus-id/benches/perf_uuid.rs
@@ -24,6 +24,7 @@ const WARMUP: usize = 10_000;
 #[inline(always)]
 fn rdtscp() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         let mut aux: u32 = 0;
         std::arch::x86_64::__rdtscp(&raw mut aux)

--- a/nexus-id/src/simd/sse2.rs
+++ b/nexus-id/src/simd/sse2.rs
@@ -27,6 +27,7 @@ pub fn hex_decode_32(bytes: &[u8; 32]) -> Result<(u64, u64), usize> {
     // references with the same lifetime as `bytes`. Alignment is irrelevant
     // because [u8; 16] has align 1.
     let hi_bytes: &[u8; 16] = unsafe { &*(bytes.as_ptr().cast::<[u8; 16]>()) };
+    // SAFETY: same as above.
     let lo_bytes: &[u8; 16] = unsafe { &*(bytes.as_ptr().add(16).cast::<[u8; 16]>()) };
 
     let hi = hex_decode_16(hi_bytes)?;

--- a/nexus-id/src/types.rs
+++ b/nexus-id/src/types.rs
@@ -129,9 +129,9 @@ impl<const CAP: usize> Uuid<CAP> {
     /// scalar on other architectures.
     #[inline]
     pub fn decode(&self) -> (u64, u64) {
+        let bytes: &[u8; 36] = self.0.as_bytes().try_into().unwrap();
         // SAFETY: self.0 was validated at construction — always valid hex+dashes.
         // Uuid is always 36 bytes. try_into is infallible here.
-        let bytes: &[u8; 36] = self.0.as_bytes().try_into().unwrap();
         unsafe { crate::simd::uuid_parse_dashed(bytes).unwrap_unchecked() }
     }
 
@@ -1341,6 +1341,7 @@ mod tests {
     fn uuid_from_bytes_unchecked_roundtrip() {
         let original: Uuid = Uuid::from_raw(0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF);
         let bytes = original.to_bytes();
+        // SAFETY: bytes came from original.to_bytes(), so it encodes a valid Uuid.
         let recovered: Uuid = unsafe { Uuid::from_bytes_unchecked(&bytes) };
         assert_eq!(original, recovered);
     }
@@ -1380,6 +1381,7 @@ mod tests {
     fn ulid_from_bytes_unchecked_roundtrip() {
         let original: Ulid = Ulid::from_raw(1_700_000_000_000, 0x1234, 0x0123_4567_89AB_CDEF);
         let bytes = original.to_bytes();
+        // SAFETY: bytes came from original.to_bytes(), so it encodes a valid Ulid.
         let recovered: Ulid = unsafe { Ulid::from_bytes_unchecked(&bytes) };
         assert_eq!(original, recovered);
     }

--- a/nexus-id/tests/lifecycle.rs
+++ b/nexus-id/tests/lifecycle.rs
@@ -106,6 +106,7 @@ fn uuid_v4_lifecycle() {
     assert_eq!(from_bytes, id);
 
     // Unsafe bytes round-trip
+    // SAFETY: bytes came from id.to_bytes(), so it encodes a valid Uuid.
     let from_unchecked = unsafe { Uuid::from_bytes_unchecked(&bytes) };
     assert_eq!(from_unchecked, id);
 
@@ -232,6 +233,7 @@ fn ulid_lifecycle() {
     assert_eq!(from_bytes, id);
 
     // Unsafe bytes round-trip
+    // SAFETY: bytes came from id.to_bytes(), so it encodes a valid Ulid.
     let from_unchecked = unsafe { Ulid::from_bytes_unchecked(&bytes) };
     assert_eq!(from_unchecked, id);
 


### PR DESCRIPTION
Adds // SAFETY: comments to 10 unsafe blocks across src, benches, and tests. Passes -W clippy::undocumented_unsafe_blocks.