### PR TITLE
adding more investigative work on timer wheel performance

### DIFF
--- a/nexus-timer/Cargo.toml
+++ b/nexus-timer/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["data-structures"]
 nexus-slab = { version = "2", path = "../nexus-slab" }
 
 [dev-dependencies]
+perf-event = "0.4.9"
 proptest = "1.4"
 seq-macro.workspace = true
 
@@ -29,4 +30,8 @@ workspace = true
 
 [[bench]]
 name = "perf_server_scenarios"
+harness = false
+
+[[bench]]
+name = "perf_669_walk"
 harness = false

--- a/nexus-timer/benches/perf_669_walk.rs
+++ b/nexus-timer/benches/perf_669_walk.rs
@@ -1,0 +1,113 @@
+//! #669 isolation micro-bench: the per-entry **cache** cost of walking a slot's
+//! entries, no-churn (`a`) vs steady-state-churn (`b`).
+//!
+//! Uses `perf_event` to count hardware events around **only** the `rebalance`
+//! call — the setup (and, in mode `b`, the fragmenting churn) is not counted, so
+//! the numbers are exactly the walk of the N live entries. No subtraction.
+//!
+//! - **mode `a` (no churn):** the N live entries are scheduled into a fresh slab
+//!   → contiguous, insertion-ordered slots.
+//! - **mode `b` (churn):** the free list is first fragmented by scheduling and
+//!   cancelling batches in shuffled order, so the N live entries land in
+//!   scattered slots — the pointer-chased DLL walk then jumps around memory.
+//!
+//! Run pinned to a P-core so the counters read the cpu_core PMU:
+//! ```text
+//! cargo build --release --bench perf_669_walk
+//! BIN=$(find target/release/deps -name 'perf_669_walk-*' -type f -executable | head -1)
+//! for mode in a b; do for n in 10000 50000; do taskset -c 0 "$BIN" $mode $n; done; done
+//! ```
+
+use std::time::{Duration, Instant};
+
+use nexus_timer::{TimerHandle, Wheel};
+use perf_event::events::Hardware;
+use perf_event::{Builder, Group};
+
+struct Rng(u64);
+impl Rng {
+    #[inline]
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args.get(1).map_or("a", String::as_str);
+    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(10_000);
+
+    let epoch = Instant::now();
+    let mut wheel: Wheel<u64> = Wheel::unbounded(4096, epoch);
+    let mut rng = Rng(0xC0FF_EE00_1234_5678);
+
+    // mode b: fragment the slab free list before the live population exists.
+    if mode == "b" {
+        let batch = n * 2;
+        for _round in 0..3 {
+            let mut handles: Vec<TimerHandle<u64>> = Vec::with_capacity(batch);
+            for _ in 0..batch {
+                handles.push(wheel.schedule(epoch + Duration::from_secs(3600), 0));
+            }
+            for i in (1..handles.len()).rev() {
+                let j = (rng.next() as usize) % (i + 1);
+                handles.swap(i, j);
+            }
+            for h in handles {
+                wheel.cancel(h);
+            }
+        }
+    }
+
+    // Live population: N entries at level-2 deadlines in [600, 1000) ticks.
+    for i in 0..n {
+        let d = 600 + (i as u64 % 400);
+        wheel.schedule_forget(epoch + Duration::from_millis(d), 0);
+    }
+
+    // Count cache-misses / cycles / instructions around ONLY the rebalance walk.
+    let mut group = Group::new().expect("perf_event Group::new (need perf_event_paranoid <= 2)");
+    let cache_misses = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::CACHE_MISSES)
+        .build()
+        .expect("cache-misses counter");
+    let cycles = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::CPU_CYCLES)
+        .build()
+        .expect("cycles counter");
+    let insns = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::INSTRUCTIONS)
+        .build()
+        .expect("instructions counter");
+
+    let now = epoch + Duration::from_millis(590);
+    group.enable().expect("enable");
+    let t0 = Instant::now();
+    let moved = wheel.rebalance(now, usize::MAX);
+    let elapsed = t0.elapsed();
+    group.disable().expect("disable");
+    assert_eq!(moved, n, "rebalance should walk+move every live entry");
+
+    let counts = group.read().expect("read counters");
+    let cm = counts[&cache_misses];
+    let cy = counts[&cycles];
+    let ins = counts[&insns];
+    let ns_total = elapsed.as_nanos();
+    println!(
+        "mode={mode} n={n:>7}  walk={:>8.3}ms  {:>6.1}ns/entry  {:>5.1}cy/entry  {:>5.2}miss/entry  IPC={:.2}  ({:.2} GHz eff)",
+        ns_total as f64 / 1e6,
+        ns_total as f64 / n as f64,
+        cy as f64 / n as f64,
+        cm as f64 / n as f64,
+        ins as f64 / cy.max(1) as f64,
+        cy as f64 / ns_total.max(1) as f64, // cycles/ns = GHz
+    );
+}

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -25,6 +25,8 @@ use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use nexus_timer::{TimerHandle, Wheel, WheelBuilder};
+use perf_event::events::Hardware;
+use perf_event::{Builder, Group};
 
 // ── deterministic RNG (xorshift64*) — identical workload every run ───────────
 struct Rng(u64);
