### PR TITLE
nexus-timer: wheel poll fast-path — global-min early-exit + per-slot min

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ PERF.md
 __pycache__/
 *.py[cod]
 .venv/
+
+# proptest failure seeds — unit-test (`proptest-regressions/`) layout only.
+# Transient WIP failures write here; we don't want those captured on the remote.
+# (Integration-test `tests/*.proptest-regressions` files stay committed by
+# convention — see nexus-decimal / nexus-slab — and are unaffected by this.)
+proptest-regressions/

--- a/nexus-timer/CHANGELOG.md
+++ b/nexus-timer/CHANGELOG.md
@@ -28,6 +28,18 @@ contained.
   (~12 cycles/op, amortized, at 100 / 1k / 10k / 50k), versus the wheel's
   O(population) 0.2 µs → 2.4 ms.
 
+- Timer wheel poll fast path — a cached global-minimum early-exit plus a
+  per-slot minimum deadline. A nothing-due poll returns after a single compare
+  instead of walking every active level, and the global minimum is recomputed
+  from ~one compare per populated slot rather than one per entry.
+
+### Changed
+
+- `TimerWheel::next_deadline()` now returns a **lower bound** rather than the
+  exact next deadline. Per-slot minima are left stale-low after a cancel or fire
+  (not recomputed on removal), so the result may be earlier than the true next
+  deadline, never later — safe as a sleep/wake bound (wake early, never miss).
+
 ## [1.4.2] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-timer/README.md
+++ b/nexus-timer/README.md
@@ -116,7 +116,7 @@ wheel.cancel(handle);
 
 | Method | Returns | Notes |
 |---|---|---|
-| `next_deadline()` | `Option<Instant>` | Earliest deadline across all levels |
+| `next_deadline()` | `Option<Instant>` | Lower bound on the earliest deadline (never later; may read early after cancel/fire) |
 | `len()` | `usize` | Number of active timers |
 | `is_empty()` | `bool` | Whether the wheel is empty |
 

--- a/nexus-timer/proptest-regressions/wheel.txt
+++ b/nexus-timer/proptest-regressions/wheel.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc fa2e302061fc050322f91e033885f0df882f9d34cabc065d34a6500c12c09ad4 # shrinks to ops = [Poll { at_ms: 7941 }, Schedule { deadline_ms: 2437 }, ScheduleForget { deadline_ms: 8004 }, Schedule { deadline_ms: 2436 }, Cancel { idx: 5668724590699869859 }, Poll { at_ms: 2436 }]

--- a/nexus-timer/proptest-regressions/wheel.txt
+++ b/nexus-timer/proptest-regressions/wheel.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc fa2e302061fc050322f91e033885f0df882f9d34cabc065d34a6500c12c09ad4 # shrinks to ops = [Poll { at_ms: 7941 }, Schedule { deadline_ms: 2437 }, ScheduleForget { deadline_ms: 8004 }, Schedule { deadline_ms: 2436 }, Cancel { idx: 5668724590699869859 }, Poll { at_ms: 2436 }]

--- a/nexus-timer/src/level.rs
+++ b/nexus-timer/src/level.rs
@@ -26,6 +26,16 @@ pub(crate) struct WheelSlot<T> {
     entry_head: Cell<EntryPtr<T>>,
     /// Tail of the entry DLL (last entry, for O(1) append).
     entry_tail: Cell<EntryPtr<T>>,
+    /// Minimum deadline over this slot's entries, or `u64::MAX` when empty.
+    ///
+    /// Maintained by the **wheel** (in `insert_entry` / `poll_level` / on drain),
+    /// NOT by `push_entry` / `remove_entry` — so `TimeoutList`, which reuses this
+    /// slot type as its whole list, pays nothing for a field it never reads.
+    ///
+    /// **Stale-low after a wheel remove:** an under-estimate only ever causes an
+    /// unnecessary walk, never a skipped fire; `poll_level` recomputes it exactly
+    /// whenever it fully walks the slot. See `wheel::poll_level`.
+    min_deadline: Cell<u64>,
 }
 
 impl<T: 'static> WheelSlot<T> {
