### PR TITLE
test: add proptests for nexus-logbuf, nexus-collections, nexus-stats-core (#223)

### DIFF
--- a/nexus-collections/Cargo.toml
+++ b/nexus-collections/Cargo.toml
@@ -16,6 +16,7 @@ slab = ["dep:nexus-slab"]
 
 [dev-dependencies]
 hdrhistogram = "7.5"
+proptest = "1.4"
 rand = "0.9.2"
 seq-macro.workspace = true
 

--- a/nexus-collections/tests/btree_test.rs
+++ b/nexus-collections/tests/btree_test.rs
@@ -328,3 +328,82 @@ fn non_empty_drop_panics_in_debug() {
         "dropping non-empty btree should panic in debug"
     );
 }
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::BTreeMap as StdMap;
+
+    /// Operation against a `BTree<u16, u64>` under test.
+    #[derive(Debug, Clone)]
+    enum Op {
+        Insert { key: u16, value: u64 },
+        Remove { key: u16 },
+    }
+
+    fn op_strategy() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            (0u16..64, any::<u64>()).prop_map(|(key, value)| Op::Insert { key, value }),
+            (0u16..64).prop_map(|key| Op::Remove { key }),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Fuzz insert/remove against a `std::collections::BTreeMap` oracle.
+        ///
+        /// Key range is deliberately small (0..64) relative to the op
+        /// count (up to 300) so keys collide often, exercising
+        /// replace-existing-key, remove-then-reinsert, and
+        /// remove-of-absent-key paths. After every operation:
+        ///
+        /// - the returned old value (from insert/remove) must match the
+        ///   oracle's -- the "record" is correct, not just present
+        /// - `tree.len()` must match the oracle's length
+        /// - `tree.verify_invariants()` must hold -- sorted keys, minimum
+        ///   occupancy, uniform leaf depth (the tree's own structural
+        ///   invariant checker)
+        ///
+        /// At the end, a full in-order content comparison against the
+        /// oracle catches anything the per-step checks missed.
+        #[test]
+        fn fuzz_insert_remove_matches_std_btreemap(
+            ops in proptest::collection::vec(op_strategy(), 1..300),
+        ) {
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
+            let slab: UnboundedSlab<BTreeNode<u16, u64, 8>> =
+                unsafe { UnboundedSlab::with_chunk_capacity(64) };
+            let mut tree = BTree::<u16, u64, 8>::new();
+            let mut oracle: StdMap<u16, u64> = StdMap::new();
+
+            for op in &ops {
+                match op {
+                    Op::Insert { key, value } => {
+                        let got = tree.insert(&slab, *key, *value);
+                        let want = oracle.insert(*key, *value);
+                        prop_assert_eq!(got, want, "insert mismatch after {:?}", op);
+                    }
+                    Op::Remove { key } => {
+                        let got = tree.remove(&slab, key);
+                        let want = oracle.remove(key);
+                        prop_assert_eq!(got, want, "remove mismatch after {:?}", op);
+                    }
+                }
+
+                prop_assert_eq!(tree.len(), oracle.len());
+                tree.verify_invariants();
+            }
+
+            let tree_pairs: Vec<(u16, u64)> = tree.iter().map(|(k, v)| (*k, *v)).collect();
+            let oracle_pairs: Vec<(u16, u64)> = oracle.into_iter().collect();
+            prop_assert_eq!(tree_pairs, oracle_pairs);
+
+            tree.clear(&slab);
+        }
+    }
+}

