### PR TITLE
docs(nexus-async-web): add SAFETY comments to undocumented unsafe blocks

### DIFF
--- a/nexus-async-web/benches/perf_async_ws_nexus.rs
+++ b/nexus-async-web/benches/perf_async_ws_nexus.rs
@@ -120,6 +120,7 @@ fn noop_waker() -> Waker {
         RawWaker::new(p, &VTABLE)
     }
     const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    // SAFETY: null data is valid; all vtable functions are noop and accept a null data pointer.
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 

--- a/nexus-async-web/benches/perf_ws_cycles_nexus.rs
+++ b/nexus-async-web/benches/perf_ws_cycles_nexus.rs
@@ -24,6 +24,7 @@ use nexus_web::ws::{FrameReader, FrameWriter, Role};
 
 #[inline(always)]
 fn rdtsc_start() -> u64 {
+    // SAFETY: x86_64 intrinsics; this benchmark requires x86_64.
     unsafe {
         core::arch::x86_64::_mm_lfence();
         core::arch::x86_64::_rdtsc()
@@ -32,6 +33,7 @@ fn rdtsc_start() -> u64 {
 
 #[inline(always)]
 fn rdtsc_end() -> u64 {
+    // SAFETY: x86_64 intrinsics; this benchmark requires x86_64.
     unsafe {
         let tsc = core::arch::x86_64::__rdtscp(&mut 0u32 as *mut _);
         core::arch::x86_64::_mm_lfence();
@@ -75,6 +77,7 @@ fn noop_waker() -> Waker {
         RawWaker::new(p, &VTABLE)
     }
     const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    // SAFETY: null data is valid; all vtable functions are noop and accept a null data pointer.
     unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
 }
 

--- a/nexus-async-web/tests/tls_handshake_piggyback.rs
+++ b/nexus-async-web/tests/tls_handshake_piggyback.rs
@@ -59,10 +59,12 @@ unsafe impl GlobalAlloc for CountingAllocator {
         if self.counting_active.load(Ordering::Relaxed) {
             self.allocs.fetch_add(1, Ordering::Relaxed);
         }
+        // SAFETY: delegates to System; layout is valid per GlobalAlloc safety contract.
         unsafe { System.alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: delegates to System; ptr and layout are valid per GlobalAlloc safety contract.
         unsafe { System.dealloc(ptr, layout) };
     }
 }


### PR DESCRIPTION
6 undocumented `unsafe {}` blocks across 3 files.

- `benches/perf_ws_cycles_nexus.rs`: 2 rdtsc functions (`rdtsc_start`, `rdtsc_end`) use x86_64 intrinsics in an x86_64-only benchmark; 1 noop waker with null data and all-noop vtable.
- `benches/perf_async_ws_nexus.rs`: 1 noop waker, same pattern.
- `tests/tls_handshake_piggyback.rs`: `alloc` and `dealloc` in a `GlobalAlloc` impl delegate directly to `System`; both cite the GlobalAlloc caller safety contract.