### PR TITLE
event-ignoring handlers and callbacks — omit the unused event parameter

### DIFF
--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -24,8 +24,10 @@ contained.
 
   Common for timers (ignore the `Instant`) and event-triggered handlers that only
   read resources. The event is still dispatched and then dropped — zero runtime
-  cost, identical to writing `_: Event`. These are the preferred form; the
-  `no_event` wrapper remains for the `E = ()` case.
+  cost, identical to writing `_: Event`. These are the preferred form. `no_event`
+  / `NoEvent` remain — the `E = ()` shorthand on the raw path, and the
+  template-dispatch mechanism `new_event_ignored` builds on (its `NoEvent<F>`
+  template impls now cover any blueprint `Event`, not just `()`).
 - **Self-referential blueprints — `CallbackTemplate` is now `Copy` / `Clone`.**
   A callback can carry its own template in its context and stamp its own successor
   (a periodic re-arm, a retry timer, any "produce the next me" pattern) through the

--- a/nexus-rt/CHANGELOG.md
+++ b/nexus-rt/CHANGELOG.md
@@ -12,6 +12,20 @@ contained.
 
 ### Added
 
+- **Ignore the event without naming it.** A handler or callback that doesn't use
+  the event can omit the trailing `_: Event` parameter and say so at the build
+  site instead:
+  - Raw handlers: `f.into_handler_event_ignored(reg)` (trait
+    `IntoHandlerIgnoringEvent`) produces a `Handler<E>` that drops the event —
+    for **any** `E`, including borrowed / non-`'static` wire events (the handler
+    stores no `E`, so there's no `'static` bound).
+  - Templates: `HandlerTemplate::new_event_ignored(f, reg)` and
+    `CallbackTemplate::new_event_ignored(f, reg)`.
+
+  Common for timers (ignore the `Instant`) and event-triggered handlers that only
+  read resources. The event is still dispatched and then dropped — zero runtime
+  cost, identical to writing `_: Event`. These are the preferred form; the
+  `no_event` wrapper remains for the `E = ()` case.
 - **Self-referential blueprints — `CallbackTemplate` is now `Copy` / `Clone`.**
   A callback can carry its own template in its context and stamp its own successor
   (a periodic re-arm, a retry timer, any "produce the next me" pattern) through the

--- a/nexus-rt/docs/callbacks.md
+++ b/nexus-rt/docs/callbacks.md
@@ -255,6 +255,20 @@ assert_eq!(callbacks[99].ctx.bytes, 20);
 assert_eq!(world.resource::<SharedState>().total, 30);
 ```
 
+### Ignoring the event
+
+If the callback function doesn't use the event (common for timers — the callback
+fires on a deadline but doesn't need the `Instant`), drop the trailing event
+parameter and build with `new_event_ignored` instead of `new`:
+
+```rust,ignore
+// fn on_fire(ctx: &mut TimerCtx, mut wheel: ResMut<TimerWheel>) { /* no _: Instant */ }
+let template = CallbackTemplate::<OnFire>::new_event_ignored(on_fire, reg);
+```
+
+The blueprint's `Event` (whatever its type) is dropped. Same as
+`into_handler_event_ignored` on the raw handler side.
+
 ## Self-Rescheduling Callbacks (Periodic Timers, Retries)
 
 `CallbackTemplate` is `Copy`, so a callback's **context can carry its own

--- a/nexus-rt/docs/handlers.md
+++ b/nexus-rt/docs/handlers.md
@@ -125,6 +125,40 @@ let mut handler = no_event(check_risk).into_handler(world.registry());
 handler.run(&mut world, ());
 ```
 
+## Ignoring the Event
+
+A handler that only reads resources and doesn't need the event can omit the
+trailing `_: Event` parameter entirely. Build it with
+`into_handler_event_ignored` instead of `into_handler` — the method name says
+"drop the event," so no wrapper or `_` placeholder is needed:
+
+```rust
+use nexus_rt::{Handler, IntoHandlerIgnoringEvent, ResMut, Resource, WorldBuilder};
+use std::time::Instant;
+
+#[derive(Resource)]
+struct Ticks(u64);
+
+fn on_tick(mut t: ResMut<Ticks>) {   // no `_: Instant`
+    t.0 += 1;
+}
+
+let mut wb = WorldBuilder::new();
+wb.register(Ticks(0));
+let mut world = wb.build();
+
+// The event type (here `Instant`) is inferred from where the handler is stored.
+let mut h: Box<dyn Handler<Instant>> =
+    Box::new(on_tick.into_handler_event_ignored(world.registry()));
+h.run(&mut world, Instant::now());   // the Instant is dropped
+assert_eq!(world.resource::<Ticks>().0, 1);
+```
+
+This works for **any** event type, including borrowed / non-`'static` events
+(e.g. a `&[u8]` wire buffer), because the produced handler stores no event. The
+`no_event(f)` wrapper shown above is the shorthand for the special `E = ()` case;
+`into_handler_event_ignored` is the general form.
+
 ## Optional Resources
 
 Handlers can declare optional dependencies that resolve to `None` if the

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -825,6 +825,30 @@ pub trait IntoHandlerIgnoringEvent<Params> {
     fn into_handler_event_ignored(self, registry: &Registry) -> Self::Handler;
 }
 
+// Arity 0: fn() with no params — ignores the event (any E). `all_tuples!` starts
+// at one param, so this arity is hand-written (mirrors the arity-0 no-event path).
+impl<F: FnMut() + Send + 'static> IntoHandlerIgnoringEvent<()> for F {
+    type Handler = IgnoreEventHandler<F, ()>;
+
+    fn into_handler_event_ignored(self, _registry: &Registry) -> Self::Handler {
+        IgnoreEventHandler {
+            f: self,
+            state: <() as Param>::init(_registry),
+            name: std::any::type_name::<F>(),
+        }
+    }
+}
+
+impl<E, F: FnMut() + Send + 'static> Handler<E> for IgnoreEventHandler<F, ()> {
+    fn run(&mut self, _world: &mut World, _event: E) {
+        (self.f)();
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
 macro_rules! impl_into_handler_ignoring_event {
     ($($P:ident),+) => {
         impl<F: Send + 'static, $($P: Param + 'static),+>

--- a/nexus-rt/src/handler.rs
+++ b/nexus-rt/src/handler.rs
@@ -769,6 +769,126 @@ macro_rules! impl_into_handler_no_event {
 all_tuples!(impl_into_handler_no_event);
 
 // =============================================================================
+// IntoHandlerIgnoringEvent — build a handler that drops the event (any E)
+// =============================================================================
+
+/// Handler produced by
+/// [`into_handler_event_ignored`](IntoHandlerIgnoringEvent::into_handler_event_ignored).
+///
+/// Implements [`Handler<E>`] for **every** `E`: it fetches its [`Param`]s,
+/// calls the function, and drops the event. It stores no `E`, so it carries no
+/// event lifetime — borrowed / non-`'static` events (e.g. wire buffers) work.
+pub struct IgnoreEventHandler<F, P: Param> {
+    f: F,
+    state: P::State,
+    name: &'static str,
+}
+
+/// Convert a function that omits the event parameter into a [`Handler<E>`] that
+/// drops the event — for **any** event type `E`.
+///
+/// The event-ignoring counterpart of [`IntoHandler`]. Use it when a handler
+/// reads only resources and doesn't need the event (e.g. a timer handler that
+/// ignores the `Instant`):
+///
+/// ```
+/// use nexus_rt::{Handler, IntoHandlerIgnoringEvent, ResMut, Resource, WorldBuilder};
+///
+/// #[derive(Resource)]
+/// struct Count(u64);
+///
+/// fn on_tick(mut c: ResMut<Count>) {
+///     c.0 += 1;
+/// } // no `_: Event` parameter
+///
+/// let mut wb = WorldBuilder::new();
+/// wb.register(Count(0));
+/// let mut world = wb.build();
+///
+/// // `E` (here `u32`) is inferred from the storage type; the event is dropped.
+/// let mut h: Box<dyn Handler<u32>> =
+///     Box::new(on_tick.into_handler_event_ignored(world.registry()));
+/// h.run(&mut world, 42);
+/// assert_eq!(world.resource::<Count>().0, 1);
+/// ```
+///
+/// This trait is deliberately **not** generic over the event type — that is
+/// what lets the produced handler support non-`'static` events. The method name
+/// is what disambiguates it from the event-taking
+/// [`into_handler`](IntoHandler::into_handler); no wrapper is needed.
+pub trait IntoHandlerIgnoringEvent<Params> {
+    /// The concrete handler type produced.
+    type Handler: Send + 'static;
+
+    /// Build the event-ignoring handler, resolving params from the registry.
+    #[must_use = "the handler must be stored or dispatched — discarding it does nothing"]
+    fn into_handler_event_ignored(self, registry: &Registry) -> Self::Handler;
+}
+
+macro_rules! impl_into_handler_ignoring_event {
+    ($($P:ident),+) => {
+        impl<F: Send + 'static, $($P: Param + 'static),+>
+            IntoHandlerIgnoringEvent<($($P,)+)> for F
+        where
+            for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+        {
+            type Handler = IgnoreEventHandler<F, ($($P,)+)>;
+
+            fn into_handler_event_ignored(self, registry: &Registry) -> Self::Handler {
+                let state = <($($P,)+) as Param>::init(registry);
+                {
+                    #[allow(non_snake_case)]
+                    let ($($P,)+) = &state;
+                    registry.check_access(&[
+                        $(
+                            (<$P as Param>::resource_id($P),
+                             std::any::type_name::<$P>()),
+                        )+
+                    ]);
+                }
+                IgnoreEventHandler {
+                    f: self,
+                    state,
+                    name: std::any::type_name::<F>(),
+                }
+            }
+        }
+
+        impl<E, F: Send + 'static, $($P: Param + 'static),+> Handler<E>
+            for IgnoreEventHandler<F, ($($P,)+)>
+        where
+            for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
+        {
+            #[allow(non_snake_case)]
+            fn run(&mut self, world: &mut World, _event: E) {
+                fn call_inner<$($P),+>(
+                    mut f: impl FnMut($($P),+),
+                    $($P: $P,)+
+                ) {
+                    f($($P),+)
+                }
+
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
+                // SAFETY: state was produced by init() on the same registry that
+                // built this world. Single-threaded sequential dispatch ensures
+                // no mutable aliasing across params.
+                let ($($P,)+) = unsafe {
+                    <($($P,)+) as Param>::fetch(world, &mut self.state)
+                };
+                call_inner(&mut self.f, $($P,)+);
+            }
+
+            fn name(&self) -> &'static str {
+                self.name
+            }
+        }
+    };
+}
+
+all_tuples!(impl_into_handler_ignoring_event);
+
+// =============================================================================
 // Opaque — marker for closures with unresolved dependencies
 // =============================================================================
 

