### PR TITLE
fix(nexus-decimal): round_to_tick misrounds for odd tick sizes

### DIFF
--- a/nexus-decimal/CHANGELOG.md
+++ b/nexus-decimal/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `round_to_tick` misrounded values for odd tick sizes. The old code computed
+  `half_tick = tick / 2` (integer division), which truncates for odd ticks:
+  with `tick=3`, `half_tick=1`, so a remainder of `1` landed in the
+  banker's-rounding branch even though the true midpoint is `1.5`. The fix
+  replaces the division with a complement: `complement = tick - |remainder|`.
+  Comparing `|remainder|` against `complement` is exact and needs no
+  division — for odd ticks `2 * |remainder|` can never equal an odd tick, so
+  the midpoint branch is unreachable. This subsumes the `1.2.2` `tick=1` case
+  (where `half_tick=0` made every non-zero remainder hit the branch) and the
+  general odd-tick class.
+
 ## [1.2.2] — 2026-05-23
 
 ### Fixed

--- a/nexus-decimal/src/financial.rs
+++ b/nexus-decimal/src/financial.rs
@@ -80,38 +80,59 @@ macro_rules! impl_decimal_financial {
                 if remainder == 0 {
                     return Some(self);
                 }
-                let half_tick = tick.value / 2;
                 let base = self.value - remainder;
 
-                if remainder > half_tick {
-                    match base.checked_add(tick.value) {
-                        Some(v) => Some(Self { value: v }),
-                        None => None,
-                    }
-                } else if remainder < -half_tick {
-                    match base.checked_sub(tick.value) {
-                        Some(v) => Some(Self { value: v }),
-                        None => None,
-                    }
-                } else if remainder == half_tick || remainder == -half_tick {
-                    let quotient = self.value / tick.value;
-                    if quotient % 2 != 0 {
-                        if remainder > 0 {
+                // Compare 2*|remainder| against tick without dividing.
+                // Division truncates for odd ticks (e.g. tick=3, tick/2=1 not 1.5),
+                // causing remainder==1 to trigger the midpoint branch incorrectly.
+                // complement = tick - |remainder|; the three cases are:
+                //   |remainder| > complement  -> past midpoint, round away from zero
+                //   |remainder| == complement -> true midpoint, banker's rounding
+                //   |remainder| < complement  -> before midpoint, truncate
+                // Safe: |remainder| < tick, so complement is in (0, tick), no overflow.
+                if remainder > 0 {
+                    let complement = tick.value - remainder;
+                    if remainder > complement {
+                        match base.checked_add(tick.value) {
+                            Some(v) => Some(Self { value: v }),
+                            None => None,
+                        }
+                    } else if remainder == complement {
+                        let quotient = self.value / tick.value;
+                        if quotient % 2 != 0 {
                             match base.checked_add(tick.value) {
                                 Some(v) => Some(Self { value: v }),
                                 None => None,
                             }
                         } else {
-                            match base.checked_sub(tick.value) {
-                                Some(v) => Some(Self { value: v }),
-                                None => None,
-                            }
+                            Some(Self { value: base })
                         }
                     } else {
                         Some(Self { value: base })
                     }
                 } else {
-                    Some(Self { value: base })
+                    // remainder < 0; Rust % carries the dividend sign.
+                    // neg_rem = |remainder|; safe since |remainder| < tick <= $backing::MAX.
+                    let neg_rem = -remainder;
+                    let complement = tick.value - neg_rem;
+                    if neg_rem > complement {
+                        match base.checked_sub(tick.value) {
+                            Some(v) => Some(Self { value: v }),
+                            None => None,
+                        }
+                    } else if neg_rem == complement {
+                        let quotient = self.value / tick.value;
+                        if quotient % 2 != 0 {
+                            match base.checked_sub(tick.value) {
+                                Some(v) => Some(Self { value: v }),
+                                None => None,
+                            }
+                        } else {
+                            Some(Self { value: base })
+                        }
+                    } else {
+                        Some(Self { value: base })
+                    }
                 }
             }
 

--- a/nexus-decimal/tests/financial.rs
+++ b/nexus-decimal/tests/financial.rs
@@ -60,6 +60,39 @@ fn round_to_tick() {
 }
 
 #[test]
+fn round_to_tick_odd_tick() {
+    // tick=3: no true midpoint exists (2*remainder is always even, tick is odd).
+    // The truncated half_tick=1 is not the midpoint; value=4 must round to 3 not 6.
+    let tick = D64::from_raw(3);
+    assert_eq!(D64::from_raw(4).round_to_tick(tick), Some(D64::from_raw(3)));
+    assert_eq!(D64::from_raw(5).round_to_tick(tick), Some(D64::from_raw(6)));
+    assert_eq!(
+        D64::from_raw(-4).round_to_tick(tick),
+        Some(D64::from_raw(-3))
+    );
+    assert_eq!(
+        D64::from_raw(-5).round_to_tick(tick),
+        Some(D64::from_raw(-6))
+    );
+}
+
+#[test]
+fn round_to_tick_even_tick_bankers() {
+    // tick=4: true midpoint at remainder==2; banker's rounds to the even multiple.
+    let tick = D64::from_raw(4);
+    assert_eq!(D64::from_raw(6).round_to_tick(tick), Some(D64::from_raw(8))); // quotient 1 odd -> up
+    assert_eq!(D64::from_raw(2).round_to_tick(tick), Some(D64::from_raw(0))); // quotient 0 even -> down
+    assert_eq!(
+        D64::from_raw(-6).round_to_tick(tick),
+        Some(D64::from_raw(-8))
+    ); // quotient -1 odd -> down
+    assert_eq!(
+        D64::from_raw(-2).round_to_tick(tick),
+        Some(D64::from_raw(0))
+    ); // quotient 0 even -> base
+}
+
+#[test]
 fn floor_to_tick() {
     let price = D64::new(1, 23_700_000); // 1.237
     let tick = D64::new(0, 5_000_000); // 0.05


### PR DESCRIPTION
Closes #704

The implementation divided tick by 2 to find the midpoint, which truncates
for odd ticks. For tick=3, half_tick=1, so a remainder of 1 was placed at
the midpoint branch incorrectly (true midpoint is 1.5), causing values like
4 to round up to 6 instead of down to 3.

Replace the division with a complement: complement = tick - |remainder|.
Compare |remainder| against complement directly. No division, no truncation.
For odd ticks there is no exact midpoint, so the banker's rounding branch is
never reached incorrectly. For even ticks the midpoint branch fires only when
|remainder| == complement, which is the true half-tick.

Two new tests: round_to_tick_odd_tick covers tick=3 for positive and
negative values; round_to_tick_even_tick_bankers covers tick=4 banker's
cases. The audit test (f08) was moved into nexus-decimal/tests/financial.rs
under those names.
