### PR TITLE
fix(nexus-platform): remove Sync from Mapping

### DIFF
--- a/nexus-platform/src/mapping/mod.rs
+++ b/nexus-platform/src/mapping/mod.rs
@@ -267,12 +267,22 @@ impl Drop for Mapping {
     }
 }
 
-// SAFETY: the mapping is a raw pointer plus its backing fd. The bytes
-// live in kernel-managed memory (file-backed or shared), not thread-local
-// state. Concurrent access to the mapped contents must be synchronized
-// by the caller — the handle itself is safe to move across threads.
+// SAFETY: a Mapping is a raw pointer plus its backing fd. Moving the handle to
+// another thread is safe because the mapped bytes live in kernel-managed memory,
+// not thread-local storage.
+//
+// Sync is NOT implemented. as_ptr, as_slice, read_at, and write_at all take
+// &self and touch the mapped bytes directly. Shared cross-thread access through
+// an Arc<Mapping> would therefore be a data race in safe code. Callers that
+// genuinely need to read or write the mapping from a second thread (e.g.
+// conductor.rs prefault) are already unsafe fn with their own exclusivity
+// invariants; they do not rely on Mapping: Sync.
+//
+// Note: as_ptr returns *mut u8 from &self. Splitting that into a const getter
+// (&self -> *const u8) and a mut getter (&mut self -> *mut u8) would make the
+// surface stricter, but conductor.rs holds &Mapping (not &mut), so that change
+// needs its own design decision. Tracked in #664.
 unsafe impl Send for Mapping {}
-unsafe impl Sync for Mapping {}
 
 // ── POSIX shared memory (forwarded to platform backend) ──────────
 
@@ -294,4 +304,19 @@ pub(crate) fn fd_size(fd: &OwnedFd) -> Result<u64, MapError> {
 
 pub(crate) fn ftruncate(fd: &OwnedFd, len: u64) -> Result<(), MapError> {
     imp::ftruncate(fd, len)
+}
+
+#[cfg(test)]
+mod trait_bounds {
+    use super::Mapping;
+
+    // Mapping must be Send (ownership transfer across threads is safe).
+    // Mapping must NOT be Sync (as_ptr/as_slice/read_at/write_at all take &self
+    // and touch the mapped bytes, so shared cross-thread access is a data race).
+    // Asserting !Sync requires trybuild compile-fail coverage; the crate has no
+    // trybuild setup, so only the positive Send bound is asserted here.
+    fn _assert_mapping_is_send() {
+        fn check<T: Send>() {}
+        check::<Mapping>();
+    }
 }


### PR DESCRIPTION
## Problem

`Mapping` implements both `Send` and `Sync`. With `Sync`, safe code can put a
`Mapping` inside an `Arc`, share it across threads, and cause data races:

- `write_at(&self, ...)` writes through a raw pointer into the mapped bytes
- `read_at(&self, ...)` reads from the same region
- `as_slice(&self)` hands out `&[u8]` over memory another thread can write

Any two of these (or two `write_at` calls) running concurrently on the same
`Mapping` via `Arc<Mapping>` is a data race and undefined behavior. No `unsafe`
block is required from the caller.

## Fix

Remove `unsafe impl Sync for Mapping {}`. Keep `unsafe impl Send for Mapping {}`.

`Send` is correct: moving ownership of a `Mapping` to another thread is safe.
The mapped bytes live in kernel-managed memory, not thread-local storage.

`Sync` is not correct: sharing `&Mapping` across threads allows concurrent
mutation through safe API methods, which is a data race.

## Call-site impact: none

Every production call site either:
- owns the `Mapping` outright (rotating/mod.rs construction paths, shm
  construction paths), or
- holds `&mut self` exclusivity on the outer struct (Writer, Reader), or
- is already `unsafe fn` with its own documented exclusivity invariant
  (conductor.rs `prefault`, which is gated on SWAP_PENDING state and does
  not rely on `Mapping: Sync` for its correctness).

`Segment` in nexus-shm becomes `!Sync` automatically (it had no explicit impl).
`SegmentSwap` is unaffected (it has `unsafe impl Sync for SegmentSwap {}` backed
by its own `UnsafeCell` state machine). `ReadRange` in nexus-journal becomes
`!Send` automatically, which is correct (it is a single-threaded borrowing
iterator).

## Regression guard

A `_assert_mapping_is_send` check is added in `#[cfg(test)]` in `mapping/mod.rs`
to keep the `Send` impl explicit. A `!Sync` negative assertion requires trybuild;
the crate has no trybuild setup and no new dev-dependency was added.

## Follow-on (out of scope)

`as_ptr(&self) -> *mut u8` returns a mutable pointer from a shared reference.
Splitting it into `as_ptr(&self) -> *const u8` and `as_mut_ptr(&mut self) ->
*mut u8` would make the surface stricter, but `conductor.rs::prefault` holds
`&Mapping` (not `&mut`), so that change requires its own design decision.
Tracked in #664.

Closes #664.

## Clippy note

`cargo clippy --all-targets` is clean on 1.94.0, which is what CI pins. On 1.96.0 a `manual_checked_ops` error fires in `nexus-journal/examples/rotating_tail.rs:210` on clean upstream main as well, so it is unrelated to this branch.
