### PR TITLE
docs(nexus-fix-codec): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-fix-codec/benches/perf_parse_cycles.rs
+++ b/nexus-fix-codec/benches/perf_parse_cycles.rs
@@ -18,6 +18,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 fn rdtsc_fenced_start() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -31,6 +32,7 @@ fn rdtsc_fenced_start() -> u64 {
 #[inline(always)]
 fn rdtsc_fenced_end() -> u64 {
     #[cfg(target_arch = "x86_64")]
+    // SAFETY: x86_64 intrinsic; block is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-fix-codec/examples/_bench_utils.rs
+++ b/nexus-fix-codec/examples/_bench_utils.rs
@@ -14,6 +14,7 @@ pub const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe { core::arch::x86_64::_rdtsc() }
 }
 
@@ -26,6 +27,7 @@ pub fn rdtsc() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc_fenced_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -41,6 +43,7 @@ pub fn rdtsc_fenced_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 pub fn rdtsc_fenced_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-fix-codec/src/types.rs
+++ b/nexus-fix-codec/src/types.rs
@@ -181,6 +181,7 @@ impl FixDecimal {
         }
 
         debug_assert!(self.scale <= 19);
+        // SAFETY: self.scale <= 19, and POW10 has 20 entries indexed 0..=19.
         let scale_pow = unsafe { *POW10.get_unchecked(self.scale as usize) };
         let integer = abs / scale_pow;
         let frac = abs % scale_pow;
@@ -215,6 +216,7 @@ impl fmt::Display for FixDecimal {
             return write!(f, "{}", self.mantissa);
         }
         debug_assert!(self.scale <= 19);
+        // SAFETY: self.scale <= 19, and POW10 has 20 entries indexed 0..=19.
         let divisor = unsafe { *POW10.get_unchecked(self.scale as usize) };
         let abs = self.mantissa.unsigned_abs();
         let integer = abs / divisor;


### PR DESCRIPTION
Adds missing `// SAFETY:` comments to all `unsafe` blocks in nexus-fix-codec, satisfying `clippy::undocumented_unsafe_blocks` with zero warnings.