### PR TITLE
docs(nexus-inference): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-inference/src/kernel/activate.rs
+++ b/nexus-inference/src/kernel/activate.rs
@@ -126,6 +126,7 @@ pub(crate) mod simd {
     /// Caller must run on a target with AVX2 and FMA enabled.
     #[inline(always)]
     pub(crate) unsafe fn tanh_8wide(x: __m256) -> __m256 {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe {
             let nan_mask = _mm256_cmp_ps(x, x, _CMP_UNORD_Q);
 
@@ -155,6 +156,7 @@ pub(crate) mod simd {
     /// Caller must run on a target with AVX2 and FMA enabled.
     #[inline(always)]
     pub(crate) unsafe fn sigmoid_8wide(x: __m256) -> __m256 {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe {
             let half = _mm256_set1_ps(0.5);
             let t = tanh_8wide(_mm256_mul_ps(x, half));
@@ -168,6 +170,7 @@ pub(crate) mod simd {
     /// Caller must run on a target with AVX2 and FMA enabled.
     #[inline(always)]
     pub(crate) unsafe fn swish_8wide(x: __m256) -> __m256 {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe { _mm256_mul_ps(x, sigmoid_8wide(x)) }
     }
 
@@ -177,6 +180,7 @@ pub(crate) mod simd {
     /// Caller must run on a target with AVX2 and FMA enabled.
     #[inline(always)]
     pub(crate) unsafe fn gelu_8wide(x: __m256) -> __m256 {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe {
             let half = _mm256_set1_ps(0.5);
             let coeff = _mm256_set1_ps(0.044_715);
@@ -205,6 +209,7 @@ pub(crate) mod simd {
         v: __m256,
         activation: crate::Activation,
     ) -> Option<__m256> {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe {
             Some(match activation {
                 crate::Activation::Relu => _mm256_max_ps(v, _mm256_setzero_ps()),
@@ -233,6 +238,7 @@ pub(crate) mod simd {
         v: __m128,
         activation: crate::Activation,
     ) -> Option<__m128> {
+        // SAFETY: caller guarantees AVX2 and FMA (safety contract on this fn).
         unsafe {
             Some(match activation {
                 crate::Activation::Relu => _mm_max_ps(v, _mm_setzero_ps()),
@@ -263,6 +269,7 @@ pub(crate) mod simd512 {
     /// Caller must run on a target with AVX-512F enabled.
     #[inline(always)]
     pub(crate) unsafe fn tanh_16wide(x: __m512) -> __m512 {
+        // SAFETY: caller guarantees AVX-512F (safety contract on this fn).
         unsafe {
             let nan_mask = _mm512_cmp_ps_mask::<_CMP_UNORD_Q>(x, x);
 
@@ -292,6 +299,7 @@ pub(crate) mod simd512 {
     /// Caller must run on a target with AVX-512F enabled.
     #[inline(always)]
     pub(crate) unsafe fn sigmoid_16wide(x: __m512) -> __m512 {
+        // SAFETY: caller guarantees AVX-512F (safety contract on this fn).
         unsafe {
             let half = _mm512_set1_ps(0.5);
             let t = tanh_16wide(_mm512_mul_ps(x, half));

--- a/nexus-inference/src/kernel/binary.rs
+++ b/nexus-inference/src/kernel/binary.rs
@@ -47,6 +47,7 @@ pub(crate) fn matvec_bias_binarize(
     debug_assert_eq!(out_size, wpr * 64);
     debug_assert_eq!(bits.len(), wpr);
 
+    // SAFETY: cfg guarantees AVX2+FMA or AVX-512F; all pointer offsets stay within weight/input/bias slice bounds.
     unsafe {
         for word_idx in 0..wpr {
             let base = word_idx * 64;
@@ -123,6 +124,7 @@ pub(crate) fn output_from_bits(
 #[inline(never)]
 pub(crate) fn output_from_bits_simd(weights: &[f32], bits: &[u64], row_sum: f32, bias: f32) -> f32 {
     use core::arch::x86_64::*;
+    // SAFETY: cfg guarantees AVX2+FMA or AVX-512F; all pointer offsets stay within weights slice bounds.
     unsafe {
         let bit_positions = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
         let mut acc = _mm256_setzero_ps();

--- a/nexus-inference/src/kernel/dot/avx2.rs
+++ b/nexus-inference/src/kernel/dot/avx2.rs
@@ -10,6 +10,7 @@ use super::scalar;
 #[inline]
 #[cfg(target_arch = "x86_64")]
 unsafe fn hsum_f32(v: __m256) -> f32 {
+    // SAFETY: caller guarantees AVX2 (safety contract on this fn).
     unsafe {
         let hi = _mm256_extractf128_ps(v, 1);
         let lo = _mm256_castps256_ps128(v);

--- a/nexus-inference/src/kernel/dot/avx512.rs
+++ b/nexus-inference/src/kernel/dot/avx512.rs
@@ -10,6 +10,7 @@ use super::scalar;
 #[inline]
 #[cfg(target_arch = "x86_64")]
 unsafe fn hsum_f32(v: __m512) -> f32 {
+    // SAFETY: caller guarantees AVX-512F (safety contract on this fn).
     unsafe {
         let lo = _mm512_castps512_ps256(v);
         let hi = _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(v), 1));

--- a/nexus-inference/src/kernel/mlp.rs
+++ b/nexus-inference/src/kernel/mlp.rs
@@ -126,6 +126,7 @@ pub(crate) fn layer_norm(
 #[inline(always)]
 pub(crate) unsafe fn hsum256(v: core::arch::x86_64::__m256) -> f32 {
     use core::arch::x86_64::*;
+    // SAFETY: caller guarantees AVX2 (safety contract on this fn).
     unsafe {
         let hi = _mm256_extractf128_ps(v, 1);
         let lo = _mm256_castps256_ps128(v);

--- a/nexus-inference/src/kernel/quantized.rs
+++ b/nexus-inference/src/kernel/quantized.rs
@@ -57,6 +57,7 @@ pub(crate) fn matvec_i8_i32(
     /// Caller must run on a target with AVX2 enabled.
     #[inline(always)]
     unsafe fn hsum_i32(acc: core::arch::x86_64::__m256i) -> i32 {
+        // SAFETY: caller guarantees AVX2 (safety contract on this fn).
         unsafe {
             let hi128 = _mm256_extracti128_si256(acc, 1);
             let lo128 = _mm256_castsi256_si128(acc);


### PR DESCRIPTION
14 undocumented `unsafe {}` blocks across 6 files.

- `src/kernel/activate.rs`: 8 inner blocks inside `unsafe fn` bodies (6 in `simd` module: tanh/sigmoid/swish/gelu/activate_8wide/activate_4wide all AVX2+FMA; 2 in `simd512`: tanh_16wide/sigmoid_16wide AVX-512F). Each cites the caller safety contract.
- `src/kernel/binary.rs`: 2 blocks in cfg-gated regular fns (`matvec_bias_binarize`, `output_from_bits_simd`); cfg guarantees AVX2+FMA or AVX-512F.
- `src/kernel/mlp.rs`: 1 block in `hsum256` (unsafe fn, AVX2).
- `src/kernel/quantized.rs`: 1 block in `hsum_i32` (unsafe fn, AVX2).
- `src/kernel/dot/avx2.rs`: 1 block in `hsum_f32` (unsafe fn, AVX2).
- `src/kernel/dot/avx512.rs`: 1 block in `hsum_f32` (unsafe fn, AVX-512F).