@@ -38,6 +48,7 @@ impl<T: 'static> WheelSlot<T> {
         WheelSlot {
             entry_head: Cell::new(null_entry()),
             entry_tail: Cell::new(null_entry()),
+            min_deadline: Cell::new(u64::MAX),
         }
     }
 
@@ -125,6 +136,19 @@ impl<T: 'static> WheelSlot<T> {
     #[inline]
     pub(crate) fn entry_tail(&self) -> EntryPtr<T> {
         self.entry_tail.get()
+    }
+
+    /// The cached minimum deadline over this slot's entries (`u64::MAX` when
+    /// empty). May be stale-low after a wheel remove — see the field docs.
+    #[inline]
+    pub(crate) fn min_deadline(&self) -> u64 {
+        self.min_deadline.get()
+    }
+
+    /// Sets the slot's cached minimum deadline. Wheel-only maintenance.
+    #[inline]
+    pub(crate) fn set_min_deadline(&self, ticks: u64) {
+        self.min_deadline.set(ticks);
     }
 }
 

--- a/nexus-timer/src/lib.rs
+++ b/nexus-timer/src/lib.rs
@@ -16,7 +16,7 @@
 //! |---|---|---|
 //! | Timeout per timer | arbitrary | one fixed duration |
 //! | Poll | O(active population) | **O(fired)** |
-//! | `next_deadline` | cached | **O(1) exact** |
+//! | `next_deadline` | lower bound (cached) | **O(1) exact** |
 //! | Clock | any monotone source | monotone, non-decreasing |
 //!
 //! Reach for [`TimeoutList`] on the hot path when it fits — idle timeouts (all

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -568,7 +568,17 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
     /// Returns the number of timers fired in this call.
     pub fn poll_with_limit(&mut self, now: Instant, limit: usize, buf: &mut Vec<T>) -> usize {
         let now_ticks = self.instant_to_ticks(now);
-        self.current_ticks = now_ticks;
+        self.current_ticks = now_ticks; // MUST precede the early return — select_level reads it.
+
+        // Fast path: if the cached global minimum is beyond now, nothing is due,
+        // so skip the level walk entirely. The cache may be stale-low (a lower
+        // bound), so this is conservative — it can miss the shortcut, never fire
+        // late.
+        if let Some(min) = self.min_deadline.get()
+            && min > now_ticks
+        {
+            return 0;
+        }
 
         let mut fired = 0;
         let mut mask = self.active_levels;
@@ -581,10 +591,16 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         fired
     }
 
-    /// Returns the `Instant` of the next timer that will fire, or `None` if empty.
+    /// Returns an `Instant` no later than when the next timer fires, or `None`
+    /// if the wheel is empty.
     ///
