### PR TITLE
nexus-timer: collect/rebalance wheel — bound the poll tail under load

### DIFF
--- a/nexus-timer/Cargo.toml
+++ b/nexus-timer/Cargo.toml
@@ -26,3 +26,7 @@ harness = false
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "perf_server_scenarios"
+harness = false

--- a/nexus-timer/README.md
+++ b/nexus-timer/README.md
@@ -8,12 +8,15 @@ Standard timer implementations (priority queues, sorted trees) have
 O(log n) insert or O(log n) cancel. Timer wheels give O(1) for both by
 hashing deadlines into coarse-grained slots across multiple levels.
 
-`nexus-timer` is a hierarchical timer wheel inspired by the Linux kernel's
-timer infrastructure (Gleixner 2016):
+`nexus-timer` is a hierarchical, rebalancing timer wheel:
 
-- **No cascade** — once placed, an entry never moves between levels.
-  Poll checks each entry's exact deadline. This eliminates the latency
-  spikes that cascading timer wheels exhibit.
+- **Collect + rebalance** — a timer is placed in the coarsest level that fits
+  its deadline, then **rebalanced** down to finer levels as its deadline nears,
+  so `poll` collects ready timers from small, exact fine-level slots instead of
+  walking a fat coarse slot on every call. Rebalancing folds into the poll
+  (`poll_and_rebalance`), can be bounded (`max_rebalances_per_poll`), or run
+  proactively off the hot path (`rebalance`) to keep the poll tail flat under a
+  large number of timers. Timers fire at their exact tick.
 - **Intrusive active-slot lists** — only non-empty slots are visited
   during poll and next-deadline queries. No bitmap, no full scan.
 - **Embedded refcounting** — lightweight `Cell<u8>` refcount per entry
@@ -194,7 +197,7 @@ Level 6:                    ≈  4.7 hour range
 
 Each level covers 8x the time range of the previous (configurable via
 `clk_shift`). A timer is placed in the coarsest level that can represent