@@ -320,6 +322,106 @@ fn print_poll_row(label: &str, samples: &[u64]) {
     );
 }
 
+/// Same realistic timeline as `run_env`, but measures the poll's **cache
+/// behavior** with `perf_event` (counters enabled only during the poll, after
+/// warmup). High IPC ⇒ compute-bound (cache-resident, like the contiguous
+/// micro-bench); low IPC ⇒ memory-bound (scattered). Pin to a P-core.
+fn realistic_cache(env: &Env, cancel_pct: u32) {
+    let epoch = Instant::now();
+    let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(epoch);
+    let mut rng = Rng(0x1234_5678_9abc_def0);
+    let periodic_count: usize = env.periodic.iter().map(|p| p.count).sum();
+    for p in env.periodic {
+        for _ in 0..p.count {
+            let first = rng.range(1, p.period_ms);
+            wheel.schedule_forget(epoch + Duration::from_millis(first), p.period_ms);
+        }
+    }
+    let mut cancels: BinaryHeap<Reverse<(u64, u64)>> = BinaryHeap::new();
+    let mut handles: Vec<Option<TimerHandle<u64>>> = Vec::new();
+    let mut buf: Vec<u64> = Vec::with_capacity(2_048);
+
+    let mut group = Group::new().expect("perf_event Group (need perf_event_paranoid <= 2)");
+    let cache_misses = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::CACHE_MISSES)
+        .build()
+        .unwrap();
+    let cycles = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::CPU_CYCLES)
+        .build()
+        .unwrap();
+    let insns = Builder::new()
+        .group(&mut group)
+        .kind(Hardware::INSTRUCTIONS)
+        .build()
+        .unwrap();
+
+    let mut total_fired: u64 = 0;
+    let mut polls: u64 = 0;
+
+    for tick in 0..(WARMUP_TICKS + SIM_TICKS) {
+        let now = epoch + Duration::from_millis(tick);
+        while let Some(&Reverse((ct, _))) = cancels.peek() {
+            if ct > tick {
+                break;
+            }
+            let Reverse((_, seq)) = cancels.pop().unwrap();
+            if let Some(h) = handles[seq as usize].take() {
+                wheel.cancel(h);
+            }
+        }
+        let live = wheel.len().saturating_sub(periodic_count);
+        for _ in live..env.population {
+            let dur = rng.range(env.dur_min_ms, env.dur_max_ms + 1);
+            let deadline = now + Duration::from_millis(dur);
+            if rng.pct(cancel_pct) {
+                let h = wheel.schedule(deadline, 0);
+                let slack = rng.range(1, dur.max(2));
+                let cancel_tick = tick + dur.saturating_sub(slack);
+                let seq = handles.len() as u64;
+                handles.push(Some(h));
+                cancels.push(Reverse((cancel_tick, seq)));
+            } else {
+                wheel.schedule_forget(deadline, 0);
+            }
+        }
+
+        buf.clear();
+        let measure = tick >= WARMUP_TICKS;
+        if measure {
+            group.enable().unwrap();
+        }
+        let fired = wheel.poll_and_rebalance(now, &mut buf);
+        if measure {
+            group.disable().unwrap();
+            total_fired += fired as u64;
+            polls += 1;
+        }
+
+        for &v in &buf {
+            if v != 0 {
+                wheel.schedule_forget(now + Duration::from_millis(v), v);
+            }
+        }
+    }
+
+    let counts = group.read().unwrap();
+    let cm = counts[&cache_misses] as f64;
+    let cy = counts[&cycles] as f64;
+    let ins = counts[&insns] as f64;
+    let fired = total_fired.max(1) as f64;
+    println!(
+        "  {:<42} IPC={:.2}  {:>6.2} miss/fired  {:>6.1} cy/fired  {:>7.3} miss/poll",
+        env.name,
+        ins / cy.max(1.0),
+        cm / fired,
+        cy / fired,
+        cm / polls.max(1) as f64,
+    );
+}
+
 fn main() {
     println!("================================================================");
     println!("TIMER WHEEL — realistic server-scenario poll cost (cycles/poll)");
@@ -403,4 +505,12 @@ fn main() {
         &format!("rebalance (ran on {ran_pct:.0}% of ticks, the empty ones)"),
         &rebal,
     );
+
+    // #669: where does a REALISTIC workload land on the cache spectrum? High IPC
+    // ⇒ compute-bound (cache-resident); low IPC ⇒ memory-bound (scattered).
+    // (perf_event; pin to a P-core, e.g. taskset -c 0.)
+    println!("\nRealistic-workload poll cache behavior (perf_event; pin to a P-core):");
+    for env in [&EDGE, &APP, &GATEWAY] {
+        realistic_cache(env, env.cancel_pct);
+    }
 }

