### PR TITLE
test(nexus-pool): address review nits from #690

### DIFF
--- a/nexus-pool/src/local.rs
+++ b/nexus-pool/src/local.rs
@@ -699,6 +699,22 @@ mod proptests {
         ]
     }
 
+    /// Operation against a `BoundedPool<u64>`.
+    #[derive(Debug, Clone)]
+    enum BoundedOp {
+        /// `try_acquire()` — succeeds unless the pool is exhausted.
+        TryAcquire,
+        /// Drop an RAII guard (from `TryAcquire`) at `idx`.
+        DropGuard { idx: usize },
+    }
+
+    fn bounded_op_strategy() -> impl Strategy<Value = BoundedOp> {
+        prop_oneof![
+            Just(BoundedOp::TryAcquire),
+            any::<usize>().prop_map(|idx| BoundedOp::DropGuard { idx }),
+        ]
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(1000))]
 
@@ -708,7 +724,10 @@ mod proptests {
         /// sitting in the pool's available stack or checked out by the test
         /// (as a manual value or an RAII guard). Invariant:
         /// `pool.available() + outstanding == n_created` after every
-        /// operation — catches leaks, double-returns, and phantom creation.
+        /// operation — catches leaks and double-returns. (Over-acquisition
+        /// isn't meaningful here: the growable pool may legitimately create
+        /// a fresh object instead of reusing one, and the invariant holds
+        /// either way — that case is `BoundedPool`'s job, below.)
         #[test]
         fn fuzz_take_put_acquire_drop(ops in proptest::collection::vec(op_strategy(), 1..300)) {
             let created = Rc::new(Cell::new(0u64));
@@ -803,21 +822,5 @@ mod proptests {
                 prop_assert_eq!(pool.available() + guards.len(), capacity);
             }
         }
-    }
-
-    /// Operation against a `BoundedPool<u64>`.
-    #[derive(Debug, Clone)]
-    enum BoundedOp {
-        /// `try_acquire()` — succeeds unless the pool is exhausted.
-        TryAcquire,
-        /// Drop an RAII guard (from `TryAcquire`) at `idx`.
-        DropGuard { idx: usize },
-    }
-
-    fn bounded_op_strategy() -> impl Strategy<Value = BoundedOp> {
-        prop_oneof![
-            Just(BoundedOp::TryAcquire),
-            any::<usize>().prop_map(|idx| BoundedOp::DropGuard { idx }),
-        ]
     }
 }


### PR DESCRIPTION
Follow-up to #690, addressing the two non-blocking nits from review:

1. The doc comment on fuzz_take_put_acquire_drop claimed the invariant
   catches "leaks, double-returns, and phantom creation." That last
   part isn't true: for the growable Pool, creating a brand new object
   instead of reusing an old one is normal and allowed, so the
   available() and outstanding equation still balances either way. The
   test genuinely can't catch a "created when it should have reused"
   bug, since the numbers add up regardless. Tightened the comment to
   only claim what the test actually checks (leaks and
   double-returns), and pointed to fuzz_bounded_try_acquire_drop as
   the place that does check over-acquisition, since BoundedPool has a
   fixed capacity where that concept applies.

2. Op (the list of possible test actions for Pool) was defined above
   the proptest! block that uses it, but BoundedOp (the same idea for
   BoundedPool) was defined below the block that uses it. Same kind of
   helper, two different spots for no real reason. Both worked fine
   either way, this is a "pick one style and be consistent" cleanup:
   moved BoundedOp/bounded_op_strategy up to match Op/op_strategy's
   placement.

No behavioral change, test logic and coverage are unchanged.