--- a/nexus-collections/tests/rbtree_test.rs
+++ b/nexus-collections/tests/rbtree_test.rs
@@ -399,3 +399,83 @@ fn non_empty_drop_panics_in_debug() {
         "dropping non-empty rbtree should panic in debug"
     );
 }
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::BTreeMap as StdMap;
+
+    /// Operation against an `RbTree<u16, u64>` under test.
+    #[derive(Debug, Clone)]
+    enum Op {
+        Insert { key: u16, value: u64 },
+        Remove { key: u16 },
+    }
+
+    fn op_strategy() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            (0u16..64, any::<u64>()).prop_map(|(key, value)| Op::Insert { key, value }),
+            (0u16..64).prop_map(|key| Op::Remove { key }),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Fuzz insert/remove against a `std::collections::BTreeMap` oracle.
+        ///
+        /// Key range is deliberately small (0..64) relative to the op
+        /// count (up to 300) so keys collide often, exercising
+        /// replace-existing-key, remove-then-reinsert, and
+        /// remove-of-absent-key paths. After every operation:
+        ///
+        /// - the returned old value (from insert/remove) must match the
+        ///   oracle's -- the "record" is correct, not just present
+        /// - `tree.len()` must match the oracle's length
+        /// - `tree.verify_invariants()` must hold -- no red-red
+        ///   violations, uniform black-height, BST ordering, correct
+        ///   leftmost/rightmost caches (the tree's own color-invariant
+        ///   checker)
+        ///
+        /// At the end, a full in-order content comparison against the
+        /// oracle catches anything the per-step checks missed.
+        #[test]
+        fn fuzz_insert_remove_matches_std_btreemap(
+            ops in proptest::collection::vec(op_strategy(), 1..300),
+        ) {
+            // SAFETY: single-threaded test; slab outlives all allocated slots.
+            let slab: UnboundedSlab<RbNode<u16, u64>> =
+                unsafe { UnboundedSlab::with_chunk_capacity(64) };
+            let mut tree: RbTree<u16, u64> = RbTree::new();
+            let mut oracle: StdMap<u16, u64> = StdMap::new();
+
+            for op in &ops {
+                match op {
+                    Op::Insert { key, value } => {
+                        let got = tree.insert(&slab, *key, *value);
+                        let want = oracle.insert(*key, *value);
+                        prop_assert_eq!(got, want, "insert mismatch after {:?}", op);
+                    }
+                    Op::Remove { key } => {
+                        let got = tree.remove(&slab, key);
+                        let want = oracle.remove(key);
+                        prop_assert_eq!(got, want, "remove mismatch after {:?}", op);
+                    }
+                }
+
+                prop_assert_eq!(tree.len(), oracle.len());
+                tree.verify_invariants();
+            }
+
+            let tree_pairs: Vec<(u16, u64)> = tree.iter().map(|(k, v)| (*k, *v)).collect();
+            let oracle_pairs: Vec<(u16, u64)> = oracle.into_iter().collect();
+            prop_assert_eq!(tree_pairs, oracle_pairs);
+
+            tree.clear(&slab);
+        }
+    }
+}

--- a/nexus-logbuf/Cargo.toml
+++ b/nexus-logbuf/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam-utils.workspace = true
 
 [dev-dependencies]
 hdrhistogram = "7.5"
+proptest = "1.4"
 rand = "0.8"
 
 [[example]]