--- a/nexus-timer/docs/INDEX.md
+++ b/nexus-timer/docs/INDEX.md
@@ -14,6 +14,10 @@ ready timers from small, exact slots.
   backends and their tradeoffs
 - [patterns.md](patterns.md) — cookbook: timeouts, heartbeats, periodic
   tasks, deadline scheduling
+- [perf-walk-locality.md](perf-walk-locality.md) — cache/locality audit (#669):
+  the poll walk is compute-bound and cache-resident at realistic sizes; when
+  slab fragmentation actually bites (> L3 working set), and why free-list
+  ordering is the wrong fix
 
 ## Related crates
 

--- a/nexus-timer/docs/perf-walk-locality.md
+++ b/nexus-timer/docs/perf-walk-locality.md
@@ -1,0 +1,127 @@
+# Timer-wheel walk locality & cache behavior (audit for #669)
+
+## TL;DR
+
+The poll / rebalance entry-walk is **compute-bound and cache-resident for
+realistic workloads**. Cancel-churn fragments the slab free list, but that only
+degrades the walk once the **live working set exceeds L3** (~200k timers on this
+machine). At the sizes that ship (≤ 50k) it is a non-issue — measured IPC ~3
+with ≈ 0 cache misses per poll. **No slab-layout change is justified.**
+
+## The question (#669)
+
+An earlier measurement on the pre-rebalance wheel reported ~45 ns per entry on a
+poll that scanned a slot's entries, and hypothesized slab **free-list
+fragmentation** under cancel churn. This audit answers, with `perf` counters:
+
+- Is the per-entry walk **cache-miss-bound** or compute-bound?
+- Does cancel **churn** fragment the slab enough to matter, and at what scale?
+
+## Method
+
+Two benches, both counting hardware events with `perf_event` (not `rdtsc`), so we
+see cache misses, not just cycles. Pinned to a **P-core** (`taskset -c 0`) — the
+CPU is hybrid, so counters must read the `cpu_core` PMU.
+
+- **`benches/perf_669_walk.rs`** — isolates the `rebalance` walk: counters wrap
+  *only* the `rebalance` call, so setup (and, in mode `b`, the fragmenting churn)
+  is not counted. Two layouts, swept 10k → 1M live entries:
+  - **mode `a` (contiguous):** N entries scheduled into a fresh slab → contiguous,
+    insertion-ordered slots.
+  - **mode `b` (scattered):** the free list is first fragmented by scheduling and
+    cancelling batches in shuffled order, so the live entries land in scattered
+    slots (worst case — uniform scatter).
+- **`benches/perf_server_scenarios.rs` → `realistic_cache`** — the realistic
+  server driver (spread deadlines, cancel-heavy one-shots + periodic events,
+  FIFO-ish cancel), with counters wrapping the `poll_and_rebalance` call across
+  the measured window. Reports IPC and misses/poll at 2k / 15k / 50k.
+
+### Environment
+
+- Intel Core Ultra 7 165U (Meteor Lake, hybrid). P-cores 0–3 up to 4.9 GHz.
+- L1d 32 KiB/core, L2 ~2 MiB/P-core module, **L3 12 MiB shared**.
+- `WheelEntry` ≈ 60 B ⇒ L3 holds ~200k entries (matches the measured crossover).
+- `perf_event_paranoid = 2` (user-space counters, no sudo).
+
+## Results
+
+### Isolated `rebalance` walk — contiguous vs worst-case scatter
+
+Wall-clock per entry, single unbounded `rebalance` of the whole population:
+
+| live entries | contiguous (a) | scattered (b) | penalty | b IPC |
+|---|---|---|---|---|
+| 10k  | 5.6 ns | 5.7 ns | ~1×  | 3.6 |
+| 50k  | 5.6 ns | 9.2 ns | 1.6× | 3.2 |
+| 200k | 7 ns   | 25 ns  | 3.6× | 1.0 |
+| 500k | 8 ns   | 73 ns  | 9×   | 0.32 |
+| 1M   | 8.5 ns | 91 ns  | 11×  | 0.29 |
+
+Contiguous stays ~6–9 ns/entry all the way to 1M — the hardware prefetcher hides
+the misses on sequential access (IPC ~3.5 even at 1 miss/entry). Scattered is
+identical up to 50k, then falls off a cliff as the working set spills past L3.
+
+### Realistic server workload — poll cache behavior
+
+| env | IPC | miss/poll | miss/fired |
+|---|---|---|---|
+| edge (2k, 90% cxl)    | 2.3 | ~0.006 | ~0.02 |
+| app (15k, 75% cxl)    | 3.0 | ~0.05  | ~0.02 |
+| gateway (50k, 95% cxl)| 2.4 | ~0.05  | ~0.17 |
+
+Realistic workloads sit next to the *contiguous* column: **IPC ~2.3–3.0, ≈ 0
+cache misses per poll.** Gateway (50k) shows the first hint of L3 pressure
+(0.17 miss/fired) but is still nowhere near the 1+/entry of the memory-bound
+regime.
+
+## Interpretation
+
+- **The penalty tracks which cache level the working set lives in, not the
+  degree of scatter.** Below L3 (~200k entries here), even uniform worst-case
+  scatter is an L3 hit → ~6–9 ns/entry. Above L3, scattered access becomes a
+  dependent-load chain to DRAM → ~90 ns/entry, IPC collapses to ~0.3. Software
+  prefetch can't help a dependent pointer chase.
+- **The move is a DLL splice, not a queue push.** Rebalancing an entry unlinks it
+  from the source slot (writes `prev.next`, `next.prev`) and links it into the
+  target slot (writes `tail.next`) — ~4 different nodes touched per entry. In the
+  DRAM regime that's ~3–4 back-to-back misses, which is the 91 ns.
+- **Realistic workloads stay compact.** The slab's LIFO free list reuses the
+  hottest recently-freed slot, and real cancel patterns are FIFO-ish
+  (completions roughly track arrivals), so the live set doesn't scatter the way
+  the synthetic uniform-shuffle does.
+
+## Conclusions & decisions
+
+- **No layout work is justified** for the sizes that ship. Realistic polls are
+  compute-bound and cache-resident.
+- **Free-list ordering is rejected.** Address-ordering the free list to keep
+  reallocation contiguous would move cache misses onto the **hot path**
+  (`schedule`/`cancel`) and break the slab's O(1) alloc/free and its LIFO
+  allocation locality — a net loss, since schedule/cancel are the high-frequency
+  ops and the walk is the cold path.
+- **Packed per-slot array is parked, gated.** A contiguous per-slot
+  `(deadline, ptr)` array is the *only* fix that doesn't rob the hot path (it
+  fixes both the scan and the splice), but it's a slot-representation rewrite that
+  duplicates the deadline and puts array growth on `schedule`. Only worth it for a
+  caller with a genuine **> L3 working set** (~100k+ live timers) under churn —
+  which does not occur in the realistic envs.
+
+## Reproduce
+
+```sh
+cargo build --release --bench perf_669_walk --bench perf_server_scenarios
+
+# Isolated walk: contiguous (a) vs scattered (b), swept by population.
+BIN=$(find target/release/deps -name 'perf_669_walk-*' -type f -executable | head -1)
+for mode in a b; do for n in 10000 50000 200000 500000 1000000; do
+  taskset -c 0 "$BIN" $mode $n
+done; done
+
+# Realistic-workload poll cache behavior (last section of the output).
+BIN=$(find target/release/deps -name 'perf_server_scenarios-*' -type f -executable | head -1)
+taskset -c 0 "$BIN"
+```
+
+Requires Linux + `perf_event` (`perf_event_paranoid <= 2`) and pinning to a
+P-core on a hybrid CPU. Numbers are hardware-specific; the *shape* (flat
+contiguous, cliff past L3, realistic ≈ contiguous) is the portable result.