-its deadline. Once placed, it never moves.
+its deadline, and rebalanced down to finer levels as its deadline nears.
 
 ### Handle Lifecycle
 

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -102,11 +102,26 @@ const EDGE: Env = Env {
     dur_max_ms: 2_000,
     cancel_pct: 90,
     periodic: &[
-        Periodic { period_ms: 3_000, count: 2 },
-        Periodic { period_ms: 5_000, count: 2 },
-        Periodic { period_ms: 10_000, count: 2 },
-        Periodic { period_ms: 15_000, count: 1 },
-        Periodic { period_ms: 30_000, count: 1 },
+        Periodic {
+            period_ms: 3_000,
+            count: 2,
+        },
+        Periodic {
+            period_ms: 5_000,
+            count: 2,
+        },
+        Periodic {
+            period_ms: 10_000,
+            count: 2,
+        },
+        Periodic {
+            period_ms: 15_000,
+            count: 1,
+        },
+        Periodic {
+            period_ms: 30_000,
+            count: 1,
+        },
     ],
 };
 const APP: Env = Env {
@@ -116,11 +131,26 @@ const APP: Env = Env {
     dur_max_ms: 5_000,
     cancel_pct: 75,
     periodic: &[
-        Periodic { period_ms: 3_000, count: 16 },
-        Periodic { period_ms: 5_000, count: 16 },
-        Periodic { period_ms: 10_000, count: 12 },
-        Periodic { period_ms: 15_000, count: 12 },
-        Periodic { period_ms: 30_000, count: 8 },
+        Periodic {
+            period_ms: 3_000,
+            count: 16,
+        },
+        Periodic {
+            period_ms: 5_000,
+            count: 16,
+        },
+        Periodic {
+            period_ms: 10_000,
+            count: 12,
+        },
+        Periodic {
+            period_ms: 15_000,
+            count: 12,
+        },
+        Periodic {
+            period_ms: 30_000,
+            count: 8,
+        },
     ],
 };
 const GATEWAY: Env = Env {
@@ -130,11 +160,26 @@ const GATEWAY: Env = Env {
     dur_max_ms: 30_000,
     cancel_pct: 95,
     periodic: &[
-        Periodic { period_ms: 3_000, count: 64 },
-        Periodic { period_ms: 5_000, count: 64 },
-        Periodic { period_ms: 10_000, count: 48 },
-        Periodic { period_ms: 15_000, count: 48 },
-        Periodic { period_ms: 30_000, count: 32 },
+        Periodic {
+            period_ms: 3_000,
+            count: 64,
+        },
+        Periodic {
+            period_ms: 5_000,
+            count: 64,
+        },
+        Periodic {
+            period_ms: 10_000,
+            count: 48,
+        },
+        Periodic {
+            period_ms: 15_000,
+            count: 48,
+        },
+        Periodic {
+            period_ms: 30_000,
+            count: 32,
+        },
     ],
 };
 
@@ -201,7 +246,7 @@ fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
         // 3. Poll — the measured hot path.
         buf.clear();
         let s = rdtsc_start();
-        let fired = black_box(wheel.poll(now, &mut buf));
+        let fired = black_box(wheel.poll_and_rebalance(now, &mut buf));
         let e = rdtsc_end();
         black_box(fired);
         if tick >= WARMUP_TICKS {
@@ -233,18 +278,26 @@ fn print_poll_row(label: &str, samples: &[u64]) {
 fn main() {
     println!("================================================================");
     println!("TIMER WHEEL — realistic server-scenario poll cost (cycles/poll)");
-    println!("  1 ms tick; {SIM_TICKS} samples/env after {WARMUP_TICKS} warmup; best effort — pin with taskset -c 0");
+    println!(
+        "  1 ms tick; {SIM_TICKS} samples/env after {WARMUP_TICKS} warmup; best effort — pin with taskset -c 0"
+    );
     println!("================================================================");
 
     println!("\nPer-environment poll cost:");
-    println!("  {:<52} {:>6} {:>6} {:>7} {:>7}", "environment", "p50", "p99", "p99.9", "max");
+    println!(
+        "  {:<52} {:>6} {:>6} {:>7} {:>7}",
+        "environment", "p50", "p99", "p99.9", "max"
+    );
     for env in [&EDGE, &APP, &GATEWAY] {
         let samples = run_env(env, env.cancel_pct);
         print_poll_row(env.name, &samples);
     }
 
     println!("\nCancel-ratio sweep (app env, 15k one-shots):");
-    println!("  {:<52} {:>6} {:>6} {:>7} {:>7}", "cancelled %", "p50", "p99", "p99.9", "max");
+    println!(
+        "  {:<52} {:>6} {:>6} {:>7} {:>7}",
+        "cancelled %", "p50", "p99", "p99.9", "max"
+    );
     for pct in [10u32, 50, 75, 90, 95] {
         let samples = run_env(&APP, pct);
         print_poll_row(&format!("{pct}% cancelled"), &samples);

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -7,10 +7,10 @@
 //! increasing scale, each a mix of both, and drives the wheel through a
 //! simulated 1 ms-tick timeline while measuring **per-poll cost in cycles**.
 //!
-//! Poll is the hot path and the operation the cascade design affects, so we
+//! Poll is the hot path and the operation the rebalance design affects, so we
 //! report its full distribution (p50 / p99 / p99.9 / max), never a mean — a
 //! mean hides exactly the two things this bench exists to compare: the
-//! cascade re-hash burst and the no-cascade per-poll re-walk of a due slot.
+//! rebalance burst and the per-poll re-walk of a fat coarse slot.
 //!
 //! Run pinned, turbo off:
 //! ```text

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -186,11 +186,34 @@ const GATEWAY: Env = Env {
 const WARMUP_TICKS: u64 = 5_000; // 5 s to reach steady-state population
 const SIM_TICKS: u64 = 30_000; // 30 s measured window (1 sample per 1 ms tick)
 
-/// Drive one environment through the simulated timeline and return the sorted
-/// per-poll cycle samples over the measured window.
-fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
+/// Which poll strategy the driver measures.
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    /// One `poll_and_rebalance` per tick (collect + maintain together).
+    Combined,
+    /// Collect-only `poll` per tick (the measured cost) plus a proactive
+    /// `rebalance` done separately — its cost tracked apart, as idle-time work.
+    Proactive,
+    /// Adaptive: collect-only `poll`, and `rebalance` only when the poll came
+    /// back empty (nothing fired) — maintain during genuine slack.
+    Opportunistic,
+}
+
+/// Drive one environment through the simulated timeline. Returns the sorted
+/// (poll-cost, rebalance-cost) cycle samples over the measured window;
+/// rebalance-cost is empty in Combined mode (folded into the poll).
+fn run_env(
+    env: &Env,
+    cancel_pct: u32,
+    rebalance_cap: usize,
+    mode: Mode,
+    rebalance_every: u64,
+) -> (Vec<u64>, Vec<u64>) {
     let epoch = Instant::now();
-    let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(epoch);
+    let mut wheel: Wheel<u64> = WheelBuilder::default()
+        .max_rebalances_per_poll(rebalance_cap)
+        .unbounded(4096)
+        .build(epoch);
     let mut rng = Rng(0x1234_5678_9abc_def0);
     let periodic_count: usize = env.periodic.iter().map(|p| p.count).sum();
 
@@ -210,6 +233,7 @@ fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
 
     let mut buf: Vec<u64> = Vec::with_capacity(2_048);
     let mut samples: Vec<u64> = Vec::with_capacity(SIM_TICKS as usize);
+    let mut rebalance_samples: Vec<u64> = Vec::new();
 
     for tick in 0..(WARMUP_TICKS + SIM_TICKS) {
         let now = epoch + Duration::from_millis(tick);
@@ -243,14 +267,34 @@ fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
             }
         }
 
-        // 3. Poll — the measured hot path.
+        // 3. Poll — the measured hot path. In Proactive mode the poll is
+        // collect-only and a separate rebalance does the maintenance, whose cost
+        // is recorded apart (a real caller runs it off the fire path).
         buf.clear();
         let s = rdtsc_start();
-        let fired = black_box(wheel.poll_and_rebalance(now, &mut buf));
+        let fired = black_box(match mode {
+            Mode::Combined => wheel.poll_and_rebalance(now, &mut buf),
+            Mode::Proactive | Mode::Opportunistic => wheel.poll(now, &mut buf),
+        });
         let e = rdtsc_end();
         black_box(fired);
         if tick >= WARMUP_TICKS {
             samples.push(e.wrapping_sub(s));
+        }
+
+        let do_rebalance = match mode {
+            Mode::Combined => false,
+            Mode::Proactive => tick % rebalance_every == 0,
+            Mode::Opportunistic => fired == 0,
+        };
+        if do_rebalance {
+            let rs = rdtsc_start();
+            let moved = black_box(wheel.rebalance(now, usize::MAX));
+            let re = rdtsc_end();
+            black_box(moved);
+            if tick >= WARMUP_TICKS {
+                rebalance_samples.push(re.wrapping_sub(rs));
+            }
         }
 
         // 4. Re-arm periodic timers that fired (non-zero value == period_ms).
@@ -262,7 +306,8 @@ fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
     }
 
     samples.sort_unstable();
-    samples
+    rebalance_samples.sort_unstable();
+    (samples, rebalance_samples)
 }
 
 fn print_poll_row(label: &str, samples: &[u64]) {
@@ -289,17 +334,73 @@ fn main() {
         "environment", "p50", "p99", "p99.9", "max"
     );
     for env in [&EDGE, &APP, &GATEWAY] {
-        let samples = run_env(env, env.cancel_pct);
+        let (samples, _) = run_env(env, env.cancel_pct, usize::MAX, Mode::Combined, 1);
         print_poll_row(env.name, &samples);
     }
 
-    println!("\nCancel-ratio sweep (app env, 15k one-shots):");
+    println!("\nCancel-ratio sweep (app env, 15k one-shots, unbounded rebalance):");
     println!(
         "  {:<52} {:>6} {:>6} {:>7} {:>7}",
         "cancelled %", "p50", "p99", "p99.9", "max"
     );
     for pct in [10u32, 50, 75, 90, 95] {
-        let samples = run_env(&APP, pct);
+        let (samples, _) = run_env(&APP, pct, usize::MAX, Mode::Combined, 1);
         print_poll_row(&format!("{pct}% cancelled"), &samples);
     }
+
+    // Option (b): does capping rebalances-per-poll flatten the tail? Same app
+    // workload, sweeping max_rebalances_per_poll from unbounded down. Expect the
+    // tail (p99.9/max) to fall as the cap tightens, at a modest cost to the body.
+    println!("\nRebalance-cap sweep (app env, 75% cancelled):");
+    println!(
+        "  {:<52} {:>6} {:>6} {:>7} {:>7}",
+        "max_rebalances_per_poll", "p50", "p99", "p99.9", "max"
+    );
+    for cap in [usize::MAX, 256, 64, 16] {
+        let (samples, _) = run_env(&APP, APP.cancel_pct, cap, Mode::Combined, 1);
+        let label = if cap == usize::MAX {
+            "unbounded".to_string()
+        } else {
+            cap.to_string()
+        };
+        print_poll_row(&label, &samples);
+    }
+
+    // Proactive rebalance: move maintenance off the collect hot path. Combined
+    // does collect+rebalance in one poll; Proactive collects with a cheap `poll`
+    // and does `rebalance` separately on a cadence (its cost shown apart, as
+    // idle-time work). Sweeping the cadence: rebalancing more often keeps the
+    // collect cheap but re-walks the look-ahead window; less often lets the
+    // collect drift up but amortizes rebalance down. (rebalance rows are
+    // per-CALL cost — amortized cost per tick ≈ that / cadence.)
+    println!("\nProactive rebalance vs combined (app env, 75% cancelled):");
+    println!(
+        "  {:<52} {:>6} {:>6} {:>7} {:>7}",
+        "operation measured", "p50", "p99", "p99.9", "max"
+    );
+    let (combined, _) = run_env(&APP, APP.cancel_pct, usize::MAX, Mode::Combined, 1);
+    print_poll_row("poll_and_rebalance (combined baseline)", &combined);
+    for every in [1u64, 16, 64, 256] {
+        let (collect, rebal) = run_env(&APP, APP.cancel_pct, usize::MAX, Mode::Proactive, every);
+        print_poll_row(
+            &format!("poll (collect-only), rebalance every {every}t"),
+            &collect,
+        );
+        print_poll_row(&format!("  rebalance call cost (every {every}t)"), &rebal);
+    }
+
+    // Adaptive: rebalance only when a poll comes back empty (nothing fired) —
+    // maintain during genuine slack, never steal from a poll that has work.
+    println!("\nOpportunistic rebalance (rebalance only on an empty poll, app env):");
+    println!(
+        "  {:<52} {:>6} {:>6} {:>7} {:>7}",
+        "operation measured", "p50", "p99", "p99.9", "max"
+    );
+    let (collect, rebal) = run_env(&APP, APP.cancel_pct, usize::MAX, Mode::Opportunistic, 1);
+    let ran_pct = rebal.len() as f64 / SIM_TICKS as f64 * 100.0;
+    print_poll_row("poll (collect-only)", &collect);
+    print_poll_row(
+        &format!("rebalance (ran on {ran_pct:.0}% of ticks, the empty ones)"),
+        &rebal,
+    );
 }

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -1,0 +1,252 @@
+//! Realistic server-scenario benchmark for [`TimerWheel`].
+//!
+//! Server code uses timers two ways: **one-shot timeouts** that are usually
+//! cancelled before they fire (a request/connection completes before its
+//! deadline), and **periodic events** at fixed intervals (heartbeats, metrics
+//! flush, health checks). This bench models three server environments of
+//! increasing scale, each a mix of both, and drives the wheel through a
+//! simulated 1 ms-tick timeline while measuring **per-poll cost in cycles**.
+//!
+//! Poll is the hot path and the operation the cascade design affects, so we
+//! report its full distribution (p50 / p99 / p99.9 / max), never a mean — a
+//! mean hides exactly the two things this bench exists to compare: the
+//! cascade re-hash burst and the no-cascade per-poll re-walk of a due slot.
+//!
+//! Run pinned, turbo off:
+//! ```text
+//! echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+//! cargo build --release --bench perf_server_scenarios
+//! taskset -c 0 ./target/release/deps/perf_server_scenarios-*
+//! ```
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use nexus_timer::{TimerHandle, Wheel, WheelBuilder};
+
+// ── deterministic RNG (xorshift64*) — identical workload every run ───────────
+struct Rng(u64);
+impl Rng {
+    #[inline]
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    /// Uniform in `[lo, hi)`.
+    #[inline]
+    fn range(&mut self, lo: u64, hi: u64) -> u64 {
+        lo + self.next() % (hi - lo).max(1)
+    }
+    #[inline]
+    fn pct(&mut self, p: u32) -> bool {
+        self.next() % 100 < p as u64
+    }
+}
+
+// ── rdtsc brackets (match perf_timeout_list.rs) ──────────────────────────────
+#[inline(always)]
+fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
+    unsafe {
+        std::arch::x86_64::_mm_lfence();
+        std::arch::x86_64::_rdtsc()
+    }
+}
+#[inline(always)]
+fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
+    unsafe {
+        let tsc = std::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
+        std::arch::x86_64::_mm_lfence();
+        tsc
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx]
+}
+
+// ── environment definitions ──────────────────────────────────────────────────
+struct Periodic {
+    period_ms: u64,
+    count: usize,
+}
+struct Env {
+    name: &'static str,
+    /// Live one-shot timeouts maintained at steady state.
+    population: usize,
+    /// One-shot deadline range (request/connection timeouts).
+    dur_min_ms: u64,
+    dur_max_ms: u64,
+    /// Percent of one-shots cancelled before firing.
+    cancel_pct: u32,
+    /// Periodic events, by interval.
+    periodic: &'static [Periodic],
+}
+
+// Standard server intervals: 3 s, 5 s, 10 s, 15 s, 30 s.
+const EDGE: Env = Env {
+    name: "edge     (2k one-shots, 90% cancelled, 8 periodic)",
+    population: 2_000,
+    dur_min_ms: 50,
+    dur_max_ms: 2_000,
+    cancel_pct: 90,
+    periodic: &[
+        Periodic { period_ms: 3_000, count: 2 },
+        Periodic { period_ms: 5_000, count: 2 },
+        Periodic { period_ms: 10_000, count: 2 },
+        Periodic { period_ms: 15_000, count: 1 },
+        Periodic { period_ms: 30_000, count: 1 },
+    ],
+};
+const APP: Env = Env {
+    name: "app      (15k one-shots, 75% cancelled, 64 periodic)",
+    population: 15_000,
+    dur_min_ms: 100,
+    dur_max_ms: 5_000,
+    cancel_pct: 75,
+    periodic: &[
+        Periodic { period_ms: 3_000, count: 16 },
+        Periodic { period_ms: 5_000, count: 16 },
+        Periodic { period_ms: 10_000, count: 12 },
+        Periodic { period_ms: 15_000, count: 12 },
+        Periodic { period_ms: 30_000, count: 8 },
+    ],
+};
+const GATEWAY: Env = Env {
+    name: "gateway  (50k one-shots, 95% cancelled, 256 periodic)",
+    population: 50_000,
+    dur_min_ms: 1_000,
+    dur_max_ms: 30_000,
+    cancel_pct: 95,
+    periodic: &[
+        Periodic { period_ms: 3_000, count: 64 },
+        Periodic { period_ms: 5_000, count: 64 },
+        Periodic { period_ms: 10_000, count: 48 },
+        Periodic { period_ms: 15_000, count: 48 },
+        Periodic { period_ms: 30_000, count: 32 },
+    ],
+};
+
+const WARMUP_TICKS: u64 = 5_000; // 5 s to reach steady-state population
+const SIM_TICKS: u64 = 30_000; // 30 s measured window (1 sample per 1 ms tick)
+
+/// Drive one environment through the simulated timeline and return the sorted
+/// per-poll cycle samples over the measured window.
+fn run_env(env: &Env, cancel_pct: u32) -> Vec<u64> {
+    let epoch = Instant::now();
+    let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(epoch);
+    let mut rng = Rng(0x1234_5678_9abc_def0);
+    let periodic_count: usize = env.periodic.iter().map(|p| p.count).sum();
+
+    // Periodic timers carry their period_ms as the value and re-arm on fire.
+    // Stagger the first fire within [1, period) so they don't clump.
+    for p in env.periodic {
+        for _ in 0..p.count {
+            let first = rng.range(1, p.period_ms);
+            wheel.schedule_forget(epoch + Duration::from_millis(first), p.period_ms);
+        }
+    }
+
+    // Pending one-shot cancels, keyed by the tick they fire at (a min-heap of
+    // (cancel_tick, seq)); handles live in `handles[seq]`.
+    let mut cancels: BinaryHeap<Reverse<(u64, u64)>> = BinaryHeap::new();
+    let mut handles: Vec<Option<TimerHandle<u64>>> = Vec::new();
+
+    let mut buf: Vec<u64> = Vec::with_capacity(2_048);
+    let mut samples: Vec<u64> = Vec::with_capacity(SIM_TICKS as usize);
+
+    for tick in 0..(WARMUP_TICKS + SIM_TICKS) {
+        let now = epoch + Duration::from_millis(tick);
+
+        // 1. Cancel one-shots that "completed" this tick (before their deadline).
+        while let Some(&Reverse((ct, _))) = cancels.peek() {
+            if ct > tick {
+                break;
+            }
+            let Reverse((_, seq)) = cancels.pop().unwrap();
+            if let Some(h) = handles[seq as usize].take() {
+                wheel.cancel(h);
+            }
+        }
+
+        // 2. Top up one-shots to maintain the target live population.
+        let live_oneshots = wheel.len().saturating_sub(periodic_count);
+        for _ in live_oneshots..env.population {
+            let dur = rng.range(env.dur_min_ms, env.dur_max_ms + 1);
+            let deadline = now + Duration::from_millis(dur);
+            if rng.pct(cancel_pct) {
+                // Will be cancelled `slack` ms before its deadline.
+                let h = wheel.schedule(deadline, 0);
+                let slack = rng.range(1, dur.max(2));
+                let cancel_tick = tick + dur.saturating_sub(slack);
+                let seq = handles.len() as u64;
+                handles.push(Some(h));
+                cancels.push(Reverse((cancel_tick, seq)));
+            } else {
+                wheel.schedule_forget(deadline, 0); // fires at its deadline
+            }
+        }
+
+        // 3. Poll — the measured hot path.
+        buf.clear();
+        let s = rdtsc_start();
+        let fired = black_box(wheel.poll(now, &mut buf));
+        let e = rdtsc_end();
+        black_box(fired);
+        if tick >= WARMUP_TICKS {
+            samples.push(e.wrapping_sub(s));
+        }
+
+        // 4. Re-arm periodic timers that fired (non-zero value == period_ms).
+        for &v in &buf {
+            if v != 0 {
+                wheel.schedule_forget(now + Duration::from_millis(v), v);
+            }
+        }
+    }
+
+    samples.sort_unstable();
+    samples
+}
+
+fn print_poll_row(label: &str, samples: &[u64]) {
+    println!(
+        "  {label:<52} {:>6} {:>6} {:>7} {:>7}",
+        percentile(samples, 50.0),
+        percentile(samples, 99.0),
+        percentile(samples, 99.9),
+        percentile(samples, 100.0),
+    );
+}
+
+fn main() {
+    println!("================================================================");
+    println!("TIMER WHEEL — realistic server-scenario poll cost (cycles/poll)");
+    println!("  1 ms tick; {SIM_TICKS} samples/env after {WARMUP_TICKS} warmup; best effort — pin with taskset -c 0");
+    println!("================================================================");
+
+    println!("\nPer-environment poll cost:");
+    println!("  {:<52} {:>6} {:>6} {:>7} {:>7}", "environment", "p50", "p99", "p99.9", "max");
+    for env in [&EDGE, &APP, &GATEWAY] {
+        let samples = run_env(env, env.cancel_pct);
+        print_poll_row(env.name, &samples);
+    }
+
+    println!("\nCancel-ratio sweep (app env, 15k one-shots):");
+    println!("  {:<52} {:>6} {:>6} {:>7} {:>7}", "cancelled %", "p50", "p99", "p99.9", "max");
+    for pct in [10u32, 50, 75, 90, 95] {
+        let samples = run_env(&APP, pct);
+        print_poll_row(&format!("{pct}% cancelled"), &samples);
+    }
+}

--- a/nexus-timer/docs/INDEX.md
+++ b/nexus-timer/docs/INDEX.md
@@ -1,12 +1,13 @@
 # nexus-timer documentation
 
-Hierarchical, no-cascade timer wheel with O(1) insert and cancel. Modeled
-on the Linux kernel timer infrastructure (Gleixner 2016).
+Hierarchical, rebalancing timer wheel with O(1) insert and cancel: entries
+rebalance down to finer levels as they near their deadline, so `poll` collects
+ready timers from small, exact slots.
 
 ## Contents
 
 - [overview.md](overview.md) — when a timer wheel is the right tool, and why
-  the no-cascade design matters
+  the collect / rebalance design matters
 - [wheel.md](wheel.md) — `Wheel`, `BoundedWheel`, `WheelBuilder`, scheduling
   and cancellation
 - [bounded-vs-unbounded.md](bounded-vs-unbounded.md) — the two storage

--- a/nexus-timer/docs/overview.md
+++ b/nexus-timer/docs/overview.md
@@ -27,38 +27,48 @@ Use `std::thread::sleep` or `tokio::time::sleep` when:
 - You're scheduling a handful of one-shot delays.
 - Timer overhead is not in your flame graph.
 
-## The no-cascade design
+## The collect / rebalance design
 
-Traditional hierarchical timer wheels (Linux pre-2016, tokio's
-`time::driver`) *cascade*: when a slot in a higher level expires, the
-entries inside it are walked and re-inserted into lower levels. This keeps
-the representation tight, but produces latency spikes — poll becomes
-proportional to the number of cascading entries, not just the number of
-firing entries.
+A hierarchical wheel places a timer in a slot sized to how far away its
+deadline is: coarse slots (wide time ranges) for distant deadlines, fine
+slots (one tick) for near ones. The question is what to do as a timer's
+deadline approaches and it no longer belongs in its coarse slot.
 
-`nexus-timer` doesn't cascade. An entry is placed in a slot based on how
-far in the future it fires, and it *stays there* until poll visits the
-slot. When poll visits a slot, it walks the entries and checks each one's
-exact deadline:
+`nexus-timer` **rebalances**. As a timer nears its deadline it is moved down
+to finer levels, so by the time it is ready it sits in a small, exact
+fine-level slot. `poll` then simply **collects** the ready timers from those
+fine slots — it never has to walk a fat coarse slot checking deadlines one at
+a time:
 
 ```text
-poll(now):
+poll(now):        // collect
     for each active level:
-        for each active slot in level:
-            for each entry in slot:
-                if entry.deadline <= now:
-                    fire(entry)
+        for each active slot whose earliest deadline <= now:
+            collect entries with deadline <= now
+
+rebalance(now):   // maintenance — separately, or folded into the poll
+    for each coarse slot nearing its deadline:
+        move its entries down to the finer level they now belong in
 ```
 
-The cost is that slots in higher levels hold entries that fire across a
-range of ticks — poll has to check deadlines rather than firing whole slots
-blindly. In exchange, there are no cascading latency spikes, and the worst
-case is bounded by `active_slots × entries_per_slot`, not the total
-population.
+This is what keeps poll flat under load. The alternative — leave every entry
+in its original coarse slot and check `deadline <= now` per entry on every
+poll — makes poll proportional to how many entries share a due coarse slot,
+i.e. roughly the population, not the number actually firing. That
+O(population) tail is exactly what rebalancing removes.
 
-For most workloads this is a much better tradeoff. The entries that
-*actually fire* are always near the current wheel position; entries in
-distant slots get cancelled before poll ever visits them.
+Rebalancing is exposed three ways, so you choose where the maintenance runs:
+
+- **`poll_and_rebalance`** folds collect + rebalance into one call — the simple
+  default.
+- **`max_rebalances_per_poll`** bounds how much rebalancing a single poll does,
+  spreading a burst across polls (it never delays a fire).
+- **`rebalance`** runs the maintenance on its own, so a latency-sensitive loop
+  can `poll` cheaply on the hot path and `rebalance` during slack (for example,
+  only when a poll comes back empty).
+
+Timers always fire at their exact tick — rebalancing changes only *where* the
+work happens, never *when* a timer fires.
 
 ## Default configuration
 

--- a/nexus-timer/docs/patterns.md
+++ b/nexus-timer/docs/patterns.md
@@ -40,7 +40,7 @@ impl RequestTracker {
     /// Periodic poll — returns IDs whose timers fired.
     pub fn poll(&mut self, now: Instant, fired: &mut Vec<RequestId>) {
         let start = fired.len();
-        self.wheel.poll(now, fired);
+        self.wheel.poll_and_rebalance(now, fired);
         for id in &fired[start..] {
             self.pending.remove(id);
         }
@@ -49,7 +49,77 @@ impl RequestTracker {
 ```
 
 The hot path here is `start` + `complete` — both are O(1). Timeouts
-(`poll` + fire) are the exception.
+(`poll_and_rebalance` + fire) are the exception. `poll_and_rebalance` both
+collects the ready timers *and* keeps the wheel tidy so the next poll stays
+cheap — see [Keeping poll cheap with many timers](#keeping-poll-cheap-with-many-timers)
+for when to manage that yourself.
+
+## Keeping poll cheap with many timers
+
+`poll` only *collects* ready timers — it does not reorganize the wheel. If you
+call bare `poll` and nothing else, entries stay in the coarse level they were
+scheduled into, and a poll that lands on a fat coarse slot walks the whole slot
+to find the few ready timers — an O(population) spike on a busy wheel. To avoid
+that, keep entries flowing down to fine, exact slots. There are three ways,
+from simplest to most control.
+
+**1. `poll_and_rebalance` — the default.** Collects *and* rebalances in one
+call, so future polls stay cheap. Reach for this unless you have a reason not
+to:
+
+```rust
+use std::time::Instant;
+use nexus_timer::Wheel;
+
+fn tick<T>(wheel: &mut Wheel<T>, now: Instant, fired: &mut Vec<T>) {
+    wheel.poll_and_rebalance(now, fired);
+}
+```
+
+**2. Bound the rebalancing per poll.** If a single `poll_and_rebalance` can
+spike when a dense slot comes due, cap how much reorganizing one poll does with
+`WheelBuilder::max_rebalances_per_poll`. The rest is spread across later polls;
+it never delays a fire:
+
+```rust
+use std::time::Instant;
+use nexus_timer::{Wheel, WheelBuilder};
+
+fn build<T: 'static>(now: Instant) -> Wheel<T> {
+    WheelBuilder::default()
+        .max_rebalances_per_poll(64) // smooth the rebalance burst
+        .unbounded(4096)
+        .build(now)
+}
+```
+
+**3. Disperse the work opportunistically — the lowest-tail option.** For the
+flattest possible collect path under a large number of timers, split the two:
+`poll` cheaply on the hot path, and `rebalance` only during genuine slack —
+e.g. whenever a poll comes back empty. Bound each call so a run of empty polls
+spreads the work instead of stalling on one sweep (`rebalance` is resumable):
+
+```rust
+use std::time::Instant;
+use nexus_timer::Wheel;
+
+const REBALANCE_BUDGET: usize = 64;
+
+fn tick<T>(wheel: &mut Wheel<T>, now: Instant, fired: &mut Vec<T>) {
+    let collected = wheel.poll(now, fired);
+    if collected == 0 {
+        // Nothing to deliver — use the slack to maintain, a bounded slice.
+        wheel.rebalance(now, REBALANCE_BUDGET);
+    }
+}
+```
+
+This keeps busy polls doing only the cheap collect and pushes the reorganizing
+onto the idle ones, which measurably flattens the collect tail at scale. It
+self-tunes to load: no cadence to pick, and maintenance happens exactly when
+there is nothing else to do. Just don't `rebalance` on *every* poll — that
+re-walks the look-ahead window and is pure overhead. See the `rebalance` API
+docs for the full rationale.
 
 ## Exchange heartbeats
 
@@ -98,7 +168,7 @@ use nexus_timer::Wheel;
 
 fn event_loop_step<T>(wheel: &mut Wheel<T>, fired: &mut Vec<T>) -> Duration {
     let now = Instant::now();
-    wheel.poll(now, fired);
+    wheel.poll_and_rebalance(now, fired);
 
     match wheel.next_deadline() {
         Some(next) => next.saturating_duration_since(Instant::now()),
@@ -112,8 +182,10 @@ next iteration. This gives you accurate wakeups without constant polling.
 
 ## Budgeted fire cap for bounded tail latency
 
-If you have thousands of timers firing in a burst, unbounded poll can spike
-your event-loop iteration time. Cap it with `poll_with_limit`:
+If you have thousands of timers firing in a burst, an unbounded poll can spike
+your event-loop iteration time. Cap the number collected per iteration with
+`poll_and_rebalance_with_limit` (or `poll_with_limit` for the collect-only
+variant):
 
 ```rust
 use std::time::Instant;
@@ -122,7 +194,7 @@ use nexus_timer::Wheel;
 const MAX_TIMERS_PER_TICK: usize = 32;
 
 fn drain<T>(wheel: &mut Wheel<T>, now: Instant, buf: &mut Vec<T>) {
-    let fired = wheel.poll_with_limit(now, MAX_TIMERS_PER_TICK, buf);
+    let fired = wheel.poll_and_rebalance_with_limit(now, MAX_TIMERS_PER_TICK, buf);
     if fired == MAX_TIMERS_PER_TICK {
         // Hit the budget — remaining timers will fire on the next iteration
         // with the *same* `now`, preserving the fair-share property.
@@ -130,8 +202,9 @@ fn drain<T>(wheel: &mut Wheel<T>, now: Instant, buf: &mut Vec<T>) {
 }
 ```
 
-The next call to `poll_with_limit` with the same `now` resumes where the
-previous call stopped, so you don't starve any slot.
+The next call with the same `now` resumes where the previous stopped, so you
+don't starve any slot. (`limit` bounds the *collect*; rebalancing is bounded
+separately by `max_rebalances_per_poll`.)
 
 ## Cancellable retries
 

--- a/nexus-timer/docs/wheel.md
+++ b/nexus-timer/docs/wheel.md
@@ -123,17 +123,29 @@ wheel.schedule_forget(now + Duration::from_millis(5), 1);
 wheel.schedule_forget(now + Duration::from_millis(10), 2);
 
 let mut fired: Vec<u64> = Vec::with_capacity(64);
-wheel.poll(now + Duration::from_millis(12), &mut fired);
+wheel.poll_and_rebalance(now + Duration::from_millis(12), &mut fired);
 // fired contains [1, 2] — all expired timer values
 ```
 
-`poll(now, buf)` fires every expired timer and appends its value to `buf`.
+`poll(now, buf)` collects every ready (expired) timer and appends its value
+to `buf`. It does **not** reorganize the wheel — see `poll_and_rebalance`
+below.
 
-`poll_with_limit(now, limit, buf)` is the budgeted version: fire up to
-`limit` timers and return how many fired. Useful in a poll loop where you
-want to cap the work done in one iteration to keep tail latency bounded.
-If the limit is hit, the next call with the same `now` will resume
-wherever you left off.
+`poll_with_limit(now, limit, buf)` is the budgeted version: collect up to
+`limit` timers and return how many. Useful in a poll loop where you want to
+cap the work done in one iteration. If the limit is hit, the next call with
+the same `now` resumes wherever you left off.
+
+`poll_and_rebalance(now, buf)` is the batteries-included poll: it collects
+ready timers **and** rebalances the wheel — moving not-yet-due entries down
+to finer levels so future polls stay cheap under a large number of timers.
+Rebalancing here is bounded by `WheelBuilder::max_rebalances_per_poll` and
+never delays a fire. Reach for this by default.
+
+`rebalance(now, limit)` does the reorganizing on its own, so a
+latency-sensitive loop can `poll` cheaply on the hot path and `rebalance`
+during slack (for example, only when a poll comes back empty). See the
+`rebalance` rustdoc for the recommended pattern.
 
 ## `next_deadline`
 

--- a/nexus-timer/src/lib.rs
+++ b/nexus-timer/src/lib.rs
@@ -37,13 +37,18 @@
 //!
 //! # Timer wheel design
 //!
-//! The wheel is hierarchical, inspired by the Linux kernel's timer
-//! infrastructure (Gleixner 2016): timers are placed into coarser slots at
-//! higher levels — no cascading, no entry movement after insertion.
+//! The wheel is hierarchical: a timer is placed into a slot at the level whose
+//! granularity matches how far away its deadline is — coarse levels for distant
+//! deadlines, fine levels for near ones.
 //!
-//! - **No cascade:** Once placed, an entry never moves. Poll checks each
-//!   entry's exact deadline. This eliminates the latency spikes that
-//!   cascading timer wheels exhibit.
+//! - **Rebalance, don't re-walk:** as a timer's deadline approaches it is moved
+//!   ("rebalanced") down to finer levels, so `poll` collects ready timers from
+//!   small, exact fine-level slots instead of walking a fat coarse slot on every
+//!   call. Rebalancing can be folded into the poll
+//!   ([`TimerWheel::poll_and_rebalance`]), bounded per poll
+//!   ([`WheelBuilder::max_rebalances_per_poll`]), or run proactively off the hot
+//!   path ([`TimerWheel::rebalance`]) to keep the poll tail flat under a large
+//!   number of timers. Timers still fire at their exact tick.
 //! - **Intrusive active-slot lists:** Only non-empty slots are visited
 //!   during poll and next-deadline queries. No bitmap, no full scan.
 //! - **Embedded refcounting:** Lightweight `Cell<u8>` refcount per entry

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -147,6 +147,21 @@ impl WheelBuilder {
             slots_log2 + max_shift < 64,
             "slots_per_level << max_shift would overflow u64"
         );
+        // Cascade progress guard. When a due slot is polled, a not-yet-due entry
+        // is relocated to a strictly finer level (see `TimerWheel::poll_level`).
+        // That requires a level's per-slot granularity (2^clk_shift) to be
+        // smaller than the number of slots per level; otherwise an entry could
+        // relocate to the *same* level and poll would live-lock. Both are powers
+        // of two, so `2^clk_shift < slots_per_level` iff `clk_shift < slots_log2`
+        // (avoids a shift that could overflow for absurd clk_shift). Checked last
+        // so a config that also overflows reports the overflow first.
+        assert!(
+            (self.clk_shift as u64) < slots_log2,
+            "2^clk_shift must be < slots_per_level so cascade relocates to a \
+             strictly finer level (got clk_shift = {}, slots_per_level = {})",
+            self.clk_shift,
+            self.slots_per_level,
+        );
     }
 
     fn tick_ns(&self) -> u64 {
@@ -874,8 +889,12 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
 
             let slot_ptr = self.levels[lvl_idx].slot(slot_idx) as *const crate::level::WheelSlot<T>;
             // SAFETY: slot_ptr points into self.levels[lvl_idx].slots
-            // (Box<[WheelSlot<T>]>), a stable heap allocation. fire_entry
-            // only mutates self.slab and self.len, not self.levels.
+            // (Box<[WheelSlot<T>]>), a stable heap allocation never reallocated
+            // during poll. fire_entry and insert_entry mutate self.slab, self.len,
+            // self.active_levels, self.min_deadline, and *other* levels' slots —
+            // cascade relocates only to strictly finer levels (< lvl_idx), never
+            // this slot — so this slot's backing memory is untouched and `slot`
+            // stays valid across the loop.
             let slot = unsafe { &*slot_ptr };
 
             // Slot-skip: if the slot's minimum deadline is beyond now, nothing
@@ -885,36 +904,53 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
                 continue;
             }
 
-            let mut new_min = u64::MAX; // recomputed over surviving entries
+            let mut new_min = u64::MAX; // min over entries that stay in this slot
             let mut entry_ptr = slot.entry_head();
 
             while !entry_ptr.is_null() && fired < limit {
                 // SAFETY: entry_ptr is in this slot's DLL
                 let entry = unsafe { entry_ref(entry_ptr) };
-                let next_entry = entry.next();
+                let next_entry = entry.next(); // captured before any unlink below
                 let dt = entry.deadline_ticks();
 
                 if dt <= now_ticks {
-                    // SAFETY: entry_ptr is in this slot's DLL (obtained from entry_head
-                    // and walked via next pointers within the same slot).
+                    // Due — fire it.
+                    // SAFETY: entry_ptr is in this slot's DLL (from entry_head,
+                    // walked via next pointers within the same slot).
                     unsafe { slot.remove_entry(entry_ptr) };
-
                     if let Some(value) = self.fire_entry(entry_ptr) {
                         buf.push(value);
                     }
                     fired += 1;
+                } else if self.select_level(dt) < lvl_idx {
+                    // Not due, and it now belongs at a strictly finer level:
+                    // cascade it down instead of re-walking it every poll until
+                    // this slot's span passes. The target (< lvl_idx) is never this
+                    // slot, so the walk terminates and the entry is not re-processed
+                    // this poll (finer levels are polled first). current_ticks ==
+                    // now_ticks (set in poll_with_limit before this loop), so
+                    // insert_entry selects the correct finer level.
+                    // SAFETY: entry_ptr is in this slot's DLL.
+                    unsafe { slot.remove_entry(entry_ptr) };
+                    self.insert_entry(entry_ptr, dt);
                 } else {
-                    new_min = new_min.min(dt); // survivor
+                    // Not due, and still belongs at this level. This happens when a
+                    // far entry shares the slot via the modular index: deadlines a
+                    // full level-range apart map to the same slot, so a slot made
+                    // due by its earliest entry can also hold entries that are not
+                    // yet within a finer level's reach. Leave it in place (it fires
+                    // or cascades on a later poll) and track it as the slot's
+                    // surviving minimum.
+                    new_min = new_min.min(dt);
                 }
 
                 entry_ptr = next_entry;
             }
 
-            // Trust the recomputed min ONLY if we walked the whole slot. If the
-            // limit truncated the walk (entry_ptr still non-null), new_min omits
-            // the un-walked entries, so setting it could be stale-HIGH — which
-            // would let a later poll skip a due entry. Leave the slot min
-            // stale-low instead; the next poll re-walks and heals it.
+            // If we walked the whole slot, its minimum is exactly the min over the
+            // entries that stayed (u64::MAX — the empty sentinel — when the slot
+            // drained via fires + cascades). A limit-truncated walk (entry_ptr
+            // non-null) leaves the min stale-low; the next poll re-walks and heals.
             if entry_ptr.is_null() {
                 slot.set_min_deadline(new_min);
             }
@@ -2058,6 +2094,65 @@ mod tests {
             .build::<u64>(now);
     }
 
+    #[test]
+    #[should_panic(expected = "strictly finer level")]
+    fn invalid_config_cascade_progress() {
+        let now = Instant::now();
+        // slots_per_level = 4 (2^2), clk_shift = 3 → 2^3 = 8 >= 4, so a not-due
+        // entry could relocate to the *same* level and poll would live-lock.
+        // Must be rejected at build time.
+        WheelBuilder::default()
+            .slots_per_level(4)
+            .clk_shift(3)
+            .num_levels(2)
+            .unbounded(64)
+            .build::<u64>(now);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cascade tests (#668)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn cascaded_entry_fires_at_its_deadline() {
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+
+        // Both deadlines land in the same level-2 slot (46): 3000>>6 == 3005>>6.
+        // At now=3000 the slot's min (3000) is due, so the slot is walked: 3000
+        // fires, and 3005 (not yet due) cascades down to a finer level rather
+        // than being re-walked. It must still fire at its exact deadline.
+        wheel.schedule_forget(now + ms(3000), 1);
+        wheel.schedule_forget(now + ms(3005), 2);
+
+        let mut buf = Vec::new();
+        wheel.poll(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec![1], "3000 fires, 3005 cascades");
+
+        buf.clear();
+        wheel.poll(now + ms(3005), &mut buf);
+        assert_eq!(buf, vec![2], "cascaded entry fires at its exact deadline");
+        assert!(wheel.is_empty());
+    }
+
+    #[test]
+    fn cancel_after_cascade() {
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+
+        wheel.schedule_forget(now + ms(3000), 1);
+        let h = wheel.schedule(now + ms(3005), 2); // cascades on the 3000 poll
+
+        let mut buf = Vec::new();
+        wheel.poll(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec![1]);
+        assert_eq!(wheel.len(), 1, "cascaded entry still live");
+
+        // cancel must find the entry at its new (finer) location and return it.
+        assert_eq!(wheel.cancel(h), Some(2));
+        assert_eq!(wheel.len(), 0);
+    }
+
     // -------------------------------------------------------------------------
     // Miri-compatible tests (L12)
     // -------------------------------------------------------------------------
@@ -2214,6 +2309,29 @@ mod tests {
         wheel.free(h3);
         wheel.free(h4);
         wheel.free(h5);
+    }
+
+    #[test]
+    fn miri_cascade_relocate_drop_type() {
+        // Exercises the cascade relocate path (insert_entry called while this
+        // slot's `&WheelSlot` is held) with a Drop type, to catch any aliasing
+        // UB in that hot-path borrow.
+        let now = Instant::now();
+        let mut wheel: Wheel<String> = Wheel::unbounded(64, now);
+
+        // Same level-2 slot: 3000>>6 == 3005>>6. At now=3000 the "fires" entry
+        // fires and the "cascades" entry relocates to a finer level.
+        wheel.schedule_forget(now + ms(3000), "fires".to_string());
+        wheel.schedule_forget(now + ms(3005), "cascades".to_string());
+
+        let mut buf = Vec::new();
+        wheel.poll(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec!["fires".to_string()]);
+
+        buf.clear();
+        wheel.poll(now + ms(3005), &mut buf);
+        assert_eq!(buf, vec!["cascades".to_string()]);
+        assert!(wheel.is_empty());
     }
 }
 

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -50,6 +50,7 @@ pub struct WheelBuilder {
     slots_per_level: usize,
     clk_shift: u32,
     num_levels: usize,
+    max_rebalances_per_poll: usize,
 }
 
 impl Default for WheelBuilder {
@@ -59,6 +60,7 @@ impl Default for WheelBuilder {
             slots_per_level: 64,
             clk_shift: 3,
             num_levels: 7,
+            max_rebalances_per_poll: usize::MAX,
         }
     }
 }
@@ -90,6 +92,35 @@ impl WheelBuilder {
     /// Sets the number of levels. Default: 7.
     pub fn num_levels(mut self, n: usize) -> Self {
         self.num_levels = n;
+        self
+    }
+
+    /// Sets the maximum number of entries **rebalanced** (moved to a finer
+    /// level) per [`poll_and_rebalance`](TimerWheel::poll_and_rebalance).
+    /// Default: `usize::MAX` (unbounded).
+    ///
+    /// Rebalancing is maintenance: as time advances, a timer scheduled far in
+    /// the future is placed in a coarse level, and when its slot comes due it is
+    /// moved down to a finer level so it is not re-scanned on every future poll.
+    /// Unbounded (the default), one poll rebalances a whole slot at once — least
+    /// total work, but a rare poll can spike. A cap spreads that work across
+    /// several polls: each poll rebalances at most `n` entries and leaves the
+    /// rest in place, trading the rare spike for slightly more total work (the
+    /// leftover entries are walked again on a later poll).
+    ///
+    /// **This bounds only rebalancing, never firing.** Every due timer is still
+    /// collected at its exact deadline regardless of the cap, because a
+    /// not-yet-due entry left un-rebalanced simply fires from whatever level it
+    /// is sitting in when its time comes. The cap can therefore never make a
+    /// timer fire late or be missed; it is purely a latency-smoothing knob for
+    /// the poll hot path.
+    ///
+    /// **Recommended to tune** for latency-sensitive loops: pick `n` large
+    /// enough to keep up with the steady rebalance rate (roughly
+    /// `population * num_levels / average_timeout_in_ticks`) so entries do not
+    /// backlog, yet small enough that no single poll stalls.
+    pub fn max_rebalances_per_poll(mut self, n: usize) -> Self {
+        self.max_rebalances_per_poll = n;
         self
     }
 
@@ -147,7 +178,7 @@ impl WheelBuilder {
             slots_log2 + max_shift < 64,
             "slots_per_level << max_shift would overflow u64"
         );
-        // Cascade progress guard. When a due slot is polled, a not-yet-due entry
+        // Rebalance progress guard. When a due slot is polled, a not-yet-due entry
         // is relocated to a strictly finer level (see `TimerWheel::poll_level`).
         // That requires a level's per-slot granularity (2^clk_shift) to be
         // smaller than the number of slots per level; otherwise an entry could
@@ -157,7 +188,7 @@ impl WheelBuilder {
         // so a config that also overflows reports the overflow first.
         assert!(
             (self.clk_shift as u64) < slots_log2,
-            "2^clk_shift must be < slots_per_level so cascade relocates to a \
+            "2^clk_shift must be < slots_per_level so rebalancing relocates to a \
              strictly finer level (got clk_shift = {}, slots_per_level = {})",
             self.clk_shift,
             self.slots_per_level,
@@ -204,6 +235,7 @@ impl UnboundedWheelBuilder {
             active_levels: 0,
             len: 0,
             min_deadline: Cell::new(None),
+            max_rebalances_per_poll: self.config.max_rebalances_per_poll,
             _marker: PhantomData,
         }
     }
@@ -244,6 +276,7 @@ impl BoundedWheelBuilder {
             active_levels: 0,
             len: 0,
             min_deadline: Cell::new(None),
+            max_rebalances_per_poll: self.config.max_rebalances_per_poll,
             _marker: PhantomData,
         }
     }
@@ -279,6 +312,9 @@ pub struct TimerWheel<
     epoch: Instant,
     len: usize,
     min_deadline: Cell<Option<u64>>,
+    /// Max entries rebalanced (moved to a finer level) per poll_and_rebalance (see
+    /// [`WheelBuilder::max_rebalances_per_poll`]). `usize::MAX` = unbounded.
+    max_rebalances_per_poll: usize,
     _marker: PhantomData<*const ()>, // !Send (overridden below), !Sync
 }
 
@@ -568,27 +604,76 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         TimerHandle::new(ptr)
     }
 
-    /// Fires all expired timers, collecting their values into `buf`.
+    /// Collects all ready (due) timers into `buf`, **without rebalancing**, and
+    /// returns how many were collected.
     ///
-    /// Returns the number of timers fired.
+    /// This is the minimal poll: it hands back the timers whose deadline has
+    /// passed and does no maintenance, so a not-yet-due entry stays in whatever
+    /// level it was placed in. Cheap on any single call — but if you *only* ever
+    /// call `poll`, entries are never moved to finer levels and a busy wheel
+    /// degrades to an O(population) scan per poll. For steady low-latency
+    /// polling, prefer [`poll_and_rebalance`](Self::poll_and_rebalance)
+    /// (collect + maintain in one pass).
     pub fn poll(&mut self, now: Instant, buf: &mut Vec<T>) -> usize {
         self.poll_with_limit(now, usize::MAX, buf)
     }
 
-    /// Fires expired timers up to `limit`, collecting values into `buf`.
+    /// Collects up to `limit` ready timers into `buf`, without rebalancing.
     ///
     /// Resumable: if the limit is hit, the next call continues where this one
-    /// left off (as long as `now` hasn't changed).
+    /// left off (as long as `now` hasn't changed). See [`poll`](Self::poll) for
+    /// the rebalancing tradeoff.
     ///
-    /// Returns the number of timers fired in this call.
+    /// Returns the number collected in this call.
     pub fn poll_with_limit(&mut self, now: Instant, limit: usize, buf: &mut Vec<T>) -> usize {
+        // Rebalance budget 0 → collect only, never move an entry to a finer level.
+        self.poll_inner(now, limit, 0, buf)
+    }
+
+    /// Collects all ready timers into `buf` **and rebalances** the wheel in the
+    /// same pass — the batteries-included poll. Returns how many were collected.
+    ///
+    /// Collecting is unbounded; **rebalancing** (moving not-yet-due entries to
+    /// finer levels so future polls stay cheap) is capped at
+    /// [`max_rebalances_per_poll`](WheelBuilder::max_rebalances_per_poll)
+    /// (default unbounded). The cap only smooths rebalance work across polls — it
+    /// never delays or drops a fire.
+    pub fn poll_and_rebalance(&mut self, now: Instant, buf: &mut Vec<T>) -> usize {
+        self.poll_and_rebalance_with_limit(now, usize::MAX, buf)
+    }
+
+    /// Collects up to `limit` ready timers into `buf` and rebalances the wheel.
+    ///
+    /// The collect phase is resumable like
+    /// [`poll_with_limit`](Self::poll_with_limit); rebalancing is capped by
+    /// [`max_rebalances_per_poll`](WheelBuilder::max_rebalances_per_poll).
+    /// Returns the number collected in this call.
+    pub fn poll_and_rebalance_with_limit(
+        &mut self,
+        now: Instant,
+        limit: usize,
+        buf: &mut Vec<T>,
+    ) -> usize {
+        self.poll_inner(now, limit, self.max_rebalances_per_poll, buf)
+    }
+
+    /// Shared poll body: collect ready timers (up to `limit`) and rebalance
+    /// not-yet-due entries to finer levels (up to `rebalance_budget`).
+    /// `rebalance_budget == 0` is collect-only.
+    fn poll_inner(
+        &mut self,
+        now: Instant,
+        limit: usize,
+        rebalance_budget: usize,
+        buf: &mut Vec<T>,
+    ) -> usize {
         let now_ticks = self.instant_to_ticks(now);
         self.current_ticks = now_ticks; // MUST precede the early return — select_level reads it.
 
         // Fast path: if the cached global minimum is beyond now, nothing is due,
-        // so skip the level walk entirely. The cache may be stale-low (a lower
-        // bound), so this is conservative — it can miss the shortcut, never fire
-        // late.
+        // so skip the level walk entirely — and with nothing due there is nothing
+        // to rebalance either. The cache may be stale-low (a lower bound), so this
+        // is conservative: it can miss the shortcut, never fire late.
         if let Some(min) = self.min_deadline.get()
             && min > now_ticks
         {
@@ -596,12 +681,23 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         }
 
         let mut fired = 0;
+        // Rebalance budget for this whole poll. Bounds only rebalancing, never
+        // collection — so the level loop below is NOT gated on it; due entries
+        // keep being collected after the budget is spent.
+        let mut rebalances = 0;
         let mut mask = self.active_levels;
 
         while mask != 0 && fired < limit {
             let lvl_idx = mask.trailing_zeros() as usize;
             mask &= mask - 1; // clear lowest set bit
-            fired += self.poll_level(lvl_idx, now_ticks, limit - fired, buf);
+            fired += self.poll_level(
+                lvl_idx,
+                now_ticks,
+                limit - fired,
+                rebalance_budget,
+                &mut rebalances,
+                buf,
+            );
         }
 
         // Refresh the global-min cache from the (now-healed) per-slot minima.
@@ -878,6 +974,8 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         lvl_idx: usize,
         now_ticks: u64,
         limit: usize,
+        rebalance_budget: usize,
+        rebalances: &mut usize,
         buf: &mut Vec<T>,
     ) -> usize {
         let mut fired = 0;
@@ -892,7 +990,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
             // (Box<[WheelSlot<T>]>), a stable heap allocation never reallocated
             // during poll. fire_entry and insert_entry mutate self.slab, self.len,
             // self.active_levels, self.min_deadline, and *other* levels' slots —
-            // cascade relocates only to strictly finer levels (< lvl_idx), never
+            // rebalancing relocates only to strictly finer levels (< lvl_idx), never
             // this slot — so this slot's backing memory is untouched and `slot`
             // stays valid across the loop.
             let slot = unsafe { &*slot_ptr };
@@ -922,25 +1020,28 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
                         buf.push(value);
                     }
                     fired += 1;
-                } else if self.select_level(dt) < lvl_idx {
-                    // Not due, and it now belongs at a strictly finer level:
-                    // cascade it down instead of re-walking it every poll until
-                    // this slot's span passes. The target (< lvl_idx) is never this
-                    // slot, so the walk terminates and the entry is not re-processed
-                    // this poll (finer levels are polled first). current_ticks ==
-                    // now_ticks (set in poll_with_limit before this loop), so
-                    // insert_entry selects the correct finer level.
+                } else if *rebalances < rebalance_budget && self.select_level(dt) < lvl_idx {
+                    // Not due, it now belongs at a strictly finer level, and we are
+                    // still under the per-poll rebalance budget: relocate it down
+                    // instead of re-walking it every poll until this slot's span
+                    // passes. The target (< lvl_idx) is never this slot, so the walk
+                    // terminates and the entry is not re-processed this poll (finer
+                    // levels are polled first). current_ticks == now_ticks (set in
+                    // poll_inner before this loop), so insert_entry selects the
+                    // correct finer level.
                     // SAFETY: entry_ptr is in this slot's DLL.
                     unsafe { slot.remove_entry(entry_ptr) };
                     self.insert_entry(entry_ptr, dt);
+                    *rebalances += 1;
                 } else {
-                    // Not due, and still belongs at this level. This happens when a
-                    // far entry shares the slot via the modular index: deadlines a
-                    // full level-range apart map to the same slot, so a slot made
-                    // due by its earliest entry can also hold entries that are not
-                    // yet within a finer level's reach. Leave it in place (it fires
-                    // or cascades on a later poll) and track it as the slot's
-                    // surviving minimum.
+                    // Not due, and left in place — either it still belongs at this
+                    // level (a far entry sharing the slot via the modular index:
+                    // deadlines a full level-range apart map to the same slot), or
+                    // the per-poll rebalance budget is spent. Either way it stays put
+                    // and fires (or rebalances) on a later poll from wherever it sits;
+                    // track it as the slot's surviving minimum. A spent budget can
+                    // never make a timer fire late — poll still fires it the moment
+                    // dt <= now, regardless of which level it is in.
                     new_min = new_min.min(dt);
                 }
 
@@ -949,7 +1050,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
 
             // If we walked the whole slot, its minimum is exactly the min over the
             // entries that stayed (u64::MAX — the empty sentinel — when the slot
-            // drained via fires + cascades). A limit-truncated walk (entry_ptr
+            // drained via fires + rebalances). A limit-truncated walk (entry_ptr
             // non-null) leaves the min stale-low; the next poll re-walks and heals.
             if entry_ptr.is_null() {
                 slot.set_min_deadline(new_min);
@@ -2096,10 +2197,10 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "strictly finer level")]
-    fn invalid_config_cascade_progress() {
+    fn invalid_config_rebalance_progress() {
         let now = Instant::now();
         // slots_per_level = 4 (2^2), clk_shift = 3 → 2^3 = 8 >= 4, so a not-due
-        // entry could relocate to the *same* level and poll would live-lock.
+        // entry could rebalance to the *same* level and poll would live-lock.
         // Must be rejected at build time.
         WheelBuilder::default()
             .slots_per_level(4)
@@ -2110,47 +2211,103 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // Cascade tests (#668)
+    // Rebalance tests (#668)
     // -------------------------------------------------------------------------
 
     #[test]
-    fn cascaded_entry_fires_at_its_deadline() {
+    fn rebalanced_entry_fires_at_its_deadline() {
         let now = Instant::now();
         let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
 
         // Both deadlines land in the same level-2 slot (46): 3000>>6 == 3005>>6.
         // At now=3000 the slot's min (3000) is due, so the slot is walked: 3000
-        // fires, and 3005 (not yet due) cascades down to a finer level rather
-        // than being re-walked. It must still fire at its exact deadline.
+        // is collected, and 3005 (not yet due) is rebalanced to a finer level
+        // rather than being re-walked. It must still fire at its exact deadline.
         wheel.schedule_forget(now + ms(3000), 1);
         wheel.schedule_forget(now + ms(3005), 2);
 
         let mut buf = Vec::new();
-        wheel.poll(now + ms(3000), &mut buf);
-        assert_eq!(buf, vec![1], "3000 fires, 3005 cascades");
+        wheel.poll_and_rebalance(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec![1], "3000 collected, 3005 rebalanced");
 
         buf.clear();
-        wheel.poll(now + ms(3005), &mut buf);
-        assert_eq!(buf, vec![2], "cascaded entry fires at its exact deadline");
+        wheel.poll_and_rebalance(now + ms(3005), &mut buf);
+        assert_eq!(buf, vec![2], "rebalanced entry fires at its exact deadline");
         assert!(wheel.is_empty());
     }
 
     #[test]
-    fn cancel_after_cascade() {
+    fn cancel_after_rebalance() {
         let now = Instant::now();
         let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
 
         wheel.schedule_forget(now + ms(3000), 1);
-        let h = wheel.schedule(now + ms(3005), 2); // cascades on the 3000 poll
+        let h = wheel.schedule(now + ms(3005), 2); // rebalanced on the 3000 poll
 
         let mut buf = Vec::new();
-        wheel.poll(now + ms(3000), &mut buf);
+        wheel.poll_and_rebalance(now + ms(3000), &mut buf);
         assert_eq!(buf, vec![1]);
-        assert_eq!(wheel.len(), 1, "cascaded entry still live");
+        assert_eq!(wheel.len(), 1, "rebalanced entry still live");
 
         // cancel must find the entry at its new (finer) location and return it.
         assert_eq!(wheel.cancel(h), Some(2));
         assert_eq!(wheel.len(), 0);
+    }
+
+    #[test]
+    fn bounded_rebalance_still_fires_everything_on_time() {
+        let now = Instant::now();
+        // Cap = 1 rebalance per poll — a herd of not-yet-due entries in one
+        // coarse slot drains over many polls instead of all at once, but every
+        // timer must still fire at its exact deadline.
+        let mut wheel: Wheel<u64> = WheelBuilder::default()
+            .max_rebalances_per_poll(1)
+            .unbounded(256)
+            .build(now);
+
+        // 20 deadlines spread across one level-2 slot (all map to slot 46).
+        let mut expected: Vec<u64> = Vec::new();
+        for i in 0..20u64 {
+            let d = 2950 + i * 2; // 2950, 2952, ... 2988 — all in level-2 slot 46
+            wheel.schedule_forget(now + ms(d), d);
+            expected.push(d);
+        }
+
+        let mut fired: Vec<u64> = Vec::new();
+        let mut buf = Vec::new();
+        for t in 0..=3000u64 {
+            buf.clear();
+            wheel.poll_and_rebalance(now + ms(t), &mut buf);
+            for &v in &buf {
+                assert!(v <= t, "timer {v} fired early at {t}");
+                fired.push(v);
+            }
+        }
+        fired.sort_unstable();
+        assert_eq!(fired, expected, "every timer fires exactly once, on time");
+        assert!(wheel.is_empty());
+    }
+
+    #[test]
+    fn rebalance_cap_zero_is_collect_only() {
+        let now = Instant::now();
+        // Cap = 0: no rebalancing at all — entries never move levels and fire
+        // from wherever they were placed (pure drip-fire). Must still be correct.
+        let mut wheel: Wheel<u64> = WheelBuilder::default()
+            .max_rebalances_per_poll(0)
+            .unbounded(256)
+            .build(now);
+
+        wheel.schedule_forget(now + ms(3000), 1);
+        wheel.schedule_forget(now + ms(3005), 2); // would rebalance if the cap allowed
+
+        let mut buf = Vec::new();
+        wheel.poll_and_rebalance(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec![1]); // 3000 collected; 3005 left in its coarse slot
+        buf.clear();
+        wheel.poll_and_rebalance(now + ms(3005), &mut buf);
+        assert_eq!(buf, vec![2]); // fires on time from its original slot
+        assert!(wheel.is_empty());
     }
 
     // -------------------------------------------------------------------------
@@ -2312,25 +2469,26 @@ mod tests {
     }
 
     #[test]
-    fn miri_cascade_relocate_drop_type() {
-        // Exercises the cascade relocate path (insert_entry called while this
+    fn miri_rebalance_relocate_drop_type() {
+        // Exercises the rebalance relocate path (insert_entry called while this
         // slot's `&WheelSlot` is held) with a Drop type, to catch any aliasing
-        // UB in that hot-path borrow.
+        // UB in that hot-path borrow. Must use poll_and_rebalance — plain poll
+        // never relocates, so it would not exercise the path.
         let now = Instant::now();
         let mut wheel: Wheel<String> = Wheel::unbounded(64, now);
 
-        // Same level-2 slot: 3000>>6 == 3005>>6. At now=3000 the "fires" entry
-        // fires and the "cascades" entry relocates to a finer level.
-        wheel.schedule_forget(now + ms(3000), "fires".to_string());
-        wheel.schedule_forget(now + ms(3005), "cascades".to_string());
+        // Same level-2 slot: 3000>>6 == 3005>>6. At now=3000 the "collected"
+        // entry fires and the "rebalanced" entry relocates to a finer level.
+        wheel.schedule_forget(now + ms(3000), "collected".to_string());
+        wheel.schedule_forget(now + ms(3005), "rebalanced".to_string());
 
         let mut buf = Vec::new();
-        wheel.poll(now + ms(3000), &mut buf);
-        assert_eq!(buf, vec!["fires".to_string()]);
+        wheel.poll_and_rebalance(now + ms(3000), &mut buf);
+        assert_eq!(buf, vec!["collected".to_string()]);
 
         buf.clear();
-        wheel.poll(now + ms(3005), &mut buf);
-        assert_eq!(buf, vec!["cascades".to_string()]);
+        wheel.poll_and_rebalance(now + ms(3005), &mut buf);
+        assert_eq!(buf, vec!["rebalanced".to_string()]);
         assert!(wheel.is_empty());
     }
 }

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -657,6 +657,79 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         self.poll_inner(now, limit, self.max_rebalances_per_poll, buf)
     }
 
+    /// **Proactively** rebalances the wheel: moves up to `limit` not-yet-due
+    /// entries down to the finest level they now belong in, and returns how many
+    /// moved. Does **not** collect or fire anything.
+    ///
+    /// This is the maintenance half of [`poll_and_rebalance`](Self::poll_and_rebalance),
+    /// exposed on its own so you can move it *off* the collect hot path.
+    ///
+    /// # When to reach for this
+    ///
+    /// Use `poll` + `rebalance` (instead of `poll_and_rebalance`) when you have a
+    /// **large number of outstanding timers and want to cut the poll tail**. The
+    /// cost of a poll that has work is dominated by walking a fat coarse slot to
+    /// find the ready timers; by pulling entries down to exact fine-level slots
+    /// *before* their slot comes due, `rebalance` keeps that walk small, so the
+    /// collect stays cheap and flat. In practice this moves the poll-tail work
+    /// off the hot path onto `rebalance`, roughly quartering the collect's p99.9
+    /// on a busy wheel — at the price of doing the maintenance yourself, when it
+    /// suits you.
+    ///
+    /// # Recommended pattern: opportunistic + bounded
+    ///
+    /// Rebalance only when a poll came back empty — i.e. during genuine slack —
+    /// and bound each call so a high-frequency loop spreads the work instead of
+    /// stalling on one big sweep (`rebalance` is resumable; the next call
+    /// continues):
+    ///
+    /// ```ignore
+    /// let fired = wheel.poll(now, &mut buf);
+    /// if fired == 0 {
+    ///     // nothing to deliver — maintain during the slack, a bounded slice
+    ///     wheel.rebalance(now, REBALANCE_BUDGET);
+    /// }
+    /// ```
+    ///
+    /// This self-tunes to load: busy iterations pay only the cheap collect, and
+    /// the maintenance lands exactly on the idle ones. A fixed cadence (rebalance
+    /// every N iterations) also works — just avoid rebalancing on *every* poll,
+    /// which re-walks the look-ahead window and is pure overhead.
+    ///
+    /// # Safety of skipping it
+    ///
+    /// `rebalance` only visits slots whose earliest entry is already within a
+    /// finer level's reach, and moving nothing is always safe: an un-rebalanced
+    /// entry simply fires from wherever it is sitting when its time comes. If you
+    /// never call it, the wheel still works — it just degrades to walking coarse
+    /// slots on the collect path (which is what [`poll_and_rebalance`] does for
+    /// you in one call).
+    ///
+    /// [`poll_and_rebalance`]: Self::poll_and_rebalance
+    pub fn rebalance(&mut self, now: Instant, limit: usize) -> usize {
+        let now_ticks = self.instant_to_ticks(now);
+        self.current_ticks = now_ticks; // select_level / rebalance_level read this.
+
+        let mut moved = 0;
+        // Level 0 is already the finest — nothing to pull down from it. Ascending
+        // order; select_level places each entry at its correct level directly, so
+        // no entry is touched twice.
+        let mut mask = self.active_levels & !1;
+        while mask != 0 && moved < limit {
+            let lvl_idx = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
+            // An entry at this level belongs at a finer one once it is within the
+            // next-finer level's range; a slot is worth visiting only if its
+            // earliest entry has reached that window.
+            let finer_reach = now_ticks.saturating_add(self.levels[lvl_idx - 1].range());
+            moved += self.rebalance_level(lvl_idx, finer_reach, limit - moved);
+        }
+
+        // Entries moved and per-slot minima changed; refresh the global-min cache.
+        self.min_deadline.set(self.walk_min_deadline());
+        moved
+    }
+
     /// Shared poll body: collect ready timers (up to `limit`) and rebalance
     /// not-yet-due entries to finer levels (up to `rebalance_budget`).
     /// `rebalance_budget == 0` is collect-only.
@@ -1067,6 +1140,70 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         }
 
         fired
+    }
+
+    /// Proactively pulls not-yet-due entries at `lvl_idx` down to a finer level.
+    /// Visits only active slots whose earliest entry has reached `finer_reach`
+    /// (is within the next-finer level's range) and relocates each entry that now
+    /// belongs at a strictly finer level, up to `limit`. Returns how many moved.
+    /// Fires nothing.
+    fn rebalance_level(&mut self, lvl_idx: usize, finer_reach: u64, limit: usize) -> usize {
+        let mut moved = 0;
+        let mut mask = self.levels[lvl_idx].active_slots();
+
+        while mask != 0 && moved < limit {
+            let slot_idx = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
+
+            let slot_ptr = self.levels[lvl_idx].slot(slot_idx) as *const crate::level::WheelSlot<T>;
+            // SAFETY: same argument as poll_level — slot_ptr points into the
+            // stable Box<[WheelSlot<T>]>; insert_entry only ever relocates to a
+            // strictly finer level (< lvl_idx), never this slot, so `slot` stays
+            // valid across the loop.
+            let slot = unsafe { &*slot_ptr };
+
+            // Nothing to pull down yet if the earliest entry hasn't reached the
+            // finer level's window.
+            if slot.min_deadline() >= finer_reach {
+                continue;
+            }
+
+            let mut new_min = u64::MAX;
+            let mut entry_ptr = slot.entry_head();
+
+            while !entry_ptr.is_null() && moved < limit {
+                // SAFETY: entry_ptr is in this slot's DLL.
+                let entry = unsafe { entry_ref(entry_ptr) };
+                let next_entry = entry.next();
+                let dt = entry.deadline_ticks();
+
+                if self.select_level(dt) < lvl_idx {
+                    // SAFETY: entry_ptr is in this slot's DLL.
+                    unsafe { slot.remove_entry(entry_ptr) };
+                    self.insert_entry(entry_ptr, dt);
+                    moved += 1;
+                } else {
+                    // Still belongs at this level (modular-index neighbor a full
+                    // range away, or budget-truncated). Leave it; track its min.
+                    new_min = new_min.min(dt);
+                }
+
+                entry_ptr = next_entry;
+            }
+
+            // Fully-walked slot: its min is exactly the min over entries that
+            // stayed. A limit-truncated walk (entry_ptr non-null) leaves it
+            // stale-low; the next rebalance/poll re-walks and heals it.
+            if entry_ptr.is_null() {
+                slot.set_min_deadline(new_min);
+            }
+
+            if slot.is_empty() {
+                self.levels[lvl_idx].deactivate_slot(slot_idx);
+            }
+        }
+
+        moved
     }
 }
 
@@ -2310,6 +2447,50 @@ mod tests {
         assert!(wheel.is_empty());
     }
 
+    #[test]
+    fn proactive_rebalance_moves_and_preserves_firing() {
+        let now = Instant::now();
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+
+        // 10 deadlines at level 2 (delta ~3000 ∈ [512, 4096)).
+        let mut expected = Vec::new();
+        for i in 0..10u64 {
+            let d = 3000 + i * 4;
+            wheel.schedule_forget(now + ms(d), d);
+            expected.push(d);
+        }
+
+        // Far from the deadlines, nothing is within a finer level's reach.
+        assert_eq!(
+            wheel.rebalance(now, usize::MAX),
+            0,
+            "nothing to pull down yet"
+        );
+
+        // Drive the timeline with proactive rebalance + collect-only poll. Every
+        // timer must still fire exactly once, on time — and rebalance must have
+        // actually pulled entries down as they approached.
+        let mut fired = Vec::new();
+        let mut buf = Vec::new();
+        let mut total_moved = 0;
+        for t in 0..=3040u64 {
+            total_moved += wheel.rebalance(now + ms(t), usize::MAX);
+            buf.clear();
+            wheel.poll(now + ms(t), &mut buf);
+            for &v in &buf {
+                assert!(v <= t, "timer {v} fired early at {t}");
+                fired.push(v);
+            }
+        }
+        assert!(
+            total_moved > 0,
+            "rebalance pulled entries down as they neared"
+        );
+        fired.sort_unstable();
+        assert_eq!(fired, expected, "every timer fires once, on time");
+        assert!(wheel.is_empty());
+    }
+
     // -------------------------------------------------------------------------
     // Miri-compatible tests (L12)
     // -------------------------------------------------------------------------
@@ -2489,6 +2670,26 @@ mod tests {
         buf.clear();
         wheel.poll_and_rebalance(now + ms(3005), &mut buf);
         assert_eq!(buf, vec!["rebalanced".to_string()]);
+        assert!(wheel.is_empty());
+    }
+
+    #[test]
+    fn miri_rebalance_method_drop_type() {
+        // Standalone rebalance() uses the same insert_entry-while-slot-borrowed
+        // pattern as poll_and_rebalance; exercise it with a Drop type.
+        let now = Instant::now();
+        let mut wheel: Wheel<String> = Wheel::unbounded(64, now);
+        wheel.schedule_forget(now + ms(3000), "a".to_string());
+        wheel.schedule_forget(now + ms(3004), "b".to_string());
+
+        // Advance so both are within a finer level's reach, then rebalance.
+        let moved = wheel.rebalance(now + ms(2960), usize::MAX);
+        assert!(moved >= 1);
+
+        let mut buf = Vec::new();
+        wheel.poll(now + ms(3004), &mut buf);
+        buf.sort();
+        assert_eq!(buf, vec!["a".to_string(), "b".to_string()]);
         assert!(wheel.is_empty());
     }
 }

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -1,9 +1,10 @@
 //! Timer wheel — the main data structure.
 //!