--- a/nexus-logbuf/src/queue/spsc.rs
+++ b/nexus-logbuf/src/queue/spsc.rs
@@ -923,3 +923,151 @@ mod tests {
         }
     }
 }
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::VecDeque;
+
+    /// Operation against an SPSC ring buffer under test.
+    #[derive(Debug, Clone)]
+    enum Op {
+        /// Claim `len` bytes, write a recognizable payload, and commit.
+        Write { len: usize },
+        /// Claim `len` bytes and drop without committing (skip-marker path).
+        Abort { len: usize },
+        /// Attempt to read and release the next record.
+        Read,
+    }
+
+    fn op_strategy() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            (1usize..48).prop_map(|len| Op::Write { len }),
+            (1usize..48).prop_map(|len| Op::Abort { len }),
+            Just(Op::Read),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        /// Fuzz write/abort/read interleaving.
+        ///
+        /// Drives the SPSC queue from a single thread with random
+        /// commit/abort/read sequences against small power-of-two
+        /// capacities, so records routinely straddle the ring boundary
+        /// (exercising the skip-marker/wraparound path). Tracks every
+        /// committed payload in an oracle queue:
+        ///
+        /// - a successful `Read` must match the oldest committed payload
+        ///   exactly (byte-for-byte, correct length, correct order) --
+        ///   the "record-length stamping" invariant
+        /// - `Read` returning nothing is only valid when the oracle is
+        ///   also empty -- with a single thread and no concurrent writer,
+        ///   any committed-but-unread record must be immediately visible,
+        ///   so this cross-checks the head/tail occupancy bookkeeping
+        /// - after draining, the oracle must be fully empty -- nothing
+        ///   committed is ever lost or duplicated
+        #[test]
+        fn fuzz_write_abort_read_roundtrip(
+            capacity_pow in 4u32..9,
+            ops in proptest::collection::vec(op_strategy(), 1..300),
+        ) {
+            let capacity = 1usize << capacity_pow;
+            let (mut producer, mut consumer) = new(capacity);
+
+            let mut expected: VecDeque<Vec<u8>> = VecDeque::new();
+            let mut tag: u8 = 0;
+
+            for op in &ops {
+                match op {
+                    Op::Write { len } => {
+                        if let Ok(mut claim) = producer.try_claim(*len) {
+                            tag = tag.wrapping_add(1);
+                            let payload = vec![tag; *len];
+                            claim.copy_from_slice(&payload);
+                            claim.commit();
+                            expected.push_back(payload);
+                        }
+                    }
+                    Op::Abort { len } => {
+                        if let Ok(_claim) = producer.try_claim(*len) {
+                            // Dropped without commit: writes a skip marker.
+                        }
+                    }
+                    Op::Read => match consumer.try_claim() {
+                        Some(record) => {
+                            let want = expected.pop_front();
+                            prop_assert_eq!(
+                                want.as_deref(),
+                                Some(&*record),
+                                "read returned unexpected payload"
+                            );
+                        }
+                        None => {
+                            prop_assert!(
+                                expected.is_empty(),
+                                "read found nothing but {} committed record(s) are still pending",
+                                expected.len()
+                            );
+                        }
+                    },
+                }
+            }
+
+            // Drain everything and confirm nothing was lost or duplicated.
+            while let Some(want) = expected.pop_front() {
+                let record = consumer
+                    .try_claim()
+                    .unwrap_or_else(|| panic!("expected record of len {} missing at drain", want.len()));
+                prop_assert_eq!(&*record, want.as_slice());
+            }
+            prop_assert!(consumer.try_claim().is_none());
+        }
+
+        /// Fuzz capacity recovery.
+        ///
+        /// Fills the buffer to `BufferFull` with same-size records, frees
+        /// exactly one via `Read`, and asserts a same-size `Write`
+        /// immediately succeeds. This is the "occupancy" invariant: a
+        /// record's footprint must be fully reclaimed once read, with no
+        /// permanent bookkeeping leak.
+        #[test]
+        fn fuzz_capacity_recovery(
+            (capacity, len) in (4u32..9).prop_flat_map(|capacity_pow| {
+                let capacity = 1usize << capacity_pow;
+                let max_len = (capacity / 4).max(2);
+                (Just(capacity), 1usize..max_len)
+            }),
+        ) {
+            let (mut producer, mut consumer) = new(capacity);
+
+            // Fill to BufferFull with same-size records.
+            let mut written = 0usize;
+            while let Ok(claim) = producer.try_claim(len) {
+                claim.commit();
+                written += 1;
+            }
+            prop_assert!(
+                written > 0,
+                "first write of len {len} did not fit in capacity {capacity}"
+            );
+
+            // Free exactly one record.
+            consumer
+                .try_claim()
+                .expect("at least one record was committed");
+
+            // The same-size write must now succeed -- space was reclaimed.
+            prop_assert!(
+                producer.try_claim(len).is_ok(),
+                "write of len {len} did not recover after freeing one record (capacity {capacity})"
+            );
+        }
+    }
+}