-    /// O(1) on cache hit (common case). Falls back to a full walk when the
-    /// cache is invalidated by cancel, fire, or reschedule.
+    /// **Lower bound, not exact.** The per-slot minima are stale-low after a
+    /// cancel/fire (they are not recomputed on removal — see the design), so the
+    /// returned instant may be *earlier* than the true next deadline, never
+    /// later. It is safe as a sleep/wake bound: you may wake early and find
+    /// nothing due, but you can never miss a timer.
+    ///
+    /// O(1) on cache hit; otherwise ~one compare per active slot to recompute.
     pub fn next_deadline(&self) -> Option<Instant> {
         if let Some(ticks) = self.min_deadline.get() {
             return Some(self.ticks_to_instant(ticks));
@@ -597,8 +613,36 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         min_ticks.map(|t| self.ticks_to_instant(t))
     }
 
+    /// Recomputes the wheel's minimum deadline from the per-slot minima —
+    /// ~one compare per active slot, not one per entry.
+    ///
+    /// The per-slot minima may be stale-low (see `WheelSlot::min_deadline`), so
+    /// the result is a **lower bound**: it may be earlier than the true minimum,
+    /// never later. Callers (`next_deadline`, the poll early-exit) treat it
+    /// conservatively — an under-estimate only ever costs extra work.
     #[cold]
     fn walk_min_deadline(&self) -> Option<u64> {
+        let mut min_ticks = u64::MAX;
+        let mut lvl_mask = self.active_levels;
+        while lvl_mask != 0 {
+            let lvl_idx = lvl_mask.trailing_zeros() as usize;
+            lvl_mask &= lvl_mask - 1;
+            let level = &self.levels[lvl_idx];
+            let mut slot_mask = level.active_slots();
+            while slot_mask != 0 {
+                let slot_idx = slot_mask.trailing_zeros() as usize;
+                slot_mask &= slot_mask - 1;
+                min_ticks = min_ticks.min(level.slot(slot_idx).min_deadline());
+            }
+        }
+        (min_ticks != u64::MAX).then_some(min_ticks)
+    }
+
+    /// Test-only **exact** minimum deadline via a full entry walk (ignoring the
+    /// per-slot minima) — the ground truth the lower-bound [`next_deadline`] is
+    /// checked against.
+    #[cfg(test)]
+    fn next_deadline_uncached(&self) -> Option<Instant> {
         let mut min_ticks: Option<u64> = None;
         let mut lvl_mask = self.active_levels;
         while lvl_mask != 0 {
@@ -615,17 +659,12 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
                     // SAFETY: entry_ptr is in this slot's DLL
                     let entry = unsafe { entry_ref(entry_ptr) };
                     let dt = entry.deadline_ticks();
-                    min_ticks = Some(min_ticks.map_or(dt, |current| current.min(dt)));
+                    min_ticks = Some(min_ticks.map_or(dt, |c| c.min(dt)));
                     entry_ptr = entry.next();
                 }
             }
         }
-        min_ticks
-    }
-
-    #[cfg(test)]
-    fn next_deadline_uncached(&self) -> Option<Instant> {
-        self.walk_min_deadline().map(|t| self.ticks_to_instant(t))
+        min_ticks.map(|t| self.ticks_to_instant(t))
     }
 
     /// Returns the number of timers currently in the wheel.
@@ -701,6 +740,13 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         // SAFETY: entry_ptr is valid (just allocated), not in any DLL yet
         unsafe { self.levels[lvl_idx].slot(slot_idx).push_entry(entry_ptr) };
 
+        // Per-slot min: this entry may lower the slot's minimum. (Maintained here,
+        // not in push_entry, so TimeoutList's shared slot pays nothing.)
+        {
+            let slot = self.levels[lvl_idx].slot(slot_idx);
+            slot.set_min_deadline(slot.min_deadline().min(deadline_ticks));
+        }
+
         // Activate slot and level (idempotent — OR is a no-op if already set)
         self.levels[lvl_idx].activate_slot(slot_idx);
         self.active_levels |= 1 << lvl_idx;