-//! `TimerWheel<T, S>` is a multi-level, no-cascade timer wheel. Entries are
-//! placed into a level based on how far in the future their deadline is.
-//! Once placed, an entry never moves — poll checks `deadline_ticks <= now`
-//! per entry.
+//! `TimerWheel<T, S>` is a multi-level, rebalancing timer wheel. Entries are
+//! placed into a level based on how far in the future their deadline is, and
+//! **rebalanced** down to finer levels as their deadline approaches; `poll`
+//! then collects ready timers from the small, exact fine-level slots. Timers
+//! fire at their exact tick, never early, never missed.
 
 use std::cell::Cell;
 use std::marker::PhantomData;
@@ -286,7 +287,7 @@ impl BoundedWheelBuilder {
 // TimerWheel
 // =============================================================================
 
-/// A multi-level, no-cascade timer wheel.
+/// A multi-level, rebalancing timer wheel.
 ///
 /// Generic over:
 /// - `T` — the user payload stored with each timer.

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -78,13 +78,19 @@ impl WheelBuilder {
         self
     }
 
-    /// Sets the number of slots per level. Must be a power of 2. Default: 64.
+    /// Sets the number of slots per level. Must be a power of 2, at most 64, and
+    /// greater than `2^clk_shift` so a rebalance always moves an entry to a
+    /// strictly finer level (`clk_shift` and `slots_per_level` are validated
+    /// together at [`build`](UnboundedWheelBuilder::build)). Default: 64.
     pub fn slots_per_level(mut self, n: usize) -> Self {
         self.slots_per_level = n;
         self
     }
 
-    /// Sets the bit shift between levels (multiplier = 2^clk_shift). Default: 3 (8x).
+    /// Sets the bit shift between levels (multiplier = 2^clk_shift). Must satisfy
+    /// `2^clk_shift < slots_per_level` so a rebalance always moves an entry to a
+    /// strictly finer level (validated at build); with the default 64 slots that
+    /// allows `clk_shift` up to 5. Default: 3 (8x).
     pub fn clk_shift(mut self, s: u32) -> Self {
         self.clk_shift = s;
         self
@@ -685,8 +691,8 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
     /// continues):
     ///
     /// ```ignore
-    /// let fired = wheel.poll(now, &mut buf);
-    /// if fired == 0 {
+    /// let collected = wheel.poll(now, &mut buf);
+    /// if collected == 0 {
     ///     // nothing to deliver — maintain during the slack, a bounded slice
     ///     wheel.rebalance(now, REBALANCE_BUDGET);
     /// }


### PR DESCRIPTION
## What

The timer wheel used to fire directly from every level: a `poll` walked each due
slot and checked `deadline <= now` on every entry, so at scale a poll walked
~the whole population to find the few ready timers — the O(population) tail
(the 2.4 ms-at-50k case).

This reworks it into a **collect / rebalance** model:

- entries **rebalance** down to finer levels as their deadline approaches, and
- **poll** collects ready timers from the small, exact fine-level slots.

Firing behavior is unchanged — every timer still fires at its exact tick, never
early, never missed. Only the internal work distribution changes.

## API

- **`poll` / `poll_with_limit`** — collect ready timers only, no reorganizing.
- **`poll_and_rebalance` / `poll_and_rebalance_with_limit`** — collect **and**
  rebalance in one pass. The batteries-included default. Firing is unbounded;
  rebalancing is capped by `WheelBuilder::max_rebalances_per_poll` (default
  `usize::MAX` = unbounded). The cap smooths rebalance work across polls and can
  never delay or drop a fire.
- **`rebalance(now, limit)`** — proactive maintenance you can run *off* the hot
  path.

## Performance (measured)

Realistic server mixes (cancel-heavy one-shot timeouts + periodic events at
3/5/10/15/30 s), `taskset -c 0`, turbo on (deltas are large enough that jitter is
irrelevant). Cycles per poll, distribution — not means. New bench:
`benches/perf_server_scenarios.rs`.

- **Collect + rebalance vs the old drip-fire** (app env, 15k, 75% cancelled):
  typical poll (p50) drops ~2× (1542 → 738); p99 ~1.9×.
- **Bounding `max_rebalances_per_poll`** flattens the tail: p99.9 falls
  monotonically as the cap tightens (unbounded ~9.2k → cap 16 ~6.7k) at no cost
  to the body.
- **Proactive `rebalance` off the hot path**: `poll` + rebalance-during-slack
  makes the collect tail **~3.5× cheaper** (p99.9 ~2.5k vs ~8.7k), with the
  maintenance batched into idle iterations (~12% more total work, paid off the
  hot path). The documented idiom `if fired == 0 { rebalance(now, budget) }`
  self-tunes to load. Do **not** rebalance on every poll — that re-walks the
  look-ahead window and is pure overhead.

## Correctness

- A proptest (`fuzz_next_deadline_cache`) caught a real hole in the naive cascade
  design: the modular slot index lets two deadlines a full level-range apart
  share a slot, so a "survivor" could relocate to the *same* slot and leak the
  empty sentinel into `next_deadline`. Fixed by relocating only to a **strictly
  finer** level (`select_level(dt) < lvl_idx`); same-level survivors stay put.
- Progress guard `2^clk_shift < slots_per_level` added to
  `WheelBuilder::validate` (otherwise a legal config can live-lock).
- **112 tests + 3 doctests**, clippy clean, `RUSTDOCFLAGS=-D warnings`,
  **miri 10/10** (including the relocate/aliasing paths with `Drop` types).

## Docs

Repositioned from the old "no-cascade" framing to the collect/rebalance model
across the crate docs (module / struct / crate rustdoc, README,
`docs/overview.md`, `docs/INDEX.md`, `docs/wheel.md`) and the
`docs/patterns.md` cookbook — which now shows three ways to manage the poll
tail: `poll_and_rebalance` (default), a bounded cap
(`max_rebalances_per_poll`), and opportunistic `poll` + `rebalance` on empty
polls.