--- a/nexus-rt/src/lib.rs
+++ b/nexus-rt/src/lib.rs
@@ -192,8 +192,8 @@ pub use combinator::{Broadcast, FanOut};
 pub use dag::{BatchDag, Dag, DagBuilder, resolve_arm};
 pub use driver::Installer;
 pub use handler::{
-    CtxFree, Handler, HandlerFn, IntoHandler, Local, NoEvent, Opaque, OpaqueHandler, Param,
-    RegistryRef, Resolved, no_event,
+    CtxFree, Handler, HandlerFn, IgnoreEventHandler, IntoHandler, IntoHandlerIgnoringEvent, Local,
+    NoEvent, Opaque, OpaqueHandler, Param, RegistryRef, Resolved, no_event,
 };
 #[cfg(feature = "reactors")]
 pub use reactor::{

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -554,6 +554,29 @@ where
         }
     }
 
+    /// Create a template from a named function that **ignores the event**.
+    ///
+    /// Like [`new`](Self::new), but `f` omits the trailing event parameter — the
+    /// blueprint's `Event` (whatever its type) is dropped. Use it for a handler
+    /// that reads only resources, e.g. a timer handler that ignores the
+    /// `Instant`:
+    ///
+    /// ```ignore
+    /// fn on_tick(mut c: ResMut<Count>) { c.0 += 1; }         // no `_: Instant`
+    /// let t = HandlerTemplate::<OnTick>::new_event_ignored(on_tick, reg);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Same as [`new`](Self::new).
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_event_ignored<F>(f: F, registry: &Registry) -> Self
+    where
+        NoEvent<F>: TemplateDispatch<K::Params, K::Event>,
+    {
+        Self::new(NoEvent(f), registry)
+    }
+
     /// Stamp out a new handler by copying pre-resolved state.
     #[must_use = "the generated handler must be stored or dispatched"]
     pub fn generate(&self) -> TemplatedHandler<K> {
@@ -753,6 +776,30 @@ where
             name: std::any::type_name::<F>(),
             _key: PhantomData,
         }
