### PR TITLE
adding errors rather than asserts and prepping timer for release

### DIFF
--- a/nexus-async-rt/src/timer.rs
+++ b/nexus-async-rt/src/timer.rs
@@ -10,13 +10,13 @@ use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
-use nexus_timer::{Wheel, WheelBuilder};
+use nexus_timer::Wheel;
 
 // =============================================================================
 // TimerDriver — owned by Runtime
 // =============================================================================
 
-/// Timer wheel driver. O(1) insert, O(1) cancel, no-cascade poll.
+/// Timer wheel driver. O(1) insert, O(1) cancel, O(fired) poll.
 pub(crate) struct TimerDriver {
     wheel: Wheel<Waker>,
     /// Pre-allocated buffer for expired wakers. Reused across cycles.
@@ -26,7 +26,7 @@ pub(crate) struct TimerDriver {
 impl TimerDriver {
     pub(crate) fn new(capacity: usize) -> Self {
         let now = Instant::now();
-        let wheel = WheelBuilder::default().unbounded(capacity).build(now);
+        let wheel = Wheel::unbounded(capacity, now);
         Self {
             wheel,
             expired: Vec::with_capacity(64),

--- a/nexus-rt/src/lib.rs
+++ b/nexus-rt/src/lib.rs
@@ -315,8 +315,9 @@ pub use self::mio::{FlexMio, InlineMio};
 #[cfg(feature = "timer")]
 pub use timer::{
     BoundedTimerInstaller, BoundedTimerPoller, BoundedTimerWheel, BoundedWheel,
-    BoundedWheelBuilder, BoxedTimers, Full, Periodic, TimerConfig, TimerHandle, TimerInstaller,
-    TimerPoller, TimerWheel, UnboundedWheelBuilder, Wheel, WheelBuilder, WheelEntry,
+    BoundedWheelBuilder, BoxedTimers, ConfigError, Full, Periodic, TimerConfig, TimerHandle,
+    TimerInstaller, TimerPoller, TimerWheel, UnboundedWheelBuilder, Wheel, WheelBuilder,
+    WheelEntry,
 };
 
 #[cfg(all(feature = "timer", feature = "smartptr"))]

--- a/nexus-rt/src/timer.rs
+++ b/nexus-rt/src/timer.rs
@@ -47,7 +47,7 @@
 //!
 //! let mut builder = WorldBuilder::new();
 //! builder.register::<bool>(false);
-//! let wheel = WheelBuilder::default().unbounded(64).build(Instant::now());
+//! let wheel = WheelBuilder::default().unbounded(64).build(Instant::now()).unwrap();
 //! let mut timer: TimerPoller = builder.install_driver(
 //!     TimerInstaller::new(wheel),
 //! );
@@ -72,8 +72,8 @@ use nexus_timer::store::SlabStore;
 
 // Re-export types that users need from nexus-timer
 pub use nexus_timer::{
-    BoundedWheel, BoundedWheelBuilder, Full, TimerHandle, UnboundedWheelBuilder, Wheel,
-    WheelBuilder, WheelEntry,
+    BoundedWheel, BoundedWheelBuilder, ConfigError, Full, TimerHandle, UnboundedWheelBuilder,
+    Wheel, WheelBuilder, WheelEntry,
 };
 
 // Resource impls for timer wheel types registered by the timer driver.
@@ -217,18 +217,19 @@ impl TimerConfig for FlexTimers {
 /// use nexus_rt::{TimerInstaller, TimerPoller, BoundedTimerPoller, WheelBuilder};
 ///
 /// // Unbounded — slab grows as needed, scheduling never fails
-/// let wheel = WheelBuilder::default().unbounded(64).build(Instant::now());
+/// let wheel = WheelBuilder::default().unbounded(64).build(Instant::now()).unwrap();
 /// let timer: TimerPoller = wb.install_driver(TimerInstaller::new(wheel));
 ///
 /// // Bounded — fixed capacity, try_schedule returns Err(Full) when full
-/// let wheel = WheelBuilder::default().bounded(1024).build(Instant::now());
+/// let wheel = WheelBuilder::default().bounded(1024).build(Instant::now()).unwrap();
 /// let timer: BoundedTimerPoller = wb.install_driver(TimerInstaller::new(wheel));
 ///
 /// // Custom tick resolution for microsecond-precision timers
 /// let wheel = WheelBuilder::default()
 ///     .tick_duration(Duration::from_micros(100))
 ///     .unbounded(256)
-///     .build(Instant::now());
+///     .build(Instant::now())
+///     .unwrap();
 /// let timer: TimerPoller = wb.install_driver(TimerInstaller::new(wheel));
 /// ```
 pub struct TimerInstaller<
@@ -1016,7 +1017,8 @@ mod tests {
             WheelBuilder::default()
                 .tick_duration(Duration::from_micros(100))
                 .unbounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1027,7 +1029,8 @@ mod tests {
             WheelBuilder::default()
                 .slots_per_level(32)
                 .unbounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1038,7 +1041,8 @@ mod tests {
             WheelBuilder::default()
                 .clk_shift(2)
                 .unbounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1049,7 +1053,8 @@ mod tests {
             WheelBuilder::default()
                 .num_levels(4)
                 .unbounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1063,7 +1068,8 @@ mod tests {
                 .clk_shift(2)
                 .num_levels(5)
                 .unbounded(128)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1073,7 +1079,7 @@ mod tests {
     fn cfg_bounded_default() {
         let now = Instant::now();
         assert_bounded_fires(TimerInstaller::new(
-            WheelBuilder::default().bounded(64).build(now),
+            WheelBuilder::default().bounded(64).build(now).unwrap(),
         ));
     }
 
@@ -1084,7 +1090,8 @@ mod tests {
             WheelBuilder::default()
                 .tick_duration(Duration::from_micros(100))
                 .bounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1095,7 +1102,8 @@ mod tests {
             WheelBuilder::default()
                 .slots_per_level(32)
                 .bounded(64)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1103,7 +1111,11 @@ mod tests {
     fn cfg_bounded_clk_shift() {
         let now = Instant::now();
         assert_bounded_fires(TimerInstaller::new(
-            WheelBuilder::default().clk_shift(2).bounded(64).build(now),
+            WheelBuilder::default()
+                .clk_shift(2)
+                .bounded(64)
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1111,7 +1123,11 @@ mod tests {
     fn cfg_bounded_num_levels() {
         let now = Instant::now();
         assert_bounded_fires(TimerInstaller::new(
-            WheelBuilder::default().num_levels(4).bounded(64).build(now),
+            WheelBuilder::default()
+                .num_levels(4)
+                .bounded(64)
+                .build(now)
+                .unwrap(),
         ));
     }
 
@@ -1125,7 +1141,8 @@ mod tests {
                 .clk_shift(2)
                 .num_levels(5)
                 .bounded(128)
-                .build(now),
+                .build(now)
+                .unwrap(),
         ));
     }
 

--- a/nexus-timer/CHANGELOG.md
+++ b/nexus-timer/CHANGELOG.md
@@ -12,7 +12,7 @@ contained.
 
 ### Added
 
-- `TimeoutList<T, S>` — a fixed-duration timeout list front-end over the same
+- `TimeoutQueue<T, S>` — a fixed-duration timeout queue front-end over the same
   slab / entry / handle machinery as the wheel. The timeout is fixed at
   construction (no per-call `deadline` parameter), so deadlines are monotone in
   insertion order: entries append at the tail of one intrusive DLL and poll
@@ -21,10 +21,10 @@ contained.
   `schedule` / `schedule_forget` / `try_schedule` / `try_schedule_forget` /
   `cancel` / `free` / `poll` / `poll_with_limit` surface as the wheel. No
   `reschedule` (cancel and re-schedule instead). Builder mirrors
-  `WheelBuilder`: `TimeoutListBuilder::new(timeout).tick_duration(..)
-  .unbounded(chunk)|.bounded(cap).build(now)`. Exports: `TimeoutList`,
-  `BoundedTimeoutList`, `TimeoutListBuilder`, `UnboundedTimeoutListBuilder`,
-  `BoundedTimeoutListBuilder`. Nothing-due poll is flat across live population
+  `WheelBuilder`: `TimeoutQueueBuilder::new(timeout).tick_duration(..)
+  .unbounded(chunk)|.bounded(cap).build(now)`. Exports: `TimeoutQueue`,
+  `BoundedTimeoutQueue`, `TimeoutQueueBuilder`, `UnboundedTimeoutQueueBuilder`,
+  `BoundedTimeoutQueueBuilder`. Nothing-due poll is flat across live population
   (~12 cycles/op, amortized, at 100 / 1k / 10k / 50k), versus the wheel's
   O(population) 0.2 µs → 2.4 ms.
 
@@ -33,12 +33,35 @@ contained.
   instead of walking every active level, and the global minimum is recomputed
   from ~one compare per populated slot rather than one per entry.
 
+- Rebalancing poll API — `poll_and_rebalance` / `poll_and_rebalance_with_limit`
+  collect ready timers **and** relocate not-yet-due entries to finer levels in
+  one pass, so a busy wheel stays cheap to poll (the fine levels a later poll
+  scans hold few entries). `rebalance(now, limit)` performs the same maintenance
+  standalone, enabling the opportunistic pattern of rebalancing only on polls
+  that fired nothing. New `WheelBuilder::max_rebalances_per_poll(n)` caps
+  relocations per poll to smooth the burst — the cap only paces maintenance work,
+  it never delays or drops a fire. Firing stays exact: a timer never fires early
+  and is never missed. `poll` / `poll_with_limit` remain the minimal
+  collect-only poll (a wheel polled only via `poll` never rebalances and degrades
+  to an O(population) scan; prefer `poll_and_rebalance` for steady polling).
+
 ### Changed
 
 - `TimerWheel::next_deadline()` now returns a **lower bound** rather than the
   exact next deadline. Per-slot minima are left stale-low after a cancel or fire
   (not recomputed on removal), so the result may be earlier than the true next
   deadline, never later — safe as a sleep/wake bound (wake early, never miss).
+
+- **Breaking:** the terminal builders' `build` now returns
+  `Result<_, ConfigError>` instead of panicking on an invalid configuration —
+  `WheelBuilder`/`BoundedWheelBuilder` (`build(now) -> Result<Wheel<T>, _>` /
+  `Result<BoundedWheel<T>, _>`) and `TimeoutQueueBuilder`'s terminal builders
+  likewise. `ConfigError::Invalid(&'static str)` names the violated constraint.
+  The convenience constructors (`Wheel::unbounded` / `Wheel::bounded`,
+  `TimeoutQueue::unbounded` / `TimeoutQueue::bounded`) stay infallible — they use
+  a valid default config and `expect` internally (the `TimeoutQueue` ones panic
+  only on a zero `timeout`, which is a caller bug). Migration: append `?` or
+  `.expect(..)` to existing `WheelBuilder::…build(now)` call sites.
 
 ## [1.4.2] and earlier
 

--- a/nexus-timer/Cargo.toml
+++ b/nexus-timer/Cargo.toml
@@ -22,7 +22,7 @@ name = "perf_timer"
 harness = false
 
 [[bench]]
-name = "perf_timeout_list"
+name = "perf_timeout_queue"
 harness = false
 
 [lints]

--- a/nexus-timer/README.md
+++ b/nexus-timer/README.md
@@ -59,7 +59,8 @@ let wheel: Wheel<u64> = WheelBuilder::default()
     .tick_duration(Duration::from_micros(100))
     .slots_per_level(32)
     .unbounded(4096)
-    .build(now);
+    .build(now)
+    .unwrap(); // Err(ConfigError) only on an invalid config
 ```
 
 The builder uses a typestate pattern — configuration setters are only
@@ -69,6 +70,11 @@ available before selecting bounded or unbounded mode:
 WheelBuilder  ─.unbounded(chunk_cap)─▶  UnboundedWheelBuilder  ─.build(now)─▶  Wheel<T>
               ─.bounded(cap)──────────▶  BoundedWheelBuilder    ─.build(now)─▶  BoundedWheel<T>
 ```
+
+`build(now)` returns `Result<_, ConfigError>` — the `Wheel<T>` / `BoundedWheel<T>`
+above is the `Ok` payload (`?`/`.unwrap()` it). `ConfigError::Invalid` is only
+produced by a bad configuration; the default-config `Wheel::unbounded` /
+`Wheel::bounded` constructors are infallible.
 
 ## Bounded vs Unbounded
 
@@ -123,7 +129,7 @@ wheel.cancel(handle);
 | `len()` | `usize` | Number of active timers |
 | `is_empty()` | `bool` | Whether the wheel is empty |
 
-## TimeoutList — Fixed-Duration Variant
+## TimeoutQueue — Fixed-Duration Variant
 
 The wheel's poll is O(active population): it walks every entry of every
 active slot to prove which are due. That is the right trade when deadlines
@@ -131,7 +137,7 @@ are *arbitrary*. But many callers schedule **one fixed timeout for
 everything** — a flat 5 s deadline on every item. For that workload the
 wheel buckets by deadline to solve an ordering problem that does not exist.
 
-`TimeoutList<T>` exploits the single duration. A constant timeout plus a
+`TimeoutQueue<T>` exploits the single duration. A constant timeout plus a
 monotone clock means deadlines are monotone in insertion order, so a new
 entry is always appended at the tail of one intrusive list, keeping it
 sorted with no comparisons. Poll walks from the head and stops at the first
@@ -144,14 +150,15 @@ merely discouraged.
 
 ```rust
 use std::time::{Duration, Instant};
-use nexus_timer::{TimeoutList, TimeoutListBuilder};
+use nexus_timer::{TimeoutQueue, TimeoutQueueBuilder};
 
 let now = Instant::now();
 
 // Every timer gets the same 5-second timeout.
-let mut list: TimeoutList<u64> = TimeoutListBuilder::new(Duration::from_secs(5))
+let mut list: TimeoutQueue<u64> = TimeoutQueueBuilder::new(Duration::from_secs(5))
     .unbounded(4096)
-    .build(now);
+    .build(now)
+    .unwrap(); // Err(ConfigError) only on a zero timeout/tick
 
 let handle = list.schedule(now, 42);   // fires at now + 5s
 let value = list.cancel(handle);       // O(1) mid-list unlink
@@ -166,7 +173,7 @@ would break the sort) and no `min_deadline` cache (the head *is* the min).
 
 Nothing-due poll is flat across population — the whole point:
 
-| Live population | wheel poll (0-fire) | `TimeoutList` poll (0-fire) |
+| Live population | wheel poll (0-fire) | `TimeoutQueue` poll (0-fire) |
 |---|---|---|
 | 100 | 0.2 µs | ~12 cycles |
 | 1,000 | 5.6 µs | ~12 cycles |
@@ -178,8 +185,8 @@ measurement floor, so the bench reports that floor and the percentile tails
 alongside these amortized figures to keep them honest.
 
 ```bash
-cargo build --release --bench perf_timeout_list -p nexus-timer
-taskset -c 0 ./target/release/deps/perf_timeout_list-*
+cargo build --release --bench perf_timeout_queue -p nexus-timer
+taskset -c 0 ./target/release/deps/perf_timeout_queue-*
 ```
 
 ## Design

--- a/nexus-timer/benches/perf_server_scenarios.rs
+++ b/nexus-timer/benches/perf_server_scenarios.rs
@@ -51,7 +51,7 @@ impl Rng {
     }
 }
 
-// ── rdtsc brackets (match perf_timeout_list.rs) ──────────────────────────────
+// ── rdtsc brackets (match perf_timeout_queue.rs) ──────────────────────────────
 #[inline(always)]
 fn rdtsc_start() -> u64 {
     // SAFETY: x86_64 intrinsic; benchmark runs on x86_64 only.
@@ -215,7 +215,8 @@ fn run_env(
     let mut wheel: Wheel<u64> = WheelBuilder::default()
         .max_rebalances_per_poll(rebalance_cap)
         .unbounded(4096)
-        .build(epoch);
+        .build(epoch)
+        .unwrap();
     let mut rng = Rng(0x1234_5678_9abc_def0);
     let periodic_count: usize = env.periodic.iter().map(|p| p.count).sum();
 
@@ -328,7 +329,10 @@ fn print_poll_row(label: &str, samples: &[u64]) {
 /// micro-bench); low IPC ⇒ memory-bound (scattered). Pin to a P-core.
 fn realistic_cache(env: &Env, cancel_pct: u32) {
     let epoch = Instant::now();
-    let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(epoch);
+    let mut wheel: Wheel<u64> = WheelBuilder::default()
+        .unbounded(4096)
+        .build(epoch)
+        .unwrap();
     let mut rng = Rng(0x1234_5678_9abc_def0);
     let periodic_count: usize = env.periodic.iter().map(|p| p.count).sum();
     for p in env.periodic {

--- a/nexus-timer/benches/perf_timeout_queue.rs
+++ b/nexus-timer/benches/perf_timeout_queue.rs
@@ -1,6 +1,6 @@
-//! TimeoutList cycle-level benchmark.
+//! TimeoutQueue cycle-level benchmark.
 //!
-//! The point of `TimeoutList` is that poll is O(fired), not O(population).
+//! The point of `TimeoutQueue` is that poll is O(fired), not O(population).
 //! This bench proves it *and* reports honest per-op costs.
 //!
 //! ## Why two methods
@@ -21,14 +21,14 @@
 //!      what matters there.
 //!
 //! Run pinned, turbo disabled, best of a few:
-//!   cargo build --release --bench perf_timeout_list -p nexus-timer
-//!   taskset -c 0 ./target/release/deps/perf_timeout_list-*
+//!   cargo build --release --bench perf_timeout_queue -p nexus-timer
+//!   taskset -c 0 ./target/release/deps/perf_timeout_queue-*
 
 use std::hint::black_box;
 use std::mem;
 use std::time::{Duration, Instant};
 
-use nexus_timer::{TimeoutList, TimerHandle};
+use nexus_timer::{TimeoutQueue, TimerHandle};
 
 const SAMPLES: usize = 50_000;
 const WARMUP: usize = 5_000;
@@ -150,7 +150,7 @@ fn main() {
 
     // schedule + cancel (paired) — self-cleaning, list stays ~empty.
     {
-        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), 4096, now);
+        let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), 4096, now);
         let c = amortized_per_op(AMORT_ITERS, || {
             let h = list.schedule(now, 0);
             black_box(list.cancel(h));
@@ -163,8 +163,8 @@ fn main() {
     {
         let mut best = f64::INFINITY;
         for _ in 0..AMORT_RUNS {
-            let mut list: TimeoutList<u64> =
-                TimeoutList::unbounded(timeout(3600), AMORT_ITERS as usize + 16, now);
+            let mut list: TimeoutQueue<u64> =
+                TimeoutQueue::unbounded(timeout(3600), AMORT_ITERS as usize + 16, now);
             let s = rdtsc_start();
             for _ in 0..AMORT_ITERS {
                 list.schedule_forget(now, 0);
@@ -177,7 +177,7 @@ fn main() {
 
     // nothing-due poll, per population — MUST be flat (O(1), no scan).
     for &pop in &POPULATIONS {
-        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+        let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), pop + 16, now);
         let mut handles: Vec<TimerHandle<u64>> = Vec::with_capacity(pop);
         for i in 0..pop {
             handles.push(list.schedule(now, i as u64));
@@ -198,7 +198,7 @@ fn main() {
 
     // schedule + cancel (paired)
     {
-        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), 4096, now);
+        let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), 4096, now);
         let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..WARMUP {
             let h = list.schedule(now, 0);
@@ -216,7 +216,7 @@ fn main() {
 
     // nothing-due poll, per population
     for &pop in &POPULATIONS {
-        let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+        let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), pop + 16, now);
         let mut handles: Vec<TimerHandle<u64>> = Vec::with_capacity(pop);
         for i in 0..pop {
             handles.push(list.schedule(now, i as u64));
@@ -249,7 +249,7 @@ fn main() {
         let iters = (SAMPLES / 20).max(1);
         let mut samples = Vec::with_capacity(iters);
         for _ in 0..(iters / 10).max(1) {
-            let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+            let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), pop + 16, now);
             for i in 0..K_DUE {
                 list.schedule_forget(due_at, i as u64);
             }
@@ -260,7 +260,7 @@ fn main() {
             black_box(list.poll_with_limit(poll_at, K_DUE, &mut buf));
         }
         for _ in 0..iters {
-            let mut list: TimeoutList<u64> = TimeoutList::unbounded(timeout(3600), pop + 16, now);
+            let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(timeout(3600), pop + 16, now);
             for i in 0..K_DUE {
                 list.schedule_forget(due_at, i as u64);
             }

--- a/nexus-timer/docs/patterns.md
+++ b/nexus-timer/docs/patterns.md
@@ -90,6 +90,7 @@ fn build<T: 'static>(now: Instant) -> Wheel<T> {
         .max_rebalances_per_poll(64) // smooth the rebalance burst
         .unbounded(4096)
         .build(now)
+        .expect("default-derived config is valid")
 }
 ```
 

--- a/nexus-timer/docs/wheel.md
+++ b/nexus-timer/docs/wheel.md
@@ -21,12 +21,17 @@ let wheel: Wheel<u64> = WheelBuilder::new()
     .clk_shift(4)           // 16x per level
     .num_levels(6)
     .unbounded(4096)
-    .build(now);
+    .build(now)
+    .unwrap();
 ```
 
-The builder validates at `.build()` time — `slots_per_level` must be a power
-of 2 and ≤ 64, `num_levels` must be ≤ 8, and the total range
-(`slots_per_level << ((num_levels-1) * clk_shift)`) must not overflow u64.
+The builder validates at `.build()` time, returning `Err(ConfigError)` on a bad
+config — `slots_per_level` must be a power of 2 and ≤ 64, `num_levels` must be
+≤ 8, `2^clk_shift` must be `< slots_per_level` (so rebalancing always relocates
+to a strictly finer level), and the total range
+(`slots_per_level << ((num_levels-1) * clk_shift)`) must not overflow u64. The
+convenience constructors (`Wheel::unbounded`, `Wheel::bounded`) use the default
+config and are infallible.
 
 `chunk_capacity` (unbounded) is the slab chunk size — how many entries the
 underlying slab allocates per chunk as it grows. `capacity` (bounded) is

--- a/nexus-timer/docs/wheel.md
+++ b/nexus-timer/docs/wheel.md
@@ -28,7 +28,8 @@ let wheel: Wheel<u64> = WheelBuilder::new()
 The builder validates at `.build()` time, returning `Err(ConfigError)` on a bad
 config — `slots_per_level` must be a power of 2 and ≤ 64, `num_levels` must be
 ≤ 8, `2^clk_shift` must be `< slots_per_level` (so rebalancing always relocates
-to a strictly finer level), and the total range
+to a strictly finer level), `tick_duration` must be non-zero and fit in u64
+nanoseconds, and the total range
 (`slots_per_level << ((num_levels-1) * clk_shift)`) must not overflow u64. The
 convenience constructors (`Wheel::unbounded`, `Wheel::bounded`) use the default
 config and are infallible.

--- a/nexus-timer/src/level.rs
+++ b/nexus-timer/src/level.rs
@@ -29,7 +29,7 @@ pub(crate) struct WheelSlot<T> {
     /// Minimum deadline over this slot's entries, or `u64::MAX` when empty.
     ///
     /// Maintained by the **wheel** (in `insert_entry` / `poll_level` / on drain),
-    /// NOT by `push_entry` / `remove_entry` — so `TimeoutList`, which reuses this
+    /// NOT by `push_entry` / `remove_entry` — so `TimeoutQueue`, which reuses this
     /// slot type as its whole list, pays nothing for a field it never reads.
     ///
     /// **Stale-low after a wheel remove:** an under-estimate only ever causes an
@@ -42,7 +42,7 @@ impl<T: 'static> WheelSlot<T> {
     /// Creates an empty slot (no entries).
     ///
     /// `pub(crate)` so both wheel front-ends can hold slots directly:
-    /// the wheel builds an array of them per level, while `TimeoutList`
+    /// the wheel builds an array of them per level, while `TimeoutQueue`
     /// holds a single one as its whole sorted list.
     pub(crate) fn new() -> Self {
         WheelSlot {
@@ -131,7 +131,7 @@ impl<T: 'static> WheelSlot<T> {
 
     /// Returns the tail entry pointer (may be null if slot is empty).
     ///
-    /// Used by `TimeoutList` to peek the last-inserted deadline for the
+    /// Used by `TimeoutQueue` to peek the last-inserted deadline for the
     /// monotone-insertion `debug_assert`. Not read on any wheel hot path.
     #[inline]
     pub(crate) fn entry_tail(&self) -> EntryPtr<T> {

--- a/nexus-timer/src/lib.rs
+++ b/nexus-timer/src/lib.rs
@@ -1,25 +1,25 @@
 //! Low-latency timer primitives: a hierarchical **timer wheel** (O(1) insert +
-//! cancel) for arbitrary deadlines, and a fixed-duration **[`TimeoutList`]** for
+//! cancel) for arbitrary deadlines, and a fixed-duration **[`TimeoutQueue`]** for
 //! the common case where every timer shares one timeout.
 //!
 //! # Two structures — pick by workload
 //!
 //! - [`TimerWheel`] ([`Wheel`] / [`BoundedWheel`]) — **arbitrary deadlines**:
 //!   timers that fire at different, unrelated future times.
-//! - [`TimeoutList`] ([`BoundedTimeoutList`]) — **a single fixed timeout**:
+//! - [`TimeoutQueue`] ([`BoundedTimeoutQueue`]) — **a single fixed timeout**:
 //!   every timer expires the *same* duration after it is scheduled.
 //!
 //! The tell: *"do all my timers time out after the same amount of time?"* —
-//! yes → [`TimeoutList`], no → the wheel.
+//! yes → [`TimeoutQueue`], no → the wheel.
 //!
-//! | | [`TimerWheel`] | [`TimeoutList`] |
+//! | | [`TimerWheel`] | [`TimeoutQueue`] |
 //! |---|---|---|
 //! | Timeout per timer | arbitrary | one fixed duration |
 //! | Poll | O(active population) | **O(fired)** |
 //! | `next_deadline` | lower bound (cached) | **O(1) exact** |
 //! | Clock | any monotone source | monotone, non-decreasing |
 //!
-//! Reach for [`TimeoutList`] on the hot path when it fits — idle timeouts (all
+//! Reach for [`TimeoutQueue`] on the hot path when it fits — idle timeouts (all
 //! 30 s), request deadlines (all 5 s), a fixed retry/debounce delay, uniform
 //! TTL expiry. Fixed duration ⇒ monotone deadlines ⇒ a sorted list, so a
 //! nothing-due poll stays flat (~12 cycles) no matter how many timers are
@@ -32,7 +32,7 @@
 //! `Instant` has no absolute zero (you can only measure durations *between*
 //! instants), so deadlines are stored relative to this epoch. Pass one monotone
 //! clock source (e.g. `Instant::now()`) to the constructor *and* to every
-//! `schedule` / `poll`. A `now` that goes backwards is a bug — [`TimeoutList`]
+//! `schedule` / `poll`. A `now` that goes backwards is a bug — [`TimeoutQueue`]
 //! debug-asserts on it.
 //!
 //! # Timer wheel design
@@ -80,17 +80,18 @@ mod entry;
 mod handle;
 mod level;
 pub mod store;
-pub mod timeout_list;
+pub mod timeout_queue;
 mod wheel;
 
 pub use entry::WheelEntry;
 pub use handle::TimerHandle;
-pub use timeout_list::{
-    BoundedTimeoutList, BoundedTimeoutListBuilder, TimeoutList, TimeoutListBuilder,
-    UnboundedTimeoutListBuilder,
+pub use timeout_queue::{
+    BoundedTimeoutQueue, BoundedTimeoutQueueBuilder, TimeoutQueue, TimeoutQueueBuilder,
+    UnboundedTimeoutQueueBuilder,
 };
 pub use wheel::{
-    BoundedWheel, BoundedWheelBuilder, TimerWheel, UnboundedWheelBuilder, Wheel, WheelBuilder,
+    BoundedWheel, BoundedWheelBuilder, ConfigError, TimerWheel, UnboundedWheelBuilder, Wheel,
+    WheelBuilder,
 };
 
 // Re-export Full for bounded wheel users

--- a/nexus-timer/src/timeout_queue.rs
+++ b/nexus-timer/src/timeout_queue.rs
@@ -40,11 +40,11 @@ use std::time::{Duration, Instant};
 
 use nexus_slab::{Full, Slot, bounded, unbounded};
 
+use crate::ConfigError;
 use crate::entry::{EntryPtr, WheelEntry, entry_ref};
 use crate::handle::TimerHandle;
 use crate::level::WheelSlot;
 use crate::store::{BoundedStore, SlabStore};
-use crate::wheel::ConfigError;
 
 // =============================================================================
 // TimeoutQueueBuilder (typestate)
@@ -86,7 +86,9 @@ pub struct TimeoutQueueBuilder {
 impl TimeoutQueueBuilder {
     /// Creates a builder with the fixed timeout every timer will use.
     ///
-    /// Tick duration defaults to 1ms. The timeout must be non-zero.
+    /// Tick duration defaults to 1ms. The timeout must be non-zero — this is not
+    /// checked here but enforced at [`build`](UnboundedTimeoutQueueBuilder::build),
+    /// which returns [`ConfigError`] otherwise.
     pub fn new(timeout: Duration) -> Self {
         TimeoutQueueBuilder {
             timeout,
@@ -128,6 +130,14 @@ impl TimeoutQueueBuilder {
         if self.tick_duration.is_zero() {
             return Err(ConfigError::Invalid("tick_duration must be non-zero"));
         }
+        // tick_ns() narrows as_nanos() (u128) to u64; reject a tick that would
+        // not fit so build() cannot produce a zero tick (divide-by-zero). See
+        // WheelBuilder::validate.
+        if self.tick_duration.as_nanos() > u64::MAX as u128 {
+            return Err(ConfigError::Invalid(
+                "tick_duration must fit in u64 nanoseconds",
+            ));
+        }
         Ok(())
     }
 
@@ -163,8 +173,8 @@ impl UnboundedTimeoutQueueBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout or
-    /// zero tick duration).
+    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout, or a
+    /// tick duration that is zero or exceeds u64 nanoseconds).
     pub fn build<T: 'static>(self, now: Instant) -> Result<TimeoutQueue<T>, ConfigError> {
         self.config.validate()?;
         let tick_ns = self.config.tick_ns();
@@ -200,8 +210,8 @@ impl BoundedTimeoutQueueBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout or
-    /// zero tick duration).
+    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout, or a
+    /// tick duration that is zero or exceeds u64 nanoseconds).
     pub fn build<T: 'static>(self, now: Instant) -> Result<BoundedTimeoutQueue<T>, ConfigError> {
         self.config.validate()?;
         let tick_ns = self.config.tick_ns();
@@ -307,7 +317,7 @@ impl<T: 'static> TimeoutQueue<T> {
         TimeoutQueueBuilder::new(timeout)
             .unbounded(chunk_capacity)
             .build(now)
-            .expect("non-zero timeout with default tick is a valid config")
+            .expect("TimeoutQueue requires a non-zero timeout")
     }
 }
 
@@ -327,7 +337,7 @@ impl<T: 'static> BoundedTimeoutQueue<T> {
         TimeoutQueueBuilder::new(timeout)
             .bounded(capacity)
             .build(now)
-            .expect("non-zero timeout with default tick is a valid config")
+            .expect("TimeoutQueue requires a non-zero timeout")
     }
 }
 
@@ -779,6 +789,17 @@ mod tests {
             .unbounded(64)
             .build::<u64>(now);
         assert_invalid(&result, "tick_duration must be non-zero");
+    }
+
+    #[test]
+    fn invalid_tick_too_large() {
+        let now = Instant::now();
+        // as_nanos() would exceed u64::MAX and truncate on the cast — reject.
+        let result = TimeoutQueueBuilder::new(ms(50))
+            .tick_duration(Duration::from_secs(20_000_000_000))
+            .unbounded(64)
+            .build::<u64>(now);
+        assert_invalid(&result, "tick_duration must fit in u64 nanoseconds");
     }
 
     // -------------------------------------------------------------------------

--- a/nexus-timer/src/timeout_queue.rs
+++ b/nexus-timer/src/timeout_queue.rs
@@ -1,6 +1,6 @@
-//! Fixed-duration timeout list — a sorted front-end over the wheel machinery.
+//! Fixed-duration timeout queue — a sorted front-end over the wheel machinery.
 //!
-//! `TimeoutList<T, S>` schedules every timer with the **same** duration, fixed
+//! `TimeoutQueue<T, S>` schedules every timer with the **same** duration, fixed
 //! at construction. Because the duration is constant and the clock is monotone,
 //! deadlines are monotone in insertion order: appending each new entry at the
 //! tail of one intrusive DLL keeps the list sorted with no comparisons. Poll
@@ -14,7 +14,7 @@
 //! among earlier and later expirations. But a large class of callers schedule
 //! **one fixed timeout for everything** (a flat 5 s deadline on every item).
 //! For that workload the wheel buckets by deadline and walks buckets to solve
-//! an ordering problem that does not exist. `TimeoutList` exploits the single
+//! an ordering problem that does not exist. `TimeoutQueue` exploits the single
 //! duration directly.
 //!
 //! # The invariant is structural, not documented
@@ -44,12 +44,13 @@ use crate::entry::{EntryPtr, WheelEntry, entry_ref};
 use crate::handle::TimerHandle;
 use crate::level::WheelSlot;
 use crate::store::{BoundedStore, SlabStore};
+use crate::wheel::ConfigError;
 
 // =============================================================================
-// TimeoutListBuilder (typestate)
+// TimeoutQueueBuilder (typestate)
 // =============================================================================
 
-/// Builder for a [`TimeoutList`], mirroring [`WheelBuilder`](crate::WheelBuilder).
+/// Builder for a [`TimeoutQueue`], mirroring [`WheelBuilder`](crate::WheelBuilder).
 ///
 /// The timeout duration is fixed up front in [`new`](Self::new) — that is the
 /// whole point of the type, so it cannot be a per-schedule parameter later.
@@ -58,34 +59,36 @@ use crate::store::{BoundedStore, SlabStore};
 ///
 /// ```
 /// use std::time::{Duration, Instant};
-/// use nexus_timer::{TimeoutList, TimeoutListBuilder};
+/// use nexus_timer::{TimeoutQueue, TimeoutQueueBuilder};
 ///
 /// let now = Instant::now();
 ///
 /// // 5-second timeout, unbounded storage, default 1ms tick.
-/// let list: TimeoutList<u64> = TimeoutListBuilder::new(Duration::from_secs(5))
+/// let list: TimeoutQueue<u64> = TimeoutQueueBuilder::new(Duration::from_secs(5))
 ///     .unbounded(4096)
-///     .build(now);
+///     .build(now)
+///     .unwrap();
 ///
 /// // Custom tick, bounded storage.
-/// let list: nexus_timer::BoundedTimeoutList<u64> =
-///     TimeoutListBuilder::new(Duration::from_millis(250))
+/// let list: nexus_timer::BoundedTimeoutQueue<u64> =
+///     TimeoutQueueBuilder::new(Duration::from_millis(250))
 ///         .tick_duration(Duration::from_micros(100))
 ///         .bounded(1024)
-///         .build(now);
+///         .build(now)
+///         .unwrap();
 /// ```
 #[derive(Debug, Clone, Copy)]
-pub struct TimeoutListBuilder {
+pub struct TimeoutQueueBuilder {
     timeout: Duration,
     tick_duration: Duration,
 }
 
-impl TimeoutListBuilder {
+impl TimeoutQueueBuilder {
     /// Creates a builder with the fixed timeout every timer will use.
     ///
     /// Tick duration defaults to 1ms. The timeout must be non-zero.
     pub fn new(timeout: Duration) -> Self {
-        TimeoutListBuilder {
+        TimeoutQueueBuilder {
             timeout,
             tick_duration: Duration::from_millis(1),
         }
@@ -101,8 +104,8 @@ impl TimeoutListBuilder {
     ///
     /// `chunk_capacity` is the slab chunk size (entries per chunk); the slab
     /// grows by adding chunks as needed.
-    pub fn unbounded(self, chunk_capacity: usize) -> UnboundedTimeoutListBuilder {
-        UnboundedTimeoutListBuilder {
+    pub fn unbounded(self, chunk_capacity: usize) -> UnboundedTimeoutQueueBuilder {
+        UnboundedTimeoutQueueBuilder {
             config: self,
             chunk_capacity,
         }
@@ -111,19 +114,21 @@ impl TimeoutListBuilder {
     /// Transitions to a bounded (fixed-capacity) builder.
     ///
     /// `capacity` is the maximum number of concurrent timers.
-    pub fn bounded(self, capacity: usize) -> BoundedTimeoutListBuilder {
-        BoundedTimeoutListBuilder {
+    pub fn bounded(self, capacity: usize) -> BoundedTimeoutQueueBuilder {
+        BoundedTimeoutQueueBuilder {
             config: self,
             capacity,
         }
     }
 
-    fn validate(&self) {
-        assert!(!self.timeout.is_zero(), "timeout must be non-zero");
-        assert!(
-            !self.tick_duration.is_zero(),
-            "tick_duration must be non-zero"
-        );
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.timeout.is_zero() {
+            return Err(ConfigError::Invalid("timeout must be non-zero"));
+        }
+        if self.tick_duration.is_zero() {
+            return Err(ConfigError::Invalid("tick_duration must be non-zero"));
+        }
+        Ok(())
     }
 
     #[inline]
@@ -144,30 +149,31 @@ impl TimeoutListBuilder {
     }
 }
 
-/// Terminal builder for an unbounded [`TimeoutList`].
+/// Terminal builder for an unbounded [`TimeoutQueue`].
 ///
-/// Created via [`TimeoutListBuilder::unbounded`]. The only method is `.build()`.
+/// Created via [`TimeoutQueueBuilder::unbounded`]. The only method is `.build()`.
 #[derive(Debug)]
-pub struct UnboundedTimeoutListBuilder {
-    config: TimeoutListBuilder,
+pub struct UnboundedTimeoutQueueBuilder {
+    config: TimeoutQueueBuilder,
     chunk_capacity: usize,
 }
 
-impl UnboundedTimeoutListBuilder {
-    /// Builds the unbounded timeout list.
+impl UnboundedTimeoutQueueBuilder {
+    /// Builds the unbounded timeout queue, validating the configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the configuration is invalid (zero timeout or zero tick).
-    pub fn build<T: 'static>(self, now: Instant) -> TimeoutList<T> {
-        self.config.validate();
+    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout or
+    /// zero tick duration).
+    pub fn build<T: 'static>(self, now: Instant) -> Result<TimeoutQueue<T>, ConfigError> {
+        self.config.validate()?;
         let tick_ns = self.config.tick_ns();
         let timeout_ticks = self.config.timeout_ticks();
-        // SAFETY: TimeoutList is single-threaded (!Sync). Every slot is freed
+        // SAFETY: TimeoutQueue is single-threaded (!Sync). Every slot is freed
         // via Slot::from_raw() + slab.free() before the list drops. The slab is
         // never shared across threads.
         let slab = unsafe { unbounded::Slab::with_chunk_capacity(self.chunk_capacity) };
-        TimeoutList {
+        Ok(TimeoutQueue {
             list: WheelSlot::new(),
             slab,
             timeout_ticks,
@@ -176,34 +182,35 @@ impl UnboundedTimeoutListBuilder {
             epoch: now,
             len: 0,
             _marker: PhantomData,
-        }
+        })
     }
 }
 
-/// Terminal builder for a bounded [`TimeoutList`].
+/// Terminal builder for a bounded [`TimeoutQueue`].
 ///
-/// Created via [`TimeoutListBuilder::bounded`]. The only method is `.build()`.
+/// Created via [`TimeoutQueueBuilder::bounded`]. The only method is `.build()`.
 #[derive(Debug)]
-pub struct BoundedTimeoutListBuilder {
-    config: TimeoutListBuilder,
+pub struct BoundedTimeoutQueueBuilder {
+    config: TimeoutQueueBuilder,
     capacity: usize,
 }
 
-impl BoundedTimeoutListBuilder {
-    /// Builds the bounded timeout list.
+impl BoundedTimeoutQueueBuilder {
+    /// Builds the bounded timeout queue, validating the configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the configuration is invalid (zero timeout or zero tick).
-    pub fn build<T: 'static>(self, now: Instant) -> BoundedTimeoutList<T> {
-        self.config.validate();
+    /// Returns [`ConfigError`] if the configuration is invalid (zero timeout or
+    /// zero tick duration).
+    pub fn build<T: 'static>(self, now: Instant) -> Result<BoundedTimeoutQueue<T>, ConfigError> {
+        self.config.validate()?;
         let tick_ns = self.config.tick_ns();
         let timeout_ticks = self.config.timeout_ticks();
-        // SAFETY: TimeoutList is single-threaded (!Sync). Every slot is freed
+        // SAFETY: TimeoutQueue is single-threaded (!Sync). Every slot is freed
         // via Slot::from_raw() + slab.free() before the list drops. The slab is
         // never shared across threads.
         let slab = unsafe { bounded::Slab::with_capacity(self.capacity) };
-        TimeoutList {
+        Ok(TimeoutQueue {
             list: WheelSlot::new(),
             slab,
             timeout_ticks,
@@ -212,22 +219,22 @@ impl BoundedTimeoutListBuilder {
             epoch: now,
             len: 0,
             _marker: PhantomData,
-        }
+        })
     }
 }
 
 // =============================================================================
-// TimeoutList
+// TimeoutQueue
 // =============================================================================
 
-/// A fixed-duration timeout list with O(fired) poll and O(1) exact next-deadline.
+/// A fixed-duration timeout queue with O(fired) poll and O(1) exact next-deadline.
 ///
 /// Generic over:
 /// - `T` — the user payload stored with each timer.
 /// - `S` — the slab storage backend. Defaults to `unbounded::Slab`.
 ///
 /// Every timer uses the same duration, fixed at construction. See the
-/// [module docs](crate::timeout_list) for the invariant this exploits.
+/// [module docs](crate::timeout_queue) for the invariant this exploits.
 ///
 /// # No `reschedule`
 ///
@@ -242,7 +249,7 @@ impl BoundedTimeoutListBuilder {
 /// `Send` but `!Sync`. Can be moved to a thread at setup but must not be
 /// shared. All internal raw pointers point into owned allocations (slab
 /// chunks) — moving the list moves the heap data with it.
-pub struct TimeoutList<
+pub struct TimeoutQueue<
     T: 'static,
     S: SlabStore<Item = WheelEntry<T>> = unbounded::Slab<WheelEntry<T>>,
 > {
@@ -259,7 +266,7 @@ pub struct TimeoutList<
     _marker: PhantomData<*const ()>, // !Send (overridden below), !Sync
 }
 
-// SAFETY: TimeoutList<T, S> exclusively owns all memory behind its raw
+// SAFETY: TimeoutQueue<T, S> exclusively owns all memory behind its raw
 // pointers. The slot head/tail and the WheelEntry prev/next links point into
 // slab-owned memory (SlotCell in a slab chunk, a Vec<SlotCell<T>> heap
 // allocation). When the list is moved, those heap allocations stay at their
@@ -271,44 +278,56 @@ pub struct TimeoutList<
 // Cell), but the list exclusively owns its slab — no shared access, no
 // aliasing. Outstanding TimerHandle<T> values are !Send and cannot follow the
 // list across threads; they become inert (consuming one requires &mut
-// TimeoutList, which the original thread no longer has). Worst case is a slot
+// TimeoutQueue, which the original thread no longer has). Worst case is a slot
 // leak (refcount stuck at 1), not unsoundness — the same reasoning as the
 // wheel.
 #[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl<T: Send + 'static, S: SlabStore<Item = WheelEntry<T>>> Send for TimeoutList<T, S> {}
+unsafe impl<T: Send + 'static, S: SlabStore<Item = WheelEntry<T>>> Send for TimeoutQueue<T, S> {}
 
-/// A timeout list backed by a fixed-capacity slab.
-pub type BoundedTimeoutList<T> = TimeoutList<T, bounded::Slab<WheelEntry<T>>>;
+/// A timeout queue backed by a fixed-capacity slab.
+pub type BoundedTimeoutQueue<T> = TimeoutQueue<T, bounded::Slab<WheelEntry<T>>>;
 
 // =============================================================================
 // Construction convenience
 // =============================================================================
 
-impl<T: 'static> TimeoutList<T> {
-    /// Creates an unbounded timeout list with the default 1ms tick.
+impl<T: 'static> TimeoutQueue<T> {
+    /// Creates an unbounded timeout queue with the default 1ms tick.
     ///
     /// Every timer fires `timeout` after the `now` passed to `schedule`. The
     /// `now` here fixes the reference epoch — pass one monotone clock source
     /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For a custom
-    /// tick duration, use [`TimeoutListBuilder`].
+    /// tick duration, use [`TimeoutQueueBuilder`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timeout` is zero. Use [`TimeoutQueueBuilder::build`] to handle
+    /// a runtime-sourced timeout without panicking.
     pub fn unbounded(timeout: Duration, chunk_capacity: usize, now: Instant) -> Self {
-        TimeoutListBuilder::new(timeout)
+        TimeoutQueueBuilder::new(timeout)
             .unbounded(chunk_capacity)
             .build(now)
+            .expect("non-zero timeout with default tick is a valid config")
     }
 }
 
-impl<T: 'static> BoundedTimeoutList<T> {
-    /// Creates a bounded timeout list with the default 1ms tick.
+impl<T: 'static> BoundedTimeoutQueue<T> {
+    /// Creates a bounded timeout queue with the default 1ms tick.
     ///
     /// Every timer fires `timeout` after the `now` passed to `schedule`. The
     /// `now` here fixes the reference epoch — pass one monotone clock source
     /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For a custom
-    /// tick duration, use [`TimeoutListBuilder`].
+    /// tick duration, use [`TimeoutQueueBuilder`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timeout` is zero. Use [`TimeoutQueueBuilder::build`] to handle
+    /// a runtime-sourced timeout without panicking.
     pub fn bounded(timeout: Duration, capacity: usize, now: Instant) -> Self {
-        TimeoutListBuilder::new(timeout)
+        TimeoutQueueBuilder::new(timeout)
             .bounded(capacity)
             .build(now)
+            .expect("non-zero timeout with default tick is a valid config")
     }
 }
 
@@ -316,7 +335,7 @@ impl<T: 'static> BoundedTimeoutList<T> {
 // Schedule
 // =============================================================================
 
-impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutQueue<T, S> {
     /// Schedules a timer for `now + timeout` and returns a handle for cancellation.
     ///
     /// The handle must be consumed via [`cancel`](Self::cancel) or
@@ -361,7 +380,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
 // Schedule — fallible (bounded slabs only)
 // =============================================================================
 
-impl<T: 'static, S: BoundedStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+impl<T: 'static, S: BoundedStore<Item = WheelEntry<T>>> TimeoutQueue<T, S> {
     /// Attempts to schedule a timer, returning a handle on success.
     ///
     /// Returns `Err(Full(value))` — with the caller's `T` recovered, not the
@@ -416,7 +435,7 @@ fn recover_value<T>(full: Full<WheelEntry<T>>) -> T {
 // Cancel / Free / Poll / Query — generic over any store
 // =============================================================================
 
-impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutQueue<T, S> {
     /// Cancels a timer and returns its value.
     ///
     /// - Still active (refs == 2): unlinks from the list, extracts the value,
@@ -600,7 +619,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
                 // SAFETY: tail, when non-null, points into self.list's DLL.
                 tail.is_null() || deadline_ticks >= unsafe { entry_ref(tail) }.deadline_ticks()
             },
-            "TimeoutList: deadline {deadline_ticks} inserted out of order \
+            "TimeoutQueue: deadline {deadline_ticks} inserted out of order \
              (did `now` go backwards?)",
         );
 
@@ -638,7 +657,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimeoutList<T, S> {
 // Drop
 // =============================================================================
 
-impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> Drop for TimeoutList<T, S> {
+impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> Drop for TimeoutQueue<T, S> {
     fn drop(&mut self) {
         // Walk the single list, free every remaining entry so nothing leaks.
         let mut entry_ptr = self.list.entry_head();
@@ -694,8 +713,8 @@ mod tests {
         Duration::from_millis(millis)
     }
 
-    fn list_50ms(now: Instant) -> TimeoutList<u64> {
-        TimeoutList::unbounded(ms(50), 1024, now)
+    fn list_50ms(now: Instant) -> TimeoutQueue<u64> {
+        TimeoutQueue::unbounded(ms(50), 1024, now)
     }
 
     // -------------------------------------------------------------------------
@@ -705,9 +724,9 @@ mod tests {
     fn assert_send<T: Send>() {}
 
     #[test]
-    fn timeout_list_is_send() {
-        assert_send::<TimeoutList<u64>>();
-        assert_send::<BoundedTimeoutList<u64>>();
+    fn timeout_queue_is_send() {
+        assert_send::<TimeoutQueue<u64>>();
+        assert_send::<BoundedTimeoutQueue<u64>>();
     }
 
     // -------------------------------------------------------------------------
@@ -726,27 +745,40 @@ mod tests {
     #[test]
     fn bounded_construction() {
         let now = Instant::now();
-        let list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 128, now);
+        let list: BoundedTimeoutQueue<u64> = BoundedTimeoutQueue::bounded(ms(50), 128, now);
         assert!(list.is_empty());
     }
 
-    #[test]
-    #[should_panic(expected = "timeout must be non-zero")]
-    fn invalid_zero_timeout() {
-        let now = Instant::now();
-        TimeoutListBuilder::new(Duration::ZERO)
-            .unbounded(64)
-            .build::<u64>(now);
+    /// Asserts `result` is `Err(ConfigError::Invalid(_))` whose message contains
+    /// `expect_substr`. Generic over the Ok type so it needs no `Debug` bound.
+    #[track_caller]
+    fn assert_invalid<T>(result: &Result<T, ConfigError>, expect_substr: &str) {
+        match result {
+            Err(ConfigError::Invalid(msg)) => assert!(
+                msg.contains(expect_substr),
+                "message {msg:?} does not contain {expect_substr:?}"
+            ),
+            Ok(_) => panic!("expected ConfigError::Invalid containing {expect_substr:?}, got Ok"),
+        }
     }
 
     #[test]
-    #[should_panic(expected = "tick_duration must be non-zero")]
+    fn invalid_zero_timeout() {
+        let now = Instant::now();
+        let result = TimeoutQueueBuilder::new(Duration::ZERO)
+            .unbounded(64)
+            .build::<u64>(now);
+        assert_invalid(&result, "timeout must be non-zero");
+    }
+
+    #[test]
     fn invalid_zero_tick() {
         let now = Instant::now();
-        TimeoutListBuilder::new(ms(50))
+        let result = TimeoutQueueBuilder::new(ms(50))
             .tick_duration(Duration::ZERO)
             .unbounded(64)
             .build::<u64>(now);
+        assert_invalid(&result, "tick_duration must be non-zero");
     }
 
     // -------------------------------------------------------------------------
@@ -833,7 +865,7 @@ mod tests {
     #[test]
     fn bounded_full() {
         let now = Instant::now();
-        let mut list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 2, now);
+        let mut list: BoundedTimeoutQueue<u64> = BoundedTimeoutQueue::bounded(ms(50), 2, now);
 
         let h1 = list.try_schedule(now, 1).unwrap();
         let h2 = list.try_schedule(now, 2).unwrap();
@@ -855,7 +887,7 @@ mod tests {
     #[test]
     fn bounded_schedule_forget_full() {
         let now = Instant::now();
-        let mut list: BoundedTimeoutList<u64> = BoundedTimeoutList::bounded(ms(50), 1, now);
+        let mut list: BoundedTimeoutQueue<u64> = BoundedTimeoutQueue::bounded(ms(50), 1, now);
 
         list.try_schedule_forget(now, 1).unwrap();
         let err = list.try_schedule_forget(now, 2);
@@ -1031,8 +1063,8 @@ mod tests {
 
         for &population in &[100usize, 1_000, 10_000, 50_000] {
             // Big timeout so nothing is due at poll time.
-            let mut list: TimeoutList<u64> =
-                TimeoutList::unbounded(Duration::from_secs(3600), population + 16, now);
+            let mut list: TimeoutQueue<u64> =
+                TimeoutQueue::unbounded(Duration::from_secs(3600), population + 16, now);
             for i in 0..population as u64 {
                 list.schedule_forget(now, i);
             }
@@ -1145,7 +1177,7 @@ mod tests {
 
         let dropped = Arc::new(AtomicUsize::new(0));
         let now = Instant::now();
-        let mut list: TimeoutList<DropCounter> = TimeoutList::unbounded(ms(50), 1024, now);
+        let mut list: TimeoutQueue<DropCounter> = TimeoutQueue::unbounded(ms(50), 1024, now);
         for i in 0..100u64 {
             list.schedule_forget(now + ms(i), DropCounter(Arc::clone(&dropped)));
         }
@@ -1178,7 +1210,7 @@ mod tests {
 
         let dropped = Arc::new(AtomicUsize::new(0));
         let now = Instant::now();
-        let mut list: TimeoutList<DropCounter> = TimeoutList::unbounded(ms(50), 1024, now);
+        let mut list: TimeoutQueue<DropCounter> = TimeoutQueue::unbounded(ms(50), 1024, now);
         for i in 0..100u64 {
             let h = list.schedule(now + ms(i), DropCounter(Arc::clone(&dropped)));
             std::mem::forget(h); // outstanding handle — never consumed (refs stays 2)
@@ -1217,7 +1249,7 @@ mod tests {
     #[test]
     fn miri_schedule_cancel_drop_type() {
         let now = Instant::now();
-        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(50), 64, now);
+        let mut list: TimeoutQueue<String> = TimeoutQueue::unbounded(ms(50), 64, now);
 
         let h = list.schedule(now, "hello".to_string());
         let val = list.cancel(h);
@@ -1228,7 +1260,7 @@ mod tests {
     #[test]
     fn miri_poll_fires_drop_type() {
         let now = Instant::now();
-        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+        let mut list: TimeoutQueue<String> = TimeoutQueue::unbounded(ms(10), 64, now);
 
         list.schedule_forget(now, "a".to_string());
         list.schedule_forget(now, "b".to_string());
@@ -1244,7 +1276,7 @@ mod tests {
     #[test]
     fn miri_cancel_zombie_drop_type() {
         let now = Instant::now();
-        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+        let mut list: TimeoutQueue<String> = TimeoutQueue::unbounded(ms(10), 64, now);
 
         let h = list.schedule(now, "zombie".to_string());
 
@@ -1259,7 +1291,7 @@ mod tests {
     #[test]
     fn miri_free_active_and_zombie() {
         let now = Instant::now();
-        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(10), 64, now);
+        let mut list: TimeoutQueue<String> = TimeoutQueue::unbounded(ms(10), 64, now);
 
         // Active → fire-and-forget via free.
         let h1 = list.schedule(now, "active".to_string());
@@ -1279,7 +1311,7 @@ mod tests {
     #[test]
     fn miri_mid_list_unlink_drop_type() {
         let now = Instant::now();
-        let mut list: TimeoutList<Vec<u8>> = TimeoutList::unbounded(ms(10), 64, now);
+        let mut list: TimeoutQueue<Vec<u8>> = TimeoutQueue::unbounded(ms(10), 64, now);
 
         let mut handles: Vec<_> = (0..5u8)
             .map(|i| list.schedule(now + Duration::from_micros(i as u64), vec![i; 32]))
@@ -1303,7 +1335,7 @@ mod tests {
     #[test]
     fn miri_drop_list_with_entries() {
         let now = Instant::now();
-        let mut list: TimeoutList<String> = TimeoutList::unbounded(ms(50), 64, now);
+        let mut list: TimeoutQueue<String> = TimeoutQueue::unbounded(ms(50), 64, now);
 
         for i in 0..20u64 {
             list.schedule_forget(now + ms(i), format!("entry-{i}"));
@@ -1315,7 +1347,7 @@ mod tests {
     #[test]
     fn miri_bounded_lifecycle() {
         let now = Instant::now();
-        let mut list: BoundedTimeoutList<String> = BoundedTimeoutList::bounded(ms(30), 4, now);
+        let mut list: BoundedTimeoutQueue<String> = BoundedTimeoutQueue::bounded(ms(30), 4, now);
 
         let h1 = list.try_schedule(now, "a".to_string()).unwrap();
         let h2 = list.try_schedule(now, "b".to_string()).unwrap();
@@ -1392,7 +1424,7 @@ mod proptests {
         #[test]
         fn fuzz_schedule_cancel_poll(ops in proptest::collection::vec(op_strategy(), 1..300)) {
             let now = Instant::now();
-            let mut list: TimeoutList<u64> = TimeoutList::unbounded(
+            let mut list: TimeoutQueue<u64> = TimeoutQueue::unbounded(
                 Duration::from_millis(TIMEOUT_MS),
                 4096,
                 now,

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -197,6 +197,15 @@ impl WheelBuilder {
         if self.tick_duration.is_zero() {
             return Err(ConfigError::Invalid("tick_duration must be non-zero"));
         }
+        // tick_ns() narrows as_nanos() (u128) to u64; a duration whose nanos
+        // exceed u64::MAX would truncate — and a nonzero multiple of 2^64 would
+        // truncate to 0, making inv_tick_ns a divide-by-zero. Reject up front so
+        // build() stays panic-free.
+        if self.tick_duration.as_nanos() > u64::MAX as u128 {
+            return Err(ConfigError::Invalid(
+                "tick_duration must fit in u64 nanoseconds",
+            ));
+        }
         let max_shift = (self.num_levels - 1) as u64 * self.clk_shift as u64;
         if max_shift >= 64 {
             return Err(ConfigError::Invalid(
@@ -2372,6 +2381,19 @@ mod tests {
             .unbounded(1024)
             .build::<u64>(now);
         assert_invalid(&result, "tick_duration must be non-zero");
+    }
+
+    #[test]
+    fn invalid_config_tick_too_large() {
+        let now = Instant::now();
+        // as_nanos() would exceed u64::MAX (~584 years), which would truncate on
+        // the cast to u64 — must be rejected, not silently narrowed (a nonzero
+        // multiple of 2^64 would truncate to 0 → divide-by-zero in build()).
+        let result = WheelBuilder::default()
+            .tick_duration(Duration::from_secs(20_000_000_000))
+            .unbounded(1024)
+            .build::<u64>(now);
+        assert_invalid(&result, "tick_duration must fit in u64 nanoseconds");
     }
 
     #[test]

--- a/nexus-timer/src/wheel.rs
+++ b/nexus-timer/src/wheel.rs
@@ -18,6 +18,29 @@ use crate::handle::TimerHandle;
 use crate::level::Level;
 use crate::store::{BoundedStore, SlabStore};
 
+/// Error returned by a builder's `build` when the configuration is invalid.
+///
+/// A wheel / queue is configured at construction from your own constants, so an
+/// invalid config is a programmer error — but it is *returned* rather than
+/// panicked, both for consistency with the rest of the workspace and so a caller
+/// that sources configuration from runtime input can handle it. The message
+/// names the constraint that was violated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    /// A configuration value is out of range; the message names the constraint.
+    Invalid(&'static str),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(msg) => write!(f, "timer configuration error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
 // =============================================================================
 // WheelBuilder (typestate)
 // =============================================================================
@@ -36,14 +59,15 @@ use crate::store::{BoundedStore, SlabStore};
 /// let now = Instant::now();
 ///
 /// // All defaults
-/// let wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(now);
+/// let wheel: Wheel<u64> = WheelBuilder::default().unbounded(4096).build(now).unwrap();
 ///
 /// // Custom config
 /// let wheel: Wheel<u64> = WheelBuilder::default()
 ///     .tick_duration(Duration::from_micros(100))
 ///     .slots_per_level(32)
 ///     .unbounded(4096)
-///     .build(now);
+///     .build(now)
+///     .unwrap();
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct WheelBuilder {
@@ -152,54 +176,51 @@ impl WheelBuilder {
         }
     }
 
-    fn validate(&self) {
-        assert!(
-            self.slots_per_level.is_power_of_two(),
-            "slots_per_level must be a power of 2, got {}",
-            self.slots_per_level
-        );
-        assert!(
-            self.slots_per_level <= 64,
-            "slots_per_level must be <= 64 (u64 bitmask), got {}",
-            self.slots_per_level
-        );
-        assert!(self.num_levels > 0, "num_levels must be > 0");
-        assert!(
-            self.num_levels <= 8,
-            "num_levels must be <= 8 (u8 bitmask), got {}",
-            self.num_levels
-        );
-        assert!(self.clk_shift > 0, "clk_shift must be > 0");
-        assert!(
-            !self.tick_duration.is_zero(),
-            "tick_duration must be non-zero"
-        );
+    fn validate(&self) -> Result<(), ConfigError> {
+        if !self.slots_per_level.is_power_of_two() {
+            return Err(ConfigError::Invalid("slots_per_level must be a power of 2"));
+        }
+        if self.slots_per_level > 64 {
+            return Err(ConfigError::Invalid(
+                "slots_per_level must be <= 64 (u64 bitmask)",
+            ));
+        }
+        if self.num_levels == 0 {
+            return Err(ConfigError::Invalid("num_levels must be > 0"));
+        }
+        if self.num_levels > 8 {
+            return Err(ConfigError::Invalid("num_levels must be <= 8 (u8 bitmask)"));
+        }
+        if self.clk_shift == 0 {
+            return Err(ConfigError::Invalid("clk_shift must be > 0"));
+        }
+        if self.tick_duration.is_zero() {
+            return Err(ConfigError::Invalid("tick_duration must be non-zero"));
+        }
         let max_shift = (self.num_levels - 1) as u64 * self.clk_shift as u64;
-        assert!(
-            max_shift < 64,
-            "(num_levels - 1) * clk_shift must be < 64, got {}",
-            max_shift
-        );
+        if max_shift >= 64 {
+            return Err(ConfigError::Invalid(
+                "(num_levels - 1) * clk_shift must be < 64",
+            ));
+        }
         let slots_log2 = self.slots_per_level.trailing_zeros() as u64;
-        assert!(
-            slots_log2 + max_shift < 64,
-            "slots_per_level << max_shift would overflow u64"
-        );
-        // Rebalance progress guard. When a due slot is polled, a not-yet-due entry
-        // is relocated to a strictly finer level (see `TimerWheel::poll_level`).
-        // That requires a level's per-slot granularity (2^clk_shift) to be
-        // smaller than the number of slots per level; otherwise an entry could
-        // relocate to the *same* level and poll would live-lock. Both are powers
-        // of two, so `2^clk_shift < slots_per_level` iff `clk_shift < slots_log2`
-        // (avoids a shift that could overflow for absurd clk_shift). Checked last
-        // so a config that also overflows reports the overflow first.
-        assert!(
-            (self.clk_shift as u64) < slots_log2,
-            "2^clk_shift must be < slots_per_level so rebalancing relocates to a \
-             strictly finer level (got clk_shift = {}, slots_per_level = {})",
-            self.clk_shift,
-            self.slots_per_level,
-        );
+        if slots_log2 + max_shift >= 64 {
+            return Err(ConfigError::Invalid(
+                "slots_per_level << max_shift would overflow u64",
+            ));
+        }
+        // Rebalance progress guard. When a due slot is polled, a not-yet-due
+        // entry is relocated to a strictly finer level (see `TimerWheel::poll_level`);
+        // that requires 2^clk_shift < slots_per_level (both powers of two, so
+        // `clk_shift < slots_log2`, avoiding a shift that could overflow for
+        // absurd clk_shift). Checked last so a config that also overflows reports
+        // the overflow first.
+        if (self.clk_shift as u64) >= slots_log2 {
+            return Err(ConfigError::Invalid(
+                "2^clk_shift must be < slots_per_level so rebalancing relocates to a strictly finer level",
+            ));
+        }
+        Ok(())
     }
 
     fn tick_ns(&self) -> u64 {
@@ -217,21 +238,22 @@ pub struct UnboundedWheelBuilder {
 }
 
 impl UnboundedWheelBuilder {
-    /// Builds the unbounded timer wheel.
+    /// Builds the unbounded timer wheel, validating the configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the configuration is invalid (non-power-of-2 slots, zero
-    /// levels, zero clk_shift, or zero tick duration).
-    pub fn build<T: 'static>(self, now: Instant) -> Wheel<T> {
-        self.config.validate();
+    /// Returns [`ConfigError`] if the configuration is invalid (e.g.
+    /// non-power-of-2 `slots_per_level`, out-of-range `num_levels` / `clk_shift`,
+    /// zero tick duration, or `2^clk_shift >= slots_per_level`).
+    pub fn build<T: 'static>(self, now: Instant) -> Result<Wheel<T>, ConfigError> {
+        self.config.validate()?;
         // SAFETY: Timer wheel is single-threaded (!Send, !Sync). All slots
         // are freed via Slot::from_raw() + slab.free() before the wheel drops.
         // The slab is never shared across threads.
         let slab = unsafe { unbounded::Slab::with_chunk_capacity(self.chunk_capacity) };
         let levels = build_levels::<T>(&self.config);
         let tick_ns = self.config.tick_ns();
-        TimerWheel {
+        Ok(TimerWheel {
             slab,
             num_levels: self.config.num_levels,
             levels,
@@ -244,7 +266,7 @@ impl UnboundedWheelBuilder {
             min_deadline: Cell::new(None),
             max_rebalances_per_poll: self.config.max_rebalances_per_poll,
             _marker: PhantomData,
-        }
+        })
     }
 }
 
@@ -258,21 +280,22 @@ pub struct BoundedWheelBuilder {
 }
 
 impl BoundedWheelBuilder {
-    /// Builds the bounded timer wheel.
+    /// Builds the bounded timer wheel, validating the configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the configuration is invalid (non-power-of-2 slots, zero
-    /// levels, zero clk_shift, or zero tick duration).
-    pub fn build<T: 'static>(self, now: Instant) -> BoundedWheel<T> {
-        self.config.validate();
+    /// Returns [`ConfigError`] if the configuration is invalid (e.g.
+    /// non-power-of-2 `slots_per_level`, out-of-range `num_levels` / `clk_shift`,
+    /// zero tick duration, or `2^clk_shift >= slots_per_level`).
+    pub fn build<T: 'static>(self, now: Instant) -> Result<BoundedWheel<T>, ConfigError> {
+        self.config.validate()?;
         // SAFETY: Timer wheel is single-threaded (!Send, !Sync). All slots
         // are freed via Slot::from_raw() + slab.free() before the wheel drops.
         // The slab is never shared across threads.
         let slab = unsafe { bounded::Slab::with_capacity(self.capacity) };
         let levels = build_levels::<T>(&self.config);
         let tick_ns = self.config.tick_ns();
-        TimerWheel {
+        Ok(TimerWheel {
             slab,
             num_levels: self.config.num_levels,
             levels,
@@ -285,7 +308,7 @@ impl BoundedWheelBuilder {
             min_deadline: Cell::new(None),
             max_rebalances_per_poll: self.config.max_rebalances_per_poll,
             _marker: PhantomData,
-        }
+        })
     }
 }
 
@@ -372,7 +395,10 @@ impl<T: 'static> Wheel<T> {
     /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For custom
     /// configuration, use [`WheelBuilder`].
     pub fn unbounded(chunk_capacity: usize, now: Instant) -> Self {
-        WheelBuilder::default().unbounded(chunk_capacity).build(now)
+        WheelBuilder::default()
+            .unbounded(chunk_capacity)
+            .build(now)
+            .expect("default WheelBuilder config is valid")
     }
 }
 
@@ -383,7 +409,10 @@ impl<T: 'static> BoundedWheel<T> {
     /// (e.g. `Instant::now()`) here and to every `schedule`/`poll`. For custom
     /// configuration, use [`WheelBuilder`].
     pub fn bounded(capacity: usize, now: Instant) -> Self {
-        WheelBuilder::default().bounded(capacity).build(now)
+        WheelBuilder::default()
+            .bounded(capacity)
+            .build(now)
+            .expect("default WheelBuilder config is valid")
     }
 }
 
@@ -948,7 +977,7 @@ impl<T: 'static, S: SlabStore<Item = WheelEntry<T>>> TimerWheel<T, S> {
         unsafe { self.levels[lvl_idx].slot(slot_idx).push_entry(entry_ptr) };
 
         // Per-slot min: this entry may lower the slot's minimum. (Maintained here,
-        // not in push_entry, so TimeoutList's shared slot pays nothing.)
+        // not in push_entry, so TimeoutQueue's shared slot pays nothing.)
         {
             let slot = self.levels[lvl_idx].slot(slot_idx);
             slot.set_min_deadline(slot.min_deadline().min(deadline_ticks));
@@ -1294,13 +1323,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "slots_per_level must be a power of 2")]
     fn invalid_config_non_power_of_two() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .slots_per_level(65)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "power of 2");
     }
 
     // -------------------------------------------------------------------------
@@ -1659,7 +1688,8 @@ mod tests {
             let wheel: Wheel<u64> = WheelBuilder::default()
                 .tick_duration(Duration::from_nanos(tick_ns))
                 .unbounded(64)
-                .build(now);
+                .build(now)
+                .unwrap();
 
             for n in 0..500u64 {
                 let nanos = n * tick_ns;
@@ -2154,7 +2184,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .slots_per_level(32)
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // Level 0 range = 32 ticks (32ms with 1ms tick)
         // Deadline at 20ms should go to level 0
@@ -2181,7 +2212,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .clk_shift(2)
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // Level 0: 64 slots × 1ms = 64ms range
         // Level 1: 64 slots × 4ms = 256ms range (with 4x multiplier)
@@ -2207,7 +2239,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .num_levels(3)
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // Level 0: 64ms, Level 1: 512ms, Level 2: 4096ms
         // Max range is level 2 = 4096ms. Beyond that, clamped.
@@ -2228,7 +2261,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .tick_duration(Duration::from_micros(100))
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // 1ms = 10 ticks, should be level 0 (< 64 ticks)
         wheel.schedule_forget(now + ms(1), 1);
@@ -2251,7 +2285,8 @@ mod tests {
             .slots_per_level(16)
             .num_levels(4)
             .bounded(8)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // Fill to capacity
         let mut handles = Vec::new();
@@ -2275,83 +2310,97 @@ mod tests {
     // Builder validation (L13)
     // -------------------------------------------------------------------------
 
+    /// Asserts `result` is `Err(ConfigError::Invalid(_))` whose message contains
+    /// `expect_substr`. Generic over the Ok type so it needs no `Debug` bound on
+    /// the built wheel.
+    #[track_caller]
+    fn assert_invalid<T>(result: &Result<T, ConfigError>, expect_substr: &str) {
+        match result {
+            Err(ConfigError::Invalid(msg)) => assert!(
+                msg.contains(expect_substr),
+                "message {msg:?} does not contain {expect_substr:?}"
+            ),
+            Ok(_) => panic!("expected ConfigError::Invalid containing {expect_substr:?}, got Ok"),
+        }
+    }
+
     #[test]
-    #[should_panic(expected = "slots_per_level must be <= 64")]
     fn invalid_config_too_many_slots() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .slots_per_level(128)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "slots_per_level must be <= 64");
     }
 
     #[test]
-    #[should_panic(expected = "num_levels must be > 0")]
     fn invalid_config_zero_levels() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .num_levels(0)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "num_levels must be > 0");
     }
 
     #[test]
-    #[should_panic(expected = "num_levels must be <= 8")]
     fn invalid_config_too_many_levels() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .num_levels(9)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "num_levels must be <= 8");
     }
 
     #[test]
-    #[should_panic(expected = "clk_shift must be > 0")]
     fn invalid_config_zero_shift() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .clk_shift(0)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "clk_shift must be > 0");
     }
 
     #[test]
-    #[should_panic(expected = "tick_duration must be non-zero")]
     fn invalid_config_zero_tick() {
         let now = Instant::now();
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .tick_duration(Duration::ZERO)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "tick_duration must be non-zero");
     }
 
     #[test]
-    #[should_panic(expected = "overflow")]
     fn invalid_config_shift_overflow() {
         let now = Instant::now();
         // 8 levels × clk_shift=8 = 56 bits shift on level 7
         // Plus 64 slots (6 bits) = 62 bits, should be OK
         // But 8 levels × clk_shift=9 = 63 + 6 = 69 bits — overflow
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .num_levels(8)
             .clk_shift(9)
             .unbounded(1024)
             .build::<u64>(now);
+        assert_invalid(&result, "overflow");
     }
 
     #[test]
-    #[should_panic(expected = "strictly finer level")]
     fn invalid_config_rebalance_progress() {
         let now = Instant::now();
         // slots_per_level = 4 (2^2), clk_shift = 3 → 2^3 = 8 >= 4, so a not-due
         // entry could rebalance to the *same* level and poll would live-lock.
         // Must be rejected at build time.
-        WheelBuilder::default()
+        let result = WheelBuilder::default()
             .slots_per_level(4)
             .clk_shift(3)
             .num_levels(2)
             .unbounded(64)
             .build::<u64>(now);
+        assert_invalid(&result, "strictly finer level");
     }
 
     // -------------------------------------------------------------------------
@@ -2361,7 +2410,7 @@ mod tests {
     #[test]
     fn rebalanced_entry_fires_at_its_deadline() {
         let now = Instant::now();
-        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now).unwrap();
 
         // Both deadlines land in the same level-2 slot (46): 3000>>6 == 3005>>6.
         // At now=3000 the slot's min (3000) is due, so the slot is walked: 3000
@@ -2383,7 +2432,7 @@ mod tests {
     #[test]
     fn cancel_after_rebalance() {
         let now = Instant::now();
-        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now).unwrap();
 
         wheel.schedule_forget(now + ms(3000), 1);
         let h = wheel.schedule(now + ms(3005), 2); // rebalanced on the 3000 poll
@@ -2407,7 +2456,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .max_rebalances_per_poll(1)
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         // 20 deadlines spread across one level-2 slot (all map to slot 46).
         let mut expected: Vec<u64> = Vec::new();
@@ -2440,7 +2490,8 @@ mod tests {
         let mut wheel: Wheel<u64> = WheelBuilder::default()
             .max_rebalances_per_poll(0)
             .unbounded(256)
-            .build(now);
+            .build(now)
+            .unwrap();
 
         wheel.schedule_forget(now + ms(3000), 1);
         wheel.schedule_forget(now + ms(3005), 2); // would rebalance if the cap allowed
@@ -2457,7 +2508,7 @@ mod tests {
     #[test]
     fn proactive_rebalance_moves_and_preserves_firing() {
         let now = Instant::now();
-        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now);
+        let mut wheel: Wheel<u64> = WheelBuilder::default().unbounded(256).build(now).unwrap();
 
         // 10 deadlines at level 2 (delta ~3000 ∈ [512, 4096)).
         let mut expected = Vec::new();


### PR DESCRIPTION
Combo cleanup ahead of a nexus-timer release: turn builder validation into a
returned error (was asserts), rename the unreleased `TimeoutList` → `TimeoutQueue`,
and backfill the missing CHANGELOG entries.

## Builder validation → `Result` (#675, breaking)

`WheelBuilder` / `BoundedWheelBuilder` and `TimeoutQueueBuilder`'s terminal
builders previously `assert!`'d on an invalid config and panicked. They now
return `Result<_, ConfigError>`:

```rust
#[derive(Debug, Clone, PartialEq, Eq)]
pub enum ConfigError {
    Invalid(&'static str), // message names the violated constraint
}
```

- Single `Invalid` variant (no `Missing`): every builder param has a default, so
  nothing can be unset. Shape/derives/`Display`/`Error` mirror
  `nexus-stats-core::ConfigError` for cross-crate consistency.
- Rationale: a bad config is a programmer error, but returning it (rather than
  panicking) is consistent with the rest of the workspace and lets a caller that
  sources config from runtime input handle it.
- **Convenience constructors stay infallible** — `Wheel::unbounded` /
  `Wheel::bounded` / `TimeoutQueue::unbounded` / `TimeoutQueue::bounded` use a
  valid default config and `expect` internally. The `TimeoutQueue` ones panic
  only on a zero `timeout` (a caller bug), now documented under `# Panics`.

Migration: append `?` or `.expect(..)` to existing
`WheelBuilder::…build(now)` call sites.

## `TimeoutList` → `TimeoutQueue`

Pure rename of the unreleased fixed-duration variant — it's a queue, so the name
should say so. Never shipped under the old name, so no deprecation shim.

## CHANGELOG backfill

- **#674 rebalancing-poll API** was never recorded — added: `poll_and_rebalance`
  / `poll_and_rebalance_with_limit`, standalone `rebalance(now, limit)`, and the
  `max_rebalances_per_poll` builder knob. `poll` stays the minimal collect-only
  poll; firing is still exact (never early, never missed).
- **#675** breaking `build → Result` entry, with the migration note.

## Blast radius

`WheelBuilder::build` is public, so dependents were updated in-tree:

- **nexus-rt** — timer-driver docs/tests `.build(now)?`; re-exports `ConfigError`
  at `nexus_rt::` and `nexus_rt::timer::`.
- **nexus-async-rt** — `TimerDriver::new` switched to the infallible
  `Wheel::unbounded`; fixed a stale "no-cascade poll" doc line.

## Checks

- `cargo test` green: nexus-timer 112 unit + doctests, nexus-rt, nexus-async-rt.
- `clippy --all-features --all-targets -D warnings` clean on the three crates;
  default-feature workspace clippy clean.
- `cargo fmt --check` clean.

No version bump / CHANGELOG finalize here — that's the release step.