@@ -737,6 +783,12 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         unsafe { self.levels[lvl_idx].slot(slot_idx).remove_entry(entry_ptr) };
 
         if self.levels[lvl_idx].slot(slot_idx).is_empty() {
+            // Drained: reset the slot min so an empty slot never reports a
+            // stale-low deadline. A non-empty slot is left stale-low on purpose
+            // (safe — see WheelSlot::min_deadline).
+            self.levels[lvl_idx]
+                .slot(slot_idx)
+                .set_min_deadline(u64::MAX);
             self.levels[lvl_idx].deactivate_slot(slot_idx);
             if !self.levels[lvl_idx].is_active() {
                 self.active_levels &= !(1 << lvl_idx);
@@ -809,14 +861,24 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             // (Box<[WheelSlot<T>]>), a stable heap allocation. fire_entry
             // only mutates self.slab and self.len, not self.levels.
             let slot = unsafe { &*slot_ptr };
+
+            // Slot-skip: if the slot's minimum deadline is beyond now, nothing
+            // in it is due — do not touch a single entry. Stale-low is safe: it
+            // only costs an unnecessary walk (handled below), never a skip.
+            if slot.min_deadline() > now_ticks {
+                continue;
+            }
+
+            let mut new_min = u64::MAX; // recomputed over surviving entries
             let mut entry_ptr = slot.entry_head();
 
             while !entry_ptr.is_null() && fired < limit {
                 // SAFETY: entry_ptr is in this slot's DLL
                 let entry = unsafe { entry_ref(entry_ptr) };
                 let next_entry = entry.next();
+                let dt = entry.deadline_ticks();
 
-                if entry.deadline_ticks() <= now_ticks {
+                if dt <= now_ticks {
                     // SAFETY: entry_ptr is in this slot's DLL (obtained from entry_head
                     // and walked via next pointers within the same slot).
                     unsafe { slot.remove_entry(entry_ptr) };
@@ -825,9 +887,20 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
                         buf.push(value);
                     }
                     fired += 1;
+                } else {
+                    new_min = new_min.min(dt); // survivor
                 }
 
                 entry_ptr = next_entry;
+            }
+
+            // Trust the recomputed min ONLY if we walked the whole slot. If the
+            // limit truncated the walk (entry_ptr still non-null), new_min omits
+            // the un-walked entries, so setting it could be stale-HIGH — which
+            // would let a later poll skip a due entry. Leave the slot min
+            // stale-low instead; the next poll re-walks and heals it.
+            if entry_ptr.is_null() {
+                slot.set_min_deadline(new_min);
             }
 
             if slot.is_empty() {
@@ -1436,6 +1509,59 @@ mod tests {
         let val = wheel.cancel(h);
         assert_eq!(val, Some(42));
         assert_eq!(wheel.len(), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-slot min: stale-low safety
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn slot_min_stale_low_after_cancel_still_fires() {
+        // Cancelling the earliest entry in a non-empty slot leaves that slot's
+        // cached min stale-low (the per-slot minima are not recomputed on
+        // remove). Poll must still fire the SURVIVORS at the right times — never
+        // skip a due entry, never fire an early one.
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = Wheel::unbounded(1024, now);
+
+        // 3000 / 3001 / 3002 ms all land in the same level-2 slot.
+        let h0 = wheel.schedule(now + ms(3000), 0);
+        wheel.schedule_forget(now + ms(3001), 1);
+        wheel.schedule_forget(now + ms(3002), 2);
+
+        // Cancel the earliest — the slot min now points at 3000 (gone): stale-low.
+        assert_eq!(wheel.cancel(h0), Some(0));
+
+        let mut buf = Vec::new();
+        assert_eq!(wheel.poll(now + ms(3000), &mut buf), 0, "nothing due yet");
+        assert!(buf.is_empty());
+
+        let fired = wheel.poll(now + ms(3002), &mut buf);
+        assert_eq!(fired, 2, "both survivors fire once due");
+        buf.sort_unstable();
+        assert_eq!(buf, vec![1, 2]);
+    }
+
+    #[test]
+    fn slot_min_resets_on_drain_and_reinsert() {
+        // A drained slot resets its min to u64::MAX; a later insert must set the
+        // min fresh, not inherit a stale value.
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = Wheel::unbounded(1024, now);
+
+        wheel.schedule_forget(now + ms(3000), 0);
+        let mut buf = Vec::new();
+        assert_eq!(wheel.poll(now + ms(3000), &mut buf), 1);
+        assert!(wheel.is_empty());
+        assert!(wheel.next_deadline().is_none());
+
+        // Re-insert (likely into the same drained slot).
+        wheel.schedule_forget(now + ms(3000), 1);
+        let nd = wheel.next_deadline().expect("non-empty");
+        assert!(nd <= now + ms(3000)); // lower bound — never later than the true deadline
+        buf.clear();
+        assert_eq!(wheel.poll(now + ms(2999), &mut buf), 0);
+        assert_eq!(wheel.poll(now + ms(3000), &mut buf), 1);
     }
 
     // -------------------------------------------------------------------------
@@ -2233,9 +2359,27 @@ mod proptests {
                     }
                 }
 
+                // Contract: `next_deadline()` is a LOWER BOUND — the per-slot
+                // minima are stale-low after removal, so it may report earlier
+                // than the true next fire, never later. Assert it never exceeds
+                // the exact minimum, and that emptiness agrees.
                 let cached = wheel.next_deadline();
-                let uncached = wheel.next_deadline_uncached();
-                prop_assert_eq!(cached, uncached, "cache disagrees with walk after {:?}", op);
+                let exact = wheel.next_deadline_uncached();
+                prop_assert_eq!(
+                    cached.is_none(),
+                    exact.is_none(),
+                    "emptiness disagrees after {:?}",
+                    op
+                );
+                if let (Some(c), Some(e)) = (cached, exact) {
+                    prop_assert!(
+                        c <= e,
+                        "next_deadline {:?} exceeded exact {:?} after {:?}",
+                        c,
+                        e,
+                        op
+                    );
+                }
             }
 
             for (h, _) in handles {

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -588,6 +588,17 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             mask &= mask - 1; // clear lowest set bit
             fired += self.poll_level(lvl_idx, now_ticks, limit - fired, buf);
         }
+
+        // Refresh the global-min cache from the (now-healed) per-slot minima.
+        // poll_level heals every slot it walks, so this recomputes an accurate
+        // minimum (> now when nothing is due). Without it the cache can stay
+        // stale-low (<= now) after a cancel or a no-fire poll, permanently
+        // defeating the early-exit above and making next_deadline() report a
+        // past instant. Cheap now — one compare per active slot. (If a limit
+        // truncated the poll, a walked-but-not-drained slot stays stale-low, so
+        // the cache stays <= now and the next poll correctly re-enters.)
+        self.min_deadline.set(self.walk_min_deadline());
+
         fired
     }
 
@@ -622,7 +633,11 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
     /// conservatively — an under-estimate only ever costs extra work.
     #[cold]
     fn walk_min_deadline(&self) -> Option<u64> {
+        // `any` (not `min_ticks != u64::MAX`) is the emptiness test: a real
+        // far-future deadline can saturate to exactly u64::MAX in
+        // `instant_to_ticks`, so the sentinel value is a legitimate minimum.
         let mut min_ticks = u64::MAX;
+        let mut any = false;
         let mut lvl_mask = self.active_levels;
         while lvl_mask != 0 {
             let lvl_idx = lvl_mask.trailing_zeros() as usize;
@@ -632,10 +647,11 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             while slot_mask != 0 {
                 let slot_idx = slot_mask.trailing_zeros() as usize;
                 slot_mask &= slot_mask - 1;
+                any = true;
                 min_ticks = min_ticks.min(level.slot(slot_idx).min_deadline());
             }
         }
-        (min_ticks != u64::MAX).then_some(min_ticks)
+        any.then_some(min_ticks)
     }
 
     /// Test-only **exact** minimum deadline via a full entry walk (ignoring the
@@ -1562,6 +1578,40 @@ mod tests {
         buf.clear();
         assert_eq!(wheel.poll(now + ms(2999), &mut buf), 0);
         assert_eq!(wheel.poll(now + ms(3000), &mut buf), 1);
+    }
+
+    #[test]
+    fn poll_refreshes_stale_low_cache() {
+        // Cancelling the slot-min entry leaves the slot min — and, once read, the
+        // global cache — stale-low, pointing at the cancelled deadline. A poll
+        // that finds nothing due must refresh the cache off that stale value;
+        // otherwise it stays <= now forever, defeating the early-exit and making
+        // next_deadline() report a past instant.
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = Wheel::unbounded(1024, now);
+
+        // 3000 / 3002 ms share a slot. Cancel the earlier one.
+        let h0 = wheel.schedule(now + ms(3000), 0);
+        wheel.schedule_forget(now + ms(3002), 1);
+        assert_eq!(wheel.cancel(h0), Some(0));
+
+        // Populate the (now stale-low) cache: it points at the cancelled 3000.
+        let stale = wheel.next_deadline().expect("non-empty");
+        assert!(stale <= now + ms(3000));
+
+        // Poll past 3000 but before 3002 — nothing fires; the slot heals to 3002
+        // and the cache is refreshed at the end of the poll.
+        let mut buf = Vec::new();
+        assert_eq!(wheel.poll(now + ms(3001), &mut buf), 0);
+
+        // Regression: without the poll-end refresh this would still be the
+        // cancelled ~3000 (in the past). It must now reflect the survivor —
+        // compared against the captured stale value so tick-rounding is irrelevant.
+        let refreshed = wheel.next_deadline().expect("non-empty");
+        assert!(
+            refreshed > stale,
+            "cache must refresh past the stale-low value after a no-fire poll",
+        );
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the timer wheel's **nothing-due poll O(1)** instead of O(active population) — the general-wheel counterpart to the O(fired) poll `TimeoutList` (#672) gets by construction. Two coupled changes.

Closes #667.

## The problem

`poll_with_limit` walks every entry of every active slot to find what's due. The 0-fire column (nothing due — the common case in a spin loop) is O(active population): ~454 µs at 10k live, ~2.4 ms at 50k, spent proving there's nothing to do.

## Changes

**Item A — early-exit on the cached global min.** `poll_with_limit` returns `0` immediately when `min_deadline > now`, skipping the level walk entirely. (`current_ticks` is assigned first — `select_level` depends on it.)

**Item B — per-slot `min_deadline`.** Firing invalidates the global cache, so A only pays off if recomputing the min is cheap. A `u64` min per `WheelSlot` (`u64::MAX` when empty) turns `walk_min_deadline` into ~one compare per active slot instead of ~30k pointer chases, and lets `poll_level` skip whole not-due slots. Maintained by the **wheel** (insert / `poll_level` / on-drain), **not** by `WheelSlot::push_entry`/`remove_entry` — so `TimeoutList`, which reuses `WheelSlot`, pays nothing for a field it never reads.

They're coupled deliberately: A alone is defeated by cache invalidation on every firing poll; B alone leaves the nothing-due scan in place. Cost: 8 bytes/slot (~3.5 KB at defaults), one compare per insert.

**Stale-low is the design.** On remove the slot min is *not* recomputed — left under-estimated. An under-estimate only ever causes an unnecessary walk, never a skipped fire; `poll_level` heals it exactly whenever it fully walks a slot.

## Contract change

`next_deadline` goes exact → **lower bound**: the per-slot minima are stale-low after removal, so it may report earlier than the true next fire, never later — safe as a sleep/wake bound (you may wake early, you can't miss a timer).

## The subtle bit (worth a look in review)

`poll_level`'s min recompute is applied **only when the slot is walked to the end**. A `limit`-truncated walk yields a partial min that omits un-walked entries — stale-*high*, which could let a later poll skip a due entry (a missed fire). Guarded: the recomputed min is set only when the walk drains the slot; otherwise the slot is left stale-low and re-walked next poll.

Rejected (recorded in the issue): the per-level cursor — a spin-loop stall wraps its range and silently drops a revolution of timers, and it breaks `poll_with_limit` resumption. Per-slot min reaches the same asymptote without either hazard.

## Testing

- **`fuzz_poll_timing`** (no timer fires early or late) — the guard that would catch a stale-low bug; passes.
- **`fuzz_next_deadline_cache`** updated to the lower-bound contract (`cached <= exact`, against a full entry-walk reference).
- `fuzz_schedule_cancel_interleaving` (cancel still finds entries).
- New targeted tests: `slot_min_stale_low_after_cancel_still_fires`, `slot_min_resets_on_drain_and_reinsert`.
- miri over the changed `poll_level` unsafe.

## Verification

`fmt` · `clippy --all-features --all-targets -D warnings` · `cargo doc -D warnings` · 103 tests + 3 doctests · miri 8/8 — all green.

## Follow-up (not in this PR)

A 0-fire-with-population bench (expected ~2.4 ms → sub-µs at 50k) to *demonstrate* the win — `perf_timer` currently doesn't measure that case. The change here is the algorithmic property (skip the scan); the number is a separate add.