+    }
+
+    /// Create a callback template from a named function that **ignores the
+    /// event**.
+    ///
+    /// Like [`new`](Self::new), but `f` omits the trailing event parameter (it
+    /// still takes `&mut Context` and its params) — the blueprint's `Event` is
+    /// dropped. This is the timer / self-rescheduling shape where the callback
+    /// doesn't need the `Instant`:
+    ///
+    /// ```ignore
+    /// fn heartbeat(ctx: &mut HeartbeatCtx, mut wheel: ResMut<TimerWheel>) { /* re-arm */ }
+    /// let cb = CallbackTemplate::<Heartbeat>::new_event_ignored(heartbeat, reg);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Same as [`new`](Self::new).
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_event_ignored<F>(f: F, registry: &Registry) -> Self
+    where
+        NoEvent<F>: CallbackTemplateDispatch<K::Context, K::Params, K::Event>,
+    {
+        Self::new(NoEvent(f), registry)
     }
 
     /// Stamp out a new callback with the given context.
@@ -1226,9 +1273,9 @@ mod tests {
     // -- no_event ignoring a non-unit event (timer shape) ---------------------
 
     #[test]
-    fn no_event_ignores_a_non_unit_event() {
+    fn new_event_ignored_drops_a_non_unit_event() {
         // A blueprint whose Event is `u32`, backed by a function that ignores it
-        // (no trailing `_: u32`). `no_event` drops the event.
+        // (no trailing `_: u32`). `new_event_ignored` drops the event.
         struct OnTick;
         impl Blueprint for OnTick {
             type Event = u32;
@@ -1243,7 +1290,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = HandlerTemplate::<OnTick>::new(no_event(bump), world.registry());
+        let template = HandlerTemplate::<OnTick>::new_event_ignored(bump, world.registry());
         let mut h = template.generate();
         h.run(&mut world, 999u32); // event dropped
         h.run(&mut world, 7u32);
@@ -1251,7 +1298,7 @@ mod tests {
     }
 
     #[test]
-    fn callback_no_event_ignores_a_non_unit_event() {
+    fn callback_new_event_ignored_drops_a_non_unit_event() {
         // The timer shape: a callback template whose Event is non-unit (`u32`,
         // stands in for `Instant`), ignored by the function.
         struct OnTimer;
@@ -1272,7 +1319,7 @@ mod tests {
         builder.register::<u64>(0);
         let mut world = builder.build();
 
-        let template = CallbackTemplate::<OnTimer>::new(no_event(fire), world.registry());
+        let template = CallbackTemplate::<OnTimer>::new_event_ignored(fire, world.registry());
         let mut cb = template.generate(0u64);
         cb.run(&mut world, 42u32); // Instant-like event dropped
         assert_eq!(*cb.ctx(), 1);

--- a/nexus-rt/src/template.rs
+++ b/nexus-rt/src/template.rs
@@ -314,41 +314,47 @@ all_tuples!(impl_template_dispatch);
 
 use crate::handler::NoEvent;
 
-// Arity 0: fn() with no event and no params
-impl<F: FnMut() + Send + 'static> TemplateDispatch<(), ()> for NoEvent<F> {
-    fn run_fn_ptr() -> unsafe fn(&mut (), &mut World, ()) {
+// Arity 0: fn() with no params, ignoring the event (any `E`).
+//
+// `E` is generic (not `()`) so `no_event(f)` also backs a template whose
+// blueprint has a non-unit `Event` — e.g. a timer callback that ignores the
+// `Instant`. The event type is pinned by the blueprint at the `new` call site,
+// so this does not introduce inference ambiguity the way generalizing the plain
+// `IntoHandler` path would.
+impl<E, F: FnMut() + Send + 'static> TemplateDispatch<(), E> for NoEvent<F> {
+    fn run_fn_ptr() -> unsafe fn(&mut (), &mut World, E) {
         /// # Safety
         ///
         /// `F` must be a ZST (enforced by `HandlerTemplate::new`).
-        unsafe fn run<F: FnMut() + Send>(_state: &mut (), _world: &mut World, _event: ()) {
+        unsafe fn run<E, F: FnMut() + Send>(_state: &mut (), _world: &mut World, _event: E) {
             // SAFETY: F is ZST — zeroed() produces the unique value.
             let mut f: F = unsafe { std::mem::zeroed() };
             f();
         }
-        run::<F>
+        run::<E, F>
     }
 
     fn validate(_state: &(), _registry: &Registry) {}
 }
 
-impl<C: Send + 'static, F: FnMut(&mut C) + Send + 'static> CallbackTemplateDispatch<C, (), ()>
+impl<E, C: Send + 'static, F: FnMut(&mut C) + Send + 'static> CallbackTemplateDispatch<C, (), E>
     for NoEvent<F>
 {
-    fn run_fn_ptr() -> unsafe fn(&mut C, &mut (), &mut World, ()) {
+    fn run_fn_ptr() -> unsafe fn(&mut C, &mut (), &mut World, E) {
         /// # Safety
         ///
         /// `F` must be a ZST (enforced by `CallbackTemplate::stamp`).
-        unsafe fn run<C: Send, F: FnMut(&mut C) + Send>(
+        unsafe fn run<E, C: Send, F: FnMut(&mut C) + Send>(
             ctx: &mut C,
             _state: &mut (),
             _world: &mut World,
-            _event: (),
+            _event: E,
         ) {
             // SAFETY: F is ZST — zeroed() produces the unique value.
             let mut f: F = unsafe { std::mem::zeroed() };
             f(ctx);
         }
-        run::<C, F>
+        run::<E, C, F>
     }
 
     fn validate(_state: &(), _registry: &Registry) {}
@@ -357,22 +363,22 @@ impl<C: Send + 'static, F: FnMut(&mut C) + Send + 'static> CallbackTemplateDispa
 // Arities 1-8: fn(Params...) with no event
 macro_rules! impl_template_dispatch_no_event {
     ($($P:ident),+) => {
-        impl<F: Send + 'static, $($P: Param + 'static),+> TemplateDispatch<($($P,)+), ()>
+        impl<E, F: Send + 'static, $($P: Param + 'static),+> TemplateDispatch<($($P,)+), E>
             for NoEvent<F>
         where
             for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
         {
-            fn run_fn_ptr() -> unsafe fn(&mut ($($P::State,)+), &mut World, ()) {
+            fn run_fn_ptr() -> unsafe fn(&mut ($($P::State,)+), &mut World, E) {
                 /// # Safety
                 ///
                 /// - `F` must be a ZST (enforced by `HandlerTemplate::new`).
                 /// - `state` must have been produced by `Param::init` on the
                 ///   same registry that built `world`.
                 #[allow(non_snake_case)]
-                unsafe fn run<F: Send + 'static, $($P: Param + 'static),+>(
+                unsafe fn run<E, F: Send + 'static, $($P: Param + 'static),+>(
                     state: &mut ($($P::State,)+),
                     world: &mut World,
-                    _event: (),
+                    _event: E,
                 ) where
                     for<'a> &'a mut F: FnMut($($P,)+) + FnMut($($P::Item<'a>,)+),
                 {
@@ -394,7 +400,7 @@ macro_rules! impl_template_dispatch_no_event {
                     let mut f: F = unsafe { std::mem::zeroed() };
                     call_inner(&mut f, $($P,)+);
                 }
-                run::<F, $($P),+>
+                run::<E, F, $($P),+>
             }
 
             #[allow(non_snake_case)]
@@ -406,20 +412,20 @@ macro_rules! impl_template_dispatch_no_event {
             }
         }
 
-        impl<C: Send + 'static, F: Send + 'static, $($P: Param + 'static),+>
-            CallbackTemplateDispatch<C, ($($P,)+), ()> for NoEvent<F>
+        impl<E, C: Send + 'static, F: Send + 'static, $($P: Param + 'static),+>
+            CallbackTemplateDispatch<C, ($($P,)+), E> for NoEvent<F>
         where
             for<'a> &'a mut F:
                 FnMut(&mut C, $($P,)+) +
                 FnMut(&mut C, $($P::Item<'a>,)+),
         {
-            fn run_fn_ptr() -> unsafe fn(&mut C, &mut ($($P::State,)+), &mut World, ()) {
+            fn run_fn_ptr() -> unsafe fn(&mut C, &mut ($($P::State,)+), &mut World, E) {
                 #[allow(non_snake_case)]
-                unsafe fn run<C: Send, F: Send + 'static, $($P: Param + 'static),+>(
+                unsafe fn run<E, C: Send, F: Send + 'static, $($P: Param + 'static),+>(
                     ctx: &mut C,
                     state: &mut ($($P::State,)+),
                     world: &mut World,
-                    _event: (),
+                    _event: E,
                 ) where
                     for<'a> &'a mut F:
                         FnMut(&mut C, $($P,)+) +
@@ -445,7 +451,7 @@ macro_rules! impl_template_dispatch_no_event {
                     let mut f: F = unsafe { std::mem::zeroed() };
                     call_inner(&mut f, ctx, $($P,)+);
                 }
-                run::<C, F, $($P),+>
+                run::<E, C, F, $($P),+>
             }
 
             #[allow(non_snake_case)]
@@ -1215,6 +1221,62 @@ mod tests {
         let a = template; // copy
         let b = template; // copy again — only compiles if `Copy`
         let _ = (a, b, template);
+    }
+
+    // -- no_event ignoring a non-unit event (timer shape) ---------------------
+
+    #[test]
+    fn no_event_ignores_a_non_unit_event() {
+        // A blueprint whose Event is `u32`, backed by a function that ignores it
+        // (no trailing `_: u32`). `no_event` drops the event.
+        struct OnTick;
+        impl Blueprint for OnTick {
+            type Event = u32;
+            type Params = (ResMut<'static, u64>,);
+        }
+
+        fn bump(mut counter: ResMut<u64>) {
+            *counter += 1;
+        }
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let template = HandlerTemplate::<OnTick>::new(no_event(bump), world.registry());
+        let mut h = template.generate();
+        h.run(&mut world, 999u32); // event dropped
+        h.run(&mut world, 7u32);
+        assert_eq!(*world.resource::<u64>(), 2);
+    }
+
+    #[test]
+    fn callback_no_event_ignores_a_non_unit_event() {
+        // The timer shape: a callback template whose Event is non-unit (`u32`,
+        // stands in for `Instant`), ignored by the function.
+        struct OnTimer;
+        impl Blueprint for OnTimer {
+            type Event = u32;
+            type Params = (ResMut<'static, u64>,);
+        }
+        impl CallbackBlueprint for OnTimer {
+            type Context = u64; // per-instance fire count
+        }
+
+        fn fire(fires: &mut u64, mut total: ResMut<u64>) {
+            *fires += 1;
+            *total += 10;
+        }
+
+        let mut builder = WorldBuilder::new();
+        builder.register::<u64>(0);
+        let mut world = builder.build();
+
+        let template = CallbackTemplate::<OnTimer>::new(no_event(fire), world.registry());
+        let mut cb = template.generate(0u64);
+        cb.run(&mut world, 42u32); // Instant-like event dropped
+        assert_eq!(*cb.ctx(), 1);
+        assert_eq!(*world.resource::<u64>(), 10);
     }
 
     // -- Convenience macros ---------------------------------------------------

--- a/nexus-rt/tests/ignore_event_handler.rs
+++ b/nexus-rt/tests/ignore_event_handler.rs
@@ -1,0 +1,53 @@
+//! The E-agnostic ignore-event raw handler path: `f.into_handler_event_ignored`
+//! drops the event for ANY E, including borrowed/non-'static events.
+use nexus_rt::{Handler, IntoHandlerIgnoringEvent, Res, ResMut, Resource, WorldBuilder};
+
+#[derive(Resource)]
+struct Count(u64);
+#[derive(Resource)]
+struct Name(&'static str);
+
+fn bump(mut c: ResMut<Count>) {
+    c.0 += 1;
+}
+
+fn bump_named(name: Res<Name>, mut c: ResMut<Count>) {
+    let _ = name.0;
+    c.0 += 1;
+}
+
+#[test]
+fn drops_owned_event() {
+    let mut wb = WorldBuilder::new();
+    wb.register(Count(0));
+    let mut world = wb.build();
+
+    // E = u32 inferred from the Box<dyn Handler<u32>>; event dropped.
+    let mut h: Box<dyn Handler<u32>> = Box::new(bump.into_handler_event_ignored(world.registry()));
+    h.run(&mut world, 999);
+    h.run(&mut world, 7);
+    assert_eq!(world.resource::<Count>().0, 2);
+}
+
+#[test]
+fn drops_borrowed_nonstatic_event() {
+    let mut wb = WorldBuilder::new();
+    wb.register(Count(0));
+    wb.register(Name("wire"));
+    let mut world = wb.build();
+
+    // The event is a BORROWED slice — NOT 'static. This is the wire-buffer case.
+    fn run_with_borrowed<'a>(
+        world: &mut nexus_rt::World,
+        h: &mut dyn Handler<&'a [u8]>,
+        buf: &'a [u8],
+    ) {
+        h.run(world, buf);
+    }
+
+    let mut h = bump_named.into_handler_event_ignored(world.registry());
+    let data = vec![1u8, 2, 3];
+    run_with_borrowed(&mut world, &mut h, &data);
+    run_with_borrowed(&mut world, &mut h, &data);
+    assert_eq!(world.resource::<Count>().0, 2);
+}

--- a/nexus-rt/tests/ignore_event_handler.rs
+++ b/nexus-rt/tests/ignore_event_handler.rs
@@ -51,3 +51,25 @@ fn drops_borrowed_nonstatic_event() {
     run_with_borrowed(&mut world, &mut h, &data);
     assert_eq!(world.resource::<Count>().0, 2);
 }
+
+// Arity-0: a `fn()` (no params, no event) ignoring the event. Guards the
+// hand-written arity-0 impl (all_tuples! starts at 1 param).
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static ARITY0_FIRES: AtomicU64 = AtomicU64::new(0);
+
+fn arity0_tick() {
+    ARITY0_FIRES.fetch_add(1, Ordering::Relaxed);
+}
+
+#[test]
+fn drops_event_arity_0() {
+    let wb = WorldBuilder::new();
+    let mut world = wb.build();
+
+    let mut h: Box<dyn Handler<u32>> =
+        Box::new(arity0_tick.into_handler_event_ignored(world.registry()));
+    h.run(&mut world, 5);
+    h.run(&mut world, 9);
+    assert_eq!(ARITY0_FIRES.load(Ordering::Relaxed), 2);
+}


### PR DESCRIPTION
Lets a handler or callback that doesn't use the event **omit the trailing
`_: Event` parameter**, saying so at the build site instead. Closes #679.

```rust
// before — the _: Instant you don't want:
fn on_tick(mut t: ResMut<Ticks>, _now: Instant) { t.0 += 1; }
let h: Box<dyn Handler<Instant>> = Box::new(on_tick.into_handler(reg));

// after — clean signature, intent at the call site:
fn on_tick(mut t: ResMut<Ticks>) { t.0 += 1; }
let h: Box<dyn Handler<Instant>> = Box::new(on_tick.into_handler_event_ignored(reg));
```

## Surfaces

- **Raw handlers** — `f.into_handler_event_ignored(reg)`, via a new
  `IntoHandlerIgnoringEvent` trait + `IgnoreEventHandler`.
- **Templates** — `HandlerTemplate::new_event_ignored(f, reg)` and
  `CallbackTemplate::new_event_ignored(f, reg)` (the timer / self-reschedule
  shape). These are thin wrappers over the existing `NoEvent` template dispatch.

The event is still dispatched and then dropped — **zero runtime cost**, identical
to writing `_: Event` today.

## Why it's shaped this way (the design that survived contact with the type system)

Three approaches were tried; the notes are worth keeping for the next person:

1. **Generalize `no_event` in place (`E=()` → any `E`)** — breaks: the handler
   type doesn't carry `E`, so generalizing leaves `E` a free selector with
   nothing to bind → `type annotations needed` at ~13 existing sites.
2. **E-carrying handler** (phantom `E` so it binds from storage) — works, but
   `IntoHandler::Handler: 'static` forces **`E: 'static`**, which rules out
   borrowed wire-buffer events. Dealbreaker.
3. **E-agnostic handler** (impls `Handler<E>` for *all* `E`, stores no `E`) —
   what shipped. No `'static` bound, so borrowed `&[u8]` events work. It can't be
   produced by the E-generic `into_handler` (that's what goes ambiguous), so it
   needs its own non-E-generic entry point — hence a **method** (`_event_ignored`)
   rather than a wrapper. The method name is the disambiguator; no wrapper needed.

Coherence: `IntoHandlerIgnoringEvent` is a separate trait (only the ignore shape,
so no overlap with the event-taking `IntoHandler`), and the `Handler<E> for all E`
blanket is per-Self, so nothing conflicts. No hot-path or event-taking machinery
is touched.

## Tests

- `tests/ignore_event_handler.rs` — raw path drops an owned event **and a borrowed
  `&'a [u8]` (non-`'static`) event**; `E` inferred from the storage type, no
  annotation.
- `template.rs` — `new_event_ignored` drops a non-unit (`u32`) event for both
  `HandlerTemplate` and `CallbackTemplate`.
- A compiling rustdoc example on `IntoHandlerIgnoringEvent`.

## Docs

- `handlers.md` "Ignoring the Event", a `callbacks.md` note, CHANGELOG entry.

## Notes

- `no_event`/`NoEvent` are kept — they're the `E=()` shorthand and the internal
  engine behind the template constructors. Deprecating direct `no_event` usage in
  favor of `_event_ignored` (a ~48-caller migration) is a separate follow-up, not
  needed here.
- No version bump (release-time).

## Checks

421 lib tests, doctests, the borrowed-event test — all pass. `clippy
--all-features --all-targets -D warnings`, rustdoc intra-doc links, `fmt --check`
clean. `cargo build --workspace --all-targets` clean (new public API breaks no
downstream crate).