--- a/nexus-stats-core/Cargo.toml
+++ b/nexus-stats-core/Cargo.toml
@@ -19,5 +19,8 @@ libm = ["dep:libm"]
 [dependencies]
 libm = { version = "0.2", optional = true }
 
+[dev-dependencies]
+proptest = "1.4"
+
 [lints]
 workspace = true

--- a/nexus-stats-core/src/monitoring/drawdown.rs
+++ b/nexus-stats-core/src/monitoring/drawdown.rs
@@ -338,3 +338,52 @@ mod tests {
         ));
     }
 }
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        /// `peak()` and `max_drawdown()` must be monotonically
+        /// non-decreasing across updates, and `drawdown()` must never go
+        /// negative -- the monotonicity invariant a drawdown/circuit-breaker
+        /// monitor depends on.
+        #[test]
+        fn fuzz_peak_and_max_drawdown_are_monotonic(
+            samples in proptest::collection::vec(-1e6f64..1e6, 1..300),
+        ) {
+            let mut dd = DrawdownF64::new();
+            let mut prev_peak = f64::NEG_INFINITY;
+            let mut prev_max_dd = 0.0f64;
+            let mut running_max_dd = 0.0f64;
+
+            for &s in &samples {
+                let current_dd = dd.update(s).unwrap();
+                prop_assert!(current_dd >= 0.0, "drawdown went negative: {current_dd}");
+
+                let peak = dd.peak().unwrap();
+                prop_assert!(peak >= prev_peak, "peak decreased: {prev_peak} -> {peak}");
+                prev_peak = peak;
+
+                let max_dd = dd.max_drawdown();
+                prop_assert!(
+                    max_dd >= prev_max_dd,
+                    "max_drawdown decreased: {prev_max_dd} -> {max_dd}"
+                );
+                prev_max_dd = max_dd;
+
+                running_max_dd = running_max_dd.max(current_dd);
+            }
+
+            // max_drawdown must equal the largest drawdown() ever observed.
+            prop_assert_eq!(dd.max_drawdown(), running_max_dd);
+        }
+    }
+}

