### PR TITLE
addressing 631 and 671 issues in nexus-rt

### DIFF
--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -10,6 +10,20 @@ contained.
 
 ## [Unreleased]
 
+### Added
+
+- **`WorldBuilder::try_register`** — a non-dropping fallible register. Returns
+  `Err(value)` (the value handed back, not dropped) when the type is already
+  registered, so a plugin can detect that another plugin registered a different
+  configuration of the same type. `ensure` now delegates to it. The
+  duplicate-registration panic in `register` also gained a hint pointing at
+  `ensure()` / `try_register()` / `contains::<T>()`.
+- **Clock pollers return the time they compute.** `RealtimeClockPoller`,
+  `TestClockPoller`, and `HistoricalClockPoller` `sync()` now return the `Clock`
+  they wrote (`Copy`), so event-loop code holding a poller can stamp/log the
+  timestamp without a second `world.resource::<Clock>()` lookup. Non-breaking —
+  the return is not `#[must_use]`, so callers that ignore it keep compiling.
+
 ## [2.4.1] — 2026-06-02
 
 ### Added

--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -18,11 +18,31 @@ contained.
   configuration of the same type. `ensure` now delegates to it. The
   duplicate-registration panic in `register` also gained a hint pointing at
   `ensure()` / `try_register()` / `contains::<T>()`.
+- **`WorldBuilder::id` / `try_id`** — resolve the `ResourceId` of a type
+  registered so far, for a driver/plugin that requires a dependency another one
+  provides (`id` panics at setup if absent; `try_id` returns `None`). Mirrors the
+  `id`/`try_id` already on `World` and `Registry` — `WorldBuilder` previously had
+  only `contains`.
 - **Clock pollers return the time they compute.** `RealtimeClockPoller`,
   `TestClockPoller`, and `HistoricalClockPoller` `sync()` now return the `Clock`
   they wrote (`Copy`), so event-loop code holding a poller can stamp/log the
-  timestamp without a second `world.resource::<Clock>()` lookup. Non-breaking —
-  the return is not `#[must_use]`, so callers that ignore it keep compiling.
+  timestamp without a second `world.resource::<Clock>()` lookup. Source-compatible
+  for the common case — the return is not `#[must_use]`, so statement-position
+  `poller.sync(...)` calls compile unchanged — but it is a return-type signature
+  change: code that named the old `-> ()` shape (a `fn` pointer, or a closure bound
+  to `FnMut(&mut World)`) would need updating.
+
+### Changed
+
+- **Clock installers register `Clock` with `ensure_default` instead of
+  `register`.** A `Clock` is a shared read dependency, not installer-owned state,
+  so a clock source now composes with anything that already registered a `Clock`
+  (e.g. a baseline default) instead of panicking on install order. The three
+  installers drive the value of whichever `Clock` slot exists. The owned-vs-shared
+  registration pattern behind this is now documented on the `Installer` trait
+  (own → `register`, share → `ensure`/`ensure_default`, require → resolve via
+  `id`, which panics at setup if absent — a missing dependency is a wiring error,
+  not a `Result`), cross-referenced from `register`, `Resource`, and `Plugin`.
 
 ## [2.4.1] — 2026-06-02
 

