### PR TITLE
docs(nexus-rt): add SAFETY comments to all unsafe blocks

### DIFF
--- a/nexus-rt/examples/mock_runtime.rs
+++ b/nexus-rt/examples/mock_runtime.rs
@@ -23,6 +23,7 @@ use nexus_rt::{
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -32,6 +33,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_construction.rs
+++ b/nexus-rt/examples/perf_construction.rs
@@ -37,6 +37,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -46,6 +47,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_dag.rs
+++ b/nexus-rt/examples/perf_dag.rs
@@ -29,6 +29,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -38,6 +39,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_fetch.rs
+++ b/nexus-rt/examples/perf_fetch.rs
@@ -24,6 +24,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -33,6 +34,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);
@@ -162,7 +164,9 @@ fn system_vec_downcast(container: &mut VecContainer) -> u64 {
     // Runtime downcast — what a naive Fetch impl would do
     let prices_ptr = container.slots[0].downcast_mut::<PriceCache>().unwrap() as *mut PriceCache;
     let venues_ptr = container.slots[4].downcast_ref::<VenueState>().unwrap() as *const VenueState;
+    // SAFETY: pointers come from successful downcast_mut/downcast_ref on non-overlapping slots.
     let prices = unsafe { &mut *prices_ptr };
+    // SAFETY: same as above.
     let venues = unsafe { &*venues_ptr };
     prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
     prices.values[0]
@@ -207,7 +211,9 @@ impl ErasedContainer {
 
 #[inline(never)]
 fn system_vec_erased(ptrs: &[*mut u8], price_id: usize, venue_id: usize) -> u64 {
+    // SAFETY: pointers in ptrs were initialized from valid Box allocations; price_id != venue_id.
     let prices = unsafe { &mut *(ptrs[price_id] as *mut PriceCache) };
+    // SAFETY: same as above.
     let venues = unsafe { &*(ptrs[venue_id] as *const VenueState) };
     prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
     prices.values[0]
@@ -222,6 +228,7 @@ fn system_vec_erased(ptrs: &[*mut u8], price_id: usize, venue_id: usize) -> u64 
 
 #[inline(never)]
 fn system_vec_unchecked(ptrs: &[*mut u8], price_id: usize, venue_id: usize) -> u64 {
+    // SAFETY: indices validated at build time; pointers are valid Box allocations; price_id != venue_id.
     unsafe {
         let prices = &mut *(*ptrs.get_unchecked(price_id) as *mut PriceCache);
         let venues = &*(*ptrs.get_unchecked(venue_id) as *const VenueState);
@@ -241,7 +248,9 @@ struct CachedFetch {
 
 #[inline(never)]
 fn system_cached(cached: &CachedFetch) -> u64 {
+    // SAFETY: prices and venues are valid non-null pointers from Box allocations; non-overlapping.
     let prices = unsafe { &mut *cached.prices };
+    // SAFETY: same as above.
     let venues = unsafe { &*cached.venues };
     prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
     prices.values[0]
@@ -257,7 +266,9 @@ struct BoxedCachedFetch {
 
 #[inline(never)]
 fn system_boxed_cached(cached: &BoxedCachedFetch) -> u64 {
+    // SAFETY: prices and venues are valid non-null pointers from Box allocations; non-overlapping.
     let prices = unsafe { &mut *cached.inner.prices };
+    // SAFETY: same as above.
     let venues = unsafe { &*cached.inner.venues };
     prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
     prices.values[0]
@@ -350,7 +361,9 @@ impl HashResolvedSystem {
 impl System for HashResolvedSystem {
     #[inline(never)]
     fn run(&mut self) -> u64 {
+        // SAFETY: pointers resolved from valid Box allocations at build time; non-overlapping.
         let prices = unsafe { &mut *(self.prices as *mut PriceCache) };
+        // SAFETY: same as above.
         let venues = unsafe { &*(self.venues as *const VenueState) };
         prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
         prices.values[0]
@@ -375,7 +388,9 @@ impl DenseResolvedSystem {
 impl System for DenseResolvedSystem {
     #[inline(never)]
     fn run(&mut self) -> u64 {
+        // SAFETY: pointers resolved from valid Box allocations at build time; non-overlapping.
         let prices = unsafe { &mut *(self.prices as *mut PriceCache) };
+        // SAFETY: same as above.
         let venues = unsafe { &*(self.venues as *const VenueState) };
         prices.values[0] = prices.values[0].wrapping_add(venues.values[0]);
         prices.values[0]

--- a/nexus-rt/examples/perf_pipeline.rs
+++ b/nexus-rt/examples/perf_pipeline.rs
@@ -61,6 +61,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -70,6 +71,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_scheduler.rs
+++ b/nexus-rt/examples/perf_scheduler.rs
@@ -27,6 +27,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -36,6 +37,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_template.rs
+++ b/nexus-rt/examples/perf_template.rs
@@ -36,6 +36,7 @@ const BATCH: u64 = 100;
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -45,6 +46,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; function is only compiled for x86_64.
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/src/callback.rs
+++ b/nexus-rt/src/callback.rs
@@ -246,11 +246,11 @@ macro_rules! impl_into_callback {
                     f(ctx, $($P,)+ event);
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by init() on the same registry
                 // that built this world. Single-threaded sequential dispatch
                 // ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -344,6 +344,9 @@ macro_rules! impl_into_callback_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by init() on the same registry
+                // that built this world. Single-threaded sequential dispatch
+                // ensures no mutable aliasing across params.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };

--- a/nexus-rt/src/ctx_pipeline.rs
+++ b/nexus-rt/src/ctx_pipeline.rs
@@ -182,14 +182,11 @@ macro_rules! impl_into_ctx_step {
                     f(ctx, $($P,)+ input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                // SAFETY: state was produced by Param::init() on the same
-                // Registry that built this World. Single-threaded sequential
-                // dispatch ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -277,6 +274,9 @@ macro_rules! impl_into_ctx_step_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by Param::init() on the same Registry
+                // that built this World. Borrows are disjoint — enforced by
+                // conflict detection at build time.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -436,11 +436,11 @@ macro_rules! impl_into_ctx_ref_step {
                     f(ctx, $($P,)+ input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same
                 // Registry that built this World. Single-threaded sequential
                 // dispatch ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -594,11 +594,11 @@ macro_rules! impl_into_ctx_producer {
                     f(ctx, $($P,)+)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same
                 // Registry that built this World. Single-threaded sequential
                 // dispatch ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };

--- a/nexus-rt/src/dag.rs
+++ b/nexus-rt/src/dag.rs
@@ -271,11 +271,11 @@ macro_rules! impl_merge2_step {
                 ) -> Output {
                     f($($P,)+ a, b)
                 }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as crate::handler::Param>::fetch(world, &mut self.state)
                 };
@@ -354,11 +354,11 @@ macro_rules! impl_merge3_step {
                 ) -> Output {
                     f($($P,)+ a, b, c)
                 }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as crate::handler::Param>::fetch(world, &mut self.state)
                 };
@@ -432,11 +432,11 @@ macro_rules! impl_merge4_step {
                     mut f: impl FnMut($($P,)+ &IA, &IB, &IC, &ID) -> Output,
                     $($P: $P,)+ a: &IA, b: &IB, c: &IC, d: &ID,
                 ) -> Output { f($($P,)+ a, b, c, d) }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as crate::handler::Param>::fetch(world, &mut self.state)
                 };
@@ -501,11 +501,11 @@ macro_rules! impl_merge5_step {
                     mut f: impl FnMut($($P,)+ &IA, &IB, &IC, &ID, &IE) -> Output,
                     $($P: $P,)+ a: &IA, b: &IB, c: &IC, d: &ID, e: &IE,
                 ) -> Output { f($($P,)+ a, b, c, d, e) }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as crate::handler::Param>::fetch(world, &mut self.state)
                 };

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -143,11 +143,11 @@ impl<T: Resource> Param for Option<Res<'_, T>> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(world: &'w World, state: &'w mut Option<ResourceId>) -> Option<Res<'w, T>> {
-        // SAFETY: state was produced by init() on the same world.
-        // Caller ensures no mutable alias exists for T.
         state.map(|id| {
             #[cfg(debug_assertions)]
             world.track_borrow(id);
+            // SAFETY: state was produced by init() on the same world.
+            // Caller ensures no mutable alias exists for T.
             unsafe { Res::new(world.get::<T>(id)) }
         })
     }
@@ -172,11 +172,11 @@ impl<T: Resource> Param for Option<ResMut<'_, T>> {
         world: &'w World,
         state: &'w mut Option<ResourceId>,
     ) -> Option<ResMut<'w, T>> {
-        // SAFETY: state was produced by init() on the same world.
-        // Caller ensures no aliases exist for T.
         state.map(|id| {
             #[cfg(debug_assertions)]
             world.track_borrow(id);
+            // SAFETY: state was produced by init() on the same world.
+            // Caller ensures no aliases exist for T.
             unsafe { ResMut::new(world.get_mut::<T>(id)) }
         })
     }
@@ -656,11 +656,11 @@ macro_rules! impl_into_handler {
                     f($($P,)+ event);
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by init() on the same registry
                 // that built this world. Single-threaded sequential dispatch
                 // ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -750,6 +750,9 @@ macro_rules! impl_into_handler_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by init() on the same registry
+                // that built this world. Single-threaded sequential dispatch
+                // ensures no mutable aliasing across params.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -917,6 +920,7 @@ mod tests {
         // New dispatch phase — previous borrows dropped above.
         #[cfg(debug_assertions)]
         world.clear_borrows();
+        // SAFETY: state from init on same registry; previous mutable borrow was dropped.
         unsafe {
             let mut read_state = <Res<u64> as Param>::init(world.registry_mut());
             let res = <Res<u64> as Param>::fetch(&world, &mut read_state);
@@ -943,6 +947,7 @@ mod tests {
         // New dispatch phase — previous borrows dropped above.
         #[cfg(debug_assertions)]
         world.clear_borrows();
+        // SAFETY: state from init on same registry; previous mutable borrow was dropped.
         unsafe {
             let mut read_state = <Res<bool> as Param>::init(world.registry_mut());
             let res = <Res<bool> as Param>::fetch(&world, &mut read_state);
@@ -1107,6 +1112,7 @@ mod tests {
     fn option_res_none_when_missing() {
         let mut world = WorldBuilder::new().build();
         let mut state = <Option<Res<u64>> as Param>::init(world.registry_mut());
+        // SAFETY: state from init on same registry; no mutable alias.
         let opt = unsafe { <Option<Res<u64>> as Param>::fetch(&world, &mut state) };
         assert!(opt.is_none());
     }
@@ -1118,6 +1124,7 @@ mod tests {
         let mut world = builder.build();
 
         let mut state = <Option<Res<u64>> as Param>::init(world.registry_mut());
+        // SAFETY: state from init on same registry; no mutable alias.
         let opt = unsafe { <Option<Res<u64>> as Param>::fetch(&world, &mut state) };
         assert_eq!(*opt.unwrap(), 42);
     }
@@ -1129,12 +1136,14 @@ mod tests {
         let mut world = builder.build();
 
         let mut state = <Option<ResMut<u64>> as Param>::init(world.registry_mut());
+        // SAFETY: state from init on same registry; exclusive access.
         unsafe {
             let opt = <Option<ResMut<u64>> as Param>::fetch(&world, &mut state);
             *opt.unwrap() = 99;
         }
         #[cfg(debug_assertions)]
         world.clear_borrows();
+        // SAFETY: state from init on same registry; previous mutable borrow was dropped.
         unsafe {
             let mut read_state = <Res<u64> as Param>::init(world.registry_mut());
             let res = <Res<u64> as Param>::fetch(&world, &mut read_state);

--- a/nexus-rt/src/pipeline.rs
+++ b/nexus-rt/src/pipeline.rs
@@ -229,11 +229,11 @@ macro_rules! impl_into_step {
                     f($($P,)+ input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -319,6 +319,9 @@ macro_rules! impl_into_step_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by Param::init() on the same Registry
+                // that built this World. Borrows are disjoint — enforced by
+                // conflict detection at build time.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -474,11 +477,11 @@ macro_rules! impl_into_ref_step {
                     f($($P,)+ input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -562,6 +565,9 @@ macro_rules! impl_into_ref_step_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by Param::init() on the same Registry
+                // that built this World. Borrows are disjoint — enforced by
+                // conflict detection at build time.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -727,11 +733,11 @@ macro_rules! impl_into_producer {
                     f($($P,)+)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -898,11 +904,11 @@ macro_rules! impl_into_scan_step {
                     f($($P,)+ acc, input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -987,6 +993,9 @@ macro_rules! impl_into_scan_step_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by Param::init() on the same Registry
+                // that built this World. Borrows are disjoint — enforced by
+                // conflict detection at build time.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1160,11 +1169,11 @@ macro_rules! impl_into_ref_scan_step {
                     f($($P,)+ acc, input)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1253,6 +1262,9 @@ macro_rules! impl_into_ref_scan_step_no_event {
 
                 #[cfg(debug_assertions)]
                 world.clear_borrows();
+                // SAFETY: state was produced by Param::init() on the same Registry
+                // that built this World. Borrows are disjoint — enforced by
+                // conflict detection at build time.
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1405,11 +1417,11 @@ macro_rules! impl_splat2_step {
                 ) -> Output {
                     f($($P,)+ a, b)
                 }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1500,11 +1512,11 @@ macro_rules! impl_splat3_step {
                 ) -> Output {
                     f($($P,)+ a, b, c)
                 }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1595,11 +1607,11 @@ macro_rules! impl_splat4_step {
                     mut f: impl FnMut($($P,)+ IA, IB, IC, ID) -> Output,
                     $($P: $P,)+ a: IA, b: IB, c: IC, d: ID,
                 ) -> Output { f($($P,)+ a, b, c, d) }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -1681,11 +1693,11 @@ macro_rules! impl_splat5_step {
                     mut f: impl FnMut($($P,)+ IA, IB, IC, ID, IE) -> Output,
                     $($P: $P,)+ a: IA, b: IB, c: IC, d: ID, e: IE,
                 ) -> Output { f($($P,)+ a, b, c, d, e) }
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same Registry
                 // that built this World. Borrows are disjoint — enforced by
                 // conflict detection at build time.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };

--- a/nexus-rt/src/system.rs
+++ b/nexus-rt/src/system.rs
@@ -274,11 +274,11 @@ macro_rules! impl_into_system {
                     f($($P),+)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by init() on the same registry
                 // that built this world. Single-threaded sequential dispatch
                 // ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -343,11 +343,11 @@ macro_rules! impl_into_system_void {
                     f($($P),+)
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by init() on the same registry
                 // that built this world. Single-threaded sequential dispatch
                 // ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -227,10 +227,10 @@ macro_rules! impl_template_dispatch {
                         f($($P,)+ event);
                     }
 
-                    // SAFETY: state produced by init() on same registry.
-                    // Single-threaded sequential dispatch — no mutable aliasing.
                     #[cfg(debug_assertions)]
                     world.clear_borrows();
+                    // SAFETY: state produced by init() on same registry.
+                    // Single-threaded sequential dispatch — no mutable aliasing.
                     let ($($P,)+) = unsafe {
                         <($($P,)+) as Param>::fetch(world, state)
                     };
@@ -280,11 +280,11 @@ macro_rules! impl_template_dispatch {
                         f(ctx, $($P,)+ event);
                     }
 
+                    #[cfg(debug_assertions)]
+                    world.clear_borrows();
                     // SAFETY: state was produced by Param::init() on the same Registry
                     // that built this World. Borrows are disjoint — enforced by
                     // conflict detection at build time.
-                    #[cfg(debug_assertions)]
-                    world.clear_borrows();
                     let ($($P,)+) = unsafe {
                         <($($P,)+) as Param>::fetch(world, state)
                     };
@@ -385,6 +385,8 @@ macro_rules! impl_template_dispatch_no_event {
 
                     #[cfg(debug_assertions)]
                     world.clear_borrows();
+                    // SAFETY: state produced by init() on same registry.
+                    // Single-threaded sequential dispatch — no mutable aliasing.
                     let ($($P,)+) = unsafe {
                         <($($P,)+) as Param>::fetch(world, state)
                     };
@@ -433,6 +435,9 @@ macro_rules! impl_template_dispatch_no_event {
 
                     #[cfg(debug_assertions)]
                     world.clear_borrows();
+                    // SAFETY: state was produced by Param::init() on the same Registry
+                    // that built this World. Borrows are disjoint — enforced by
+                    // conflict detection at build time.
                     let ($($P,)+) = unsafe {
                         <($($P,)+) as Param>::fetch(world, state)
                     };

--- a/nexus-rt/src/world.rs
+++ b/nexus-rt/src/world.rs
@@ -1196,6 +1196,7 @@ mod tests {
         assert_ne!(id0, id2);
 
         let world = builder.build();
+        // SAFETY: ids obtained from register() on this world; types match the registered types.
         unsafe {
             assert_eq!(world.get::<Price>(id0).value, 0.0);
             assert_eq!(world.get::<Venue>(id1).name, "");
@@ -1310,6 +1311,7 @@ mod tests {
         let config_id = builder.register::<Config>(Config { max_orders: 500 });
         let world = builder.build();
 
+        // SAFETY: ids obtained from register() on this world; types match the registered types.
         unsafe {
             assert_eq!(world.get::<Price>(price_id).value, 10.0);
             assert_eq!(world.get::<Venue>(venue_id).name, "CB");
@@ -1554,6 +1556,7 @@ mod tests {
         let world = builder.build();
 
         // Handle's pre-resolved ID can access the resource.
+        // SAFETY: counter_id was obtained from register() inside install_driver; type matches.
         unsafe {
             assert_eq!(*world.get::<u64>(handle.counter_id), 0);
         }


### PR DESCRIPTION
Adds missing `// SAFETY:` comments to all `unsafe` blocks in nexus-rt, satisfying `clippy::undocumented_unsafe_blocks` with zero warnings.