### PR TITLE
improvements to templates + resource derives + clock pollers

### DIFF
--- a/nexus-rt-derive/CHANGELOG.md
+++ b/nexus-rt-derive/CHANGELOG.md
@@ -10,6 +10,23 @@ contained.
 
 ## [Unreleased]
 
+### Fixed
+
+- `#[derive(Resource)]` on a **concrete** type no longer emits an explicit
+  `where Self: Send + 'static` predicate. The `Resource: Send + 'static`
+  supertrait already enforces the bound — and reports it cleanly at the derived
+  type — but the explicit predicate additionally forced the `Send` auto-trait to
+  be proven *eagerly*, which **overflowed** on legitimately self-referential
+  resource types (e.g. a timer-wheel slot
+  `struct Pending(Option<TemplatedCallback<K>>)`, the shape the self-rescheduling
+  callback pattern uses). Such a type now derives `Resource`; a genuinely
+  non-`Send` concrete type is still rejected at the derive.
+
+  **Generic** types keep the conditional `where Self: Send + 'static` predicate,
+  so `impl<T> Resource for Foo<T>` applies exactly when `Foo<T>: Send + 'static`
+  (rather than requiring every instantiation to be `Send`). Behavior for generic
+  types is unchanged.
+
 ## [1.2.0] and earlier
 
 Earlier history is not documented in this CHANGELOG. See git history

