### PR TITLE
docs(nexus-ascii): add SAFETY comments to undocumented unsafe blocks in SIMD hash

### DIFF
--- a/nexus-ascii/src/hash/xxh3_avx2.rs
+++ b/nexus-ascii/src/hash/xxh3_avx2.rs
@@ -28,7 +28,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
     // Large input - use AVX2
     #[cfg(target_arch = "x86_64")]
     {
-        // Safety: This module only compiles when target_feature = "avx2"
+        // SAFETY: This module only compiles when target_feature = "avx2"
         unsafe { hash_long_avx2(data, seed) }
     }
 
@@ -41,6 +41,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn hash_long_avx2(data: &[u8], seed: u64) -> u64 {
+    // SAFETY: #[target_feature(enable = "avx2")] on this function guarantees AVX2 is available.
     unsafe {
         let len = data.len();
 
@@ -114,6 +115,7 @@ unsafe fn accumulate_stripe_avx2(
     stripe: *const u8,
     secret_offset: usize,
 ) {
+    // SAFETY: #[target_feature(enable = "avx2")] on this function guarantees AVX2 is available.
     unsafe {
         let secret_ptr = SECRET.as_ptr().add(secret_offset);
 
@@ -150,6 +152,7 @@ unsafe fn accumulate_stripe_avx2(
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn scramble_acc_avx2(acc0: &mut __m256i, acc1: &mut __m256i) {
+    // SAFETY: #[target_feature(enable = "avx2")] on this function guarantees AVX2 is available.
     unsafe {
         let prime = _mm256_set1_epi32(PRIME32_1 as i32);
         let secret_ptr = SECRET.as_ptr().add(128);

--- a/nexus-ascii/src/hash/xxh3_avx512.rs
+++ b/nexus-ascii/src/hash/xxh3_avx512.rs
@@ -33,7 +33,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
     // Large input - use AVX-512
     #[cfg(target_arch = "x86_64")]
     {
-        // Safety: This module only compiles when target_feature = "avx512f"
+        // SAFETY: This module only compiles when target_feature = "avx512f"
         unsafe { hash_long_avx512(data, seed) }
     }
 
@@ -46,6 +46,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f")]
 unsafe fn hash_long_avx512(data: &[u8], seed: u64) -> u64 {
+    // SAFETY: #[target_feature(enable = "avx512f")] on this function guarantees AVX-512 is available.
     unsafe {
         let len = data.len();
 
@@ -123,6 +124,7 @@ unsafe fn accumulate_stripe_avx512(
     stripe: *const u8,
     secret_offset: usize,
 ) -> __m512i {
+    // SAFETY: #[target_feature(enable = "avx512f")] on this function guarantees AVX-512 is available.
     unsafe {
         let secret_ptr = SECRET.as_ptr().add(secret_offset);
 
@@ -152,6 +154,7 @@ unsafe fn accumulate_stripe_avx512(
 #[inline]
 #[target_feature(enable = "avx512f")]
 unsafe fn scramble_acc_avx512(acc: __m512i) -> __m512i {
+    // SAFETY: #[target_feature(enable = "avx512f")] on this function guarantees AVX-512 is available.
     unsafe {
         let prime = _mm512_set1_epi32(PRIME32_1 as i32);
         let secret_ptr = SECRET.as_ptr().add(128);

--- a/nexus-ascii/src/hash/xxh3_sse2.rs
+++ b/nexus-ascii/src/hash/xxh3_sse2.rs
@@ -27,7 +27,7 @@ pub fn hash_bounded_with_seed<const CAP: usize>(data: &[u8], seed: u64) -> u64 {
     // Large input - use SSE2
     #[cfg(target_arch = "x86_64")]
     {
-        // Safety: SSE2 is always available on x86_64
+        // SAFETY: SSE2 is always available on x86_64
         unsafe { hash_long_sse2(data, seed) }
     }
 


### PR DESCRIPTION
Three SIMD hash files had undocumented `unsafe` blocks under the workspace `undocumented_unsafe_blocks` lint enabled in #661.

**`src/hash/xxh3_avx2.rs`, `xxh3_avx512.rs`, `xxh3_sse2.rs`** (dispatch sites): comments read `// Safety:` (lowercase) rather than `// SAFETY:`; corrected the casing so the lint recognises them.

**`xxh3_avx2.rs`, `xxh3_avx512.rs`** (function bodies): each `unsafe fn` opened an inner `unsafe {}` block for the SIMD intrinsics without a preceding `// SAFETY:`; added one noting that the `#[target_feature]` attribute on the enclosing function guarantees the CPU feature is available.