### PR TITLE
nexus-timer: `TimeoutList<T>` — fixed-duration timeout list (O(fired) poll)

### DIFF
--- a/nexus-timer/CHANGELOG.md
+++ b/nexus-timer/CHANGELOG.md
@@ -10,6 +10,24 @@ contained.
 
 ## [Unreleased]
 
+### Added
+
+- `TimeoutList<T, S>` — a fixed-duration timeout list front-end over the same
+  slab / entry / handle machinery as the wheel. The timeout is fixed at
+  construction (no per-call `deadline` parameter), so deadlines are monotone in
+  insertion order: entries append at the tail of one intrusive DLL and poll
+  walks from the head, giving **O(fired)** poll and **O(1)** exact
+  `next_deadline()` (the head is the min — no cache). Same
+  `schedule` / `schedule_forget` / `try_schedule` / `try_schedule_forget` /
+  `cancel` / `free` / `poll` / `poll_with_limit` surface as the wheel. No
+  `reschedule` (cancel and re-schedule instead). Builder mirrors
+  `WheelBuilder`: `TimeoutListBuilder::new(timeout).tick_duration(..)
+  .unbounded(chunk)|.bounded(cap).build(now)`. Exports: `TimeoutList`,
+  `BoundedTimeoutList`, `TimeoutListBuilder`, `UnboundedTimeoutListBuilder`,
+  `BoundedTimeoutListBuilder`. Nothing-due poll is flat across live population
+  (~12 cycles/op, amortized, at 100 / 1k / 10k / 50k), versus the wheel's
+  O(population) 0.2 µs → 2.4 ms.
+
 ## [1.4.2] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-timer/Cargo.toml
+++ b/nexus-timer/Cargo.toml
@@ -20,5 +20,9 @@ seq-macro.workspace = true
 name = "perf_timer"
 harness = false
 
+[[bench]]
+name = "perf_timeout_list"
+harness = false
+
 [lints]
 workspace = true

--- a/nexus-timer/README.md
+++ b/nexus-timer/README.md
@@ -120,6 +120,61 @@ wheel.cancel(handle);
 | `len()` | `usize` | Number of active timers |
 | `is_empty()` | `bool` | Whether the wheel is empty |
 
+## TimeoutList — Fixed-Duration Variant
+
+The wheel's poll is O(active population): it walks every entry of every
+active slot to prove which are due. That is the right trade when deadlines
+are *arbitrary*. But many callers schedule **one fixed timeout for
+everything** — a flat 5 s deadline on every item. For that workload the
+wheel buckets by deadline to solve an ordering problem that does not exist.
+
+`TimeoutList<T>` exploits the single duration. A constant timeout plus a
+monotone clock means deadlines are monotone in insertion order, so a new
+entry is always appended at the tail of one intrusive list, keeping it
+sorted with no comparisons. Poll walks from the head and stops at the first
+not-due entry — **O(fired)**. `next_deadline()` is the head's deadline:
+exact, O(1), no cache.
+
+The timeout is fixed at construction, so there is **no `deadline` parameter**
+anywhere in the API — out-of-order insertion is unrepresentable rather than
+merely discouraged.
+
+```rust
+use std::time::{Duration, Instant};
+use nexus_timer::{TimeoutList, TimeoutListBuilder};
+
+let now = Instant::now();
+
+// Every timer gets the same 5-second timeout.
+let mut list: TimeoutList<u64> = TimeoutListBuilder::new(Duration::from_secs(5))
+    .unbounded(4096)
+    .build(now);
+
+let handle = list.schedule(now, 42);   // fires at now + 5s
+let value = list.cancel(handle);       // O(1) mid-list unlink
+assert_eq!(value, Some(42));
+```
+
+Same `schedule` / `schedule_forget` / `try_schedule` / `cancel` / `free` /
+`poll` / `poll_with_limit` / `next_deadline` surface as the wheel, backed by
+the same slab storage, handle refcount protocol, and DLL splice logic. There
+is no `reschedule` (cancel and re-schedule instead — rescheduling *earlier*
+would break the sort) and no `min_deadline` cache (the head *is* the min).
+
+Nothing-due poll is flat across population — the whole point:
+
+| Live population | wheel poll (0-fire) | `TimeoutList` poll (0-fire) |
+|---|---|---|
+| 100 | 0.2 µs | ~30 cycles |
+| 1,000 | 5.6 µs | ~30 cycles |
+| 10,000 | 454 µs | ~30 cycles |
+| 50,000 | 2.4 ms | ~30 cycles |
+
+```bash
+cargo build --release --bench perf_timeout_list -p nexus-timer
+taskset -c 0 ./target/release/deps/perf_timeout_list-*
+```
+
 ## Design
 
 ### Level Structure

--- a/nexus-timer/README.md
+++ b/nexus-timer/README.md
@@ -165,10 +165,14 @@ Nothing-due poll is flat across population — the whole point:
 
 | Live population | wheel poll (0-fire) | `TimeoutList` poll (0-fire) |
 |---|---|---|