--- a/nexus-stats-core/src/statistics/welford.rs
+++ b/nexus-stats-core/src/statistics/welford.rs
@@ -362,3 +362,95 @@ mod tests {
         assert_eq!(w.count(), 0);
     }
 }
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        /// Variance must never go negative, and must match an independent
+        /// two-pass reference computation within a tight tolerance -- the
+        /// numerical-stability invariant Welford's algorithm exists for
+        /// (avoiding the catastrophic cancellation of the naive
+        /// sum-of-squares-minus-square-of-sum approach).
+        #[test]
+        fn fuzz_variance_matches_two_pass_reference(
+            samples in proptest::collection::vec(-1e6f64..1e6, 2..200),
+        ) {
+            let mut w = WelfordF64::new();
+            for &s in &samples {
+                w.update(s).unwrap();
+            }
+
+            prop_assert_eq!(w.count(), samples.len() as u64);
+
+            let var = w.variance().unwrap();
+            prop_assert!(var >= 0.0, "variance went negative: {var}");
+
+            // Independent two-pass reference: mean, then sum of squared
+            // deviations from that mean, then divide by (n-1).
+            let n = samples.len() as f64;
+            let ref_mean = samples.iter().sum::<f64>() / n;
+            let ref_var =
+                samples.iter().map(|s| (s - ref_mean).powi(2)).sum::<f64>() / (n - 1.0);
+
+            let mean = w.mean().unwrap();
+            let mean_scale = ref_mean.abs().max(1.0);
+            prop_assert!(
+                (mean - ref_mean).abs() <= 1e-6 * mean_scale,
+                "mean diverged from reference: welford={mean}, reference={ref_mean}"
+            );
+
+            let var_scale = ref_var.abs().max(1.0);
+            prop_assert!(
+                (var - ref_var).abs() <= 1e-6 * var_scale,
+                "variance diverged from reference: welford={var}, reference={ref_var}"
+            );
+        }
+
+        /// Splitting a sequence across two accumulators and merging them
+        /// (Chan's algorithm) must match feeding the whole sequence into a
+        /// single accumulator.
+        #[test]
+        fn fuzz_merge_matches_single_pass(
+            samples in proptest::collection::vec(-1e6f64..1e6, 2..200),
+            split in 1usize..199,
+        ) {
+            let split = split.min(samples.len() - 1).max(1);
+
+            let mut whole = WelfordF64::new();
+            for &s in &samples {
+                whole.update(s).unwrap();
+            }
+
+            let mut left = WelfordF64::new();
+            for &s in &samples[..split] {
+                left.update(s).unwrap();
+            }
+            let mut right = WelfordF64::new();
+            for &s in &samples[split..] {
+                right.update(s).unwrap();
+            }
+            left.merge(&right);
+
+            prop_assert_eq!(left.count(), whole.count());
+
+            let mean_scale = whole.mean().unwrap().abs().max(1.0);
+            prop_assert!(
+                (left.mean().unwrap() - whole.mean().unwrap()).abs() <= 1e-6 * mean_scale
+            );
+
+            let whole_var = whole.variance().unwrap();
+            let merged_var = left.variance().unwrap();
+            let var_scale = whole_var.abs().max(1.0);
+            prop_assert!((merged_var - whole_var).abs() <= 1e-6 * var_scale);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Continues the proptest coverage push from #223. Three crates get new property tests in this PR; two others turned out to already be covered and needed no changes (noted below for the record).

**nexus-logbuf** (`queue/spsc.rs`)
- `fuzz_write_abort_read_roundtrip`: random write/abort/read sequences against small power-of-two capacities, checked against an oracle queue of committed payloads for exact content/order. `Read` returning nothing is only valid when the oracle is also empty, cross-checking the head/tail occupancy bookkeeping. Small capacities force records across the ring boundary constantly, exercising the wraparound/skip-marker path.
- `fuzz_capacity_recovery`: fills to `BufferFull`, frees one record, asserts a same-size write immediately recovers — no bookkeeping leak.

**nexus-collections** (`btree_test.rs`, `rbtree_test.rs`)
- Fuzzes insert/remove for both `BTree` and `RbTree` against a `std::collections::BTreeMap` oracle, with a small key range relative to op count so keys collide often (replace-existing, remove-then-reinsert, remove-of-absent-key).
- Cross-checks each tree's own `verify_invariants()` after every op (already existed in the source, just wasn't exercised by randomized input) — min-occupancy/sorted-keys for BTree, red-black color/black-height for RbTree.

**nexus-stats-core** (`statistics/welford.rs`, `monitoring/drawdown.rs`)
- The `nexus-stats` crate named in #223 is a pure re-export facade; the actual implementations live in `nexus-stats-core`, so that's where these landed.
- `WelfordF64`: variance never negative, matches an independent two-pass reference within tolerance, and merge (Chan's algorithm) matches a single-pass accumulation of the same data.
- `DrawdownF64`: `peak()`/`max_drawdown()` monotonically non-decreasing across updates, `drawdown()` never negative.

**Already covered, no changes needed:**
- `nexus-decimal` — had proptest coverage (`tests/*_props.rs`) predating #223.
- `nexus-queue` — has loom-based tests (`tests/loom_{spsc,mpsc,spmc}.rs`) covering FIFO order, no-lost-items, no-duplicates, and wraparound under real concurrency, which is the correct tool for that crate's invariant (plain proptest replays on one thread and can't exercise contention).

This closes out every crate on #223's list.