### PR TITLE
fix(nexus-id): uuid v7 sequence wraps through u16 after exhaustion

### DIFF
--- a/nexus-id/CHANGELOG.md
+++ b/nexus-id/CHANGELOG.md
@@ -10,6 +10,18 @@ contained.
 
 ## [Unreleased]
 
+### Fixed
+
+- `UuidV7` sequence counter wrapped through `u16::MAX` after exhaustion.
+  `wrapping_add` incremented the counter past `SEQUENCE_MAX` (4095) on
+  every error-returning call. After 61440 further calls the counter
+  cycled back to `0`, and the next call succeeded with sequence `0`,
+  reusing a value within the same millisecond. This produced duplicate
+  and non-monotonic UUIDs. Fixed by checking `sequence >= SEQUENCE_MAX`
+  before incrementing: once exhausted the counter stays at `4095`
+  permanently and every subsequent call returns `SequenceExhausted`.
+
+
 ## [1.1.5] — 2026-05-10
 
 Doc + bench infra release. No public API change.

--- a/nexus-id/src/uuid/v7.rs
+++ b/nexus-id/src/uuid/v7.rs
@@ -131,13 +131,13 @@ impl UuidV7 {
 
         // Handle sequence
         if ts_ms == self.last_ts_ms {
-            self.sequence = self.sequence.wrapping_add(1);
-            if self.sequence > SEQUENCE_MAX {
+            if self.sequence >= SEQUENCE_MAX {
                 return Err(SequenceExhausted {
                     tick: ts_ms,
                     max_sequence: SEQUENCE_MAX as u64,
                 });
             }
+            self.sequence += 1;
         } else {
             self.last_ts_ms = ts_ms;
             self.sequence = 0;
@@ -398,5 +398,23 @@ mod tests {
 
         let uuid = generator.next(epoch).unwrap();
         assert_eq!(uuid.len(), 36);
+    }
+
+    #[test]
+    fn sequence_exhausted_state_is_permanent() {
+        // After all 4096 sequence slots are used, every further call for the same
+        // timestamp must return Err. With wrapping_add the counter eventually returns
+        // to 0 and the call succeeds again, reusing sequence 0.
+        let epoch = Instant::now();
+        let mut v7 = UuidV7::new(epoch, 1_700_000_000_000, 42);
+        for _ in 0..=SEQUENCE_MAX {
+            v7.next_raw(epoch).unwrap();
+        }
+        // Drive the u16 counter through its remaining values (4096..=65535 = 61440 steps)
+        for _ in 0..(u16::MAX as usize - SEQUENCE_MAX as usize) {
+            let _ = v7.next_raw(epoch);
+        }
+        // wrapping_add would return the counter to 0; the call must still fail
+        assert!(v7.next_raw(epoch).is_err());
     }
 }


### PR DESCRIPTION
Closes #705

wrapping_add incremented the counter past SEQUENCE_MAX, cycling it back
through 0 after 65536 total calls (4096 successes + 61440 errors). The
counter returned to 0, allowing sequence reuse within the same millisecond.

Fix: check the limit before incrementing. The counter now stays at
SEQUENCE_MAX permanently once exhausted. Any call after that returns
SequenceExhausted for the lifetime of the generator.

New test sequence_exhausted_state_is_permanent drives the counter through
its remaining u16 range after exhaustion and asserts the final call still
fails. The audit test (f13) was replaced by this test.