### PR DESCRIPTION
Captures the `perf`-based investigation behind #669 — is the timer-wheel
poll/rebalance entry-walk cache-miss-bound, and does cancel churn fragment the
slab enough to matter? — plus the write-up, so the data and reasoning are on
record for future audits to check against.

## What's here

- **`benches/perf_669_walk.rs`** — isolates the `rebalance` walk with
  `perf_event` counters wrapping *only* the rebalance call, comparing a
  contiguous slab (mode `a`) vs a churn-fragmented one (mode `b`), swept
  10k → 1M live entries.
- **`benches/perf_server_scenarios.rs` → `realistic_cache`** — measures the
  *realistic* server workload's poll cache behavior (IPC, misses/poll) at
  2k / 15k / 50k. (Also folds in the cap / proactive / opportunistic-rebalance
  sweeps.)
- **`docs/perf-walk-locality.md`** — the full audit: question, method,
  environment, both result tables, interpretation, decisions, and copy-paste
  reproduce commands. Indexed in `docs/INDEX.md`.

## What we found

- The walk is **compute-bound and cache-resident at realistic sizes.** The
  penalty tracks *which cache level the live working set lives in*, not the
  degree of scatter.
- **≤ 50k** (fits L3 — 12 MiB here ≈ 200k entries): even worst-case uniform
  scatter is ~6–9 ns/entry, IPC ~3–5.
- **> L3** (500k–1M): scattered access becomes a DRAM dependent-load chain —
  ~91 ns/entry, IPC ~0.3 — while contiguous stays ~8 ns (the prefetcher hides
  the misses on sequential access).
- **Realistic server workloads (perf-measured)** sit at the *contiguous* end —
  IPC ~2.3–3.0, ≈ 0 cache misses per poll.

## Decisions (see the doc)

- **No slab-layout work is justified** for the sizes that ship.
- **Free-list ordering rejected** — address-ordering the free list to keep
  reallocation contiguous would move misses onto the hot path
  (`schedule`/`cancel`) and break the slab's O(1) alloc/free + LIFO allocation
  locality. Wrong trade.
- **Packed per-slot array parked**, gated on a genuine > L3 working set
  (~100k+ live timers under churn) — which the realistic envs never reach.

## Notes

Reference branch — numbers are hardware-specific, but the *shape* (flat
contiguous, cliff past L3, realistic ≈ contiguous) is the portable result. The
perf benches are Linux + `perf_event` (`perf_event_paranoid <= 2`) + P-core-pin
only; if this ever merges into cross-platform CI, the `perf-event` dev-dep and
those two benches would want `cfg(target_os = "linux")` gating.