--- a/nexus-rt/src/clock.rs
+++ b/nexus-rt/src/clock.rs
@@ -145,7 +145,11 @@ impl Installer for RealtimeClockInstaller {
     type Poller = RealtimeClockPoller;
 
     fn install(self, world: &mut WorldBuilder) -> RealtimeClockPoller {
-        let clock_id = world.register(Clock::default());
+        // `Clock` is a shared dependency (handlers read it via `Res<Clock>`); the
+        // installer owns the value it writes each `sync()`, not the slot. `ensure`
+        // rather than `register` so a clock source composes even if something else
+        // already registered a `Clock` — see the `Installer` trait docs.
+        let clock_id = world.ensure_default::<Clock>();
 
         let (base_instant, base_nanos, gap) =
             RealtimeClockPoller::calibrate(self.threshold, self.max_retries);
@@ -214,7 +218,8 @@ impl RealtimeClockPoller {
         let elapsed = now.saturating_duration_since(self.base_instant);
         let nanos = self.base_nanos + elapsed.as_nanos() as i128;
 
-        // SAFETY: clock_id was returned by register() during install()
+        // SAFETY: clock_id was obtained via ensure_default() during install()
+        // and points at the registered Clock.
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = now;
         clock.unix_nanos = nanos;
@@ -375,7 +380,11 @@ impl Installer for TestClockInstaller {
     type Poller = TestClockPoller;
 
     fn install(self, world: &mut WorldBuilder) -> TestClockPoller {
-        let clock_id = world.register(Clock::default());
+        // `Clock` is a shared dependency (handlers read it via `Res<Clock>`); the
+        // installer owns the value it writes each `sync()`, not the slot. `ensure`
+        // rather than `register` so a clock source composes even if something else
+        // already registered a `Clock` — see the `Installer` trait docs.
+        let clock_id = world.ensure_default::<Clock>();
         TestClockPoller {
             clock_id,
             elapsed: Duration::ZERO,
@@ -404,7 +413,8 @@ impl TestClockPoller {
     /// return is fine.
     #[inline]
     pub fn sync(&self, world: &mut World) -> Clock {
-        // SAFETY: clock_id was returned by register() during install()
+        // SAFETY: clock_id was obtained via ensure_default() during install()
+        // and points at the registered Clock.
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = self.base_instant + self.elapsed;
         clock.unix_nanos = self.base_nanos + self.elapsed.as_nanos() as i128;
@@ -502,7 +512,11 @@ impl Installer for HistoricalClockInstaller {
     type Poller = HistoricalClockPoller;
 
     fn install(self, world: &mut WorldBuilder) -> HistoricalClockPoller {
-        let clock_id = world.register(Clock::default());
+        // `Clock` is a shared dependency (handlers read it via `Res<Clock>`); the
+        // installer owns the value it writes each `sync()`, not the slot. `ensure`
+        // rather than `register` so a clock source composes even if something else
+        // already registered a `Clock` — see the `Installer` trait docs.
+        let clock_id = world.ensure_default::<Clock>();
         HistoricalClockPoller {
             clock_id,
             start_nanos: self.start_nanos,
@@ -538,7 +552,8 @@ impl HistoricalClockPoller {
         let elapsed = (self.current_nanos - self.start_nanos).max(0);
         let elapsed_nanos = u64::try_from(elapsed).unwrap_or(u64::MAX);
 
-        // SAFETY: clock_id was returned by register() during install()
+        // SAFETY: clock_id was obtained via ensure_default() during install()
+        // and points at the registered Clock.
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = self.base_instant + Duration::from_nanos(elapsed_nanos);
         clock.unix_nanos = self.current_nanos;

--- a/nexus-rt/src/clock.rs
+++ b/nexus-rt/src/clock.rs
@@ -201,8 +201,12 @@ pub struct RealtimeClockPoller {
 
 impl RealtimeClockPoller {
     /// Sync the Clock resource with the current time.
+    ///
+    /// Returns the [`Clock`] it just wrote (it's `Copy`), so event-loop code
+    /// holding the poller can stamp/log the timestamp without a second
+    /// `world.resource::<Clock>()` lookup. Ignoring the return is fine.
     #[inline]
-    pub fn sync(&mut self, world: &mut World, now: Instant) {
+    pub fn sync(&mut self, world: &mut World, now: Instant) -> Clock {
         if now.saturating_duration_since(self.last_resync) >= self.resync_interval {
             self.resync_at(now);
         }
@@ -214,6 +218,7 @@ impl RealtimeClockPoller {
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = now;
         clock.unix_nanos = nanos;
+        *clock
     }
 
     /// Force recalibration.
@@ -393,12 +398,17 @@ pub struct TestClockPoller {
 
 impl TestClockPoller {
     /// Sync the Clock resource with the test clock's current state.
+    ///
+    /// Returns the [`Clock`] it just wrote (it's `Copy`), matching the other
+    /// pollers — no `world.resource::<Clock>()` round-trip needed. Ignoring the
+    /// return is fine.
     #[inline]
-    pub fn sync(&self, world: &mut World) {
+    pub fn sync(&self, world: &mut World) -> Clock {
         // SAFETY: clock_id was returned by register() during install()
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = self.base_instant + self.elapsed;
         clock.unix_nanos = self.base_nanos + self.elapsed.as_nanos() as i128;
+        *clock
     }
 
     /// Advances time by the given duration.
@@ -519,9 +529,12 @@ pub struct HistoricalClockPoller {
 impl HistoricalClockPoller {
     /// Sync the Clock resource and auto-advance the replay position.
     ///
-    /// Writes current position into Clock, then advances by one step.
+    /// Writes current position into Clock, then advances by one step. Returns
+    /// the [`Clock`] it wrote — the replay position *before* the advance, i.e.
+    /// the timestamp now visible via `Res<Clock>` this iteration. Ignoring the
+    /// return is fine.
     #[inline]
-    pub fn sync(&mut self, world: &mut World) {
+    pub fn sync(&mut self, world: &mut World) -> Clock {
         let elapsed = (self.current_nanos - self.start_nanos).max(0);
         let elapsed_nanos = u64::try_from(elapsed).unwrap_or(u64::MAX);
 
@@ -529,6 +542,7 @@ impl HistoricalClockPoller {
         let clock = unsafe { world.get_mut::<Clock>(self.clock_id) };
         clock.instant = self.base_instant + Duration::from_nanos(elapsed_nanos);
         clock.unix_nanos = self.current_nanos;
+        let synced = *clock;
 
         if !self.exhausted {
             self.current_nanos += self.step_nanos;
@@ -537,6 +551,8 @@ impl HistoricalClockPoller {
                 self.exhausted = true;
             }
         }
+
+        synced
     }
 
     /// Whether the replay has reached `end_nanos`.
@@ -776,5 +792,46 @@ mod tests {
         assert!(HistoricalClockInstaller::new(1000, 1000, Duration::from_nanos(100)).is_err());
         assert!(HistoricalClockInstaller::new(2000, 1000, Duration::from_nanos(100)).is_err());
         assert!(HistoricalClockInstaller::new(0, 1000, Duration::ZERO).is_err());
+    }
+
+    // =========================================================================
+    // sync() returns the Clock it wrote (#631)
+    // =========================================================================
+
+    #[test]
+    fn sync_returns_the_written_clock() {
+        // Realtime: the returned Clock matches what landed in the World.
+        let mut wb = WorldBuilder::new();
+        let mut poller = wb.install_driver(RealtimeClockInstaller::default());
+        let mut world = wb.build();
+        let returned = poller.sync(&mut world, Instant::now());
+        let in_world = world.resource::<Clock>();
+        assert_eq!(returned.unix_nanos(), in_world.unix_nanos());
+        assert_eq!(returned.instant(), in_world.instant());
+
+        // Test clock.
+        let mut wb = WorldBuilder::new();
+        let poller = wb.install_driver(TestClockInstaller::new());
+        let mut world = wb.build();
+        let returned = poller.sync(&mut world);
+        assert_eq!(
+            returned.unix_nanos(),
+            world.resource::<Clock>().unix_nanos()
+        );
+
+        // Historical: returns the pre-advance position (what `Res<Clock>` sees
+        // this iteration), not the advanced cursor.
+        let installer =
+            HistoricalClockInstaller::new(1000, 2000, Duration::from_nanos(100)).unwrap();
+        let mut wb = WorldBuilder::new();
+        let mut poller = wb.install_driver(installer);
+        let mut world = wb.build();
+        let returned = poller.sync(&mut world);
+        assert_eq!(returned.unix_nanos(), 1000);
+        assert_eq!(
+            returned.unix_nanos(),
+            world.resource::<Clock>().unix_nanos()
+        );
+        assert_eq!(poller.current_nanos(), 1100); // cursor advanced, return did not
     }
 }

--- a/nexus-rt/src/driver.rs
+++ b/nexus-rt/src/driver.rs
@@ -13,6 +13,33 @@ use crate::world::WorldBuilder;
 /// different drivers need different parameters (e.g. a timer driver
 /// needs `Instant`, an IO driver does not).
 ///
+/// # Registering resources: owned vs. shared
+///
+/// Choose the [`WorldBuilder`] registration method by **who owns the resource**:
+///
+/// - **Owned** — the installer creates it and is its sole writer (a driver's
+///   wheel, an IO poller's state). Use [`register`](WorldBuilder::register). A
+///   duplicate is a wiring bug, so it panics — and the panic names `ensure` /
+///   `try_register` for anyone who meant to share. This is the default for
+///   driver-private state.
+/// - **Shared** — a common dependency several drivers read (e.g.
+///   [`Clock`](crate::clock::Clock)); the installer may drive its value but does not
+///   exclusively own the slot. Use [`ensure`](WorldBuilder::ensure) /
+///   [`ensure_default`](WorldBuilder::ensure_default). Idempotent: the first
+///   caller creates it, later callers get the same id, so it composes
+///   regardless of install order. (Do not `ensure` a resource you *move* in and
+///   exclusively mutate — the value would be dropped and you'd alias someone
+///   else's; that is what "owned" is for.)
+/// - **Required (provided elsewhere)** — a resource another installer must
+///   register that this one cannot default. Resolve it with
+///   [`id`](WorldBuilder::id) (check [`contains`](WorldBuilder::contains) first
+///   if the dependency is optional). If it is absent, `id` panics with a
+///   message naming how to provide it. Do **not** return `Result` from
+///   `install` for this: a missing dependency is a deterministic composition
+///   error caught at startup, with no runtime recovery — panic, fail fast.
+///   Only *config values* are fallible; validate those to a `Result` (e.g. a
+///   `ConfigError`) in your builder, before `install`.
+///
 /// # Examples
 ///
 /// ```ignore

--- a/nexus-rt/src/plugin.rs
+++ b/nexus-rt/src/plugin.rs
@@ -9,6 +9,12 @@ use crate::world::WorldBuilder;
 /// Plugins register resources into a [`WorldBuilder`]. The runtime is
 /// assembled by installing plugins via [`WorldBuilder::install_plugin`].
 ///
+/// When choosing how to register — [`register`](WorldBuilder::register) for a
+/// resource the plugin owns, [`ensure`](WorldBuilder::ensure) /
+/// [`ensure_default`](WorldBuilder::ensure_default) for one it shares with other
+/// plugins — see the owned-vs-shared guidance on the
+/// [`Installer`](crate::Installer) trait.
+///
 /// # Examples
 ///
 /// ```ignore

--- a/nexus-rt/src/world.rs
+++ b/nexus-rt/src/world.rs
@@ -463,6 +463,11 @@ pub struct WorldBuilder {
 /// Without the marker trait, two modules can independently register
 /// `u64` and silently collide. The `Resource` bound forces a newtype,
 /// making collisions a compile error.
+///
+/// When a collision is *intentional* — several drivers sharing one resource
+/// type — register it with [`ensure`](WorldBuilder::ensure) rather than
+/// [`register`](WorldBuilder::register); see the owned-vs-shared guidance on
+/// the [`Installer`](crate::Installer) trait.
 #[diagnostic::on_unimplemented(
     message = "this type cannot be stored as a resource in the World",
     note = "add `#[derive(Resource)]` to your type, or use `new_resource!` for a newtype wrapper"
@@ -498,6 +503,12 @@ impl WorldBuilder {
     /// The value is heap-allocated inside a `ResourceCell<T>` and ownership
     /// is transferred to the container. The pointer is stable for the
     /// lifetime of the resulting [`World`].
+    ///
+    /// Use this when the caller **owns** the resource (its sole writer). For a
+    /// resource multiple drivers may share, use [`ensure`](Self::ensure); to
+    /// detect a duplicate without dropping your value, use
+    /// [`try_register`](Self::try_register). See the
+    /// [`Installer`](crate::Installer) docs for the owned-vs-shared pattern.
     ///
     /// # Panics
     ///
@@ -616,6 +627,26 @@ impl WorldBuilder {
     /// Returns `true` if a resource of type `T` has been registered.
     pub fn contains<T: Resource>(&self) -> bool {
         self.registry.contains::<T>()
+    }
+
+    /// Resolve the [`ResourceId`] for a type registered so far.
+    ///
+    /// Use during install to resolve a **required** dependency another driver
+    /// or plugin must have registered earlier (install order matters). See the
+    /// [`Installer`](crate::Installer) owned-vs-shared guidance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource type has not been registered.
+    pub fn id<T: Resource>(&self) -> ResourceId {
+        self.registry.id::<T>()
+    }
+
+    /// Resolve the [`ResourceId`] for a type, or `None` if it has not been
+    /// registered — the non-panicking form of [`id`](Self::id), for an optional
+    /// dependency.
+    pub fn try_id<T: Resource>(&self) -> Option<ResourceId> {
+        self.registry.try_id::<T>()
     }
 
     /// Install a plugin. The plugin is consumed and registers its
@@ -1496,6 +1527,23 @@ mod tests {
         // Original registration untouched.
         let world = builder.build();
         assert_eq!(*world.resource::<u64>(), 42);
+    }
+
+    #[test]
+    fn builder_id_and_try_id_resolve_during_build() {
+        let mut builder = WorldBuilder::new();
+        assert!(builder.try_id::<Price>().is_none());
+
+        let id = builder.register::<Price>(Price { value: 1.0 });
+        assert_eq!(builder.id::<Price>(), id);
+        assert_eq!(builder.try_id::<Price>(), Some(id));
+    }
+
+    #[test]
+    #[should_panic(expected = "not registered")]
+    fn builder_id_panics_when_absent() {
+        let builder = WorldBuilder::new();
+        builder.id::<Price>();
     }
 
     // -- Sequence tests -----------------------------------------------------------

--- a/nexus-rt/src/world.rs
+++ b/nexus-rt/src/world.rs
@@ -507,7 +507,9 @@ impl WorldBuilder {
         let type_id = TypeId::of::<T>();
         assert!(
             !self.registry.indices.contains_key(&type_id),
-            "resource `{}` already registered",
+            "resource `{}` already registered \
+             (use `ensure()` if duplicate registration is expected, or \
+             `try_register()` / `contains::<T>()` to branch on it)",
             type_name::<T>(),
         );
 
@@ -533,20 +535,39 @@ impl WorldBuilder {
         self.register(T::default())
     }
 
+    /// Attempts to register a resource, returning its [`ResourceId`].
+    ///
+    /// Returns `Err(value)` if a resource of the same type is already
+    /// registered — the value is handed **back** rather than dropped, so the
+    /// caller can decide whether the duplicate is benign (e.g. compare it to
+    /// the existing registration's configuration).
+    ///
+    /// Use [`ensure`](Self::ensure) when the existing registration always wins
+    /// and the value is safe to discard; use [`register`](Self::register) when
+    /// a duplicate is a bug that should panic.
+    #[cold]
+    pub fn try_register<T: Resource>(&mut self, value: T) -> Result<ResourceId, T> {
+        if self.registry.contains::<T>() {
+            return Err(value);
+        }
+        Ok(self.register(value))
+    }
+
     /// Ensure a resource is registered, returning its [`ResourceId`].
     ///
     /// If the type is already registered, returns the existing ID and
     /// drops `value`. If not, registers it and returns the new ID.
     ///
     /// Use [`register`](Self::register) when duplicate registration is a
-    /// bug that should panic. Use `ensure` when multiple plugins or
-    /// drivers may independently need the same resource type.
+    /// bug that should panic, or [`try_register`](Self::try_register) when the
+    /// caller wants the rejected value handed back. Use `ensure` when multiple
+    /// plugins or drivers may independently need the same resource type.
     #[cold]
     pub fn ensure<T: Resource>(&mut self, value: T) -> ResourceId {
-        if let Some(id) = self.registry.try_id::<T>() {
-            return id;
+        match self.try_register(value) {
+            Ok(id) => id,
+            Err(_) => self.registry.id::<T>(),
         }
-        self.register(value)
     }
 
     /// Ensure a resource is registered using its [`Default`] value,
@@ -1449,6 +1470,32 @@ mod tests {
         assert_eq!(id, world.id::<Vec<u32>>());
         // Original value preserved.
         assert_eq!(*world.resource::<Vec<u32>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn try_register_fresh_returns_ok() {
+        let mut builder = WorldBuilder::new();
+        let id = builder
+            .try_register::<u64>(42)
+            .expect("fresh type registers");
+        let world = builder.build();
+
+        assert_eq!(id, world.id::<u64>());
+        assert_eq!(*world.resource::<u64>(), 42);
+    }
+
+    #[test]
+    fn try_register_duplicate_hands_value_back() {
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(42);
+
+        // Duplicate: the rejected value is returned, not dropped — unlike
+        // `ensure`, which discards it.
+        assert_eq!(builder.try_register::<u64>(99), Err(99));
+
+        // Original registration untouched.
+        let world = builder.build();
+        assert_eq!(*world.resource::<u64>(), 42);
     }
 
     // -- Sequence tests -----------------------------------------------------------


### PR DESCRIPTION
Two small, independent nexus-rt ergonomics fixes. Closes #631 and #671.

## #631 — clock pollers return the time they compute

`RealtimeClockPoller`, `TestClockPoller`, and `HistoricalClockPoller` compute the
current time in `sync()` and write it into the `Clock` resource, but only
`HistoricalClockPoller` let you read it back — everyone else had to re-fetch via
`world.resource::<Clock>()`. Now all three `sync()` return the `Clock` they wrote:

```rust
let now = clock_poller.sync(&mut world, Instant::now());
outbound.stamp(now.unix_nanos());   // no second lookup
```

- `Clock` is `Copy` and already computed inside `sync()` — zero extra state.
- **Source-compatible for the common case:** the return is *not* `#[must_use]`, so
  statement-position `poller.sync(...)` calls compile unchanged. It is still a
  return-type signature change, so code that named the old `-> ()` shape (a `fn`
  pointer, or a closure bound to `FnMut(&mut World)`) would need updating.
- `HistoricalClockPoller` returns the **pre-advance** position — the timestamp
  `Res<Clock>` sees this iteration, not the advanced replay cursor. Documented and
  asserted.

## #671 — `try_register` + a duplicate-registration panic that names the way out

Plugins/drivers that independently need the same resource type had only `register`
(panics on duplicate) and `ensure` (silently drops the loser) — no way to detect
that another plugin registered a *different configuration*, and the duplicate panic
gave no signpost.

**Change 1 — the panic points at the escape hatches:**

```
resource `Foo` already registered (use `ensure()` if duplicate registration is
expected, or `try_register()` / `contains::<T>()` to branch on it)
```

Still contains `"already registered"`, so the existing `#[should_panic]` test is untouched.

**Change 2 — `try_register`, a non-dropping fallible variant; `ensure` delegates to it:**

```rust
pub fn try_register<T: Resource>(&mut self, value: T) -> Result<ResourceId, T> {
    if self.registry.contains::<T>() { return Err(value); } // handed back, not dropped
    Ok(self.register(value))
}
```

`Err(value)` returns the rejected value so the caller can compare it to the existing
registration rather than losing it.

## Tests

- `sync_returns_the_written_clock` — all three pollers; asserts the return equals
  the `Clock` in the World, and that Historical returns pre-advance while its cursor
  moves on.
- `try_register_fresh_returns_ok` / `try_register_duplicate_hands_value_back`
  (asserts the rejected value comes back as `Err`).

## Checks

- nexus-rt lib: 415 passed, 0 failed; duplicate-panic test still green.
- `clippy --all-features --all-targets -D warnings` clean; `fmt --check` clean.
- `cargo build --workspace --all-targets` clean — the `sync` return-type change
  disturbs no downstream caller in the workspace.

CHANGELOG `[Unreleased]` updated; no version bump (release-time).