--- a/nexus-rt-derive/src/lib.rs
+++ b/nexus-rt-derive/src/lib.rs
@@ -34,18 +34,36 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    // Add Send + 'static where clause so errors point at the derive,
-    // not at the register() call site.
-    let mut bounds = where_clause.cloned();
-    let predicate: syn::WherePredicate = syn::parse_quote!(#name #ty_generics: Send + 'static);
-    bounds
-        .get_or_insert_with(|| syn::parse_quote!(where))
-        .predicates
-        .push(predicate);
+    // The `Resource: Send + 'static` supertrait is what actually enforces the
+    // bound. How we express the impl depends on whether the type is generic:
+    //
+    // - CONCRETE type: rely on the supertrait alone (no explicit predicate). It
+    //   still reports a genuinely non-Send type at the derive site, and — unlike
+    //   an explicit predicate — is discharged coinductively, so it does NOT
+    //   overflow on self-referential resources such as a timer-wheel slot
+    //   `struct Pending(Option<TemplatedCallback<K>>)`. (An explicit
+    //   `where Self: Send + 'static` forces `Send` to be proven eagerly and
+    //   overflows on that shape.)
+    // - GENERIC type: add `where Self: Send + 'static` so the impl is
+    //   *conditional*. Without it, an unconditional `impl<T> Resource for Foo<T>`
+    //   would require EVERY instantiation to be Send + 'static and reject e.g.
+    //   `Foo<Rc<_>>`. With it, `Foo<T>` is a `Resource` exactly when it is
+    //   Send + 'static.
+    let where_clause = if input.generics.params.is_empty() {
+        where_clause.cloned()
+    } else {
+        let mut bounds = where_clause.cloned();
+        let predicate: syn::WherePredicate = syn::parse_quote!(#name #ty_generics: Send + 'static);
+        bounds
+            .get_or_insert_with(|| syn::parse_quote!(where))
+            .predicates
+            .push(predicate);
+        bounds
+    };
 
     quote! {
         impl #impl_generics ::nexus_rt::Resource for #name #ty_generics
-            #bounds
+            #where_clause
         {}
     }
     .into()

--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -12,6 +12,16 @@ contained.
 
 ### Added
 
+- **Self-referential blueprints — `CallbackTemplate` is now `Copy` / `Clone`.**
+  A callback can carry its own template in its context and stamp its own successor
+  (a periodic re-arm, a retry timer, any "produce the next me" pattern) through the
+  safe API — no `&mut World` reach-in, no unsafe borrow split. The impls are
+  hand-written (not derived) so the `K` blueprint marker needn't be `Copy`/`Clone`;
+  the copy is `State` (already `Copy`), a fn pointer, and a `&'static str`.
+  Paired with a `nexus-rt-derive` fix so `#[derive(Resource)]` works on the
+  self-referential slot type this pattern uses
+  (`struct Pending(Option<TemplatedCallback<K>>)`), which previously overflowed
+  auto-trait resolution.
 - **`WorldBuilder::try_register`** — a non-dropping fallible register. Returns
   `Err(value)` (the value handed back, not dropped) when the type is already
   registered, so a plugin can detect that another plugin registered a different

--- a/nexus-rt/docs/callbacks.md
+++ b/nexus-rt/docs/callbacks.md
@@ -255,6 +255,93 @@ assert_eq!(callbacks[99].ctx.bytes, 20);
 assert_eq!(world.resource::<SharedState>().total, 30);
 ```
 
+## Self-Rescheduling Callbacks (Periodic Timers, Retries)
+
+`CallbackTemplate` is `Copy`, so a callback's **context can carry its own
+template** and use it to stamp its own successor — a periodic re-arm, a
+retry-with-backoff, any "produce the next me" pattern. This happens entirely
+through the safe API: no `&mut World` reach-in, no unsafe borrow split. The
+self-reference is not a cyclic type — the template holds a fn pointer and
+pre-resolved state, never the context — so a context can hold a
+`CallbackTemplate<K>` field as plain data.
+
+The canonical case is a **self-rearming timer**. The callback fires, does its
+work, then stamps a fresh copy of itself and schedules it back into the timer
+wheel at the next deadline:
+
+```rust
+use std::time::{Duration, Instant};
+use nexus_rt::{WorldBuilder, ResMut};
+use nexus_rt::timer::{TimerInstaller, TimerWheel, Wheel};
+use nexus_rt::template::CallbackTemplate;
+
+// The context carries the callback's OWN template (the self-reference),
+// plus whatever per-timer state it needs.
+struct HeartbeatCtx {
+    template: CallbackTemplate<Heartbeat>,
+    interval: Duration,
+    remaining: u32,
+}
+
+// `now: Instant` is the fire time the timer driver dispatches with.
+fn heartbeat(ctx: &mut HeartbeatCtx, mut wheel: ResMut<TimerWheel>, now: Instant) {
+    // ... do the periodic work (send a ping, sample a metric) ...
+
+    if ctx.remaining > 0 {
+        // Copy our own template out of the context and stamp the successor.
+        let next = ctx.template.generate(HeartbeatCtx {
+            template: ctx.template,          // `Copy` — no move, template stays usable
+            interval: ctx.interval,
+            remaining: ctx.remaining - 1,
+        });
+        // Re-arm: schedule the successor one interval out. The wheel stores
+        // `Box<dyn Handler<Instant>>`, so the concrete callback type is erased.
+        wheel.schedule_forget(now + ctx.interval, Box::new(next));
+    }
+}
+
+nexus_rt::callback_blueprint!(
+    Heartbeat,
+    Context = HeartbeatCtx,
+    Event = Instant,
+    Params = (ResMut<'static, TimerWheel>,)
+);
+
+// Setup: install the timer driver, then prime the first heartbeat.
+let mut wb = WorldBuilder::new();
+let mut timer = wb.install_driver(TimerInstaller::new(Wheel::unbounded(64, Instant::now())));
+let mut world = wb.build();
+
+let template = CallbackTemplate::<Heartbeat>::new(heartbeat, world.registry());
+let first = template.generate(HeartbeatCtx {
+    template,                                 // the template copies into the context
+    interval: Duration::from_millis(10),
+    remaining: 5,
+});
+world.resource_mut::<TimerWheel>().schedule_forget(Instant::now(), Box::new(first));
+
+// In the poll loop, `timer.poll(&mut world, Instant::now())` fires due
+// callbacks; each fire re-arms the next until `remaining` reaches 0.
+```
+
+**Storing typed callbacks instead of erasing them.** The timer wheel erases to
+`Box<dyn Handler<Instant>>`, which sidesteps the type entirely. If instead you
+keep a *typed* slot — a resource holding `Option<TemplatedCallback<K>>` or a
+`Vec<TemplatedCallback<K>>` — that resource type is **self-referential**
+(`Slot` → `TemplatedCallback<K>` → context → reads `Slot`). This is a
+well-formed, finite type, and `#[derive(Resource)]` works on it:
+
+```rust
+use nexus_rt::Resource;
+use nexus_rt::template::TemplatedCallback;
+
+#[derive(Resource)]
+struct Pending(Option<TemplatedCallback<Heartbeat>>);
+```
+
+(Earlier versions of the `Resource` derive overflowed auto-trait resolution on
+this self-referential shape; that is fixed — see [derives.md](derives.md).)
+
 ## Returning Callbacks from Functions (Rust 2024)
 
 When a factory function takes `&Registry` and returns `impl Handler<E>`,

--- a/nexus-rt/docs/derives.md
+++ b/nexus-rt/docs/derives.md
@@ -34,6 +34,21 @@ note: add `#[derive(Resource)]` to your type, or use `new_resource!` for a newty
 Use `#[derive(Resource)]` on any struct you pass to
 `WorldBuilder::register()`.
 
+A genuinely non-`Send` type (e.g. one holding an `Rc`) is still rejected — the
+error points at the derived struct and names the offending field, via the
+`Resource: Send + 'static` supertrait.
+
+### Self-referential resource types
+
+Some resources are legitimately self-referential — most commonly a slot that
+holds callbacks which themselves read that slot, e.g. a timer-wheel-like
+`struct Pending(Option<TemplatedCallback<K>>)` used by the
+[self-rescheduling pattern](callbacks.md#self-rescheduling-callbacks-periodic-timers-retries).
+The referenced type is finite (a callback holds a fn pointer and pre-resolved
+state, never the slot), so `#[derive(Resource)]` works on it. (The derive no
+longer emits an explicit `Send` bound, which previously overflowed auto-trait
+resolution on exactly this shape.)
+
 ## `new_resource!`
 
 Shorthand for a newtype wrapper that implements `Resource`, `Deref`,

--- a/nexus-rt/docs/derives.md
+++ b/nexus-rt/docs/derives.md
@@ -41,13 +41,14 @@ error points at the derived struct and names the offending field, via the
 ### Self-referential resource types
 
 Some resources are legitimately self-referential — most commonly a slot that
-holds callbacks which themselves read that slot, e.g. a timer-wheel-like
-`struct Pending(Option<TemplatedCallback<K>>)` used by the
+holds callbacks which themselves read that slot. For a concrete callback
+blueprint `Heartbeat`, that slot is
+`struct Pending(Option<TemplatedCallback<Heartbeat>>)`, as used by the
 [self-rescheduling pattern](callbacks.md#self-rescheduling-callbacks-periodic-timers-retries).
 The referenced type is finite (a callback holds a fn pointer and pre-resolved
-state, never the slot), so `#[derive(Resource)]` works on it. (The derive no
-longer emits an explicit `Send` bound, which previously overflowed auto-trait
-resolution on exactly this shape.)
+state, never the slot), so `#[derive(Resource)]` works on it. (For a concrete
+type the derive no longer emits an explicit `Send` bound, which previously
+overflowed auto-trait resolution on exactly this shape.)
 
 ## `new_resource!`
 

--- a/nexus-rt/docs/templates.md
+++ b/nexus-rt/docs/templates.md
@@ -72,6 +72,11 @@ for id in 0..100 {
 }
 ```
 
+`CallbackTemplate` is `Copy`, so a callback's context can even hold **its own
+template** and stamp its own successor — the basis for self-rearming timers and
+retry loops. See
+[Self-Rescheduling Callbacks](callbacks.md#self-rescheduling-callbacks-periodic-timers-retries).
+
 ## Blueprint Macros
 
 The `handler_blueprint!` and `callback_blueprint!` macros use keyword

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -647,6 +647,63 @@ type CallbackRunFn<K> = unsafe fn(
 ///
 /// // Each carries its own context, shares pre-resolved state.
 /// ```
+///
+/// # Self-rescheduling (self-referential blueprint)
+///
+/// Because `CallbackTemplate` is `Copy`, a callback's context can hold **its own
+/// template** and use it to stamp its successor — a periodic re-arm, a retry
+/// timer, any "produce the next me" pattern — entirely through the safe API,
+/// with no `&mut World` reach-in and no unsafe borrow split:
+///
+/// ```
+/// use nexus_rt::{WorldBuilder, ResMut, Handler, Resource, no_event};
+/// use nexus_rt::template::{Blueprint, CallbackBlueprint, CallbackTemplate, TemplatedCallback};
+///
+/// #[derive(Resource)]
+/// struct Fires(u64);
+///
+/// // The "reschedule" target — a real driver uses a timer wheel; here, one slot.
+/// // `#[derive(Resource)]` works even though this type is self-referential
+/// // (`Pending` → `TemplatedCallback<Reschedule>` → ... → reads `Pending`).
+/// #[derive(Resource)]
+/// struct Pending(Option<TemplatedCallback<Reschedule>>);
+///
+/// // The context carries the callback's OWN template — the self-reference.
+/// struct ReschedCtx { template: CallbackTemplate<Reschedule>, remaining: u64 }
+///
+/// struct Reschedule;
+/// impl Blueprint for Reschedule {
+///     type Event = ();
+///     type Params = (ResMut<'static, Fires>, ResMut<'static, Pending>);
+/// }
+/// impl CallbackBlueprint for Reschedule {
+///     type Context = ReschedCtx;
+/// }
+///
+/// fn tick(ctx: &mut ReschedCtx, mut fires: ResMut<Fires>, mut pending: ResMut<Pending>) {
+///     fires.0 += 1;
+///     if ctx.remaining > 0 {
+///         // Copy our own template out of the context and stamp the successor.
+///         pending.0 = Some(ctx.template.generate(ReschedCtx {
+///             template: ctx.template,        // `Copy` — no `Reschedule: Copy` needed
+///             remaining: ctx.remaining - 1,
+///         }));
+///     }
+/// }
+///
+/// let mut builder = WorldBuilder::new();
+/// builder.register(Fires(0));
+/// builder.register(Pending(None));
+/// let mut world = builder.build();
+///
+/// let template = CallbackTemplate::<Reschedule>::new(no_event(tick), world.registry());
+/// let mut next = Some(template.generate(ReschedCtx { template, remaining: 3 }));
+/// while let Some(mut cb) = next.take() {
+///     cb.run(&mut world, ());
+///     next = world.resource_mut::<Pending>().0.take();
+/// }
+/// assert_eq!(world.resource::<Fires>().0, 4); // 1 initial fire + 3 reschedules
+/// ```
 pub struct CallbackTemplate<K: CallbackBlueprint>
 where
     <K::Params as Param>::State: Copy,
@@ -704,6 +761,25 @@ where
         }
     }
 }
+
+// `CallbackTemplate` is `Copy`. Hand-written rather than `#[derive(Copy, Clone)]`:
+// a derive would emit `K: Copy` / `K: Clone` bounds from the
+// `PhantomData<fn() -> K>` field, but `K` is a ZST blueprint marker that
+// implements neither — and the copy does not depend on it. Every real field is
+// `Copy`: `prototype` (`State`) by the where-clause, `run_fn` is a fn pointer,
+// `name` is `&'static str`. Being `Copy` is what lets a callback carry its own
+// template in its context and stamp its own successor (a periodic re-arm or
+// retry timer) with no `&mut World` and no unsafe — see the type-level docs.
+impl<K: CallbackBlueprint> Clone for CallbackTemplate<K>
+where
+    <K::Params as Param>::State: Copy,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<K: CallbackBlueprint> Copy for CallbackTemplate<K> where <K::Params as Param>::State: Copy {}
 
 // =============================================================================
 // TemplatedCallback<K>
@@ -1064,6 +1140,81 @@ mod tests {
         cb.ctx_mut().order_id = 99;
         cb.run(&mut world, ());
         assert_eq!(*world.resource::<u64>(), 42 + 99);
+    }
+
+    // -- Self-referential blueprint: a callback reschedules itself -------------
+
+    // A one-slot "reschedule" target. A real driver uses a timer wheel; a slot
+    // is enough to drive the chain in a test. `Resource` requires `Send +
+    // 'static`, so this also asserts `TemplatedCallback<SelfResched>: Send`.
+    struct Pending(Option<TemplatedCallback<SelfResched>>);
+    impl crate::world::Resource for Pending {}
+
+    // The context carries the callback's OWN template — the self-reference.
+    struct ReschedCtx {
+        template: CallbackTemplate<SelfResched>,
+        remaining: u64,
+    }
+
+    struct SelfResched;
+    impl Blueprint for SelfResched {
+        type Event = ();
+        type Params = (ResMut<'static, u64>, ResMut<'static, Pending>);
+    }
+    impl CallbackBlueprint for SelfResched {
+        type Context = ReschedCtx;
+    }
+
+    fn reschedule(ctx: &mut ReschedCtx, mut count: ResMut<u64>, mut pending: ResMut<Pending>) {
+        *count += 1;
+        if ctx.remaining > 0 {
+            // Copy our own template out of the context and stamp the successor.
+            pending.0 = Some(ctx.template.generate(ReschedCtx {
+                template: ctx.template, // Copy — no `SelfResched: Copy` needed
+                remaining: ctx.remaining - 1,
+            }));
+        }
+    }
+
+    #[test]
+    fn self_referential_blueprint_reschedules_itself() {
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        builder.register::<Pending>(Pending(None));
+        let mut world = builder.build();
+
+        let template = CallbackTemplate::<SelfResched>::new(no_event(reschedule), world.registry());
+
+        const N: u64 = 5;
+        let mut next = Some(template.generate(ReschedCtx {
+            template,
+            remaining: N,
+        }));
+        let mut fired = 0u64;
+        while let Some(mut cb) = next.take() {
+            cb.run(&mut world, ());
+            fired += 1;
+            next = world.resource_mut::<Pending>().0.take();
+        }
+
+        assert_eq!(fired, N + 1, "one initial fire + N reschedules");
+        assert_eq!(*world.resource::<u64>(), N + 1);
+    }
+
+    #[test]
+    fn template_copies_without_requiring_key_copy() {
+        // `SelfResched` is a ZST marker implementing neither `Copy` nor `Clone`;
+        // the template still copies. Guards against an accidental
+        // `#[derive(Copy, Clone)]`, which would add a bogus `K: Copy` bound.
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        builder.register::<Pending>(Pending(None));
+        let world = builder.build();
+
+        let template = CallbackTemplate::<SelfResched>::new(no_event(reschedule), world.registry());
+        let a = template; // copy
+        let b = template; // copy again — only compiles if `Copy`
+        let _ = (a, b, template);
     }
 
     // -- Convenience macros ---------------------------------------------------

--- a/nexus-rt/tests/derive_generic_resource.rs
+++ b/nexus-rt/tests/derive_generic_resource.rs
@@ -1,0 +1,27 @@
+//! `#[derive(Resource)]` on a generic type must produce a *conditional* impl:
+//! `Foo<T>: Resource` exactly when `Foo<T>: Send + 'static`. Guards against a
+//! regression to an unconditional impl (which would require every instantiation
+//! to be Send and fail to compile at the derive).
+
+use std::sync::Arc;
+
+use nexus_rt::{Resource, WorldBuilder};
+
+#[derive(Resource)]
+struct Wrap<T>(T);
+
+// A generic with its own where-clause — exercises the predicate-merge path in
+// the derive (the type's `where` is preserved, `Self: Send + 'static` appended).
+#[derive(Resource)]
+struct Bounded<T: Clone>(T);
+
+#[test]
+fn generic_resource_registers_for_send_instantiations() {
+    let mut wb = WorldBuilder::new();
+    wb.register(Wrap(42u64));
+    wb.register(Bounded(Arc::new(7u64)));
+    let world = wb.build();
+
+    assert_eq!(world.resource::<Wrap<u64>>().0, 42);
+    assert_eq!(*world.resource::<Bounded<Arc<u64>>>().0, 7);
+}

--- a/nexus-rt/tests/ui/derive_resource_non_send.rs
+++ b/nexus-rt/tests/ui/derive_resource_non_send.rs
@@ -1,0 +1,8 @@
+// A non-Send type deriving Resource must still be rejected (supertrait), and the
+// error should mention Send — this guards the derive-fix from silently accepting.
+use nexus_rt::Resource;
+
+#[derive(Resource)]
+struct Bad(std::rc::Rc<u32>);
+
+fn main() {}

--- a/nexus-rt/tests/ui/derive_resource_non_send.stderr
+++ b/nexus-rt/tests/ui/derive_resource_non_send.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `Rc<u32>` cannot be sent between threads safely
+ --> tests/ui/derive_resource_non_send.rs:6:8
+  |
+6 | struct Bad(std::rc::Rc<u32>);
+  |        ^^^ `Rc<u32>` cannot be sent between threads safely
+  |
+  = help: within `Bad`, the trait `Send` is not implemented for `Rc<u32>`
+note: required because it appears within the type `Bad`
+ --> tests/ui/derive_resource_non_send.rs:6:8
+  |
+6 | struct Bad(std::rc::Rc<u32>);
+  |        ^^^
+note: required by a bound in `Resource`
+ --> src/world.rs
+  |
+  | pub trait Resource: Send + 'static {}
+  |                     ^^^^ required by this bound in `Resource`

--- a/nexus-rt/tests/ui/register_generic_resource_non_send.rs
+++ b/nexus-rt/tests/ui/register_generic_resource_non_send.rs
@@ -1,0 +1,14 @@
+// `#[derive(Resource)]` on a generic type is conditional: `Wrap<T>` is a
+// `Resource` only when `Wrap<T>: Send + 'static`. Registering a non-Send
+// instantiation must therefore be rejected.
+use std::rc::Rc;
+
+use nexus_rt::{Resource, WorldBuilder};
+
+#[derive(Resource)]
+struct Wrap<T>(T);
+
+fn main() {
+    let mut wb = WorldBuilder::new();
+    wb.register(Wrap(Rc::new(0u32)));
+}

--- a/nexus-rt/tests/ui/register_generic_resource_non_send.stderr
+++ b/nexus-rt/tests/ui/register_generic_resource_non_send.stderr
@@ -1,0 +1,32 @@
+error[E0277]: `Rc<u32>` cannot be sent between threads safely
+  --> tests/ui/register_generic_resource_non_send.rs:13:17
+   |
+13 |     wb.register(Wrap(Rc::new(0u32)));
+   |        -------- ^^^^^^^^^^^^^^^^^^^ `Rc<u32>` cannot be sent between threads safely
+   |        |
+   |        required by a bound introduced by this call
+   |
+   = help: within `Wrap<Rc<u32>>`, the trait `Send` is not implemented for `Rc<u32>`
+help: the trait `Resource` is implemented for `Wrap<T>`
+  --> tests/ui/register_generic_resource_non_send.rs:8:10
+   |
+ 8 | #[derive(Resource)]
+   |          ^^^^^^^^
+note: required because it appears within the type `Wrap<Rc<u32>>`
+  --> tests/ui/register_generic_resource_non_send.rs:9:8
+   |
+ 9 | struct Wrap<T>(T);
+   |        ^^^^
+note: required for `Wrap<Rc<u32>>` to implement `Resource`
+  --> tests/ui/register_generic_resource_non_send.rs:8:10
+   |
+ 8 | #[derive(Resource)]
+   |          ^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+ 9 | struct Wrap<T>(T);
+   |        ^^^^^^^
+note: required by a bound in `WorldBuilder::register`
+  --> src/world.rs
+   |
+   |     pub fn register<T: Resource>(&mut self, value: T) -> ResourceId {
+   |                        ^^^^^^^^ required by this bound in `WorldBuilder::register`
+   = note: this error originates in the derive macro `Resource` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Self-referential blueprints for nexus-rt, plus the `Resource` derive fix that
makes the pattern usable and docs for it. Closes #670. Spans two crates
(`nexus-rt` + `nexus-rt-derive`).

## #670 — self-rescheduling callbacks (`CallbackTemplate: Copy`)

`CallbackTemplate<K>` is now `Copy` / `Clone`, so a callback can carry **its own
template** in its context and stamp its own successor — a periodic re-arm, a
retry timer, any "produce the next me" pattern — entirely through the safe API,
no `&mut World` reach-in and no unsafe borrow split.

- Impls are **hand-written**, not `#[derive]`: a derive would demand `K: Copy` /
  `K: Clone` from the `PhantomData<fn() -> K>` field, but `K` is a ZST blueprint
  marker that implements neither. The copy is `State` (already `Copy`), a fn
  pointer, and a `&'static str` — zero new bounds.
- The self-reference is **not a cyclic type** (the template holds a fn pointer +
  pre-resolved state, never the context), so a context can hold a
  `CallbackTemplate<K>` field as plain data.
- No workaround to delete — this is purely additive.

```rust
fn heartbeat(ctx: &mut HeartbeatCtx, mut wheel: ResMut<TimerWheel>, now: Instant) {
    // ... periodic work ...
    if ctx.remaining > 0 {
        let next = ctx.template.generate(HeartbeatCtx {
            template: ctx.template,          // Copy — stays usable
            interval: ctx.interval,
            remaining: ctx.remaining - 1,
        });
        wheel.schedule_forget(now + ctx.interval, Box::new(next));   // re-arm
    }
}
```

## `nexus-rt-derive` — `#[derive(Resource)]` fix

The self-reschedule pattern stores successors in a resource — a timer-wheel slot
`struct Pending(Option<TemplatedCallback<K>>)`, which is **self-referential**.
`#[derive(Resource)]` on that shape **overflowed** `Send` auto-trait resolution.

Cause: the derive emitted an explicit `where Self: Send + 'static` predicate
(for error locality), which forced `Send` to be proven *eagerly*. Fix:

- **Concrete** types rely on the `Resource: Send + 'static` **supertrait** alone
  — it's discharged coinductively (no overflow) and still reports a genuinely
  non-`Send` type at the derive site (verified: the error even points at the
  struct and names the offending field).
- **Generic** types keep the conditional `where Self: Send + 'static` so
  `impl<T> Resource for Foo<T>` applies exactly when `Foo<T>: Send + 'static`
  (an unconditional impl would reject `Foo<Rc<_>>`). Generic behavior unchanged.

## Docs

- `callbacks.md` — new **"Self-Rescheduling Callbacks (Periodic Timers,
  Retries)"** section with the timer example above and the typed-slot note.
- `derives.md` — self-referential resource types + the non-`Send` rejection.
- `templates.md` — pointer to the pattern.
- Rustdoc example on `CallbackTemplate`.

## Tests

| Case | Test |
|------|------|
| Self-reschedule fires N+1 | `template.rs::self_referential_blueprint_reschedules_itself` |
| Template copies w/o `K: Copy` | `template.rs::template_copies_without_requiring_key_copy` |
| Derive on self-referential type | `template.rs` doctest (uses `#[derive(Resource)]`) |
| Concrete non-`Send` rejected | UI `derive_resource_non_send.rs` |
| Generic derive is conditional | `derive_generic_resource.rs` (plain + `where`-clause) |
| Generic non-`Send` instantiation rejected | UI `register_generic_resource_non_send.rs` |

## Follow-up

Filed #679 — infer event-ignoring handlers/callbacks (omit the unused `_: E`
param, common for timers). Separate work.

## Checks

419 lib tests, doctests, UI suite, both crates `clippy --all-features
--all-targets -D warnings` clean, `fmt --check` clean, workspace builds.
CHANGELOGs updated (`nexus-rt` Added, `nexus-rt-derive` Fixed); no version bump.
