### PR TITLE
docs(nexus-rt): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-rt/examples/mio_timer.rs
+++ b/nexus-rt/examples/mio_timer.rs
@@ -35,6 +35,7 @@ use nexus_rt::{
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; guarded by #[cfg(target_arch = "x86_64")].
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -44,6 +45,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; guarded by #[cfg(target_arch = "x86_64")].
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/examples/perf_reactors.rs
+++ b/nexus-rt/examples/perf_reactors.rs
@@ -32,6 +32,7 @@ nexus_rt::new_resource!(Out(u64));
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; guarded by #[cfg(target_arch = "x86_64")].
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -41,6 +42,7 @@ fn rdtsc_start() -> u64 {
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; guarded by #[cfg(target_arch = "x86_64")].
     unsafe {
         let mut aux = 0u32;
         let tsc = core::arch::x86_64::__rdtscp(&raw mut aux);

--- a/nexus-rt/src/reactor.rs
+++ b/nexus-rt/src/reactor.rs
@@ -1089,6 +1089,7 @@ mod tests {
     // same pattern as production dispatch code.
     #[allow(clippy::mut_from_ref)]
     fn notify_mut(world: &World, id: ResourceId) -> &mut ReactorNotify {
+        // SAFETY: id is a ResourceId for a ReactorNotify registered in this World; no concurrent alias at this call site.
         unsafe { world.get_mut::<ReactorNotify>(id) }
     }
 

--- a/nexus-rt/src/reactor.rs
+++ b/nexus-rt/src/reactor.rs
@@ -665,11 +665,11 @@ macro_rules! impl_into_reactor {
                     f(ctx, $($P,)+);
                 }
 
+                #[cfg(debug_assertions)]
+                world.clear_borrows();
                 // SAFETY: state was produced by Param::init() on the same
                 // Registry that built this World. Single-threaded sequential
                 // dispatch ensures no mutable aliasing across params.
-                #[cfg(debug_assertions)]
-                world.clear_borrows();
                 let ($($P,)+) = unsafe {
                     <($($P,)+) as Param>::fetch(world, &mut self.state)
                 };
@@ -905,6 +905,8 @@ impl ReactorSystem {
 
         // Poll — scoped &mut, dropped before reactor dispatch.
         {
+            // SAFETY: notify_ptr is valid for World's lifetime. Scoped &mut
+            // is dropped before reactor dispatch begins.
             let notify = unsafe { &mut *notify_ptr };
             notify.poll(&mut self.events);
         }
@@ -914,9 +916,9 @@ impl ReactorSystem {
         // &mut ReactorNotify is scoped tightly to avoid aliasing during run().
         for token in self.events.drain() {
             let idx = token.index();
-            // SAFETY: notify_ptr is valid for World's lifetime. Scoped &mut
-            // is dropped before reactor.run() to avoid aliasing.
             let reactor = {
+                // SAFETY: notify_ptr is valid for World's lifetime. Scoped &mut
+                // is dropped before reactor.run() to avoid aliasing.
                 let notify = unsafe { &mut *notify_ptr };
                 notify.take_reactor(idx)
             };
@@ -942,6 +944,7 @@ impl ReactorSystem {
             }
         }
         // Put the (now empty) Vec back for reuse.
+        // SAFETY: removals_id from same WorldBuilder. All dispatch and cleanup complete.
         let removals = unsafe { world.get_mut::<DeferredRemovals>(self.removals_id) };
         removals.put(pending);
 
@@ -1089,7 +1092,8 @@ mod tests {
     // same pattern as production dispatch code.
     #[allow(clippy::mut_from_ref)]
     fn notify_mut(world: &World, id: ResourceId) -> &mut ReactorNotify {
-        // SAFETY: id is a ResourceId for a ReactorNotify registered in this World; no concurrent alias at this call site.
+        // SAFETY: id is a ResourceId for a ReactorNotify registered in this World;
+        // single-threaded sequential dispatch ensures no mutable aliasing.
         unsafe { world.get_mut::<ReactorNotify>(id) }
     }
 

--- a/nexus-rt/tests/compile_tests.rs
+++ b/nexus-rt/tests/compile_tests.rs
@@ -5036,6 +5036,7 @@ mod reactors {
     /// with world.registry(). Same pattern as ReactorSystem::dispatch.
     #[allow(clippy::mut_from_ref)]
     fn notify_mut(world: &World, id: ResourceId) -> &mut ReactorNotify {
+        // SAFETY: id is a ResourceId for a ReactorNotify registered in this World; no concurrent alias at this call site.
         unsafe { world.get_mut::<ReactorNotify>(id) }
     }
 


### PR DESCRIPTION
6 undocumented `unsafe {}` blocks across 4 files.

- `examples/mio_timer.rs`, `examples/perf_reactors.rs`: `rdtsc_start` and `rdtsc_end` use x86_64 intrinsics; both functions are guarded by `#[cfg(target_arch = "x86_64")]`.
- `src/reactor.rs`, `tests/compile_tests.rs`: `world.get_mut::<ReactorNotify>(id)` -- id is a registered ResourceId with no concurrent alias at the call site.