-| 100 | 0.2 µs | ~30 cycles |
-| 1,000 | 5.6 µs | ~30 cycles |
-| 10,000 | 454 µs | ~30 cycles |
-| 50,000 | 2.4 ms | ~30 cycles |
+| 100 | 0.2 µs | ~12 cycles |
+| 1,000 | 5.6 µs | ~12 cycles |
+| 10,000 | 454 µs | ~12 cycles |
+| 50,000 | 2.4 ms | ~12 cycles |
+
+Amortized cycles/op — a single-op `rdtsc` bracket carries a ~20-cycle
+measurement floor, so the bench reports that floor and the percentile tails
+alongside these amortized figures to keep them honest.
 
 ```bash
 cargo build --release --bench perf_timeout_list -p nexus-timer

--- a/nexus-timer/benches/perf_timeout_list.rs
+++ b/nexus-timer/benches/perf_timeout_list.rs
@@ -1,0 +1,279 @@
+//! TimeoutList cycle-level benchmark.
+//!
+//! The point of `TimeoutList` is that poll is O(fired), not O(population).
+//! This bench proves it *and* reports honest per-op costs.
+//!
+//! ## Why two methods
+//!
+//! These operations cost tens of cycles. A single-op `rdtsc` bracket
+//! (`lfence;rdtsc` … op … `rdtscp;lfence`) has a floor of ~20-30 cycles — the
+//! cost of measuring *nothing* — added to every sample and impossible to
+//! subtract cleanly from a distribution. At these scales that floor dominates
+//! and inflates the absolute numbers.
+//!
+//! So we report:
+//!   1. the **measurement floor** itself, so the percentile rows are interpretable;
+//!   2. **amortized cycles/op** — N ops between one `rdtsc` pair, divided by N,
+//!      best of several runs — which drives the floor to ~0 and gives the true
+//!      steady-state cost;
+//!   3. **percentile tails** (single-op) for the distribution shape — inflated by
+//!      the floor, but the *shape* (and the flat-across-population property) is
+//!      what matters there.
+//!
+//! Run pinned, turbo disabled, best of a few:
+//!   cargo build --release --bench perf_timeout_list -p nexus-timer
+//!   taskset -c 0 ./target/release/deps/perf_timeout_list-*
+
+use std::hint::black_box;
+use std::mem;
+use std::time::{Duration, Instant};
+
+use nexus_timer::{TimeoutList, TimerHandle};
+
+const SAMPLES: usize = 50_000;
+const WARMUP: usize = 5_000;
+const POPULATIONS: [usize; 4] = [100, 1_000, 10_000, 50_000];
+const K_DUE: usize = 10; // batch fired per k-due poll
+
+// Amortized measurement: many ops per rdtsc pair, best of a few runs.
+const AMORT_ITERS: u64 = 200_000;
+const AMORT_RUNS: usize = 7;
+
+// =============================================================================
+// Timing infrastructure
+// =============================================================================
+
+#[inline(always)]
+fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
+    unsafe {
+        std::arch::x86_64::_mm_lfence();
+        std::arch::x86_64::_rdtsc()
+    }
+}
+
+#[inline(always)]
+fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
+    unsafe {
+        let tsc = std::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
+        std::arch::x86_64::_mm_lfence();
+        tsc
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    let idx = ((sorted.len() as f64) * p / 100.0) as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn print_row(label: &str, samples: &mut [u64]) {
+    samples.sort_unstable();
+    println!(
+        "  {:<34} p50={:>5}  p90={:>5}  p99={:>6}  p999={:>7}  max={:>8}",
+        label,
+        percentile(samples, 50.0),
+        percentile(samples, 90.0),
+        percentile(samples, 99.0),
+        percentile(samples, 99.9),
+        samples[samples.len() - 1],
+    );
+}
+
+/// True per-op cost: run `f` `iters` times between one rdtsc pair, divide by
+/// `iters`, take the best (lowest) of `AMORT_RUNS`. The per-pair rdtsc floor is
+/// amortized to ~0, so this is the steady-state work, not the instrument.
+fn amortized_per_op(iters: u64, mut f: impl FnMut()) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..AMORT_RUNS {
+        let s = rdtsc_start();
+        for _ in 0..iters {
+            f();
+        }
+        let e = rdtsc_end();
+        let per = e.wrapping_sub(s) as f64 / iters as f64;
+        if per < best {
+            best = per;
+        }
+    }
+    best
+}
+
+fn print_amort(label: &str, cycles: f64) {
+    println!("  {label:<34} {cycles:>6.1} cycles/op");
+}
+
+fn timeout(secs: u64) -> Duration {
+    Duration::from_secs(secs)
+}
+
+fn main() {
+    let now = Instant::now();
+    println!("TIMEOUT LIST — cycle-level bench");
+    println!("================================================================");
+
+    // ── Measurement floor: an empty single-op rdtsc bracket ─────────────
+    // This is the ~20-30 cycles baked into every percentile row below. The
+    // amortized rows do NOT include it.
+    {
+        let mut samples = Vec::with_capacity(SAMPLES);
+        for _ in 0..WARMUP {
+            let s = rdtsc_start();
+            black_box(0u64);
+            let e = rdtsc_end();
+            black_box(e.wrapping_sub(s));
+        }
+        for _ in 0..SAMPLES {
+            let s = rdtsc_start();
+            black_box(0u64);
+            let e = rdtsc_end();
+            samples.push(e.wrapping_sub(s));
+        }
+        samples.sort_unstable();
+        let floor_amort = amortized_per_op(AMORT_ITERS, || {
+            black_box(0u64);
+        });
+        println!(
+            "\nmeasurement floor (empty single-op bracket): p50={} min={} cycles",
+            percentile(&samples, 50.0),
+            samples[0],
+        );
+        println!("  loop overhead (amortized empty body):        {floor_amort:>6.1} cycles/op");
+        println!(
+            "  → the TAIL rows below include the ~{}-cycle floor; the TRUE COST rows do not.",
+            percentile(&samples, 50.0),
+        );
+    }
+
+    // ── TRUE PER-OP COST (amortized, floor-free) ────────────────────────
+    println!("\nTRUE PER-OP COST  (amortized over {AMORT_ITERS} ops, best of {AMORT_RUNS}):");
+
+    // schedule + cancel (paired) — self-cleaning, list stays ~empty.
+    {
+        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), 4096, now);
+        let c = amortized_per_op(AMORT_ITERS, || {
+            let h = list.schedule(now, 0);
+            black_box(list.cancel(h));
+        });
+        print_amort("schedule + cancel (paired)", c);
+    }
+
+    // schedule_forget — pure insert. Fresh, pre-sized list per run (no slab
+    // growth mid-measurement); list drops between runs.
+    {
+        let mut best = f64::INFINITY;
+        for _ in 0..AMORT_RUNS {
+            let mut list: TimeoutList<u64> =
+                TimeoutList::unbounded(timeout(3600), AMORT_ITERS as usize + 16, now);
+            let s = rdtsc_start();
+            for _ in 0..AMORT_ITERS {
+                list.schedule_forget(now, 0);
+            }
+            let e = rdtsc_end();
+            best = best.min(e.wrapping_sub(s) as f64 / AMORT_ITERS as f64);
+        }
+        print_amort("schedule_forget", best);
+    }
+
+    // nothing-due poll, per population — MUST be flat (O(1), no scan).
+    for &pop in &POPULATIONS {
+        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+        let mut handles: Vec<TimerHandle<u64>> = Vec::with_capacity(pop);
+        for i in 0..pop {
+            handles.push(list.schedule(now, i as u64));
+        }
+        let poll_at = now + Duration::from_millis(1); // nothing due
+        let mut buf = Vec::new();
+        let c = amortized_per_op(AMORT_ITERS, || {
+            black_box(list.poll(black_box(poll_at), &mut buf));
+        });
+        print_amort(&format!("poll nothing-due @{pop} live"), c);
+        for h in handles {
+            mem::forget(h);
+        }
+    }
+
+    // ── TAIL DISTRIBUTION (single-op rdtsc; includes the floor) ─────────
+    println!("\nTAIL DISTRIBUTION  (single-op rdtsc, {SAMPLES} samples — includes the floor):");
+
+    // schedule + cancel (paired)
+    {
+        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), 4096, now);
+        let mut samples = Vec::with_capacity(SAMPLES);
+        for _ in 0..WARMUP {
+            let h = list.schedule(now, 0);
+            black_box(list.cancel(h));
+        }
+        for _ in 0..SAMPLES {
+            let s = rdtsc_start();
+            let h = list.schedule(now, 0);
+            black_box(list.cancel(h));
+            let e = rdtsc_end();
+            samples.push(e.wrapping_sub(s));
+        }
+        print_row("schedule + cancel (paired)", &mut samples);
+    }
+
+    // nothing-due poll, per population
+    for &pop in &POPULATIONS {
+        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+        let mut handles: Vec<TimerHandle<u64>> = Vec::with_capacity(pop);
+        for i in 0..pop {
+            handles.push(list.schedule(now, i as u64));
+        }
+        let poll_at = now + Duration::from_millis(1);
+        let mut buf = Vec::new();
+        let mut samples = Vec::with_capacity(SAMPLES);
+        for _ in 0..WARMUP {
+            black_box(list.poll(poll_at, &mut buf));
+        }
+        for _ in 0..SAMPLES {
+            let s = rdtsc_start();
+            black_box(list.poll(poll_at, &mut buf));
+            let e = rdtsc_end();
+            samples.push(e.wrapping_sub(s));
+        }
+        print_row(&format!("poll nothing-due @{pop} live"), &mut samples);
+        for h in handles {
+            mem::forget(h);
+        }
+    }
+
+    // k-due poll: fire K_DUE out of `pop` live. Each sample rebuilds the
+    // population, so this stays single-op — but the op fires 10 entries, so
+    // the floor is a small fraction of the reading.
+    for &pop in &POPULATIONS {
+        let due_at = now;
+        let not_due_at = now + Duration::from_secs(1);
+        let poll_at = now + Duration::from_secs(3600) + Duration::from_millis(1);
+        let iters = (SAMPLES / 20).max(1);
+        let mut samples = Vec::with_capacity(iters);
+        for _ in 0..(iters / 10).max(1) {
+            let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+            for i in 0..K_DUE {
+                list.schedule_forget(due_at, i as u64);
+            }
+            for i in K_DUE..pop {
+                list.schedule_forget(not_due_at, i as u64);
+            }
+            let mut buf = Vec::with_capacity(K_DUE);
+            black_box(list.poll_with_limit(poll_at, K_DUE, &mut buf));
+        }
+        for _ in 0..iters {
+            let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+            for i in 0..K_DUE {
+                list.schedule_forget(due_at, i as u64);
+            }
+            for i in K_DUE..pop {
+                list.schedule_forget(not_due_at, i as u64);
+            }
+            let mut buf = Vec::with_capacity(K_DUE);
+            let s = rdtsc_start();
+            let fired = black_box(list.poll_with_limit(poll_at, K_DUE, &mut buf));
+            let e = rdtsc_end();
+            debug_assert_eq!(fired, K_DUE);
+            samples.push(e.wrapping_sub(s));
+        }
+        print_row(&format!("poll {K_DUE}-due @{pop} live"), &mut samples);
+    }
+}

--- a/nexus-timer/src/level.rs
+++ b/nexus-timer/src/level.rs
@@ -29,7 +29,12 @@ pub(crate) struct WheelSlot<T> {
 }
 
 impl<T: 'static> WheelSlot<T> {
-    fn new() -> Self {
+    /// Creates an empty slot (no entries).
+    ///
+    /// `pub(crate)` so both wheel front-ends can hold slots directly:
+    /// the wheel builds an array of them per level, while `TimeoutList`
+    /// holds a single one as its whole sorted list.
+    pub(crate) fn new() -> Self {
         WheelSlot {
             entry_head: Cell::new(null_entry()),
             entry_tail: Cell::new(null_entry()),
@@ -111,6 +116,15 @@ impl<T: 'static> WheelSlot<T> {
     #[inline]
     pub(crate) fn entry_head(&self) -> EntryPtr<T> {
         self.entry_head.get()
+    }
+
+    /// Returns the tail entry pointer (may be null if slot is empty).
+    ///
+    /// Used by `TimeoutList` to peek the last-inserted deadline for the
+    /// monotone-insertion `debug_assert`. Not read on any wheel hot path.
+    #[inline]
+    pub(crate) fn entry_tail(&self) -> EntryPtr<T> {
+        self.entry_tail.get()
     }
 }
 

--- a/nexus-timer/src/lib.rs
+++ b/nexus-timer/src/lib.rs
@@ -41,10 +41,15 @@ mod entry;
 mod handle;
 mod level;
 pub mod store;
+pub mod timeout_list;
 mod wheel;
 
 pub use entry::WheelEntry;
 pub use handle::TimerHandle;
+pub use timeout_list::{
+    BoundedTimeoutList, BoundedTimeoutListBuilder, TimeoutList, TimeoutListBuilder,
+    UnboundedTimeoutListBuilder,
+};
 pub use wheel::{
     BoundedWheel, BoundedWheelBuilder, TimerWheel, UnboundedWheelBuilder, Wheel, WheelBuilder,
 };

--- a/nexus-timer/src/lib.rs
+++ b/nexus-timer/src/lib.rs
@@ -1,11 +1,45 @@
-//! High-performance timer wheel with O(1) insert and cancel.
+//! Low-latency timer primitives: a hierarchical **timer wheel** (O(1) insert +
+//! cancel) for arbitrary deadlines, and a fixed-duration **[`TimeoutList`]** for
+//! the common case where every timer shares one timeout.
 //!
-//! `nexus-timer` provides a hierarchical timer wheel inspired by the Linux
-//! kernel's timer infrastructure (Gleixner 2016). Timers are placed into
-//! coarser slots at higher levels — no cascading, no entry movement after
-//! insertion.
+//! # Two structures — pick by workload
 //!
-//! # Design
+//! - [`TimerWheel`] ([`Wheel`] / [`BoundedWheel`]) — **arbitrary deadlines**:
+//!   timers that fire at different, unrelated future times.
+//! - [`TimeoutList`] ([`BoundedTimeoutList`]) — **a single fixed timeout**:
+//!   every timer expires the *same* duration after it is scheduled.
+//!
+//! The tell: *"do all my timers time out after the same amount of time?"* —
+//! yes → [`TimeoutList`], no → the wheel.
+//!
+//! | | [`TimerWheel`] | [`TimeoutList`] |
+//! |---|---|---|
+//! | Timeout per timer | arbitrary | one fixed duration |
+//! | Poll | O(active population) | **O(fired)** |
+//! | `next_deadline` | cached | **O(1) exact** |
+//! | Clock | any monotone source | monotone, non-decreasing |
+//!
+//! Reach for [`TimeoutList`] on the hot path when it fits — idle timeouts (all
+//! 30 s), request deadlines (all 5 s), a fixed retry/debounce delay, uniform
+//! TTL expiry. Fixed duration ⇒ monotone deadlines ⇒ a sorted list, so a
+//! nothing-due poll stays flat (~12 cycles) no matter how many timers are
+//! outstanding. A handful of distinct durations → one list each; many or
+//! arbitrary deadlines → the wheel.
+//!
+//! # The clock
+//!
+//! Every constructor takes `now` — it fixes the **reference epoch**. An
+//! `Instant` has no absolute zero (you can only measure durations *between*
+//! instants), so deadlines are stored relative to this epoch. Pass one monotone
+//! clock source (e.g. `Instant::now()`) to the constructor *and* to every
+//! `schedule` / `poll`. A `now` that goes backwards is a bug — [`TimeoutList`]
+//! debug-asserts on it.
+//!
+//! # Timer wheel design
+//!
+//! The wheel is hierarchical, inspired by the Linux kernel's timer
+//! infrastructure (Gleixner 2016): timers are placed into coarser slots at
+//! higher levels — no cascading, no entry movement after insertion.
 //!
 //! - **No cascade:** Once placed, an entry never moves. Poll checks each
 //!   entry's exact deadline. This eliminates the latency spikes that

--- a/nexus-timer/src/timeout_list.rs
+++ b/nexus-timer/src/timeout_list.rs
@@ -28,7 +28,7 @@
 //!
 //! # Reuse
 //!
-//! [`WheelEntry`](crate::WheelEntry), [`TimerHandle`], the slab
+//! [`WheelEntry`], [`TimerHandle`], the slab
 //! [`store`](crate::store) traits, and the DLL splice logic (`WheelSlot`) are
 //! shared verbatim with the wheel — this front-end is the same machinery with
 //! one head/tail pair in place of `Vec<Level>`, and the whole `min_deadline`
@@ -287,7 +287,10 @@ pub type BoundedTimeoutList<T> = TimeoutList<T, bounded::Slab<WheelEntry<T>>>;
 impl<T: 'static> TimeoutList<T> {
     /// Creates an unbounded timeout list with the default 1ms tick.
     ///
-    /// For custom tick duration, use [`TimeoutListBuilder`].
+    /// Every timer fires `timeout` after the `now` passed to `schedule`. The
+    /// `now` here fixes the reference epoch — pass one monotone clock source
+    /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For a custom
+    /// tick duration, use [`TimeoutListBuilder`].
     pub fn unbounded(timeout: Duration, chunk_capacity: usize, now: Instant) -> Self {
         TimeoutListBuilder::new(timeout)
             .unbounded(chunk_capacity)
@@ -298,7 +301,10 @@ impl<T: 'static> TimeoutList<T> {
 impl<T: 'static> BoundedTimeoutList<T> {
     /// Creates a bounded timeout list with the default 1ms tick.
     ///
-    /// For custom tick duration, use [`TimeoutListBuilder`].
+    /// Every timer fires `timeout` after the `now` passed to `schedule`. The
+    /// `now` here fixes the reference epoch — pass one monotone clock source
+    /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For a custom
+    /// tick duration, use [`TimeoutListBuilder`].
     pub fn bounded(timeout: Duration, capacity: usize, now: Instant) -> Self {
         TimeoutListBuilder::new(timeout)
             .bounded(capacity)

--- a/nexus-timer/src/timeout_list.rs
+++ b/nexus-timer/src/timeout_list.rs
@@ -1,0 +1,1491 @@
+//! Fixed-duration timeout list — a sorted front-end over the wheel machinery.
+//!
+//! `TimeoutList<T, S>` schedules every timer with the **same** duration, fixed
+//! at construction. Because the duration is constant and the clock is monotone,
+//! deadlines are monotone in insertion order: appending each new entry at the
+//! tail of one intrusive DLL keeps the list sorted with no comparisons. Poll
+//! then walks from the head and stops at the first not-due entry — **O(fired)**,
+//! not O(population) as the wheel's per-entry scan is. `next_deadline()` is the
+//! head's deadline: exact, O(1), no cache.
+//!
+//! # When to use this instead of [`TimerWheel`](crate::TimerWheel)
+//!
+//! A wheel earns its keep when deadlines are *arbitrary* — timers interleaved
+//! among earlier and later expirations. But a large class of callers schedule
+//! **one fixed timeout for everything** (a flat 5 s deadline on every item).
+//! For that workload the wheel buckets by deadline and walks buckets to solve
+//! an ordering problem that does not exist. `TimeoutList` exploits the single
+//! duration directly.
+//!
+//! # The invariant is structural, not documented
+//!
+//! There is no per-call `deadline` parameter anywhere in this API. Deadlines
+//! are computed internally as `now + timeout`. Out-of-order insertion is
+//! *unrepresentable*, not merely prohibited — one caller passing a shorter
+//! deadline would break ordering and fire timers late, the worst failure shape
+//! because it is invisible until it matters. A `debug_assert!` on insert is the
+//! backstop for clock weirdness (a `now` that goes backwards).
+//!
+//! # Reuse
+//!
+//! [`WheelEntry`](crate::WheelEntry), [`TimerHandle`], the slab
+//! [`store`](crate::store) traits, and the DLL splice logic (`WheelSlot`) are
+//! shared verbatim with the wheel — this front-end is the same machinery with
+//! one head/tail pair in place of `Vec<Level>`, and the whole `min_deadline`
+//! cache removed (the head *is* the min).
+
+use std::marker::PhantomData;
+use std::mem;
+use std::time::{Duration, Instant};
+
+use nexus_slab::{Full, Slot, bounded, unbounded};
+
+use crate::entry::{EntryPtr, WheelEntry, entry_ref};
+use crate::handle::TimerHandle;
+use crate::level::WheelSlot;
+use crate::store::{BoundedStore, SlabStore};
+
+// =============================================================================
+// TimeoutListBuilder (typestate)
+// =============================================================================
+
+/// Builder for a [`TimeoutList`], mirroring [`WheelBuilder`](crate::WheelBuilder).
+///
+/// The timeout duration is fixed up front in [`new`](Self::new) — that is the
+/// whole point of the type, so it cannot be a per-schedule parameter later.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::{Duration, Instant};
+/// use nexus_timer::{TimeoutList, TimeoutListBuilder};
+///
+/// let now = Instant::now();
+///
+/// // 5-second timeout, unbounded storage, default 1ms tick.
+/// let list: TimeoutList<u64> = TimeoutListBuilder::new(Duration::from_secs(5))
+///     .unbounded(4096)
+///     .build(now);
+///
+/// // Custom tick, bounded storage.
+/// let list: nexus_timer::BoundedTimeoutList<u64> =
+///     TimeoutListBuilder::new(Duration::from_millis(250))
+///         .tick_duration(Duration::from_micros(100))
+///         .bounded(1024)
+///         .build(now);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TimeoutListBuilder {
+    timeout: Duration,
+    tick_duration: Duration,
+}
+
+impl TimeoutListBuilder {
+    /// Creates a builder with the fixed timeout every timer will use.
+    ///
+    /// Tick duration defaults to 1ms. The timeout must be non-zero.
+    pub fn new(timeout: Duration) -> Self {
+        TimeoutListBuilder {
+            timeout,
+            tick_duration: Duration::from_millis(1),
+        }
+    }
+
+    /// Sets the tick duration (internal time quantum). Default: 1ms.
+    pub fn tick_duration(mut self, d: Duration) -> Self {
+        self.tick_duration = d;
+        self
+    }
+
+    /// Transitions to an unbounded (growable) builder.
+    ///
+    /// `chunk_capacity` is the slab chunk size (entries per chunk); the slab
+    /// grows by adding chunks as needed.
+    pub fn unbounded(self, chunk_capacity: usize) -> UnboundedTimeoutListBuilder {
+        UnboundedTimeoutListBuilder {
+            config: self,
+            chunk_capacity,
+        }
+    }
+
+    /// Transitions to a bounded (fixed-capacity) builder.
+    ///
+    /// `capacity` is the maximum number of concurrent timers.
+    pub fn bounded(self, capacity: usize) -> BoundedTimeoutListBuilder {
+        BoundedTimeoutListBuilder {
+            config: self,
+            capacity,
+        }
+    }
+
+    fn validate(&self) {
+        assert!(!self.timeout.is_zero(), "timeout must be non-zero");
+        assert!(
+            !self.tick_duration.is_zero(),
+            "tick_duration must be non-zero"
+        );
+    }
+
+    #[inline]
+    fn tick_ns(&self) -> u64 {
+        self.tick_duration.as_nanos().min(u64::MAX as u128) as u64
+    }
+
+    /// Fixed timeout expressed in whole ticks (rounded up, minimum 1 tick).
+    ///
+    /// Ceiling division so the effective timeout is never *shorter* than
+    /// requested. Computed once at build time — never on the hot path.
+    #[inline]
+    fn timeout_ticks(&self) -> u64 {
+        let tick_ns = self.tick_ns() as u128;
+        let timeout_ns = self.timeout.as_nanos();
+        let ticks = timeout_ns.div_ceil(tick_ns);
+        ticks.min(u64::MAX as u128).max(1) as u64
+    }
+}
+
+/// Terminal builder for an unbounded [`TimeoutList`].
+///
+/// Created via [`TimeoutListBuilder::unbounded`]. The only method is `.build()`.
+#[derive(Debug)]
+pub struct UnboundedTimeoutListBuilder {
+    config: TimeoutListBuilder,
+    chunk_capacity: usize,
+}
+
+impl UnboundedTimeoutListBuilder {
+    /// Builds the unbounded timeout list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the configuration is invalid (zero timeout or zero tick).
+    pub fn build<T: 'static>(self, now: Instant) -> TimeoutList<T> {
+        self.config.validate();
+        let tick_ns = self.config.tick_ns();
+        let timeout_ticks = self.config.timeout_ticks();
+        // SAFETY: TimeoutList is single-threaded (!Sync). Every slot is freed
+        // via Slot::from_raw() + slab.free() before the list drops. The slab is
+        // never shared across threads.
+        let slab = unsafe { unbounded::Slab::with_chunk_capacity(self.chunk_capacity) };
+        TimeoutList {
+            list: WheelSlot::new(),
+            slab,
+            timeout_ticks,
+            tick_ns,
+            inv_tick_ns: (1u128 << 64) / tick_ns as u128,
+            epoch: now,
+            len: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Terminal builder for a bounded [`TimeoutList`].
+///
+/// Created via [`TimeoutListBuilder::bounded`]. The only method is `.build()`.
+#[derive(Debug)]
+pub struct BoundedTimeoutListBuilder {
+    config: TimeoutListBuilder,
+    capacity: usize,
+}
+
+impl BoundedTimeoutListBuilder {
+    /// Builds the bounded timeout list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the configuration is invalid (zero timeout or zero tick).
+    pub fn build<T: 'static>(self, now: Instant) -> BoundedTimeoutList<T> {
+        self.config.validate();
+        let tick_ns = self.config.tick_ns();
+        let timeout_ticks = self.config.timeout_ticks();
+        // SAFETY: TimeoutList is single-threaded (!Sync). Every slot is freed
+        // via Slot::from_raw() + slab.free() before the list drops. The slab is
+        // never shared across threads.
+        let slab = unsafe { bounded::Slab::with_capacity(self.capacity) };
+        TimeoutList {
+            list: WheelSlot::new(),
+            slab,
+            timeout_ticks,
+            tick_ns,
+            inv_tick_ns: (1u128 << 64) / tick_ns as u128,
+            epoch: now,
+            len: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// =============================================================================
+// TimeoutList
+// =============================================================================
+
+/// A fixed-duration timeout list with O(fired) poll and O(1) exact next-deadline.
+///
+/// Generic over:
+/// - `T` — the user payload stored with each timer.
+/// - `S` — the slab storage backend. Defaults to `unbounded::Slab`.
+///
+/// Every timer uses the same duration, fixed at construction. See the
+/// [module docs](crate::timeout_list) for the invariant this exploits.
+///
+/// # No `reschedule`
+///
+/// Rescheduling *later* is push-to-tail and stays ordered, but rescheduling
+/// *earlier* would break the sort — and the two are indistinguishable in a
+/// single API. So no `reschedule` is offered: callers `cancel` and re-`schedule`,
+/// which is the same two operations without the ordering hazard. (This mirrors
+/// the wheel's `reschedule`, deliberately omitted here.)
+///
+/// # Thread Safety
+///
+/// `Send` but `!Sync`. Can be moved to a thread at setup but must not be
+/// shared. All internal raw pointers point into owned allocations (slab
+/// chunks) — moving the list moves the heap data with it.
+pub struct TimeoutList<
+    T: 'static,
+    S: SlabStore<Item = WheelEntry<T>> = unbounded::Slab<WheelEntry<T>>,
+> {
+    /// The whole sorted list: one head/tail intrusive DLL. Reuses the wheel's
+    /// `WheelSlot` splice logic (push at tail, unlink from anywhere).
+    list: WheelSlot<T>,
+    slab: S,
+    /// Fixed timeout in ticks. Added to `now` on every schedule.
+    timeout_ticks: u64,
+    tick_ns: u64,
+    inv_tick_ns: u128,
+    epoch: Instant,
+    len: usize,
+    _marker: PhantomData<*const ()>, // !Send (overridden below), !Sync
+}
+
+// SAFETY: TimeoutList<T, S> exclusively owns all memory behind its raw
+// pointers. The slot head/tail and the WheelEntry prev/next links point into
+// slab-owned memory (SlotCell in a slab chunk, a Vec<SlotCell<T>> heap
+// allocation). When the list is moved, those heap allocations stay at their
+// addresses, so the internal pointers remain valid. No thread-local state, no
+// shared ownership.
+//
+// T: Send is required because timer values cross the thread boundary with the
+// list. S is NOT required to be Send: slab types are !Send (raw pointers,
+// Cell), but the list exclusively owns its slab — no shared access, no
+// aliasing. Outstanding TimerHandle<T> values are !Send and cannot follow the
+// list across threads; they become inert (consuming one requires &mut
+// TimeoutList, which the original thread no longer has). Worst case is a slot
+// leak (refcount stuck at 1), not unsoundness — the same reasoning as the
+// wheel.
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl<T: Send + 'static, S: SlabStore<Item = WheelEntry<T>>> Send for TimeoutList<T, S> {}
+
+/// A timeout list backed by a fixed-capacity slab.
+pub type BoundedTimeoutList<T> = TimeoutList<T, bounded::Slab<WheelEntry<T>>>;
+
+// =============================================================================
+// Construction convenience
+// =============================================================================
+
+impl<T: 'static> TimeoutList<T> {
+    /// Creates an unbounded timeout list with the default 1ms tick.
+    ///
+    /// For custom tick duration, use [`TimeoutListBuilder`].
+    pub fn unbounded(timeout: Duration, chunk_capacity: usize, now: Instant) -> Self {
+        TimeoutListBuilder::new(timeout)
+            .unbounded(chunk_capacity)
+            .build(now)
+    }
+}
+
+impl<T: 'static> BoundedTimeoutList<T> {
+    /// Creates a bounded timeout list with the default 1ms tick.
+    ///
+    /// For custom tick duration, use [`TimeoutListBuilder`].
+    pub fn bounded(timeout: Duration, capacity: usize, now: Instant) -> Self {
+        TimeoutListBuilder::new(timeout)
+            .bounded(capacity)
+            .build(now)
+    }
+}
+
+// =============================================================================
+// Schedule
+// =============================================================================
+
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+    /// Schedules a timer for `now + timeout` and returns a handle for cancellation.
+    ///
+    /// The handle must be consumed via [`cancel`](Self::cancel) or
+    /// [`free`](Self::free). Dropping it is a programming error.
+    ///
+    /// `now` must be monotonically non-decreasing across calls (a plain
+    /// `Instant::now()` at each call site satisfies this). A `now` that goes
+    /// backwards trips a `debug_assert!` in debug builds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing slab is at capacity (bounded slabs only). This is
+    /// a capacity planning error — size the list for peak load.
+    pub fn schedule(&mut self, now: Instant, value: T) -> TimerHandle<T> {
+        let deadline_ticks = self.deadline_for(now);
+        let entry = WheelEntry::new(deadline_ticks, value, 2);
+        let ptr = self.slab.alloc(entry).into_raw();
+        self.insert_entry(ptr, deadline_ticks);
+        self.len += 1;
+        TimerHandle::new(ptr)
+    }
+
+    /// Schedules a fire-and-forget timer for `now + timeout` (no handle returned).
+    ///
+    /// The timer fires during poll and its value is collected. It cannot be
+    /// cancelled. See [`schedule`](Self::schedule) for the `now` monotonicity
+    /// requirement.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing slab is at capacity (bounded slabs only).
+    pub fn schedule_forget(&mut self, now: Instant, value: T) {
+        let deadline_ticks = self.deadline_for(now);
+        let entry = WheelEntry::new(deadline_ticks, value, 1);
+        let ptr = self.slab.alloc(entry).into_raw();
+        self.insert_entry(ptr, deadline_ticks);
+        self.len += 1;
+    }
+}
+
+// =============================================================================
+// Schedule — fallible (bounded slabs only)
+// =============================================================================
+
+impl<T: 'static, S: BoundedStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+    /// Attempts to schedule a timer, returning a handle on success.
+    ///
+    /// Returns `Err(Full(value))` — with the caller's `T` recovered, not the
+    /// internal `WheelEntry` — if the slab is at capacity. Use this when
+    /// capacity exhaustion should be handled gracefully; otherwise use
+    /// [`schedule`](Self::schedule).
+    pub fn try_schedule(&mut self, now: Instant, value: T) -> Result<TimerHandle<T>, Full<T>> {
+        let deadline_ticks = self.deadline_for(now);
+        let entry = WheelEntry::new(deadline_ticks, value, 2);
+        match self.slab.try_alloc(entry) {
+            Ok(slot) => {
+                let ptr = slot.into_raw();
+                self.insert_entry(ptr, deadline_ticks);
+                self.len += 1;
+                Ok(TimerHandle::new(ptr))
+            }
+            Err(full) => Err(Full(recover_value(full))),
+        }
+    }
+
+    /// Attempts to schedule a fire-and-forget timer.
+    ///
+    /// Returns `Err(Full(value))` — with the caller's `T` recovered — if the
+    /// slab is at capacity. Otherwise use [`schedule_forget`](Self::schedule_forget).
+    pub fn try_schedule_forget(&mut self, now: Instant, value: T) -> Result<(), Full<T>> {
+        let deadline_ticks = self.deadline_for(now);
+        let entry = WheelEntry::new(deadline_ticks, value, 1);
+        match self.slab.try_alloc(entry) {
+            Ok(slot) => {
+                let ptr = slot.into_raw();
+                self.insert_entry(ptr, deadline_ticks);
+                self.len += 1;
+                Ok(())
+            }
+            Err(full) => Err(Full(recover_value(full))),
+        }
+    }
+}
+
+/// Extracts the user's `T` from a `Full<WheelEntry<T>>` produced by a rejected
+/// `try_alloc`. The entry was just constructed with `Some(value)` and never
+/// inserted, so the value is present.
+#[inline]
+fn recover_value<T>(full: Full<WheelEntry<T>>) -> T {
+    let wheel_entry = full.into_inner();
+    // SAFETY: entry was just constructed with Some(value) and never inserted
+    // into the list — no other code has accessed it. Single-threaded.
+    unsafe { wheel_entry.take_value() }.expect("entry was just constructed with Some(value)")
+}
+
+// =============================================================================
+// Cancel / Free / Poll / Query — generic over any store
+// =============================================================================
+
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+    /// Cancels a timer and returns its value.
+    ///
+    /// - Still active (refs == 2): unlinks from the list, extracts the value,
+    ///   frees the slab entry. Returns `Some(T)`. O(1) — a mid-list unlink,
+    ///   no residency, no tombstone.
+    /// - Already fired (zombie handle, refs == 1): frees the slab entry.
+    ///   Returns `None`.
+    ///
+    /// Consumes the handle (no Drop runs).
+    pub fn cancel(&mut self, handle: TimerHandle<T>) -> Option<T> {
+        let ptr = handle.ptr;
+        // Consume handle without running Drop.
+        mem::forget(handle);
+
+        // SAFETY: handle guarantees ptr is valid and allocated from our slab.
+        let entry = unsafe { entry_ref(ptr) };
+        let refs = entry.refs();
+
+        if refs == 2 {
+            // Active timer with handle — unlink, extract, free.
+            // SAFETY: single-threaded; entry is still in the list (refs == 2),
+            // so the value has not been taken by fire_entry.
+            let value = unsafe { entry.take_value() };
+            // SAFETY: ptr is in self.list's DLL (invariant from insert_entry).
+            unsafe { self.list.remove_entry(ptr) };
+            self.len -= 1;
+            // SAFETY: ptr was allocated from our slab via into_raw().
+            self.slab.free(unsafe { Slot::from_raw(ptr) });
+            value
+        } else {
+            // refs == 1: the list already fired this (zombie). The fire path
+            // decremented 2 -> 1 and left the entry for us to free.
+            debug_assert_eq!(refs, 1, "unexpected refcount {refs} in cancel");
+            // SAFETY: ptr was allocated from our slab via into_raw().
+            self.slab.free(unsafe { Slot::from_raw(ptr) });
+            None
+        }
+    }
+
+    /// Releases a timer handle without cancelling.
+    ///
+    /// - Still active: converts to fire-and-forget (refs 2 -> 1). The timer
+    ///   stays in the list and fires normally during poll.
+    /// - Already fired (zombie): frees the slab entry (refs 1 -> 0).
+    ///
+    /// Consumes the handle (no Drop runs).
+    pub fn free(&mut self, handle: TimerHandle<T>) {
+        let ptr = handle.ptr;
+        mem::forget(handle);
+
+        // SAFETY: handle guarantees ptr is valid.
+        let entry = unsafe { entry_ref(ptr) };
+        let new_refs = entry.dec_refs();
+
+        if new_refs == 0 {
+            // Was a zombie (fired already, refs was 1) — free the entry.
+            // SAFETY: ptr was allocated from our slab via into_raw().
+            self.slab.free(unsafe { Slot::from_raw(ptr) });
+        }
+        // new_refs == 1: timer is now fire-and-forget, stays in the list.
+    }
+
+    /// Fires all expired timers, collecting their values into `buf`.
+    ///
+    /// Returns the number of timers fired. O(fired): the list is sorted, so
+    /// this walks from the head and stops at the first not-due entry.
+    pub fn poll(&mut self, now: Instant, buf: &mut Vec<T>) -> usize {
+        self.poll_with_limit(now, usize::MAX, buf)
+    }
+
+    /// Fires expired timers up to `limit`, collecting values into `buf`.
+    ///
+    /// Returns the number fired in this call. Truncation is resumable: this
+    /// stops at a head that is either not-due or beyond `limit`, and the next
+    /// call picks up at exactly that head. No bookmark is needed — the sorted
+    /// list *is* the cursor. (The wheel needs a resumption argument because it
+    /// re-derives its scan position each call; here there is nothing to
+    /// re-derive.)
+    pub fn poll_with_limit(&mut self, now: Instant, limit: usize, buf: &mut Vec<T>) -> usize {
+        let now_ticks = self.instant_to_ticks(now);
+        let mut fired = 0;
+
+        while fired < limit {
+            let ptr = self.list.entry_head();
+            if ptr.is_null() {
+                break;
+            }
+            // SAFETY: ptr is the non-null head of self.list's DLL.
+            let entry = unsafe { entry_ref(ptr) };
+
+            #[cfg(test)]
+            {
+                poll_examined_inc();
+            }
+
+            if entry.deadline_ticks() > now_ticks {
+                // Sorted: nothing behind the head is due either.
+                break;
+            }
+
+            // SAFETY: ptr is the current head of self.list's DLL.
+            unsafe { self.list.remove_entry(ptr) };
+            if let Some(value) = self.fire_entry(ptr) {
+                buf.push(value);
+            }
+            fired += 1;
+        }
+
+        fired
+    }
+
+    /// Returns the `Instant` of the next timer that will fire, or `None` if empty.
+    ///
+    /// O(1), exact: the sorted list's head *is* the minimum deadline. No cache.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        let head = self.list.entry_head();
+        if head.is_null() {
+            return None;
+        }
+        // SAFETY: head is non-null and points into self.list's DLL.
+        let ticks = unsafe { entry_ref(head) }.deadline_ticks();
+        Some(self.ticks_to_instant(ticks))
+    }
+
+    /// Returns the number of timers currently in the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the list contains no timers.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    // =========================================================================
+    // Internal: tick conversion (replicated from the wheel)
+    // =========================================================================
+
+    #[inline]
+    fn instant_to_ticks(&self, instant: Instant) -> u64 {
+        let dur = instant.saturating_duration_since(self.epoch);
+        let nanos = dur.as_nanos().min(u64::MAX as u128) as u64;
+        ((nanos as u128 * self.inv_tick_ns) >> 64) as u64
+    }
+
+    #[inline]
+    fn ticks_to_instant(&self, ticks: u64) -> Instant {
+        self.epoch + Duration::from_nanos(ticks.saturating_mul(self.tick_ns))
+    }
+
+    /// Deadline in ticks for a timer scheduled at `now`: `now + fixed timeout`.
+    ///
+    /// Saturating add guards the (unrealistic, ~584-year) case where `now` is
+    /// far enough out that the tick count plus the timeout would overflow u64.
+    #[inline]
+    fn deadline_for(&self, now: Instant) -> u64 {
+        self.instant_to_ticks(now)
+            .saturating_add(self.timeout_ticks)
+    }
+
+    // =========================================================================
+    // Internal: insert / fire
+    // =========================================================================
+
+    /// Appends an entry at the tail of the sorted list.
+    ///
+    /// Correctness rests on the caller's `deadline_ticks` being >= the current
+    /// tail's — guaranteed by a monotone `now` and a constant timeout. The
+    /// `debug_assert!` is the backstop for a clock that goes backwards.
+    #[inline]
+    fn insert_entry(&mut self, entry_ptr: EntryPtr<T>, deadline_ticks: u64) {
+        // The entry's `level`/`slot_idx` stay at their `WheelEntry::new` default
+        // of (0, 0): a single sorted list has no slot to record, and the unlink
+        // path (`WheelSlot::remove_entry`) splices via prev/next and never reads
+        // location. So there is no `set_location` write on this hot path.
+        debug_assert!(
+            {
+                let tail = self.list.entry_tail();
+                // SAFETY: tail, when non-null, points into self.list's DLL.
+                tail.is_null() || deadline_ticks >= unsafe { entry_ref(tail) }.deadline_ticks()
+            },
+            "TimeoutList: deadline {deadline_ticks} inserted out of order \
+             (did `now` go backwards?)",
+        );
+
+        // SAFETY: entry_ptr is valid (just allocated) and not in any DLL yet.
+        unsafe { self.list.push_entry(entry_ptr) };
+    }
+
+    /// Fires a single entry: extracts value, decrements refcount, possibly frees.
+    ///
+    /// Returns `Some(T)` if the value was still present (not already cancelled).
+    /// The caller has already unlinked `entry_ptr` from the list.
+    #[inline]
+    fn fire_entry(&mut self, entry_ptr: EntryPtr<T>) -> Option<T> {
+        // SAFETY: entry_ptr was the head we just unlinked; still a live slab slot.
+        let entry = unsafe { entry_ref(entry_ptr) };
+
+        // SAFETY: single-threaded.
+        let value = unsafe { entry.take_value() };
+
+        let new_refs = entry.dec_refs();
+        if new_refs == 0 {
+            // Fire-and-forget (was refs == 1) — free the slab entry immediately.
+            // SAFETY: entry_ptr was allocated from our slab via into_raw().
+            self.slab.free(unsafe { Slot::from_raw(entry_ptr) });
+        }
+        // new_refs == 1: handle exists (was refs == 2), entry becomes a zombie.
+        // The handle holder frees it via cancel() or free().
+
+        self.len -= 1;
+        value
+    }
+}
+
+// =============================================================================
+// Drop
+// =============================================================================
+
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> Drop for TimeoutList<T, S> {
+    fn drop(&mut self) {
+        // Walk the single list, free every remaining entry so nothing leaks.
+        let mut entry_ptr = self.list.entry_head();
+        while !entry_ptr.is_null() {
+            // SAFETY: entry_ptr is in self.list's DLL.
+            let next_entry = unsafe { entry_ref(entry_ptr) }.next();
+            // SAFETY: entry_ptr was allocated from our slab via into_raw().
+            self.slab.free(unsafe { Slot::from_raw(entry_ptr) });
+            entry_ptr = next_entry;
+        }
+    }
+}
+
+// =============================================================================
+// Test-only instrumentation: entries examined during poll
+// =============================================================================
+//
+// A nothing-due poll must be flat across population — it examines only the
+// head (one deadline compare) and fires nothing, never scanning the list the
+// way the wheel does. This counter proves that: tests reset it, poll, and
+// assert the count is 1 (non-empty, nothing due) regardless of population.
+
+#[cfg(test)]
+thread_local! {
+    static POLL_EXAMINED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn poll_examined_inc() {
+    POLL_EXAMINED.with(|c| c.set(c.get() + 1));
+}
+
+#[cfg(test)]
+fn poll_examined_reset() {
+    POLL_EXAMINED.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+fn poll_examined_get() -> usize {
+    POLL_EXAMINED.with(std::cell::Cell::get)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn ms(millis: u64) -> Duration {
+        Duration::from_millis(millis)
+    }
+
+    fn list_50ms(now: Instant) -> TimeoutList<u64> {
+        TimeoutList::unbounded(ms(50), 1024, now)
+    }
+
+    // -------------------------------------------------------------------------
+    // Thread safety
+    // -------------------------------------------------------------------------
+
+    fn assert_send<T: Send>() {}
+
+    #[test]
+    fn timeout_list_is_send() {
+        assert_send::<TimeoutList<u64>>();
+        assert_send::<BoundedTimeoutList<u64>>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn default_construction() {
+        let now = Instant::now();
+        let list = list_50ms(now);
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+        assert!(list.next_deadline().is_none());
+    }
+
+    #[test]
+    fn bounded_construction() {
+        let now = Instant::now();
+        let list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 128, now);
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "timeout must be non-zero")]
+    fn invalid_zero_timeout() {
+        let now = Instant::now();
+        TimeoutListBuilder::new(Duration::ZERO)
+            .unbounded(64)
+            .build::<u64>(now);
+    }
+
+    #[test]
+    #[should_panic(expected = "tick_duration must be non-zero")]
+    fn invalid_zero_tick() {
+        let now = Instant::now();
+        TimeoutListBuilder::new(ms(50))
+            .tick_duration(Duration::ZERO)
+            .unbounded(64)
+            .build::<u64>(now);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle (ported from wheel.rs)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn schedule_and_cancel() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let h = list.schedule(now, 42);
+        assert_eq!(list.len(), 1);
+
+        let val = list.cancel(h);
+        assert_eq!(val, Some(42));
+        assert_eq!(list.len(), 0);
+    }
+
+    #[test]
+    fn schedule_forget_fires() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        list.schedule_forget(now, 99);
+        assert_eq!(list.len(), 1);
+
+        let mut buf = Vec::new();
+        let fired = list.poll(now + ms(60), &mut buf);
+        assert_eq!(fired, 1);
+        assert_eq!(buf, vec![99]);
+        assert_eq!(list.len(), 0);
+    }
+
+    #[test]
+    fn cancel_after_fire_returns_none() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let h = list.schedule(now, 42);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(60), &mut buf);
+        assert_eq!(buf, vec![42]);
+
+        // Handle is now a zombie.
+        let val = list.cancel(h);
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn free_active_timer_becomes_fire_and_forget() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let h = list.schedule(now, 42);
+        list.free(h); // releases handle, timer stays
+        assert_eq!(list.len(), 1);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(60), &mut buf);
+        assert_eq!(buf, vec![42]);
+        assert_eq!(list.len(), 0);
+    }
+
+    #[test]
+    fn free_zombie_handle() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let h = list.schedule(now, 42);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(60), &mut buf);
+
+        // Handle is a zombie, free cleans up.
+        list.free(h);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bounded full
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn bounded_full() {
+        let now = Instant::now();
+        let mut list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 2, now);
+
+        let h1 = list.try_schedule(now, 1).unwrap();
+        let h2 = list.try_schedule(now, 2).unwrap();
+
+        let err = list.try_schedule(now, 3);
+        assert!(err.is_err());
+        // The caller's T is recovered, not the WheelEntry wrapper.
+        let recovered = err.unwrap_err().into_inner();
+        assert_eq!(recovered, 3);
+
+        // Cancel one, room again.
+        list.cancel(h1);
+        let h3 = list.try_schedule(now, 3).unwrap();
+
+        list.free(h2);
+        list.free(h3);
+    }
+
+    #[test]
+    fn bounded_schedule_forget_full() {
+        let now = Instant::now();
+        let mut list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 1, now);
+
+        list.try_schedule_forget(now, 1).unwrap();
+        let err = list.try_schedule_forget(now, 2);
+        assert!(err.is_err());
+        assert_eq!(err.unwrap_err().into_inner(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ordering / FIFO
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn poll_respects_deadline() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        // Fixed 50ms timeout; schedule at staggered `now`s.
+        list.schedule_forget(now, 1); // deadline ~50ms
+        list.schedule_forget(now + ms(40), 2); // deadline ~90ms
+        list.schedule_forget(now + ms(90), 3); // deadline ~140ms
+
+        let mut buf = Vec::new();
+
+        let fired = list.poll(now + ms(60), &mut buf);
+        assert_eq!(fired, 1);
+        assert_eq!(buf, vec![1]);
+        assert_eq!(list.len(), 2);
+
+        buf.clear();
+        let fired = list.poll(now + ms(100), &mut buf);
+        assert_eq!(fired, 1);
+        assert_eq!(buf, vec![2]);
+
+        buf.clear();
+        let fired = list.poll(now + ms(200), &mut buf);
+        assert_eq!(fired, 1);
+        assert_eq!(buf, vec![3]);
+
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn mid_list_cancel_preserves_fifo() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        // Five timers at strictly increasing `now`s → strictly increasing
+        // deadlines, in insertion order.
+        let mut handles: Vec<_> = (0..5u64).map(|i| list.schedule(now + ms(i), i)).collect();
+        assert_eq!(list.len(), 5);
+
+        // Cancel index 2 (value 2), then index 0 (value 0). Remaining, in
+        // list order: [1, 3, 4].
+        let v2 = list.cancel(handles.remove(2));
+        assert_eq!(v2, Some(2));
+        let v0 = list.cancel(handles.remove(0));
+        assert_eq!(v0, Some(0));
+        assert_eq!(list.len(), 3);
+
+        let mut buf = Vec::new();
+        let fired = list.poll(now + ms(1000), &mut buf);
+        assert_eq!(fired, 3);
+        // Exact Vec equality — FIFO order, not sorted-after-the-fact.
+        assert_eq!(buf, vec![1, 3, 4]);
+
+        // Remaining handles are zombies now.
+        for h in handles {
+            assert_eq!(list.cancel(h), None);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // poll_with_limit truncation + resumption
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn poll_with_limit_truncation_then_resumption() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        for i in 0..10u64 {
+            list.schedule_forget(now + ms(i), i);
+        }
+
+        let mut buf = Vec::new();
+        let poll_at = now + ms(1000);
+
+        let fired = list.poll_with_limit(poll_at, 3, &mut buf);
+        assert_eq!(fired, 3);
+        assert_eq!(list.len(), 7);
+
+        let fired = list.poll_with_limit(poll_at, 3, &mut buf);
+        assert_eq!(fired, 3);
+        assert_eq!(list.len(), 4);
+
+        let fired = list.poll(poll_at, &mut buf);
+        assert_eq!(fired, 4);
+        assert!(list.is_empty());
+
+        // Full set, in order, across the truncated calls.
+        assert_eq!(buf, (0..10u64).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn poll_with_limit_mixed_expiry() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        // Three due at poll time, two not.
+        list.schedule_forget(now, 1);
+        list.schedule_forget(now, 2);
+        list.schedule_forget(now, 3);
+        list.schedule_forget(now + ms(500), 4); // deadline ~550ms
+        list.schedule_forget(now + ms(500), 5);
+        assert_eq!(list.len(), 5);
+
+        let mut buf = Vec::new();
+
+        let fired = list.poll_with_limit(now + ms(60), 2, &mut buf);
+        assert_eq!(fired, 2);
+        assert_eq!(list.len(), 3);
+
+        let fired = list.poll_with_limit(now + ms(60), 5, &mut buf);
+        assert_eq!(fired, 1); // only the third due entry; 4 and 5 not due
+        assert_eq!(list.len(), 2);
+
+        assert_eq!(buf, vec![1, 2, 3]);
+    }
+
+    // -------------------------------------------------------------------------
+    // next_deadline
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn next_deadline_is_head_before_and_after_cancel() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let h0 = list.schedule(now, 0); // deadline ~ now+50
+        list.schedule_forget(now + ms(30), 1); // deadline ~ now+80
+        list.schedule_forget(now + ms(60), 2); // deadline ~ now+110
+
+        // Head is the first-scheduled: ~ now + 50ms.
+        let d0 = list.next_deadline().unwrap();
+        let delta0 = d0.duration_since(now);
+        assert!(delta0 >= ms(49) && delta0 <= ms(51), "delta0 = {delta0:?}");
+
+        // Cancel the head — next deadline becomes the second entry (~now+80ms).
+        assert_eq!(list.cancel(h0), Some(0));
+        let d1 = list.next_deadline().unwrap();
+        let delta1 = d1.duration_since(now);
+        assert!(delta1 >= ms(79) && delta1 <= ms(81), "delta1 = {delta1:?}");
+    }
+
+    #[test]
+    fn next_deadline_empty_after_drain() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+        list.schedule_forget(now, 1);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(60), &mut buf);
+        assert!(list.next_deadline().is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Nothing-due poll touches (examines) only the head — flat across population
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn nothing_due_poll_examines_only_head() {
+        let now = Instant::now();
+
+        for &population in &[100usize, 1_000, 10_000, 50_000] {
+            // Big timeout so nothing is due at poll time.
+            let mut list: TimeoutList<u64> =
+                TimeoutList::unbounded(Duration::from_secs(3600), population + 16, now);
+            for i in 0..population as u64 {
+                list.schedule_forget(now, i);
+            }
+            assert_eq!(list.len(), population);
+
+            let mut buf = Vec::new();
+            poll_examined_reset();
+            let fired = list.poll(now + ms(1), &mut buf); // nothing due
+            assert_eq!(fired, 0);
+            assert!(buf.is_empty());
+
+            // Exactly one entry examined (the head), regardless of population.
+            // This is the O(1) nothing-due property — no population scan.
+            assert_eq!(
+                poll_examined_get(),
+                1,
+                "population {population}: nothing-due poll examined more than the head",
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_due_poll_empty_examines_zero() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let mut buf = Vec::new();
+        poll_examined_reset();
+        let fired = list.poll(now + ms(1), &mut buf);
+        assert_eq!(fired, 0);
+        // Empty list: literally zero entries touched.
+        assert_eq!(poll_examined_get(), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Same-deadline entries (all scheduled at the same `now`)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn multiple_entries_same_deadline() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        let mut handles: Vec<_> = (0..5u64).map(|i| list.schedule(now, i)).collect();
+        assert_eq!(list.len(), 5);
+
+        let v2 = list.cancel(handles.remove(2));
+        assert_eq!(v2, Some(2));
+        let v0 = list.cancel(handles.remove(0));
+        assert_eq!(v0, Some(0));
+        assert_eq!(list.len(), 3);
+
+        let mut buf = Vec::new();
+        let fired = list.poll(now + ms(60), &mut buf);
+        assert_eq!(fired, 3);
+        assert_eq!(buf, vec![1, 3, 4]);
+
+        for h in handles {
+            assert_eq!(list.cancel(h), None);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Reuse after drain
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn reuse_after_full_drain() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        for i in 0..10u64 {
+            list.schedule_forget(now, i);
+        }
+        let mut buf = Vec::new();
+        list.poll(now + ms(60), &mut buf);
+        assert_eq!(buf.len(), 10);
+        assert!(list.is_empty());
+
+        buf.clear();
+        for i in 10..20u64 {
+            list.schedule_forget(now + ms(100), i);
+        }
+        assert_eq!(list.len(), 10);
+        list.poll(now + ms(200), &mut buf);
+        assert_eq!(buf.len(), 10);
+        assert!(list.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Drop
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn drop_cleans_up_active_entries() {
+        // Prove the list drops the VALUES of unfired timers on `Drop`, not just
+        // that it reclaims the slab slots. `unbounded::Slab::free` drops the
+        // value (store.rs), but nothing else in the suite verifies it — the miri
+        // run uses `-Zmiri-ignore-leaks`, so a value leak would slip straight
+        // past. A `Drop`-counting value makes the property observable.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct DropCounter(Arc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let now = Instant::now();
+        let mut list: TimeoutList<DropCounter> = TimeoutList::unbounded(ms(50), 1024, now);
+        for i in 0..100u64 {
+            list.schedule_forget(now + ms(i), DropCounter(Arc::clone(&dropped)));
+        }
+        assert_eq!(list.len(), 100);
+
+        drop(list);
+        assert_eq!(
+            dropped.load(Ordering::Relaxed),
+            100,
+            "every unfired timer's value must be dropped when the list is dropped",
+        );
+    }
+
+    #[test]
+    fn drop_with_outstanding_handles() {
+        // Dropping the list must free the VALUES of handle-bearing (refs == 2)
+        // entries too, even when the handles were never consumed — the one Drop
+        // path `drop_cleans_up_active_entries` (refs == 1) does not cover. The
+        // handles are `mem::forget`ed to stand in for "still outstanding"
+        // without tripping `TimerHandle`'s drop debug_assert.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct DropCounter(Arc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let now = Instant::now();
+        let mut list: TimeoutList<DropCounter> = TimeoutList::unbounded(ms(50), 1024, now);
+        for i in 0..100u64 {
+            let h = list.schedule(now + ms(i), DropCounter(Arc::clone(&dropped)));
+            std::mem::forget(h); // outstanding handle — never consumed (refs stays 2)
+        }
+        assert_eq!(list.len(), 100);
+
+        drop(list);
+        assert_eq!(
+            dropped.load(Ordering::Relaxed),
+            100,
+            "handle-bearing (refs == 2) timer values must be dropped with the list",
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Deadline-in-the-past fires immediately
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn poll_far_past_deadline_fires() {
+        let now = Instant::now();
+        let mut list = list_50ms(now);
+
+        list.schedule_forget(now, 42);
+        let mut buf = Vec::new();
+        // Way past the 50ms deadline.
+        let fired = list.poll(now + ms(10_000), &mut buf);
+        assert_eq!(fired, 1);
+        assert_eq!(buf, vec![42]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Miri-compatible tests (raw-pointer paths with a Drop type)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn miri_schedule_cancel_drop_type() {
+        let now = Instant::now();
+        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(50), 64, now);
+
+        let h = list.schedule(now, "hello".to_string());
+        let val = list.cancel(h);
+        assert_eq!(val, Some("hello".to_string()));
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn miri_poll_fires_drop_type() {
+        let now = Instant::now();
+        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+
+        list.schedule_forget(now, "a".to_string());
+        list.schedule_forget(now, "b".to_string());
+        list.schedule_forget(now, "c".to_string());
+
+        let mut buf = Vec::new();
+        let fired = list.poll(now + ms(20), &mut buf);
+        assert_eq!(fired, 3);
+        assert_eq!(buf, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn miri_cancel_zombie_drop_type() {
+        let now = Instant::now();
+        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+
+        let h = list.schedule(now, "zombie".to_string());
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(20), &mut buf);
+        assert_eq!(buf, vec!["zombie".to_string()]);
+
+        let val = list.cancel(h);
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn miri_free_active_and_zombie() {
+        let now = Instant::now();
+        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+
+        // Active → fire-and-forget via free.
+        let h1 = list.schedule(now, "active".to_string());
+        list.free(h1);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(20), &mut buf);
+        assert_eq!(buf, vec!["active".to_string()]);
+
+        // Zombie → free.
+        let h2 = list.schedule(now, "will-fire".to_string());
+        buf.clear();
+        list.poll(now + ms(20), &mut buf);
+        list.free(h2);
+    }
+
+    #[test]
+    fn miri_mid_list_unlink_drop_type() {
+        let now = Instant::now();
+        let mut list: TimeoutList<Vec<u8>> = TimeoutList::unbounded(ms(10), 64, now);
+
+        let mut handles: Vec<_> = (0..5u8)
+            .map(|i| list.schedule(now + Duration::from_micros(i as u64), vec![i; 32]))
+            .collect();
+
+        // Cancel middle, then head.
+        let v2 = list.cancel(handles.remove(2));
+        assert_eq!(v2.unwrap(), vec![2u8; 32]);
+        let v0 = list.cancel(handles.remove(0));
+        assert_eq!(v0.unwrap(), vec![0u8; 32]);
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(20), &mut buf);
+        assert_eq!(buf.len(), 3);
+
+        for h in handles {
+            assert_eq!(list.cancel(h), None);
+        }
+    }
+
+    #[test]
+    fn miri_drop_list_with_entries() {
+        let now = Instant::now();
+        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(50), 64, now);
+
+        for i in 0..20u64 {
+            list.schedule_forget(now + ms(i), format!("entry-{i}"));
+        }
+        assert_eq!(list.len(), 20);
+        drop(list);
+    }
+
+    #[test]
+    fn miri_bounded_lifecycle() {
+        let now = Instant::now();
+        let mut list: BoundedTimeoutList<String> = BoundedTimeoutList::bounded(ms(30), 4, now);
+
+        let h1 = list.try_schedule(now, "a".to_string()).unwrap();
+        let h2 = list.try_schedule(now, "b".to_string()).unwrap();
+        let h3 = list.try_schedule(now, "c".to_string()).unwrap();
+        let h4 = list.try_schedule(now, "d".to_string()).unwrap();
+
+        assert!(list.try_schedule(now, "e".to_string()).is_err());
+
+        list.cancel(h1);
+        let h5 = list.try_schedule(now, "e".to_string()).unwrap();
+
+        let mut buf = Vec::new();
+        list.poll(now + ms(40), &mut buf);
+
+        // Everything fired; remaining handles are zombies.
+        list.free(h2);
+        list.free(h3);
+        list.free(h4);
+        list.free(h5);
+    }
+}
+
+// =============================================================================
+// Property tests
+// =============================================================================
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::{HashMap, HashSet};
+    use std::time::{Duration, Instant};
+
+    const TIMEOUT_MS: u64 = 100;
+    // With a 1ms tick and an exact-multiple timeout, the reciprocal tick
+    // conversion is at most one tick low, so a timer can fire at most 1ms
+    // before its nominal `schedule_now + TIMEOUT_MS` deadline.
+    const EARLY_SLOP_MS: u64 = 1;
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Schedule,
+        ScheduleForget,
+        Cancel { idx: usize },
+        Poll,
+        Advance,
+    }
+
+    fn op_strategy() -> impl Strategy<Value = (Op, u64)> {
+        // Every op carries a non-negative clock advance, keeping `now`
+        // monotone so the fixed-timeout deadlines stay sorted.
+        let advance = 0u64..500;
+        let op = prop_oneof![
+            Just(Op::Schedule),
+            Just(Op::ScheduleForget),
+            any::<usize>().prop_map(|idx| Op::Cancel { idx }),
+            Just(Op::Poll),
+            Just(Op::Advance),
+        ];
+        (op, advance)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(400))]
+
+        /// Random schedule / schedule_forget / cancel / poll interleaving.
+        ///
+        /// Invariants:
+        /// - `len` always matches the live (scheduled, not cancelled, not
+        ///   fired) count.
+        /// - every value fires exactly once.
+        /// - no value fires before its deadline (within 1ms tick slop).
+        /// - each poll's output is non-decreasing in deadline.
+        #[test]
+        fn fuzz_schedule_cancel_poll(ops in proptest::collection::vec(op_strategy(), 1..300)) {
+            let now = Instant::now();
+            let mut list: TimeoutList<u64> = TimeoutList::unbounded(
+                Duration::from_millis(TIMEOUT_MS),
+                4096,
+                now,
+            );
+
+            // value -> nominal deadline_ms (schedule clock + TIMEOUT_MS)
+            let mut live: HashMap<u64, u64> = HashMap::new();
+            // outstanding active handles: (handle, value, deadline_ms)
+            let mut handles: Vec<(TimerHandle<u64>, u64, u64)> = Vec::new();
+            let mut fired: HashSet<u64> = HashSet::new();
+            let mut clock: u64 = 0;
+            let mut next_id: u64 = 0;
+
+            for (op, advance) in &ops {
+                clock += *advance; // monotone
+
+                match op {
+                    Op::Schedule => {
+                        let id = next_id;
+                        next_id += 1;
+                        let deadline = clock + TIMEOUT_MS;
+                        let h = list.schedule(now + Duration::from_millis(clock), id);
+                        handles.push((h, id, deadline));
+                        live.insert(id, deadline);
+                    }
+                    Op::ScheduleForget => {
+                        let id = next_id;
+                        next_id += 1;
+                        let deadline = clock + TIMEOUT_MS;
+                        list.schedule_forget(now + Duration::from_millis(clock), id);
+                        live.insert(id, deadline);
+                    }
+                    Op::Cancel { idx } => {
+                        if !handles.is_empty() {
+                            let i = idx % handles.len();
+                            let (h, val, _) = handles.swap_remove(i);
+                            // Handles only ever hold active timers here (zombies
+                            // are freed right after each poll), so cancel returns
+                            // Some.
+                            let r = list.cancel(h);
+                            prop_assert_eq!(r, Some(val));
+                            prop_assert!(live.remove(&val).is_some());
+                            prop_assert!(!fired.contains(&val));
+                        }
+                    }
+                    Op::Poll => {
+                        let mut buf = Vec::new();
+                        list.poll(now + Duration::from_millis(clock), &mut buf);
+
+                        let mut prev_deadline = 0u64;
+                        for &v in &buf {
+                            let deadline = *live.get(&v)
+                                .expect("fired value must be live");
+                            // No early fire (within tick slop).
+                            prop_assert!(
+                                deadline <= clock + EARLY_SLOP_MS,
+                                "value {} deadline {}ms fired at {}ms",
+                                v, deadline, clock,
+                            );
+                            // Non-decreasing in deadline within this poll.
+                            prop_assert!(deadline >= prev_deadline);
+                            prev_deadline = deadline;
+                            // Fires exactly once.
+                            prop_assert!(fired.insert(v));
+                            live.remove(&v);
+                        }
+
+                        // Free zombie handles whose timers just fired.
+                        let fired_now: HashSet<u64> = buf.iter().copied().collect();
+                        let mut i = 0;
+                        while i < handles.len() {
+                            if fired_now.contains(&handles[i].1) {
+                                let (h, _, _) = handles.swap_remove(i);
+                                list.free(h);
+                            } else {
+                                i += 1;
+                            }
+                        }
+                    }
+                    Op::Advance => {}
+                }
+
+                prop_assert_eq!(list.len(), live.len());
+            }
+
+            // Fire everything remaining.
+            let mut buf = Vec::new();
+            list.poll(now + Duration::from_secs(1_000_000), &mut buf);
+            for &v in &buf {
+                prop_assert!(fired.insert(v));
+                prop_assert!(live.remove(&v).is_some());
+            }
+            // All remaining handles are zombies now.
+            for (h, _, _) in handles {
+                list.free(h);
+            }
+
+            prop_assert!(live.is_empty());
+            prop_assert!(list.is_empty());
+        }
+    }
+}

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -310,7 +310,9 @@ pub type Wheel<T> = TimerWheel<T, unbounded::Slab<WheelEntry<T>>>;
 impl<T: 'static> Wheel<T> {
     /// Creates an unbounded timer wheel with default configuration.
     ///
-    /// For custom configuration, use [`WheelBuilder`].
+    /// `now` fixes the reference epoch — pass one monotone clock source
+    /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For custom
+    /// configuration, use [`WheelBuilder`].
     pub fn unbounded(chunk_capacity: usize, now: Instant) -> Self {
         WheelBuilder::default().unbounded(chunk_capacity).build(now)
     }
@@ -319,7 +321,9 @@ impl<T: 'static> Wheel<T> {
 impl<T: 'static> BoundedWheel<T> {
     /// Creates a bounded timer wheel with default configuration.
     ///
-    /// For custom configuration, use [`WheelBuilder`].
+    /// `now` fixes the reference epoch — pass one monotone clock source
+    /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For custom
+    /// configuration, use [`WheelBuilder`].
     pub fn bounded(capacity: usize, now: Instant) -> Self {
         WheelBuilder::default().bounded(capacity).build(now)
     }


### PR DESCRIPTION
## Summary

Adds `TimeoutList<T>` — a fixed-duration timeout list for the common case where **every timer shares one timeout** (idle timeouts all 30 s, request deadlines all 5 s, a fixed retry/debounce delay, uniform TTL). When all timeouts are equal, deadlines come out monotone in insertion order, so a single sorted intrusive DLL beats the wheel: **O(fired) poll, O(1) exact `next_deadline`, no per-slot scan.**

Closes #666.

## How it works

- **Reuses the wheel's machinery verbatim** — `WheelEntry`, `TimerHandle`, the `SlabStore` (bounded/unbounded), and one `WheelSlot` as the whole list (the DLL splice). No fork of the intrusive-DLL / refcount-zombie / slab protocol; only two `pub(crate)` `WheelSlot` accessors were added.
- **Invariant:** timeout fixed at construction ⇒ `deadline = now + timeout` ⇒ monotone `now` ⇒ deadlines monotone in insertion order ⇒ tail-append stays sorted ⇒ poll walks from the head and stops at the first not-due. The bad case is *unrepresentable* — there is no per-call `deadline` parameter; a backwards clock trips a `debug_assert`.
- **Drops vs the wheel:** the `Vec<Level>`, per-slot bucketing, and the entire `min_deadline` cache + its invalidation branches — a class of bug gone, not just a speedup.

## API

`schedule` / `schedule_forget` (+ bounded `try_*`), `cancel` / `free`, `poll` / `poll_with_limit`, `next_deadline`, `len` / `is_empty`. Same shape as the wheel, minus `reschedule` (cancel + re-schedule instead). Builder mirrors `WheelBuilder`; convenience ctors `TimeoutList::unbounded(timeout, chunk, now)` / `BoundedTimeoutList::bounded(timeout, cap, now)`. Cancel/free mirror the wheel's exact refcount/zombie protocol.

The one thing that reads differently from the wheel: `schedule(now, …)` takes *now*, not a deadline — the deadline is `now + fixed_timeout`.

## Performance (measured, `taskset -c 0`, amortized)

- **Nothing-due poll: ~12 cycles/op, flat** across 100 / 1k / 10k / 50k live — the O(1) property (vs the wheel's O(population) 0.2 µs → 2.4 ms).
- `schedule + cancel` ~25, `schedule_forget` ~24 cycles/op (slab/cache-bound, not the DLL logic).

The bench was reworked to report a **measurement-floor baseline** and **amortized cycles/op** (single-op `rdtsc` carries a ~20-cycle floor that inflated the raw numbers) alongside the percentile tails.

## Testing

33 new tests: lifecycle (schedule/cancel/fire/zombie/free), FIFO ordering (exact `Vec` equality after mid-list cancel), poll-limit truncation + resumption, a nothing-due-touches-only-the-head counter (flat across population), a 400-case proptest (monotone clock; len-matches-live, fire-exactly-once, no-early-fire, non-decreasing output), 7 miri tests on the unsafe (with `Drop` types), and **two `Drop`-counter leak-proofs** (refs==1 and refs==2) asserting every value is dropped — the one property `-Zmiri-ignore-leaks` can't observe.

## Docs

Crate doc gains a **"which structure to use"** section + decision table and a **clock/epoch** note; all four convenience constructors (wheel *and* list) now document that `now` fixes the reference epoch.

## Verification

`fmt` · `clippy --all-features --all-targets -D warnings` · `cargo doc -D warnings` · 101 tests + 3 doctests · miri 7/7 — all green.
